### PR TITLE
fix(pos): show real product description instead of hardcoded placeholder

### DIFF
--- a/components/pos/ProductCard.vue
+++ b/components/pos/ProductCard.vue
@@ -6,20 +6,13 @@
     @mouseleave="isHovered = false"
     @click="$emit('select', product)"
   >
-    <!-- Add to cart (+) button overlay — top right -->
-    <div class="absolute top-1.5 right-1.5 w-6 h-6 rounded-full bg-white/80 shadow flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-150 pointer-events-none" aria-hidden="true">
-      <svg class="w-3.5 h-3.5 text-text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 4.5v15m7.5-7.5h-15" />
-      </svg>
-    </div>
-
     <!-- Product icon in white bubble -->
     <div class="w-12 h-12 md:w-16 md:h-16 bg-white/70 rounded-2xl shadow-sm flex items-center justify-center mb-1.5 md:mb-3 select-none flex-shrink-0">
       <span class="text-xl md:text-3xl">{{ product.image }}</span>
     </div>
 
     <!-- Name -->
-    <p class="text-[10px] md:text-xs font-semibold text-text-primary text-center leading-tight line-clamp-2 min-h-[2rem] flex items-center justify-center px-0.5">
+    <p class="text-xs md:text-sm font-semibold text-text-primary text-center leading-tight line-clamp-2 min-h-[2rem] flex items-center justify-center px-0.5">
       {{ product.name }}
     </p>
 

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -505,7 +505,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
-import { useQuery } from '@pinia/colada'
+import { useQuery, useQueryCache } from '@pinia/colada'
 import { useMenuIngredientsQuery } from '@/composables/queries/useMenuIngredients'
 import { useActiveStationsQuery } from '@/composables/queries/useActiveStations'
 import { useTenantReactive } from '@/composables/useTenantReactive'
@@ -527,6 +527,7 @@ definePageMeta({
 
 const route = useRoute()
 const router = useRouter()
+const cache = useQueryCache()
 const { currentTenant, businessProfile } = useTenantReactive()
 
 // Tax config — only show selector when tenant has taxes enabled
@@ -821,7 +822,8 @@ const handleSubmit = async () => {
       body: cleanedForm
     })
 
-    // clearNuxtData()
+    cache.invalidateQueries()
+
     await router.push('/menu/productos')
   } catch (error: any) {
     console.error('❌ Error al actualizar producto:', error)

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -701,7 +701,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import { useQuery } from '@pinia/colada'
+import { useQuery, useQueryCache } from '@pinia/colada'
 import { useMenuIngredientsQuery } from '@/composables/queries/useMenuIngredients'
 import { useActiveStationsQuery } from '@/composables/queries/useActiveStations'
 import { useTenantReactive } from '@/composables/useTenantReactive'
@@ -713,6 +713,7 @@ definePageMeta({
 useHead({ title: 'Crear Producto' })
 
 const router = useRouter()
+const cache = useQueryCache()
 const { currentTenant, businessProfile } = useTenantReactive()
 
 // Tax config — only show selector when tenant has taxes enabled
@@ -1050,7 +1051,8 @@ async function submitProduct() {
       body: cleanedForm
     })
 
-    // clearNuxtData()
+    cache.invalidateQueries()
+
     await router.push('/menu/productos')
   } catch (error: any) {
     console.error('Error creating product:', error)

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -514,6 +514,7 @@ watch(() => productsData.value, (data) => {
     const productsToCache: CachedProduct[] = data.data.map((p: any) => ({
       id: p.id,
       name: p.name,
+      description: p.description || '',
       price: Number(p.price) || 0,
       image: p.image_url || '🍽️',
       category: p.category_name || p.category?.name || 'Sin categoría',

--- a/pages/pos/producto/[id].vue
+++ b/pages/pos/producto/[id].vue
@@ -50,6 +50,7 @@ const product = computed(() => {
   return {
     id: p.id,
     name: p.name,
+    description: p.description || '',
     price: Number(p.price) || 0,
     category: p.category,
     image: p.image,
@@ -498,8 +499,11 @@ onUnmounted(() => {
                 </span>
               </div>
               <h2 class="text-xl md:text-2xl font-bold text-text-primary mb-2">{{ product.name }}</h2>
-              <p class="text-text-secondary text-xs md:text-sm mb-3 md:mb-4 leading-relaxed">
-                Delicioso producto preparado con los mejores ingredientes. Personaliza tu pedido a tu gusto.
+              <p
+                v-if="product.description"
+                class="text-text-secondary text-sm md:text-base mb-3 md:mb-4 leading-relaxed"
+              >
+                {{ product.description }}
               </p>
               <div class="text-lg md:text-xl font-bold text-primary">
                 {{ formatCurrency(product.price) }}

--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -52,6 +52,7 @@ export interface TabItem {
 export interface CachedProduct {
     id: string
     name: string
+    description: string
     price: number
     image: string
     category: string


### PR DESCRIPTION
## Summary

The POS product detail page was rendering a hardcoded marketing string ("Delicioso producto preparado con los mejores ingredientes...") in place of the real description entered at `/menu/productos`. This PR wires the real description end-to-end through the POS data pipeline and invalidates Pinia Colada cache on product save so POS and the public storefront (`/[tenant]`) pick up edits immediately.

## Stack
🟢 Nuxt 3 + 🎨 UX (no backend changes — backend already persists and returns the field correctly)

## Root cause

`pages/pos/producto/[id].vue:501-503` had a hardcoded paragraph that was shown for every product. The real `description` was already stored and returned by `GET /api/menu/products`, but it was being dropped in three places:

1. The `productsToCache` mapper in `pages/pos/index.vue` (didn't copy the field).
2. The `CachedProduct` interface in `stores/usePOSStore.ts` (didn't declare it).
3. The `product` computed in `pages/pos/producto/[id].vue` (didn't pass it through).

So even when the API returned the real description, the POS rendered the marketing placeholder.

## Changes

- `stores/usePOSStore.ts` — add `description: string` to `CachedProduct`.
- `pages/pos/index.vue:515` — copy `p.description` into the cached product.
- `pages/pos/producto/[id].vue` — include `description` in the `product` computed; render `product.description` (with `v-if`) in place of the hardcoded paragraph.
- `components/pos/ProductCard.vue` — UX fixes flagged in the audit:
  - `text-[10px] md:text-xs` → `text-xs md:text-sm` (above 12px readability floor).
  - Remove decorative `pointer-events-none` `(+)` overlay (was below 44×44 touch target and non-interactive).
- `pages/menu/productos/[id].vue` and `pages/menu/productos/crear.vue` — call `cache.invalidateQueries()` after a successful save (per CLAUDE.md). Without this, the POS, storefront `/[tenant]`, and admin product listing could show stale data after an edit.

## Testing

Manual end-to-end (against `localhost:8080` + local API):

- [ ] Edit a product at `/menu/productos`, set a unique sentinel description ("TEST-454-{ts}").
- [ ] Save, then go to `/pos` → click the product → assert the detail page shows the sentinel verbatim (not the old hardcoded marketing string).
- [ ] Open `/waro-colombia` → click the product → assert `ProductDetailDrawer` shows the same sentinel.
- [ ] Edit again with a different sentinel and re-verify both surfaces refresh without manual reload.

## Notes

- 117 of 143 products in DB have empty `description`. The render is `v-if="product.description"` so empty descriptions show no paragraph at all (cleaner than the old hardcoded text for everyone, and accurate when description is set).
- No backend or DB schema changes — `product.description` was always persisted correctly.

Closes #454