### PR TITLE
feat(categories): use inline dots loader on Crear categoría button

### DIFF
--- a/components/Commons/InlineDots.vue
+++ b/components/Commons/InlineDots.vue
@@ -1,0 +1,65 @@
+<template>
+  <span
+    role="status"
+    aria-live="polite"
+    :aria-label="ariaLabel"
+    class="inline-flex items-center gap-1 align-middle"
+  >
+    <span class="dot" :style="dotStyle" />
+    <span class="dot" :style="{ ...dotStyle, animationDelay: '0.15s' }" />
+    <span class="dot" :style="{ ...dotStyle, animationDelay: '0.3s' }" />
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+interface Props {
+  /** Diameter of each dot in pixels. Default: 6 */
+  size?: number
+  /** Tailwind utility for the dot color. Default: 'currentColor' */
+  color?: string
+  /** Accessible label announced to screen readers. */
+  ariaLabel?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 6,
+  color: 'currentColor',
+  ariaLabel: 'Cargando',
+})
+
+const dotStyle = computed(() => ({
+  width: `${props.size}px`,
+  height: `${props.size}px`,
+  backgroundColor: props.color,
+}))
+</script>
+
+<style scoped>
+.dot {
+  display: inline-block;
+  border-radius: 9999px;
+  animation: dotBounce 1s infinite ease-in-out both;
+}
+
+@keyframes dotBounce {
+  0%,
+  80%,
+  100% {
+    transform: scale(0.4);
+    opacity: 0.4;
+  }
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dot {
+    animation: none;
+    opacity: 0.7;
+  }
+}
+</style>

--- a/components/categorias/CategoriaPanel.vue
+++ b/components/categorias/CategoriaPanel.vue
@@ -129,11 +129,13 @@
             :disabled="loading || !name.trim()"
             class="min-h-[44px] px-5 py-2 rounded-lg bg-primary text-white text-sm font-semibold hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition-colors flex items-center gap-2"
           >
-            <svg v-if="loading" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
-            </svg>
-            {{ loading ? 'Creando…' : 'Crear categoría' }}
+            <template v-if="loading">
+              <span>Creando</span>
+              <CommonsInlineDots aria-label="Creando categoría" :size="5" />
+            </template>
+            <template v-else>
+              Crear categoría
+            </template>
           </button>
         </div>
       </div>


### PR DESCRIPTION
Replaces the SVG spinner in the CategoriaPanel submit button with a small reusable bouncing-dots animation next to a 'Creando' label. Adds `components/Commons/InlineDots.vue` (a11y: role=status, aria-live, prefers-reduced-motion). Closes the visual gap noted post-merge of #458.