### PR TITLE
feat(operaciones): apply first-load + progressive-loading pattern (#461)

### DIFF
--- a/pages/operaciones/comandas.vue
+++ b/pages/operaciones/comandas.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="space-y-4 sm:space-y-6">
 
+    <!-- First-load — block UI until critical queries resolve (issue #461) -->
+    <div v-if="isLoading" class="flex items-center justify-center min-h-[400px]">
+      <CommonsTheCustomLoader size="large" />
+    </div>
+
+    <template v-else>
     <!-- ══════ COMANDAS Y COCINA — TOGGLES ══════ -->
     <div class="bg-surface border-2 border-border rounded-xl p-4 sm:p-6">
       <div class="flex items-center gap-2 mb-5">
@@ -262,6 +268,7 @@
         </template>
       </UiResponsiveDataView>
     </div>
+    </template>
 
     <!-- Station Deactivate Confirmation Modal -->
     <Teleport to="body">
@@ -421,7 +428,7 @@ const { currentTenant } = useTenantReactive()
 const toast = useToast()
 
 // ─── Business profile ───
-const { data: profileData, refetch: refreshProfile } = useQuery({
+const { data: profileData, asyncStatus: profileAsyncStatus, refetch: refreshProfile } = useQuery({
   key: () => ['tenant', 'negocio-profile', currentTenant.value?.id],
   query: () => $fetch<{ success: boolean; data: any }>('/api/api/tenant/public-profile'),
   enabled: () => !!currentTenant.value,
@@ -430,7 +437,7 @@ const { data: profileData, refetch: refreshProfile } = useQuery({
 const businessProfile = computed(() => profileData.value?.data ?? null)
 
 // ─── Stations & categories ───
-const { data: stationsData, refetch: refetchStations } = useQuery({
+const { data: stationsData, asyncStatus: stationsAsyncStatus, refetch: refetchStations } = useQuery({
   key: () => ['tenant', 'stations', currentTenant.value?.id],
   query: () => $fetch<{ success: boolean; data: any[] }>('/api/api/stations'),
   enabled: () => !!currentTenant.value,
@@ -438,19 +445,48 @@ const { data: stationsData, refetch: refetchStations } = useQuery({
 })
 const stations = computed(() => stationsData.value?.data ?? [])
 
-const { data: categoryStationsData, refetch: refetchCategoryStations } = useQuery({
+const { data: categoryStationsData, asyncStatus: categoryStationsAsyncStatus, refetch: refetchCategoryStations } = useQuery({
   key: () => ['tenant', 'category-stations', currentTenant.value?.id],
   query: () => $fetch<{ success: boolean; data: any[] }>('/api/api/stations/categories'),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })
 
-const { data: categoriesData } = useQuery({
+const { data: categoriesData, asyncStatus: categoriesAsyncStatus, refetch: refetchCategories } = useQuery({
   key: () => ['tenant', 'menu-categories', currentTenant.value?.id],
   query: () => $fetch<{ success: boolean; data: any[] }>('/api/menu/categories'),
   enabled: () => !!currentTenant.value,
   staleTime: 60_000,
 })
+
+// ─── Layout-level loading orchestration (issue #461) ───
+// First-load: block UI until the queries that drive the main listing have data.
+// `stationsData` + `categoriesData` are the critical ones; profile and category-station
+// mappings load alongside but their loading is non-blocking (rendered inline).
+const isLoading = computed(() => !stationsData.value || !categoriesData.value)
+
+// Progressive refresh: any of the four queries revalidating with data in place.
+// OR-combined so any background refetch surfaces in the layout indicator.
+const isRefreshing = computed(() => (
+  (profileAsyncStatus.value === 'loading' && profileData.value != null) ||
+  (stationsAsyncStatus.value === 'loading' && stationsData.value != null) ||
+  (categoryStationsAsyncStatus.value === 'loading' && categoryStationsData.value != null) ||
+  (categoriesAsyncStatus.value === 'loading' && categoriesData.value != null)
+))
+
+const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
+registerProgressiveLoading(isRefreshing)
+
+const refreshAll = async () => {
+  await Promise.all([
+    refreshProfile(),
+    refetchStations(),
+    refetchCategoryStations(),
+    refetchCategories(),
+  ])
+}
+onMounted(() => setRefreshHandler(refreshAll))
+onUnmounted(() => clearRefreshHandler(refreshAll))
 
 const mappedCategories = computed(() => {
   const cats = categoriesData.value?.data ?? []

--- a/pages/operaciones/mesas.vue
+++ b/pages/operaciones/mesas.vue
@@ -18,8 +18,21 @@ const { data: tablesData, status: tablesStatus, asyncStatus: tablesAsyncStatus, 
   staleTime: 30_000,
 })
 
+// Business profile (shared cache key) — declared up here so its asyncStatus
+// can join the layout's progressive-loading indicator (issue #461).
+const { data: profileData, asyncStatus: profileAsyncStatus, refetch: refreshProfile } = useQuery({
+  key: () => ['tenant', 'negocio-profile', currentTenant.value?.id],
+  query: () => $fetch<{ success: boolean; data: any }>('/api/api/tenant/public-profile'),
+  enabled: () => !!currentTenant.value,
+  staleTime: 30_000,
+})
+const businessProfile = computed(() => profileData.value?.data ?? null)
+
 const loadingTables = computed(() => !tablesData.value)
-const isRefreshing = computed(() => tablesAsyncStatus.value === 'loading' && tablesData.value != null)
+const isRefreshing = computed(() => (
+  (tablesAsyncStatus.value === 'loading' && tablesData.value != null) ||
+  (profileAsyncStatus.value === 'loading' && profileData.value != null)
+))
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 registerProgressiveLoading(isRefreshing)
@@ -164,17 +177,13 @@ const badgeVariant = (status: string) => {
   return 'secondary'
 }
 
-onMounted(() => setRefreshHandler(refetch))
-onUnmounted(() => clearRefreshHandler(refetch))
-
-// ── Business profile (shared cache key) ───────────────────────────────────
-const { data: profileData, refetch: refreshProfile } = useQuery({
-  key: () => ['tenant', 'negocio-profile', currentTenant.value?.id],
-  query: () => $fetch<{ success: boolean; data: any }>('/api/api/tenant/public-profile'),
-  enabled: () => !!currentTenant.value,
-  staleTime: 30_000,
-})
-const businessProfile = computed(() => profileData.value?.data ?? null)
+// Refresh handler — fan out to both queries so the layout's manual refresh
+// button updates the table list AND the tables-enabled toggle in one go.
+const refreshAll = async () => {
+  await Promise.all([refetch(), refreshProfile()])
+}
+onMounted(() => setRefreshHandler(refreshAll))
+onUnmounted(() => clearRefreshHandler(refreshAll))
 
 // ── Toggle tables module ───────────────────────────────────────────────────
 const posStore = usePOSStore()


### PR DESCRIPTION
## Summary

Aligns `pages/operaciones/comandas.vue` and `pages/operaciones/mesas.vue` with the loader pattern already established in `pages/ventas/ordenes.vue` and used by 67 other pages via `composables/useLayoutActions.ts`.

## Stack
🟢 Nuxt 3 · 🎨 UX

## Changes

### `pages/operaciones/comandas.vue` (was missing the pattern entirely)
- Destructure \`asyncStatus\` + \`refetch\` on the 4 \`useQuery\` (profile, stations, category-stations, categories)
- \`isLoading\` driven by stations + categories (the critical queries); profile and category-stations are non-blocking
- \`isRefreshing\` OR-combined across the 4 \`asyncStatus\`
- \`registerProgressiveLoading(isRefreshing)\`
- \`setRefreshHandler\` bound to \`refreshAll\` wrapper (\`Promise.all\` of all four refetch); \`clearRefreshHandler\` on unmount
- Wrap the 3 main sections in \`<template v-else>\` with \`<CommonsTheCustomLoader size="large" />\` shown while \`isLoading\`. Modals/Teleports stay outside the wrap so \`isLoadingDeactivateInfo\` keeps working

### \`pages/operaciones/mesas.vue\` (had the pattern only for tablesData)
- Move \`profileData\` \`useQuery\` up so its \`asyncStatus\` can join \`isRefreshing\`
- \`isRefreshing\` now combines \`tablesAsyncStatus\` + \`profileAsyncStatus\`
- \`setRefreshHandler\` now uses \`refreshAll\` wrapper (\`refetch() + refreshProfile()\` in parallel) — toggling tables-enabled now surfaces in the layout indicator
- No template changes (\`loadingTables\` already covers first load)

## Validation

- ✅ \`bun run build\` clean (498 MB / 120 MB gzip)
- [ ] Manual: cold-load \`/operaciones/comandas\` shows the loader; the page renders only after stations + categories arrive
- [ ] Manual: pressing the layout refresh button on \`/operaciones/comandas\` shows the progressive indicator while all 4 queries refetch
- [ ] Manual: toggling tables-enabled on \`/operaciones/mesas\` now surfaces the progressive indicator (was silent before)
- [ ] Manual: switching tenant on either page shows the progressive indicator while queries refetch

Closes #461