### PR TITLE
Guard receipt-email button + surface failures (api-warolabs#134)

### DIFF
--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -29,6 +29,7 @@ useHead({ title: 'Checkout' })
 const router = useRouter()
 const posStore = usePOSStore()
 const cache = useQueryCache()
+const toast = useToast()
 const { currentTenant, businessProfile } = useTenantReactive()
 
 // Inject subtitle setter from layout
@@ -834,8 +835,18 @@ const sendReceiptEmail = async () => {
       }
     })
     emailSent.value = true
-  } catch {
-    // Silent failure — cashier can try again or skip
+  } catch (e: any) {
+    // Surface the failure so the cashier knows the email did NOT go out (#134).
+    // Most common case: 422 from EmailStr validation when the address is empty
+    // or malformed. detail can be either an array (Pydantic) or a string.
+    const detail = e?.data?.detail
+    const message =
+      Array.isArray(detail)
+        ? detail[0]?.msg ?? 'No se pudo enviar el correo.'
+        : typeof detail === 'string'
+          ? detail
+          : 'No se pudo enviar el correo. Verifica la dirección.'
+    toast.error(message, { title: 'Error al enviar recibo' })
   } finally {
     isSendingEmail.value = false
   }
@@ -2051,7 +2062,7 @@ onUnmounted(() => {
                   <span class="flex-1 truncate text-sm text-text-primary">{{ receiptEmail }}</span>
                   <button
                     @click="sendReceiptEmail"
-                    :disabled="isSendingEmail"
+                    :disabled="!receiptEmail || isSendingEmail"
                     class="shrink-0 min-h-[36px] px-4 py-1.5 rounded-lg text-sm font-semibold transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed bg-primary text-primary-foreground hover:bg-primary/90"
                   >
                     <span v-if="isSendingEmail">Enviando...</span>


### PR DESCRIPTION
## Summary

Frontend half of [api-warolabs#134](https://github.com/uno0uno/api-warolabs/issues/134). Pairs with [api-warolabs#136](https://github.com/uno0uno/api-warolabs/pull/136).

## Stack

🟢 Nuxt 3 · 🎨 UX

## Why

Two UX bugs in `pages/pos/checkout.vue` that combine to hide an SES failure from the cashier:

1. The **"Confirmar envío"** button (auto-confirm path when `emailFromProfile === true`) was `:disabled="isSendingEmail"` only — it allowed the click even with an empty `receiptEmail`, sending a malformed payload to the backend.
2. `sendReceiptEmail()` had a `catch {}` block with comment *"Silent failure — cashier can try again or skip"* — the cashier never saw the error.

When a customer profile happened to have a malformed email (or none), the cashier clicked → backend → SES → `InvalidParameterValue: Missing final '@domain'` → frontend silently swallowed it. Order #13233 on 2026-04-29 13:07 was the trigger.

## Changes

- `pages/pos/checkout.vue` — `useToast()` initialized at the top of `<script setup>`.
- `pages/pos/checkout.vue` — `sendReceiptEmail()` catch now calls `toast.error(...)`. Reads `e?.data?.detail` (Pydantic returns array, FastAPI returns string) and falls back to a generic message.
- `pages/pos/checkout.vue` — "Confirmar envío" button now has `:disabled="!receiptEmail || isSendingEmail"` (mirrors the manual-input button).

## Test plan

- [ ] Customer profile with malformed email (e.g. `"facturacion"`) → "Confirmar envío" button disabled until cashier clears/edits.
- [ ] Force a 422 from the backend (with [api-warolabs#136](https://github.com/uno0uno/api-warolabs/pull/136) deployed) → toast appears with the specific Pydantic message.
- [ ] Network error → toast with the generic fallback message.
- [ ] Valid email → email sends as today, no regression.

## Compatibility

- `useToast()` is the canonical Nuxt UI helper, used elsewhere in the app (`pages/facturacion.vue:15`, etc.). No new dependency.
- No template restructure — only one class predicate and one catch block changed.

Closes #134