### PR TITLE
fix(checkout): auto-advance identity step when OTP session already active (#131)

### DIFF
--- a/components/online/checkout/StepIdentity.vue
+++ b/components/online/checkout/StepIdentity.vue
@@ -171,6 +171,9 @@ const countdown = ref(0)
 let countdownInterval: ReturnType<typeof setInterval> | null = null
 
 onMounted(() => {
+  if (otpAuthStore.isAuthenticated) {
+    emit('verified')
+  }
   countdownInterval = setInterval(() => {
     countdown.value = otpAuthStore.otpCooldownRemaining
   }, 1000)


### PR DESCRIPTION
## Summary
- When a customer already has an active OTP session (previous verification in same browser session), Step 3 (Identity) was stuck showing "Identidad verificada" with no way to proceed
- Root cause: `emit('verified')` only fired inside the OTP verify handler — never on mount when `isAuthenticated` was already `true`
- Fix: 3-line addition in `onMounted` that emits `'verified'` immediately if already authenticated

## Changes
- `components/online/checkout/StepIdentity.vue`: added early emit in `onMounted`

## Test plan
- [ ] Customer with active session: Step 3 auto-advances to Step 4 (Confirm)
- [ ] Customer without session: Step 3 shows OTP form normally
- [ ] Completing OTP in normal flow still auto-advances as before

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)