### PR TITLE
feat(products): UI for products without ingredients (skip inventory tracking)

### DIFF
--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -118,7 +118,7 @@
                 <div class="relative">
                   <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
                   <input
-                    :value="formatCurrency(calculatedCost)"
+                    :value="calculatedCost === null ? '—' : formatCurrency(calculatedCost)"
                     type="text"
                     disabled
                     class="input-base w-full pl-8 pr-4 py-2 bg-surface-secondary cursor-not-allowed"
@@ -132,7 +132,7 @@
             </div>
 
             <!-- Margin Display -->
-            <div v-if="form.price > 0 && calculatedCost > 0" class="mt-4 p-4 bg-surface-secondary rounded-lg">
+            <div v-if="form.price > 0 && calculatedCost !== null && calculatedCost > 0" class="mt-4 p-4 bg-surface-secondary rounded-lg">
               <div class="flex items-center justify-between">
                 <span class="text-sm font-medium text-text-primary">Margen:</span>
                 <div class="flex items-center gap-3">
@@ -140,8 +140,8 @@
                     {{ formatCurrency(form.price - calculatedCost) }}
                   </span>
                   <UiStatusBadge
-                    :label="`${calculateMargin(form.price, calculatedCost)}%`"
-                    :variant="calculateMargin(form.price, calculatedCost) > 50 ? 'success' : 'warning'"
+                    :label="`${calculateMargin(form.price, calculatedCost) ?? 0}%`"
+                    :variant="(calculateMargin(form.price, calculatedCost) ?? 0) > 50 ? 'success' : 'warning'"
                   />
                 </div>
               </div>
@@ -197,7 +197,41 @@
             </div>
           </div>
 
+          <!-- Toggle: ¿Controla inventario? -->
+          <div class="mt-8 flex items-start gap-3 p-4 bg-surface-secondary border border-border rounded-lg">
+            <button
+              type="button"
+              role="switch"
+              :aria-checked="tracksInventory"
+              @click="tracksInventory = !tracksInventory"
+              :class="[
+                'relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors',
+                'focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2',
+                tracksInventory ? 'bg-primary' : 'bg-border'
+              ]"
+            >
+              <span
+                :class="[
+                  'inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform',
+                  tracksInventory ? 'translate-x-5' : 'translate-x-0.5'
+                ]"
+              />
+            </button>
+            <div class="flex-1">
+              <p class="text-sm font-semibold text-text-primary">Este producto controla inventario</p>
+              <p class="text-xs text-text-secondary mt-1">
+                <template v-if="tracksInventory">
+                  Define la receta del producto. Cada venta descontará los ingredientes del inventario.
+                </template>
+                <template v-else>
+                  No se descontará nada del inventario al venderlo. Útil para servicios, propinas, promos o productos sin trazabilidad de costo.
+                </template>
+              </p>
+            </div>
+          </div>
+
           <!-- Recetas Base (Opcional) -->
+          <template v-if="tracksInventory">
           <div class="mt-8">
             <div class="flex justify-between items-center mb-4">
               <h3 class="text-lg font-semibold text-text-primary">Recetas Base (Opcional)</h3>
@@ -350,6 +384,7 @@
               Agregar Ingrediente
             </UiButton>
           </div>
+          </template>
 
           <!-- Configuración -->
           <div class="mt-8">
@@ -410,12 +445,16 @@
 
             <div class="flex justify-between text-sm">
               <span class="text-text-secondary">Costo:</span>
-              <span class="font-semibold text-text-primary">{{ formatCurrency(calculatedCost) }}</span>
+              <span class="font-semibold text-text-primary">
+                {{ calculatedCost === null ? '—' : formatCurrency(calculatedCost) }}
+              </span>
             </div>
 
             <div class="flex justify-between text-sm pt-3 border-t border-border">
               <span class="text-text-secondary">Margen:</span>
-              <span class="font-semibold text-primary">{{ formatCurrency(form.price - calculatedCost) }}</span>
+              <span class="font-semibold text-primary">
+                {{ calculatedCost === null ? '—' : formatCurrency(form.price - calculatedCost) }}
+              </span>
             </div>
 
             <div class="flex justify-between text-sm">
@@ -690,6 +729,9 @@ const isSubmitting = ref(false)
 const submitError = ref('')
 const duplicateRecipeBaseError = ref('')
 const quantityError = ref('')
+// Derived from product state on load: true if has any recipe rows.
+// User can flip OFF to remove inventory tracking.
+const tracksInventory = ref(true)
 
 // Watch product data and populate form
 watch(productData, (data) => {
@@ -721,17 +763,29 @@ watch(productData, (data) => {
         }
       }),
     }
+    // Derive toggle from existing data — product without any recipe row → OFF
+    tracksInventory.value = (
+      (product.recipe_base_ids?.length ?? 0) > 0 ||
+      (product.ingredients?.length ?? 0) > 0
+    )
   }
 }, { immediate: true })
 
 // Read-only: station inherited from the product's category (returned by backend)
 const inheritedStation = computed(() => productData.value?.data?.station ?? null)
 
-// Computed
-const calculatedCost = computed(() => {
+// Computed — null when product doesn't track inventory (UI renders "—")
+const calculatedCost = computed<number | null>(() => {
+  if (!tracksInventory.value) return null
+  if (
+    selectedRecipeBaseIngredients.value.length === 0 &&
+    form.value.ingredients.length === 0
+  ) {
+    return null
+  }
+
   let totalCost = 0
 
-  // Add cost from all recipe base ingredients
   if (selectedRecipeBaseIngredients.value.length > 0) {
     totalCost += selectedRecipeBaseIngredients.value.reduce((sum: number, ing: any) => {
       const ingredient = ingredients.value.find((i: any) => i.id === ing.ingredient_id)
@@ -740,7 +794,6 @@ const calculatedCost = computed(() => {
     }, 0)
   }
 
-  // Add cost from additional ingredients
   totalCost += form.value.ingredients.reduce((sum, ing) => {
     const ingredient = ingredientCache.value[ing.ingredient_id]
     const costPerUnit = ingredient?.costo_unitario || ingredient?.price || 0
@@ -752,6 +805,8 @@ const calculatedCost = computed(() => {
 
 // Methods
 function addRecipeBase() {
+  // Adding a recipe base implies the product tracks inventory.
+  tracksInventory.value = true
   form.value.recipe_base_ids.push('')
 }
 
@@ -770,6 +825,8 @@ const onRecipeBaseChange = () => {
 }
 
 const addIngredient = () => {
+  // Adding an ingredient implies the product tracks inventory.
+  tracksInventory.value = true
   form.value.ingredients.push({
     ingredient_id: '',
     ingredient_name: '',
@@ -792,11 +849,13 @@ const handleSubmit = async () => {
   duplicateRecipeBaseError.value = ''
   quantityError.value = ''
 
-  // Validate ingredient quantities > 0
-  const hasZeroQuantity = form.value.ingredients.some(ing => !ing.quantity || ing.quantity <= 0)
-  if (hasZeroQuantity) {
-    quantityError.value = 'Todos los ingredientes deben tener una cantidad mayor a 0.'
-    return
+  // Validate ingredient quantities > 0 (only when tracking inventory)
+  if (tracksInventory.value) {
+    const hasZeroQuantity = form.value.ingredients.some(ing => !ing.quantity || ing.quantity <= 0)
+    if (hasZeroQuantity) {
+      quantityError.value = 'Todos los ingredientes deben tener una cantidad mayor a 0.'
+      return
+    }
   }
 
   isSubmitting.value = true
@@ -812,10 +871,11 @@ const handleSubmit = async () => {
       return
     }
 
-    // Filter out empty recipe base IDs before sending
+    // When toggle is OFF, force empty recipe arrays — product won't track inventory.
     const cleanedForm = {
       ...form.value,
-      recipe_base_ids: uniqueRecipeBaseIds
+      recipe_base_ids: tracksInventory.value ? uniqueRecipeBaseIds : [],
+      ingredients: tracksInventory.value ? form.value.ingredients : [],
     }
     await $fetch(`/api/menu/products/${productId}`, {
       method: 'PUT',
@@ -871,8 +931,8 @@ const formatCurrency = (value: number) => {
   }).format(value)
 }
 
-const calculateMargin = (price: number, cost: number) => {
-  if (!cost) return 0
+const calculateMargin = (price: number, cost: number | null) => {
+  if (cost == null || cost <= 0) return null
   return Math.round(((price - cost) / cost) * 100)
 }
 

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -348,7 +348,41 @@
           <div class="p-4 sm:p-6">
             <h3 class="text-base sm:text-lg font-semibold text-text-primary mb-4">Receta / Ingredientes</h3>
 
+            <!-- Toggle: ¿Este producto controla inventario? -->
+            <div class="flex items-start gap-3 p-4 mb-6 bg-surface-secondary border border-border rounded-lg">
+              <button
+                type="button"
+                role="switch"
+                :aria-checked="tracksInventory"
+                @click="tracksInventory = !tracksInventory"
+                :class="[
+                  'relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors',
+                  'focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2',
+                  tracksInventory ? 'bg-primary' : 'bg-border'
+                ]"
+              >
+                <span
+                  :class="[
+                    'inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform',
+                    tracksInventory ? 'translate-x-5' : 'translate-x-0.5'
+                  ]"
+                />
+              </button>
+              <div class="flex-1">
+                <p class="text-sm font-semibold text-text-primary">Este producto controla inventario</p>
+                <p class="text-xs text-text-secondary mt-1">
+                  <template v-if="tracksInventory">
+                    Define la receta del producto. Cada venta descontará los ingredientes del inventario.
+                  </template>
+                  <template v-else>
+                    No se descontará nada del inventario al venderlo. Útil para servicios (cargo de domicilio, propina), promos o productos sin trazabilidad de costo.
+                  </template>
+                </p>
+              </div>
+            </div>
+
             <!-- Recetas Base (Opcional) -->
+            <template v-if="tracksInventory">
             <div class="mb-6">
               <div class="flex justify-between items-center mb-2">
                 <label class="block text-sm font-medium text-text-primary">
@@ -514,6 +548,7 @@
                 </div>
               </div>
             </div>
+            </template>
           </div>
         </div>
 
@@ -622,7 +657,9 @@
                   </div>
                   <div class="flex justify-between items-center">
                     <span class="text-sm text-text-secondary">Costo Calculado</span>
-                    <span class="text-sm font-semibold text-text-primary">{{ formatCurrency(calculatedCost) }}</span>
+                    <span class="text-sm font-semibold text-text-primary">
+                      {{ calculatedCost === null ? '—' : formatCurrency(calculatedCost) }}
+                    </span>
                   </div>
                   <div class="flex justify-between items-center">
                     <span class="text-sm text-text-secondary">Margen</span>
@@ -630,7 +667,9 @@
                   </div>
                   <div class="flex justify-between items-center pt-2 border-t border-border">
                     <span class="text-sm font-semibold text-text-primary">Ganancia</span>
-                    <span class="text-base font-bold text-crocus-600">{{ formatCurrency(marginValue) }}</span>
+                    <span class="text-base font-bold text-crocus-600">
+                      {{ marginValue === null ? '—' : formatCurrency(marginValue) }}
+                    </span>
                   </div>
                 </div>
               </div>
@@ -733,6 +772,9 @@ const currentStep = ref(1)
 const isSubmitting = ref(false)
 const submitError = ref<string | null>(null)
 const nameError = ref('')
+// Toggle for "this product tracks inventory". Default ON (backward compatible).
+// When OFF, Step 2 is skipped at submit (recipe_base_ids and ingredients sent empty).
+const tracksInventory = ref(true)
 
 // Form data
 const form = ref({
@@ -877,10 +919,19 @@ const isLoadingData = computed(() => {
   return !categoriesData.value
 })
 
-const calculatedCost = computed(() => {
+// Returns null when the product has no recipe (toggle off or empty lists).
+// null is rendered as "—" in the UI and means "no aplica" in cost reports.
+const calculatedCost = computed<number | null>(() => {
+  if (!tracksInventory.value) return null
+  if (
+    selectedRecipeBaseIngredients.value.length === 0 &&
+    form.value.ingredients.length === 0
+  ) {
+    return null
+  }
+
   let totalCost = 0
 
-  // Add cost from all recipe base ingredients
   if (selectedRecipeBaseIngredients.value.length > 0) {
     totalCost += selectedRecipeBaseIngredients.value.reduce((sum: number, ing: any) => {
       const ingredient = availableIngredients.value.find((i: any) => i.id === ing.ingredient_id)
@@ -888,7 +939,6 @@ const calculatedCost = computed(() => {
     }, 0)
   }
 
-  // Add cost from additional ingredients
   totalCost += form.value.ingredients.reduce((sum, ing) => {
     const cached = ingredientCache.value[ing.ingredient_id]
     const ingredient = cached || availableIngredients.value.find((i: any) => i.id === ing.ingredient_id)
@@ -899,13 +949,15 @@ const calculatedCost = computed(() => {
   return totalCost
 })
 
-const marginValue = computed(() => {
+const marginValue = computed<number | null>(() => {
+  if (calculatedCost.value === null) return null
   return form.value.price - calculatedCost.value
 })
 
 const formatMarginPercent = computed(() => {
-  if (!form.value.price || !calculatedCost.value) return '—'
-  const margin = ((form.value.price - calculatedCost.value) / calculatedCost.value * 100)
+  const cost = calculatedCost.value
+  if (!form.value.price || cost === null || cost <= 0) return '—'
+  const margin = ((form.value.price - cost) / cost * 100)
   return `${margin.toFixed(1)}%`
 })
 
@@ -914,6 +966,8 @@ const canProceed = computed(() => {
     return form.value.name && form.value.category_id && form.value.price > 0
   }
   if (currentStep.value === 2) {
+    // Toggle off → no recipe required, can always proceed
+    if (!tracksInventory.value) return true
     return form.value.ingredients.length === 0 ||
            form.value.ingredients.every(i => i.ingredient_id && i.quantity > 0)
   }
@@ -966,6 +1020,8 @@ function onCustomIngredientCreated(ingredient: any) {
 }
 
 function addIngredient() {
+  // Adding an ingredient implies the product tracks inventory.
+  tracksInventory.value = true
   form.value.ingredients.push({
     ingredient_id: '',
     quantity: 0,
@@ -979,6 +1035,8 @@ function removeIngredient(index: number) {
 
 
 function addRecipeBase() {
+  // Adding a recipe base implies the product tracks inventory.
+  tracksInventory.value = true
   form.value.recipe_base_ids.push('')
 }
 
@@ -1040,10 +1098,11 @@ async function submitProduct() {
 
     form.value.tenant_id = currentTenant.value?.id || ''
 
-    // Filter out empty recipe base IDs before sending
+    // When toggle is OFF, force empty recipe arrays — product won't track inventory.
     const cleanedForm = {
       ...form.value,
-      recipe_base_ids: uniqueRecipeBaseIds
+      recipe_base_ids: tracksInventory.value ? uniqueRecipeBaseIds : [],
+      ingredients: tracksInventory.value ? form.value.ingredients : [],
     }
 
     await $fetch('/api/menu/products', {

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -112,6 +112,13 @@
                   :variant="item.is_available ? 'success' : 'secondary'"
                   size="sm"
                 />
+                <UiStatusBadge
+                  v-if="!productTracksInventory(item)"
+                  value="Sin inventario"
+                  format="text"
+                  variant="secondary"
+                  size="sm"
+                />
               </div>
             </div>
           </template>
@@ -131,7 +138,9 @@
           </template>
 
           <template #cell-costo_calculado="{ value }">
-            <span class="text-sm text-text-primary">{{ formatCurrency(value) }}</span>
+            <span class="text-sm text-text-primary">
+              {{ value === null || value === undefined ? '—' : formatCurrency(value) }}
+            </span>
           </template>
 
           <template #cell-margen="{ row }">
@@ -646,6 +655,15 @@ const getMarginValue = (product: any): number | null => {
   if (price <= 0 || cost <= 0) return null
   const margin = ((price - cost) / cost) * 100
   return isFinite(margin) ? margin : null
+}
+
+// True if the product has any recipe row (direct ingredients or recipe bases).
+// Null/zero costo_calculado is the proxy: the backend persists NULL when no recipe.
+// A product with cost=0 but with a recipe (extreme case) is treated as tracking — safer.
+const productTracksInventory = (product: any): boolean => {
+  if ((product?.recipe_base_ids?.length ?? 0) > 0) return true
+  if ((product?.ingredients?.length ?? 0) > 0) return true
+  return product?.costo_calculado != null
 }
 
 // Display product names in Title Case (DB stores them as ALL CAPS)


### PR DESCRIPTION
## Summary

Adds the UI to create and edit products that do not control inventory. Pairs with the API PR that removes the backend validators.

## Stack
🟢 Nuxt 3 · 🎨 UX

## Changes

### Form (`pages/menu/productos/crear.vue` and `[id].vue`)

- New toggle "Este producto controla inventario" at the top of the recipe section (Step 2 in the wizard, top of the recipe block in edit). Default ON — backward compatible.
- When OFF: the recipe panel (recipe-bases + additional ingredients) is hidden via `<template v-if>`. The form submits empty arrays for `ingredients` and `recipe_base_ids`.
- Auto-sync: clicking "Add ingredient" or "Add recipe base" implicitly flips the toggle ON to keep state coherent.
- In edit mode the toggle is derived from the loaded product's recipe state.

### Defensive fixes (UX audit from issue research)

- `crear.vue:calculatedCost` — returns `null` (instead of `0`) when no recipe; the summary card renders "—" for cost/margin/profit.
- `[id].vue:calculateMargin` — returns `null` (was prone to `Infinity`) when cost is 0 or null. Margin badge guarded with `?? 0`.
- `[id].vue` summary cards — render "—" when `calculatedCost === null`, avoiding `NaN`.

### Listado (`pages/menu/productos/index.vue`)

- Cost column renders "—" when `costo_calculado` is null.
- New "Sin inventario" badge next to the availability badge for products without recipe.
- New helper `productTracksInventory(product)` derives state from `recipe_base_ids` / `ingredients` / `costo_calculado`.

## Testing

- [x] `bun run build` — clean (498 MB / 120 MB gzip).
- [x] Templates balanced (1 open `tracksInventory` template + 1 close per file).
- [ ] Manual: create product with toggle OFF → verify backend persists empty recipe.
- [ ] Manual: navigate to `/pos`, sell that product → confirm no inventory movement.
- [ ] Manual: navigate to `/{tenant}` storefront, sell same product → confirm same.
- [ ] Manual: edit existing product, toggle OFF → save → verify recipe is cleared.

## Pairs with

`uno0uno/api-warolabs` PR — backend validator removal.

Closes #456