### PR TITLE
feat(categories): inline create from product wizard via slide-over (#458)

### DIFF
--- a/components/categorias/CategoriaPanel.vue
+++ b/components/categorias/CategoriaPanel.vue
@@ -1,0 +1,251 @@
+<template>
+  <Teleport to="body">
+    <!-- Backdrop -->
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-200"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="modelValue"
+        class="fixed inset-0 z-40 bg-foreground/40"
+        @click="close"
+        aria-hidden="true"
+      />
+    </Transition>
+
+    <!-- Panel: bottom sheet en mobile, slide-over en desktop -->
+    <Transition name="panel">
+      <div
+        v-if="modelValue"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Crear nueva categoría"
+        @keydown.esc="close"
+        class="fixed z-50 flex flex-col bg-surface shadow-2xl
+               inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh]
+               md:inset-y-0 md:right-0 md:bottom-auto md:left-auto md:inset-x-auto md:rounded-none md:w-full md:max-w-md md:max-h-none md:h-full"
+      >
+        <!-- Mobile drag handle -->
+        <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
+          <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+        </div>
+
+        <!-- Header -->
+        <div class="flex-shrink-0 bg-surface-secondary/40 border-b border-border px-6 py-4">
+          <div class="flex items-start justify-between gap-3">
+            <div class="flex items-center gap-3 min-w-0 flex-1">
+              <div class="flex-shrink-0 w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+                </svg>
+              </div>
+              <div class="min-w-0">
+                <h2 class="text-base font-bold text-text-primary leading-tight">Nueva categoría</h2>
+                <p class="text-xs text-text-secondary leading-snug mt-0.5">
+                  Solo será visible para tu restaurante
+                </p>
+              </div>
+            </div>
+            <button
+              @click="close"
+              type="button"
+              aria-label="Cerrar panel"
+              class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+            >
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- Body -->
+        <form @submit.prevent="submit" class="flex-1 overflow-y-auto px-6 py-5 space-y-4">
+          <div class="flex flex-col gap-1.5">
+            <label for="cat-name" class="text-sm font-medium text-text-primary">
+              Nombre <span class="text-destructive" aria-hidden="true">*</span>
+            </label>
+            <input
+              id="cat-name"
+              ref="nameInputRef"
+              v-model="name"
+              type="text"
+              required
+              maxlength="100"
+              placeholder="Ej: Bebidas, Postres, Combos"
+              class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary bg-surface"
+              autocomplete="off"
+              :disabled="loading"
+            />
+            <p class="text-xs text-text-tertiary">
+              {{ name.length }} / 100 caracteres
+            </p>
+          </div>
+
+          <div class="flex flex-col gap-1.5">
+            <label for="cat-description" class="text-sm font-medium text-text-primary">
+              Descripción <span class="text-text-tertiary text-xs font-normal">(opcional)</span>
+            </label>
+            <textarea
+              id="cat-description"
+              v-model="description"
+              rows="3"
+              maxlength="500"
+              placeholder="Para qué se usa esta categoría"
+              class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary bg-surface resize-y"
+              :disabled="loading"
+            />
+          </div>
+
+          <p
+            v-if="errorMsg"
+            role="alert"
+            class="flex items-start gap-2 text-sm text-destructive"
+          >
+            <svg class="w-4 h-4 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4a2 2 0 00-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z" />
+            </svg>
+            <span>{{ errorMsg }}</span>
+          </p>
+        </form>
+
+        <!-- Footer -->
+        <div class="flex-shrink-0 border-t border-border px-6 py-4 flex items-center justify-end gap-3">
+          <button
+            type="button"
+            @click="close"
+            :disabled="loading"
+            class="px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-primary/30 rounded-lg"
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            @click="submit"
+            :disabled="loading || !name.trim()"
+            class="min-h-[44px] px-5 py-2 rounded-lg bg-primary text-white text-sm font-semibold hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition-colors flex items-center gap-2"
+          >
+            <svg v-if="loading" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
+            </svg>
+            {{ loading ? 'Creando…' : 'Crear categoría' }}
+          </button>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { nextTick, ref, watch } from 'vue'
+import { useQueryCache } from '@pinia/colada'
+import { useTenantReactive } from '~/composables/useTenantReactive'
+import type { CategoryRow } from '~/composables/useCategorySearch'
+
+interface Props {
+  modelValue: boolean
+  initialName?: string
+}
+
+interface Emits {
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'saved', category: CategoryRow): void
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  initialName: '',
+})
+
+const emit = defineEmits<Emits>()
+
+const cache = useQueryCache()
+const { currentTenant } = useTenantReactive()
+
+const name = ref(props.initialName)
+const description = ref('')
+const loading = ref(false)
+const errorMsg = ref<string | null>(null)
+const nameInputRef = ref<HTMLInputElement | null>(null)
+
+// Reset state every time the panel opens; pre-fill name from parent.
+watch(
+  () => props.modelValue,
+  async (open) => {
+    if (open) {
+      name.value = props.initialName
+      description.value = ''
+      errorMsg.value = null
+      loading.value = false
+      await nextTick()
+      nameInputRef.value?.focus()
+    }
+  },
+)
+
+function close() {
+  if (loading.value) return
+  emit('update:modelValue', false)
+}
+
+async function submit() {
+  const trimmedName = name.value.trim()
+  if (!trimmedName) {
+    errorMsg.value = 'El nombre es obligatorio'
+    return
+  }
+  if (trimmedName.length > 100) {
+    errorMsg.value = 'El nombre no puede tener más de 100 caracteres'
+    return
+  }
+
+  loading.value = true
+  errorMsg.value = null
+  try {
+    const res = await $fetch<{ success: boolean; data: CategoryRow }>(
+      '/api/menu/categories',
+      {
+        method: 'POST',
+        body: {
+          name: trimmedName,
+          description: description.value.trim() || null,
+        },
+      },
+    )
+    // Invalidate the listing cache so any other place that consumes it refreshes.
+    cache.invalidateQueries({ key: ['categories', currentTenant.value?.id] })
+    emit('saved', res.data)
+    emit('update:modelValue', false)
+  } catch (e: any) {
+    if (e?.response?.status === 409 || e?.statusCode === 409) {
+      errorMsg.value = 'Ya existe una categoría con ese nombre'
+    } else {
+      errorMsg.value = e?.data?.detail || e?.message || 'Error al crear la categoría'
+    }
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<style scoped>
+.panel-enter-active,
+.panel-leave-active {
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+.panel-enter-from,
+.panel-leave-to {
+  opacity: 0;
+  transform: translateY(100%);
+}
+@media (min-width: 768px) {
+  .panel-enter-from,
+  .panel-leave-to {
+    transform: translateX(100%);
+  }
+}
+</style>

--- a/components/ui/CategorySearchInput.vue
+++ b/components/ui/CategorySearchInput.vue
@@ -1,0 +1,136 @@
+<template>
+  <div class="relative">
+    <input
+      type="text"
+      v-model="searchTerm"
+      @input="onInput"
+      @focus="onFocus"
+      @blur="onBlur"
+      role="combobox"
+      :aria-expanded="showResults && (results.length > 0 || (allowCreate && !!query.trim()))"
+      aria-autocomplete="list"
+      aria-controls="category-search-results"
+      class="w-full px-3 py-2 pl-8 pr-8 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary bg-surface"
+      :placeholder="placeholder"
+      autocomplete="off"
+    />
+    <!-- Search icon (left) -->
+    <span class="absolute left-2.5 top-2.5 text-text-secondary pointer-events-none" aria-hidden="true">
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0"/>
+      </svg>
+    </span>
+    <!-- Loading spinner (right) -->
+    <span v-if="loading" class="absolute right-2.5 top-2.5 text-text-secondary pointer-events-none" aria-hidden="true">
+      <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
+      </svg>
+    </span>
+    <!-- Results dropdown — shown when there are results OR when allowCreate and query has value -->
+    <ul
+      v-if="showResults && (results.length > 0 || (allowCreate && !!query.trim()))"
+      id="category-search-results"
+      role="listbox"
+      class="absolute z-50 w-full mt-1 bg-surface border border-border rounded-lg shadow-lg max-h-48 overflow-y-auto"
+    >
+      <li
+        v-for="cat in results"
+        :key="cat.id"
+        role="option"
+        @mousedown.prevent="select(cat)"
+        class="px-3 py-2 text-sm text-text-primary hover:bg-surface-secondary cursor-pointer flex items-center gap-1.5"
+      >
+        <span>{{ cat.name }}</span>
+        <span v-if="!cat.tenant_id" class="text-xs bg-surface-secondary text-text-secondary rounded px-1 flex-shrink-0">Global</span>
+      </li>
+      <!-- "No results" message -->
+      <li
+        v-if="!results.length && !loading && query.trim()"
+        role="presentation"
+        aria-hidden="true"
+        class="px-3 py-2 text-sm text-text-secondary/60 select-none"
+      >
+        Sin resultados
+      </li>
+      <!-- "Crear" footer — only when allowCreate, query has text, and no exact case-insensitive match -->
+      <li
+        v-if="allowCreate && query.trim() && !loading && !exactMatch"
+        role="option"
+        @mousedown.prevent="$emit('create', query.trim())"
+        class="px-3 py-2 text-sm text-primary border-t border-border hover:bg-surface-secondary cursor-pointer flex items-center gap-1.5"
+      >
+        <svg class="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+        </svg>
+        Crear "{{ query.trim() }}"
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useCategorySearch, type CategoryRow } from '~/composables/useCategorySearch'
+
+interface Props {
+  placeholder?: string
+  initialValue?: string
+  allowCreate?: boolean
+}
+
+interface Emits {
+  (e: 'select', category: CategoryRow): void
+  (e: 'create', term: string): void
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  placeholder: 'Buscar categoría...',
+  initialValue: '',
+  allowCreate: false,
+})
+
+const emit = defineEmits<Emits>()
+
+const searchTerm = ref(props.initialValue)
+const showResults = ref(false)
+
+const { query, results, loading } = useCategorySearch()
+
+// Keep input synced when parent updates initialValue (e.g. after loading product in edit mode)
+watch(() => props.initialValue, (val) => {
+  searchTerm.value = val
+})
+
+// Hide "Crear" button if the typed name matches an existing category exactly (case-insensitive).
+// Avoids accidental duplicates and respects the unique constraint.
+const exactMatch = computed(() => {
+  const q = query.value.trim().toLowerCase()
+  if (!q) return false
+  return results.value.some(cat => cat.name.toLowerCase() === q)
+})
+
+function onInput(e: Event) {
+  const val = (e.target as HTMLInputElement).value
+  query.value = val
+  showResults.value = true
+}
+
+function onFocus() {
+  // Show dropdown on focus so the user sees existing categories before typing
+  query.value = searchTerm.value
+  showResults.value = true
+}
+
+function onBlur() {
+  // Delay closing so mousedown.prevent on options can fire first
+  setTimeout(() => { showResults.value = false }, 150)
+}
+
+function select(category: CategoryRow) {
+  searchTerm.value = category.name
+  showResults.value = false
+  query.value = ''
+  emit('select', category)
+}
+</script>

--- a/composables/useCategorySearch.ts
+++ b/composables/useCategorySearch.ts
@@ -1,0 +1,58 @@
+import { useDebounceFn } from '@vueuse/core'
+
+/**
+ * Composable for debounced server-side category search (issue #458).
+ *
+ * Backend filters by `(tenant_id IS NULL OR tenant_id = current_tenant)`,
+ * so the result already respects the per-tenant scope — the frontend just
+ * renders what arrives.
+ *
+ * Usage:
+ *   const { query, results, loading } = useCategorySearch()
+ *   // bind query to the search input v-model
+ */
+export interface CategoryRow {
+  id: string
+  name: string
+  description: string | null
+  tenant_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+export const useCategorySearch = () => {
+  const results = ref<CategoryRow[]>([])
+  const loading = ref(false)
+  const error = ref<Error | null>(null)
+  const query = ref('')
+
+  const doSearch = useDebounceFn(async (q: string) => {
+    loading.value = true
+    error.value = null
+    try {
+      const data = await $fetch<{ data: CategoryRow[] }>('/api/menu/categories', {
+        query: q && q.trim().length > 0
+          ? { search: q.trim(), limit: 50 }
+          : { limit: 50 },
+      })
+      results.value = data?.data ?? []
+    } catch (e: any) {
+      error.value = e
+      results.value = []
+    } finally {
+      loading.value = false
+    }
+  }, 300)
+
+  watch(query, (val) => {
+    loading.value = true // immediate spinner before the debounce fires
+    doSearch(val)
+  })
+
+  // Initial load — show full list when the input is opened with empty query
+  onMounted(() => {
+    doSearch('')
+  })
+
+  return { query, results, loading, error }
+}

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -45,16 +45,13 @@
                 <label class="block text-sm font-medium text-text-primary mb-2">
                   Categoría *
                 </label>
-                <select
-                  v-model="form.category_id"
-                  required
-                  class="input-base w-full px-4 py-2"
-                >
-                  <option value="" disabled>Seleccione una categoría</option>
-                  <option v-for="category in categories" :key="category.id" :value="category.id">
-                    {{ category.name }}
-                  </option>
-                </select>
+                <UiCategorySearchInput
+                  :allow-create="true"
+                  :initial-value="selectedCategoryName"
+                  placeholder="Buscar o crear categoría..."
+                  @select="onCategorySelected"
+                  @create="onCategoryCreateRequested"
+                />
               </div>
 
               <!-- Inherited kitchen station (read-only, comandas only) -->
@@ -539,6 +536,12 @@
       :initial-name="customIngModalName"
       @saved="onCustomIngredientCreated"
     />
+
+    <CategoriasCategoriaPanel
+      v-model="showNewCategoryModal"
+      :initial-name="newCategoryName"
+      @saved="onCategoryCreated"
+    />
   </div>
 </template>
 
@@ -691,6 +694,26 @@ function onCustomIngredientCreated(ingredient: any) {
   customIngModalIndex.value = -1
 }
 
+// ── Category search + create flow (issue #458) ────────────────────────────
+const showNewCategoryModal = ref(false)
+const newCategoryName = ref('')
+const selectedCategoryName = ref('')
+
+function onCategorySelected(cat: { id: string; name: string }) {
+  form.value.category_id = cat.id
+  selectedCategoryName.value = cat.name
+}
+
+function onCategoryCreateRequested(typedName: string) {
+  newCategoryName.value = typedName
+  showNewCategoryModal.value = true
+}
+
+function onCategoryCreated(cat: { id: string; name: string }) {
+  form.value.category_id = cat.id
+  selectedCategoryName.value = cat.name
+}
+
 const categories = computed(() => categoriesData.value?.data || [])
 const recipeBases = computed(() => recipeBasesData.value?.data || [])
 
@@ -768,6 +791,8 @@ watch(productData, (data) => {
       (product.recipe_base_ids?.length ?? 0) > 0 ||
       (product.ingredients?.length ?? 0) > 0
     )
+    // Pre-fill the category search input with the product's current category name
+    selectedCategoryName.value = product.category_name || ''
   }
 }, { immediate: true })
 

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -197,21 +197,18 @@
                 />
               </div>
 
-              <!-- Category -->
+              <!-- Category — search + inline create (issue #458) -->
               <div>
                 <label class="block text-sm font-medium text-text-primary mb-2">
                   Categoría *
                 </label>
-                <select
-                  v-model="form.category_id"
-                  class="w-full px-4 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-text-primary bg-surface"
-                  required
-                >
-                  <option value="">Seleccionar categoría</option>
-                  <option v-for="category in categories" :key="category.id" :value="category.id">
-                    {{ category.name }}
-                  </option>
-                </select>
+                <UiCategorySearchInput
+                  :allow-create="true"
+                  :initial-value="selectedCategoryName"
+                  placeholder="Buscar o crear categoría..."
+                  @select="onCategorySelected"
+                  @create="onCategoryCreateRequested"
+                />
               </div>
 
               <!-- Inherited kitchen station (read-only, comandas only) -->
@@ -735,6 +732,12 @@
       :initial-name="customIngModalName"
       @saved="onCustomIngredientCreated"
     />
+
+    <CategoriasCategoriaPanel
+      v-model="showNewCategoryModal"
+      :initial-name="newCategoryName"
+      @saved="onCategoryCreated"
+    />
   </div>
 </template>
 
@@ -1017,6 +1020,26 @@ function onCustomIngredientCreated(ingredient: any) {
   if (index < 0 || index >= form.value.ingredients.length) return
   selectIngredient(ingredient, index)
   customIngModalIndex.value = -1
+}
+
+// ── Category search + create flow (issue #458) ────────────────────────────
+const showNewCategoryModal = ref(false)
+const newCategoryName = ref('')
+const selectedCategoryName = ref('')
+
+function onCategorySelected(cat: { id: string; name: string }) {
+  form.value.category_id = cat.id
+  selectedCategoryName.value = cat.name
+}
+
+function onCategoryCreateRequested(typedName: string) {
+  newCategoryName.value = typedName
+  showNewCategoryModal.value = true
+}
+
+function onCategoryCreated(cat: { id: string; name: string }) {
+  form.value.category_id = cat.id
+  selectedCategoryName.value = cat.name
 }
 
 function addIngredient() {


### PR DESCRIPTION
## Summary

Replaces the `<select>` dropdown for category in `/menu/productos/crear` and `/menu/productos/[id]` with a search input + inline-create slide-over. Mirrors the existing ingredient search/create flow.

When the user types a name that doesn't match any existing category, a **Crear '{name}'** footer appears in the dropdown. Clicking it opens a slide-over (Teleport, mobile bottom-sheet / desktop right slide-over, 250ms ease) that creates the category and auto-selects it on the form.

## Stack
🟢 Nuxt 3 · 🎨 UX

## Files

| File | Change |
|---|---|
| `composables/useCategorySearch.ts` | new — debounced 300ms fetch to GET /api/menu/categories |
| `components/ui/CategorySearchInput.vue` | new — combobox a11y (role, aria-expanded, aria-autocomplete, listbox); footer hides when query matches case-insensitively |
| `components/categorias/CategoriaPanel.vue` | new — minimal slide-over (~250 lines), name + description, Esc closes, focus auto, 409 mapped to inline error |
| `pages/menu/productos/crear.vue` | modify — replace `<select>` on L205 + handlers |
| `pages/menu/productos/[id].vue` | modify — replace `<select>` on L48, pre-fill from product.category_name |

## Pairs with

[api-warolabs#141](https://github.com/uno0uno/api-warolabs/pull/141) — new POST endpoint, per-tenant scoping, migration `055`. Requires that PR (and its migration) deployed before this one to avoid 404 / 401 / 500 from POST.

## Validation

- ✅ `bun run build` clean (498 MB / 120 MB gzip)
- ✅ Templates balanced
- ✅ A11y: role="combobox", aria-expanded, aria-autocomplete, role="listbox", role="option", `aria-label="Cerrar panel"`, Esc closes panel
- [ ] Manual end-to-end (post-merge): create new category from `/menu/productos/crear` → select → save product → verify DB row has `tenant_id = current_tenant`
- [ ] Manual: same in `/menu/productos/[id]` → verify pre-fill of existing category

Closes #458 (frontend half)