### PR TITLE
feat(ui): compact RestaurantHeader card on public page (#64)

### DIFF
--- a/components/public/RestaurantHeader.vue
+++ b/components/public/RestaurantHeader.vue
@@ -18,12 +18,12 @@
 
     <!-- Restaurant Info -->
     <div class="max-w-7xl mx-auto px-4 -mt-16 relative z-10">
-      <div class="bg-white rounded-xl shadow-lg p-6 md:p-8">
-        <div class="flex flex-col md:flex-row gap-6 items-start md:items-center">
+      <div class="bg-white rounded-xl shadow-lg p-4">
+        <div class="flex flex-row gap-3 items-center">
           <!-- Logo -->
           <div class="flex-shrink-0">
             <div
-              class="w-24 h-24 md:w-32 md:h-32 rounded-2xl bg-white shadow-md flex items-center justify-center border-4 border-white overflow-hidden"
+              class="w-16 h-16 rounded-xl bg-white shadow-md flex items-center justify-center border-2 border-white overflow-hidden"
             >
               <img
                 v-if="restaurant.logo_url && restaurant.logo_url.startsWith('http')"
@@ -31,16 +31,16 @@
                 :alt="restaurant.display_name"
                 class="w-full h-full object-contain"
               />
-              <div v-else class="text-5xl md:text-6xl">
+              <div v-else class="text-3xl">
                 {{ restaurant.logo_url || '🍽️' }}
               </div>
             </div>
           </div>
 
           <!-- Name and Description -->
-          <div class="flex-1">
+          <div class="flex-1 min-w-0">
             <div class="flex items-center gap-3 flex-wrap">
-              <h1 class="text-3xl md:text-4xl font-bold text-gray-900">
+              <h1 class="text-xl md:text-2xl font-bold text-gray-900">
                 {{ restaurant.display_name }}
               </h1>
 
@@ -61,41 +61,42 @@
               </span>
             </div>
 
-            <p v-if="restaurant.description" class="mt-3 text-gray-600 text-lg">
+            <p v-if="restaurant.description" class="mt-1 text-gray-600 text-sm line-clamp-2">
               {{ restaurant.description }}
             </p>
 
             <!-- Contact Info -->
-            <div class="mt-4 flex flex-wrap gap-4 text-base text-gray-500">
+            <div class="mt-2 flex flex-wrap gap-3 text-sm text-gray-500">
               <div v-if="restaurant.phone_number" class="flex items-center gap-2">
-                <span>📞</span>
+                <span aria-hidden="true">📞</span>
                 <a :href="`tel:${restaurant.phone_number}`" class="hover:text-blue-600">
                   {{ restaurant.phone_number }}
                 </a>
               </div>
 
               <div v-if="restaurant.address" class="flex items-center gap-2">
-                <span>📍</span>
+                <span aria-hidden="true">📍</span>
                 <span>{{ restaurant.address }}</span>
               </div>
 
               <div v-if="restaurant.city" class="flex items-center gap-2">
-                <span>🏙️</span>
+                <span aria-hidden="true">🏙️</span>
                 <span>{{ restaurant.city }}{{ restaurant.neighborhood ? `, ${restaurant.neighborhood}` : '' }}</span>
               </div>
             </div>
 
             <!-- Social Media -->
-            <div v-if="hasSocialMedia" class="mt-4 flex gap-3">
+            <div v-if="hasSocialMedia" class="mt-2 flex flex-wrap gap-2">
               <a
                 v-if="restaurant.social_media?.whatsapp"
                 :href="`https://wa.me/${restaurant.social_media.whatsapp.replace(/[^0-9]/g, '')}`"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="inline-flex items-center justify-center w-11 h-11 rounded-full bg-green-500 text-white hover:bg-green-600 transition-colors text-xl"
+                aria-label="WhatsApp"
                 title="WhatsApp"
               >
-                💬
+                <span aria-hidden="true">💬</span>
               </a>
 
               <a
@@ -104,9 +105,10 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 class="inline-flex items-center justify-center w-11 h-11 rounded-full bg-blue-600 text-white hover:bg-blue-700 transition-colors text-xl"
+                aria-label="Facebook"
                 title="Facebook"
               >
-                f
+                <span aria-hidden="true">f</span>
               </a>
 
               <a
@@ -115,18 +117,20 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 class="inline-flex items-center justify-center w-11 h-11 rounded-full bg-gradient-to-r from-purple-500 to-pink-500 text-white hover:from-purple-600 hover:to-pink-600 transition-colors text-xl"
+                aria-label="Instagram"
                 title="Instagram"
               >
-                📷
+                <span aria-hidden="true">📷</span>
               </a>
             </div>
           </div>
         </div>
 
         <!-- Business Hours -->
-        <div v-if="restaurant.business_hours && Object.keys(restaurant.business_hours).length > 0" class="mt-6 pt-6 border-t border-gray-200">
+        <div v-if="restaurant.business_hours && Object.keys(restaurant.business_hours).length > 0" class="mt-3 pt-3 border-t border-gray-200">
           <button
             @click="showHours = !showHours"
+            :aria-expanded="showHours"
             class="flex items-center gap-2 text-sm font-medium text-gray-700 hover:text-gray-900"
           >
             <span>🕐</span>


### PR DESCRIPTION
## Summary
- Switch from vertical stacked layout to inline `flex-row` — logo beside name at all breakpoints (biggest height reducer)
- Logo reduced from 96px to 64px
- Name font size reduced from `text-3xl/4xl` to `text-xl/2xl`
- Description clamped to 2 lines
- Card padding reduced to `p-4`
- All spacing tightened: contact, social, business hours sections
- Accessibility: decorative emojis get `aria-hidden`, social links get `aria-label`, hours toggle gets `aria-expanded`

## Stack
Nuxt 3 + UX

## Changes
- `components/public/RestaurantHeader.vue`: All layout, sizing, spacing, and accessibility changes

## Testing
- Visit `/waro-colombia` (or any tenant page)
- On mobile (375px): verify logo is inline with name, card height is visibly shorter
- Verify at least 2 product cards are visible without scrolling on iPhone 13 Mini / SE
- Check with VoiceOver/screen reader that social buttons announce correctly

Closes #64