### PR TITLE
fix(auth): use useRequestFetch() in customer-auth middleware (#129)

### DIFF
--- a/middleware/customer-auth.ts
+++ b/middleware/customer-auth.ts
@@ -1,7 +1,10 @@
 export default defineNuxtRouteMiddleware(async (to) => {
-  const headers = useRequestHeaders(['cookie'])
+  // useRequestFetch() forwards cookies automatically:
+  // - On SSR: clones the incoming request's Cookie header
+  // - On client: browser attaches waro_customer_session automatically
+  const apiFetch = useRequestFetch()
   try {
-    await $fetch('/api/customer/me', { headers })
+    await apiFetch('/api/customer/me')
   } catch {
     return navigateTo('/auth/customer-verify?redirect=' + encodeURIComponent(to.fullPath))
   }


### PR DESCRIPTION
## Summary
- Fixes `customer-auth` middleware always redirecting authenticated customers
- Root cause: `useRequestHeaders(['cookie'])` returns empty on client-side navigation — `waro_customer_session` HttpOnly cookie was never sent to FastAPI
- Fix: replace with `useRequestFetch()` which handles SSR (clones Cookie header) and client (browser attaches automatically) transparently

## Stack
🟢 Nuxt 3

## Changes
- `middleware/customer-auth.ts`: replaced manual header forwarding with `useRequestFetch()`

## Test plan
- [ ] After OTP verify + checkout, clicking "Ver mi pedido" lands directly on `/mis-pedidos/{id}`
- [ ] Opening `/mis-pedidos` directly (no session) still redirects to `/auth/customer-verify`
- [ ] Opening email tracking link redirects to verify (expected — cookie not in email client)

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)