### PR TITLE
fix(cart): resolve first-add race condition and show spinner on add

### DIFF
--- a/components/online/CartDrawer.vue
+++ b/components/online/CartDrawer.vue
@@ -139,7 +139,7 @@
                   class="w-full py-2 text-sm font-semibold text-destructive hover:bg-destructive/5 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   @click="confirmClear = true"
                 >
-                  🗑️ Vaciar Carrito
+                  Vaciar Carrito
                 </button>
               </Transition>
             </div>
@@ -179,12 +179,7 @@ const showError = (msg: string) => {
   errorTimeout = setTimeout(() => { errorMsg.value = null }, 4000)
 }
 
-const deliveryFee = computed(() => {
-  if (cartStore.orderType === 'delivery') {
-    return cartStore.subtotal >= 50000 ? 0 : 5000
-  }
-  return 0
-})
+const deliveryFee = computed(() => 0)
 
 const minimumOrder = computed(() => {
   return cartStore.orderType === 'delivery' ? 20000 : 0

--- a/components/online/checkout/StepConfirm.vue
+++ b/components/online/checkout/StepConfirm.vue
@@ -198,9 +198,7 @@ const displayAddress = computed(() =>
   addressStore.selectedAddress ?? addressStore.pendingAddress,
 )
 
-const deliveryFee = computed(() =>
-  cartStore.orderType === 'delivery' && cartStore.subtotal < 50000 ? 5000 : 0,
-)
+const deliveryFee = computed(() => 0)
 
 const orderTypeIcon = computed(() => ({
   delivery: 'M8 16a3 3 0 01-3-3V7a3 3 0 013-3h8a3 3 0 013 3v6a3 3 0 01-3 3H8zm-4 0h1m14 0h1M1 10h2m18 0h2M5 20h14',

--- a/components/online/checkout/StepEmail.vue
+++ b/components/online/checkout/StepEmail.vue
@@ -15,8 +15,8 @@
         type="email"
         autocomplete="email"
         class="w-full h-10 px-3 rounded-md border border-input bg-background text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-        placeholder="you@email.com"
-        :disabled="isFetching"
+        placeholder="tu@correo.com"
+        :disabled="isFetching || previewDone"
         @keyup.enter="onNext"
       />
       <p v-if="email && !isEmailValid" class="text-xs text-destructive">
@@ -63,7 +63,7 @@ const isEmailValid = computed(() =>
 const isValid = computed(() => isEmailValid.value)
 
 const onNext = async () => {
-  if (!isEmailValid.value || isFetching.value) return
+  if (!isEmailValid.value || isFetching.value || previewDone.value) return
 
   isFetching.value = true
   previewDone.value = false

--- a/components/online/checkout/StepIdentity.vue
+++ b/components/online/checkout/StepIdentity.vue
@@ -181,9 +181,7 @@ onUnmounted(() => {
 })
 
 // Delivery fee (mirrors confirm.vue logic)
-const deliveryFee = computed(() =>
-  cartStore.orderType === 'delivery' && cartStore.subtotal < 50000 ? 5000 : 0,
-)
+const deliveryFee = computed(() => 0)
 
 // ── OTP send ──────────────────────────────────────────────────────────────
 const handleSendOTP = async () => {

--- a/components/public/PublicProductCard.vue
+++ b/components/public/PublicProductCard.vue
@@ -56,9 +56,9 @@
           {{ formatPrice(product.price) }}
         </div>
 
-        <!-- NOT in cart → + button -->
+        <!-- NOT in cart → + button (also show while adding) -->
         <button
-          v-if="!isInCart"
+          v-if="!isInCart || isAdding"
           @click.stop="handleClick"
           :disabled="isAdding || !product.is_available"
           class="w-11 h-11 flex items-center justify-center rounded-xl bg-primary text-primary-foreground text-xl font-bold hover:bg-primary/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-none"
@@ -69,7 +69,7 @@
         </button>
 
         <!-- IN cart → − N + inline controls -->
-        <div v-else class="flex items-center gap-1" @click.stop>
+        <div v-else-if="!isAdding" class="flex items-center gap-1" @click.stop>
           <button
             @click="decrease"
             :disabled="cartStore.isLoading"
@@ -161,24 +161,24 @@
 
       <!-- Cart controls (compact) -->
       <div class="flex-shrink-0" @click.stop>
-        <!-- NOT in cart → + button -->
+        <!-- NOT in cart → + button (also show while adding) -->
         <button
-          v-if="!isInCart"
+          v-if="!isInCart || isAdding"
           @click.stop="handleClick"
           :disabled="isAdding || !product.is_available"
-          class="w-9 h-9 flex items-center justify-center rounded-xl bg-primary text-primary-foreground text-lg font-bold hover:bg-primary/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-none"
+          class="w-11 h-11 flex items-center justify-center rounded-xl bg-primary text-primary-foreground text-lg font-bold hover:bg-primary/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-none"
           aria-label="Agregar al carrito"
         >
-          <span v-if="isAdding" class="w-3.5 h-3.5 border-2 border-white border-t-transparent rounded-full animate-spin inline-block" />
+          <span v-if="isAdding" class="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin inline-block" />
           <span v-else>+</span>
         </button>
 
         <!-- IN cart → − N + inline controls (compact) -->
-        <div v-else class="flex items-center gap-1">
+        <div v-else-if="!isAdding" class="flex items-center gap-1">
           <button
             @click="decrease"
             :disabled="cartStore.isLoading"
-            class="w-9 h-9 flex items-center justify-center rounded-xl bg-muted hover:bg-red-100 text-foreground hover:text-red-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed text-base font-bold"
+            class="w-11 h-11 flex items-center justify-center rounded-xl bg-muted hover:bg-red-100 text-foreground hover:text-red-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed text-base font-bold"
             aria-label="Quitar uno"
           >−</button>
           <span class="min-w-[1.25rem] text-center font-bold text-foreground text-sm">
@@ -187,7 +187,7 @@
           <button
             @click="increase"
             :disabled="cartStore.isLoading || !product.is_available"
-            class="w-9 h-9 flex items-center justify-center rounded-xl bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed text-base font-bold focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-none"
+            class="w-11 h-11 flex items-center justify-center rounded-xl bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed text-base font-bold focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-none"
             aria-label="Agregar uno más"
           >+</button>
         </div>
@@ -197,7 +197,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, nextTick } from 'vue'
 import { useOnlineCartStore } from '~/stores/online_cart'
 
 const props = defineProps({
@@ -230,12 +230,8 @@ const isInCart = computed(() => totalQtyInCart.value > 0)
 // Local loading state for the initial "add" action (before item appears in cart)
 const isAdding = ref(false)
 
-watch(isInCart, (nowInCart) => {
-  if (nowInCart) isAdding.value = false
-})
-
 watch(() => cartStore.isLoading, (loading) => {
-  if (!loading && !isInCart.value) isAdding.value = false
+  if (!loading) isAdding.value = false
 })
 
 // Decrement: target the last item added (LIFO)
@@ -264,10 +260,14 @@ const increase = async () => {
   }
 }
 
-function handleClick() {
+async function handleClick() {
   if (!props.product.is_available) return
   if (isInCart.value) return
-  if (!props.product.has_modifiers) isAdding.value = true
+  if (isAdding.value) return                    // double-click guard
+  if (!props.product.has_modifiers) {
+    isAdding.value = true
+    await nextTick()                            // render spinner before optimistic push flips isInCart
+  }
   emit('click', props.product)
 }
 

--- a/pages/[tenant]/index.vue
+++ b/pages/[tenant]/index.vue
@@ -46,20 +46,26 @@ const { data: menuData, error: menuError, pending: pendingMenu } = await useAsyn
 
 const restaurant = computed(() => profileData.value?.data || null)
 
-// Set tenant UUID from profile data and recover session once tenant is known
-watch(restaurant, async (val) => {
-  if (!val?.tenant_id) return
-  cartStore.setTenant(val.tenant_id)
-  // Session recovery — client-only, runs once after tenant UUID is available
-  if (!process.client || !cartStore.sessionId) return
+// Declared at setup scope so $fetch Nuxt auto-import is in context.
+const recoverCartSession = async (tenantId: string) => {
   try {
     const cart = await $fetch<{ data: any }>(`/api/online/cart/session/${cartStore.sessionId}`, {
-      query: { tenant_id: val.tenant_id }
+      query: { tenant_id: tenantId }
     })
     if (cart?.data) cartStore.hydrateFromBackend(cart.data)
   } catch {
-    // No active cart for this session, that's expected
+    // No active cart for this session — expected on first visit
   }
+}
+
+// Set tenant UUID from profile data and recover session once tenant is known.
+// The recovery promise is registered in the store so addItem() can await it
+// and avoid racing with hydrateFromBackend() on the first click.
+watch(restaurant, (val: any) => {
+  if (!val?.tenant_id) return
+  cartStore.setTenant(val.tenant_id)
+  if (!process.client || !cartStore.sessionId) return
+  cartStore.setRecoveryPromise(recoverCartSession(val.tenant_id))
 }, { immediate: true })
 
 const categories = computed(() => menuData.value?.data?.categories || [])

--- a/stores/online_cart.ts
+++ b/stores/online_cart.ts
@@ -4,6 +4,10 @@
  */
 import { defineStore } from 'pinia'
 
+// Module-level lock: addItem awaits this before proceeding so it never
+// races with hydrateFromBackend() during the initial session recovery.
+let _recoveryPromise: Promise<void> | null = null
+
 export interface CartModifier {
   id: string
   name: string
@@ -104,6 +108,14 @@ export const useOnlineCartStore = defineStore('onlineCart', {
     },
 
     /**
+     * Register the session-recovery promise so addItem() can await it.
+     * Called from the page before the recovery fetch starts.
+     */
+    setRecoveryPromise(p: Promise<void>) {
+      _recoveryPromise = p
+    },
+
+    /**
      * Hydrate local state from a backend cart response (session recovery)
      */
     hydrateFromBackend(cartData: BackendCart) {
@@ -151,6 +163,13 @@ export const useOnlineCartStore = defineStore('onlineCart', {
       modifiers: CartModifier[] = [],
       notes?: string
     ) {
+      // Wait for session recovery to complete before adding so we don't
+      // race with hydrateFromBackend() which would wipe the optimistic item.
+      if (_recoveryPromise) {
+        await _recoveryPromise
+        _recoveryPromise = null
+      }
+
       this.isLoading = true
 
       try {
@@ -268,7 +287,7 @@ export const useOnlineCartStore = defineStore('onlineCart', {
     },
 
     /**
-     * Update item quantity — local only (no dedicated endpoint); calls removeItem if quantity ≤ 0
+     * Update item quantity — persists full cart via batch POST; calls removeItem if quantity ≤ 0
      */
     async updateItemQuantity(itemId: string, quantity: number) {
       if (quantity <= 0) {
@@ -281,6 +300,32 @@ export const useOnlineCartStore = defineStore('onlineCart', {
       const modifiersTotal = item.modifiers.reduce((sum, mod) => sum + mod.price, 0)
       item.quantity = quantity
       item.total = (item.unit_price + modifiersTotal) * quantity
+
+      this.isLoading = true
+      try {
+        const data = await $fetch<{ data: BackendCart }>('/api/online/cart/batch', {
+          method: 'POST',
+          body: {
+            tenant_id: this.tenantId,
+            session_id: this.sessionId,
+            order_type: this.orderType,
+            items: this.items.map(i => ({
+              product_id: i.product_id,
+              product_name: i.product_name,
+              quantity: i.quantity,
+              unit_price: i.unit_price,
+              modifiers: i.modifiers,
+              notes: i.notes,
+            })),
+          },
+        })
+        this.cartId = data.data.id
+        this.syncItemIds(data.data.items)
+      } catch (error: any) {
+        throw new Error(error.data?.detail || 'Error al actualizar la cantidad')
+      } finally {
+        this.isLoading = false
+      }
     },
 
     /**


### PR DESCRIPTION
## Summary

- **First-click not adding product**: `addItem()` now awaits the session recovery promise before proceeding, preventing `hydrateFromBackend()` from wiping the optimistic item when the user clicks fast after page load
- **Spinner never visible**: `handleClick` is now async with `await nextTick()` before emit, forcing Vue to render the spinner frame before the optimistic push flips `isInCart`
- **Double-click**: added `isAdding` guard at the top of `handleClick`
- **Quantity not persisting**: `updateItemQuantity` now calls the batch POST endpoint to sync changes to backend
- **UX touch target**: horizontal card buttons raised from 36px to 44px (WCAG 2.5.5)
- Also includes: delivery fee always 0, Spanish email placeholder, block re-verification

## Stack
🟢 Nuxt 3 + 🎨 UX

## Changes
- `stores/online_cart.ts`: `_recoveryPromise` lock, `setRecoveryPromise` action, await in `addItem`, fix `updateItemQuantity`
- `pages/[tenant]/index.vue`: register recovery promise via IIFE
- `components/public/PublicProductCard.vue`: async `handleClick`, `nextTick`, double-click guard, button sizes
- `components/online/CartDrawer.vue`: delivery fee = 0
- `components/online/checkout/StepConfirm.vue`: delivery fee = 0
- `components/online/checkout/StepIdentity.vue`: delivery fee = 0
- `components/online/checkout/StepEmail.vue`: Spanish placeholder, block re-verification

## Testing
1. Clear localStorage, open `/waro-colombia` fresh
2. Click `+` immediately on page load — product should appear in cart
3. Click `+` again — spinner should be visible during API call
4. Double-click `+` — only one item added
5. Adjust qty with `+`/`−`, refresh page — quantity should persist

Closes #81