### PR TITLE
feat(stations): inline create from product wizard via slide-over (#463)

### DIFF
--- a/components/cocina/StationPanel.vue
+++ b/components/cocina/StationPanel.vue
@@ -1,0 +1,317 @@
+<template>
+  <Teleport to="body">
+    <!-- Backdrop -->
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-200"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="modelValue"
+        class="fixed inset-0 z-40 bg-foreground/40"
+        @click="close"
+        aria-hidden="true"
+      />
+    </Transition>
+
+    <!-- Panel: bottom sheet on mobile, slide-over on desktop -->
+    <Transition name="panel">
+      <div
+        v-if="modelValue"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Crear nueva estación de cocina"
+        @keydown.esc="close"
+        class="fixed z-50 flex flex-col bg-surface shadow-2xl
+               inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh]
+               md:inset-y-0 md:right-0 md:bottom-auto md:left-auto md:inset-x-auto md:rounded-none md:w-full md:max-w-md md:max-h-none md:h-full"
+      >
+        <!-- Mobile drag handle -->
+        <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
+          <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+        </div>
+
+        <!-- Header -->
+        <div class="flex-shrink-0 bg-surface-secondary/40 border-b border-border px-6 py-4">
+          <div class="flex items-start justify-between gap-3">
+            <div class="flex items-center gap-3 min-w-0 flex-1">
+              <div class="flex-shrink-0 w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10c0-2 .5-5 2.986-7C14 5 16.09 5.24 17 7.07c.66 1.32.59 2.93.42 4.43-.07.62-.17 1.24-.32 1.85-.05.21-.21.46-.43.65a3.5 3.5 0 003.49.49M9 13a3 3 0 116 0 3 3 0 01-6 0z" />
+                </svg>
+              </div>
+              <div class="min-w-0">
+                <h2 class="text-base font-bold text-text-primary leading-tight">Nueva estación</h2>
+                <p class="text-xs text-text-secondary leading-snug mt-0.5">
+                  Punto de preparación para comandas (KDS)
+                </p>
+              </div>
+            </div>
+            <button
+              @click="close"
+              type="button"
+              aria-label="Cerrar panel"
+              class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+            >
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- Body -->
+        <form @submit.prevent="submit" class="flex-1 overflow-y-auto px-6 py-5 space-y-4">
+          <div class="flex flex-col gap-1.5">
+            <label for="station-name" class="text-sm font-medium text-text-primary">
+              Nombre <span class="text-destructive" aria-hidden="true">*</span>
+            </label>
+            <input
+              id="station-name"
+              ref="nameInputRef"
+              v-model="name"
+              type="text"
+              required
+              maxlength="100"
+              placeholder="Ej: Cocina Principal, Bar, Parrilla"
+              class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary bg-surface"
+              autocomplete="off"
+              :disabled="loading"
+            />
+            <p class="text-xs text-text-tertiary">{{ name.length }} / 100 caracteres</p>
+          </div>
+
+          <div class="flex flex-col gap-1.5">
+            <label for="station-color" class="text-sm font-medium text-text-primary">Color</label>
+            <div class="flex items-center gap-2">
+              <input
+                id="station-color"
+                v-model="color"
+                type="color"
+                aria-label="Selector de color"
+                :disabled="loading"
+                class="w-11 h-11 rounded-lg cursor-pointer border border-border p-0 overflow-hidden disabled:cursor-not-allowed disabled:opacity-50"
+              />
+              <input
+                v-model="color"
+                type="text"
+                pattern="^#[0-9A-Fa-f]{6}$"
+                placeholder="#6B7280"
+                aria-label="Código de color en hex"
+                :disabled="loading"
+                class="flex-1 px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm font-mono uppercase text-text-primary bg-surface"
+              />
+            </div>
+            <p class="text-xs text-text-tertiary">
+              Indicador visual de la estación en el listado y en el KDS
+            </p>
+          </div>
+
+          <div class="flex flex-col gap-1.5">
+            <label for="station-kitchen-name" class="text-sm font-medium text-text-primary">
+              Nombre del monitor <span class="text-text-tertiary text-xs font-normal">(opcional)</span>
+            </label>
+            <input
+              id="station-kitchen-name"
+              v-model="kitchenName"
+              type="text"
+              maxlength="50"
+              placeholder="Ej: K1, BAR-01"
+              class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary bg-surface"
+              autocomplete="off"
+              :disabled="loading"
+            />
+            <p class="text-xs text-text-tertiary">
+              Nombre corto que se muestra en la pantalla de cocina (KDS)
+            </p>
+          </div>
+
+          <div class="flex flex-col gap-1.5">
+            <label for="station-display-order" class="text-sm font-medium text-text-primary">
+              Orden <span class="text-text-tertiary text-xs font-normal">(opcional)</span>
+            </label>
+            <input
+              id="station-display-order"
+              v-model.number="displayOrder"
+              type="number"
+              min="0"
+              placeholder="0"
+              class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary bg-surface"
+              :disabled="loading"
+            />
+            <p class="text-xs text-text-tertiary">
+              Posición en el listado (números más bajos aparecen primero)
+            </p>
+          </div>
+
+          <p
+            v-if="errorMsg"
+            role="alert"
+            class="flex items-start gap-2 text-sm text-destructive"
+          >
+            <svg class="w-4 h-4 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4a2 2 0 00-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z" />
+            </svg>
+            <span>{{ errorMsg }}</span>
+          </p>
+        </form>
+
+        <!-- Footer -->
+        <div class="flex-shrink-0 border-t border-border px-6 py-4 flex items-center justify-end gap-3">
+          <button
+            type="button"
+            @click="close"
+            :disabled="loading"
+            class="px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-primary/30 rounded-lg"
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            @click="submit"
+            :disabled="loading || !canSubmit"
+            class="min-h-[44px] px-5 py-2 rounded-lg bg-primary text-white text-sm font-semibold hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition-colors flex items-center gap-2"
+          >
+            <template v-if="loading">
+              <span>Creando</span>
+              <CommonsInlineDots aria-label="Creando estación" :size="5" />
+            </template>
+            <template v-else>
+              Crear estación
+            </template>
+          </button>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue'
+import { useQueryCache } from '@pinia/colada'
+import { useTenantReactive } from '~/composables/useTenantReactive'
+
+interface Station {
+  id: string
+  name: string
+  kitchen_name: string | null
+  color: string
+  is_active: boolean
+  display_order: number
+  alert_threshold_1_min: number
+  alert_threshold_2_min: number
+  tenant_id: string
+}
+
+interface Props {
+  modelValue: boolean
+}
+
+interface Emits {
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'saved', station: Station): void
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<Emits>()
+
+const cache = useQueryCache()
+const { currentTenant } = useTenantReactive()
+
+const name = ref('')
+const color = ref('#6B7280')
+const kitchenName = ref('')
+const displayOrder = ref<number>(0)
+const loading = ref(false)
+const errorMsg = ref<string | null>(null)
+const nameInputRef = ref<HTMLInputElement | null>(null)
+
+// Backend's CreateStationRequest validates color with regex ^#[0-9A-Fa-f]{6}$.
+// Mirror the rule client-side so we don't ship a request guaranteed to fail.
+const isValidColor = computed(() => /^#[0-9A-Fa-f]{6}$/.test(color.value))
+const canSubmit = computed(() => name.value.trim().length > 0 && isValidColor.value)
+
+// Reset state every time the panel opens; auto-focus the name input.
+watch(
+  () => props.modelValue,
+  async (open) => {
+    if (open) {
+      name.value = ''
+      color.value = '#6B7280'
+      kitchenName.value = ''
+      displayOrder.value = 0
+      errorMsg.value = null
+      loading.value = false
+      await nextTick()
+      nameInputRef.value?.focus()
+    }
+  },
+)
+
+function close() {
+  if (loading.value) return
+  emit('update:modelValue', false)
+}
+
+async function submit() {
+  const trimmedName = name.value.trim()
+  if (!trimmedName) {
+    errorMsg.value = 'El nombre es obligatorio'
+    return
+  }
+  if (!isValidColor.value) {
+    errorMsg.value = 'El color debe estar en formato #RRGGBB'
+    return
+  }
+
+  loading.value = true
+  errorMsg.value = null
+  try {
+    const res = await $fetch<{ success: boolean; data: Station }>('/api/stations', {
+      method: 'POST',
+      body: {
+        name: trimmedName,
+        color: color.value,
+        kitchen_name: kitchenName.value.trim() || null,
+        display_order: displayOrder.value || 0,
+        // Thresholds use backend defaults (8 / 15) — kept out of this slide-over
+        // for compactness. Editing thresholds is done from /operaciones/comandas.
+        alert_threshold_1_min: 8,
+        alert_threshold_2_min: 15,
+      },
+    })
+    cache.invalidateQueries({ key: ['tenant', 'stations', currentTenant.value?.id] })
+    emit('saved', res.data)
+    emit('update:modelValue', false)
+  } catch (e: any) {
+    if (e?.response?.status === 409 || e?.statusCode === 409) {
+      errorMsg.value = 'Ya existe una estación con ese nombre'
+    } else {
+      errorMsg.value = e?.data?.detail || e?.message || 'Error al crear la estación'
+    }
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<style scoped>
+.panel-enter-active,
+.panel-leave-active {
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+.panel-enter-from,
+.panel-leave-to {
+  opacity: 0;
+  transform: translateY(100%);
+}
+@media (min-width: 768px) {
+  .panel-enter-from,
+  .panel-leave-to {
+    transform: translateX(100%);
+  }
+}
+</style>

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -67,6 +67,13 @@
                   </template>
                   <template v-else>
                     <span class="text-text-tertiary">Sin comanda — asigna una estación a la categoría</span>
+                    <button
+                      type="button"
+                      @click="showNewStationModal = true"
+                      class="ml-auto text-xs font-medium text-primary hover:text-primary/80 focus:outline-none focus:ring-2 focus:ring-primary/30 rounded px-2 py-1"
+                    >
+                      + Crear estación
+                    </button>
                   </template>
                 </div>
               </div>
@@ -542,6 +549,11 @@
       :initial-name="newCategoryName"
       @saved="onCategoryCreated"
     />
+
+    <CocinaStationPanel
+      v-model="showNewStationModal"
+      @saved="onStationCreated"
+    />
   </div>
 </template>
 
@@ -570,6 +582,7 @@ definePageMeta({
 const route = useRoute()
 const router = useRouter()
 const cache = useQueryCache()
+const toast = useToast()
 const { currentTenant, businessProfile } = useTenantReactive()
 
 // Tax config — only show selector when tenant has taxes enabled
@@ -712,6 +725,18 @@ function onCategoryCreateRequested(typedName: string) {
 function onCategoryCreated(cat: { id: string; name: string }) {
   form.value.category_id = cat.id
   selectedCategoryName.value = cat.name
+}
+
+// ── Kitchen station inline create flow (issue #463) ───────────────────────
+const showNewStationModal = ref(false)
+
+function onStationCreated(station: { id: string; name: string }) {
+  toast.success(
+    `Estación "${station.name}" creada. Asígnala a una categoría desde Operaciones › Comandas.`,
+    { title: 'Estación creada' }
+  )
+  cache.invalidateQueries({ key: ['tenant', 'stations', currentTenant.value?.id] })
+  cache.invalidateQueries({ key: ['tenant', 'category-stations', currentTenant.value?.id] })
 }
 
 const categories = computed(() => categoriesData.value?.data || [])

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -224,6 +224,13 @@
                   </template>
                   <template v-else>
                     <span class="text-text-tertiary">Sin comanda — asigna una estación a la categoría</span>
+                    <button
+                      type="button"
+                      @click="showNewStationModal = true"
+                      class="ml-auto text-xs font-medium text-primary hover:text-primary/80 focus:outline-none focus:ring-2 focus:ring-primary/30 rounded px-2 py-1"
+                    >
+                      + Crear estación
+                    </button>
                   </template>
                 </div>
               </div>
@@ -738,6 +745,11 @@
       :initial-name="newCategoryName"
       @saved="onCategoryCreated"
     />
+
+    <CocinaStationPanel
+      v-model="showNewStationModal"
+      @saved="onStationCreated"
+    />
   </div>
 </template>
 
@@ -756,6 +768,7 @@ useHead({ title: 'Crear Producto' })
 
 const router = useRouter()
 const cache = useQueryCache()
+const toast = useToast()
 const { currentTenant, businessProfile } = useTenantReactive()
 
 // Tax config — only show selector when tenant has taxes enabled
@@ -1040,6 +1053,18 @@ function onCategoryCreateRequested(typedName: string) {
 function onCategoryCreated(cat: { id: string; name: string }) {
   form.value.category_id = cat.id
   selectedCategoryName.value = cat.name
+}
+
+// ── Kitchen station inline create flow (issue #463) ───────────────────────
+const showNewStationModal = ref(false)
+
+function onStationCreated(station: { id: string; name: string }) {
+  toast.success(
+    `Estación "${station.name}" creada. Asígnala a una categoría desde Operaciones › Comandas.`,
+    { title: 'Estación creada' }
+  )
+  cache.invalidateQueries({ key: ['tenant', 'stations', currentTenant.value?.id] })
+  cache.invalidateQueries({ key: ['tenant', 'category-stations', currentTenant.value?.id] })
 }
 
 function addIngredient() {


### PR DESCRIPTION
## Summary

Adds inline kitchen station creation from \`/menu/productos/crear\` and \`/menu/productos/[id]\` via a slide-over (mirrors #458 category flow). When the category has no station yet, "Cocina heredada" now shows a "+ Crear estación" button that opens the slide-over.

## Stack
🟢 Nuxt 3 · 🎨 UX

## Files

| File | Change |
|---|---|
| \`components/cocina/StationPanel.vue\` | new — slide-over (~250 lines, 4 fields: name + color + kitchen_name + display_order; thresholds use backend defaults 8/15) |
| \`pages/menu/productos/crear.vue\` | modify — button + slide-over mount + handler with toast + cache invalidation |
| \`pages/menu/productos/[id].vue\` | modify — same |

## Pairs with

[api-warolabs PR](https://github.com/uno0uno/api-warolabs/pulls?q=is%3Apr+head%3Afeat%2Fissue-463-stations-409) — adds 409 mapping for UniqueViolationError. Required so the slide-over can render duplicate-name attempts inline.

## Validation

- ✅ \`bun run build\` clean (498 MB / 120 MB gzip)
- ✅ Templates balanced
- ✅ Backend imports clean

Closes #463