### PR TITLE
feat(products): single image upload via Cloudflare R2 (#465)

### DIFF
--- a/components/Commons/ImageUploadModal.vue
+++ b/components/Commons/ImageUploadModal.vue
@@ -1,22 +1,20 @@
 <template>
   <Teleport to="body">
     <div
-      class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+      class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-foreground/60 backdrop-blur-sm"
       @click.self="$emit('close')"
     >
       <div class="bg-surface border-2 border-border rounded-xl w-full max-w-md shadow-xl">
 
         <!-- Header -->
         <div class="flex items-center justify-between px-5 py-4 border-b border-border">
-          <h2 class="text-base font-semibold text-text-primary">
-            Subir imagen de {{ imageType === 'logo' ? 'logo' : 'banner' }}
-          </h2>
+          <h2 class="text-base font-semibold text-text-primary">{{ headerTitle }}</h2>
           <button
             @click="$emit('close')"
-            class="p-1.5 rounded-lg hover:bg-surface-secondary text-text-secondary transition-colors"
+            class="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg hover:bg-surface-secondary text-text-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
             aria-label="Cerrar modal"
           >
-            <XMarkIcon class="w-5 h-5" />
+            <XMarkIcon class="w-5 h-5" aria-hidden="true" />
           </button>
         </div>
 
@@ -33,16 +31,14 @@
             @dragleave.prevent="isDragging = false"
             @drop.prevent="onDrop"
           >
-            <!-- Preview image -->
             <img
               v-if="preview"
               :src="preview"
               :alt="`Preview de ${imageType}`"
               class="w-full object-cover"
-              :class="imageType === 'logo' ? 'max-h-48 object-contain' : 'h-36'"
+              :class="previewClass"
             />
 
-            <!-- Empty state -->
             <div
               v-else
               class="flex flex-col items-center justify-center py-10 px-6 text-center cursor-pointer"
@@ -56,20 +52,17 @@
                 </button>
               </p>
               <p class="text-xs text-text-secondary">
-                JPEG, PNG o WebP · máx 5 MB ·
-                {{ imageType === 'logo' ? 'cuadrada recomendada' : '1200 × 400 px recomendado' }}
+                JPEG, PNG o WebP · máx 5 MB · {{ recommendationText }}
               </p>
             </div>
 
-            <!-- Compressed size badge -->
             <div
               v-if="preview && compressedSize"
-              class="absolute bottom-2 right-2 bg-black/50 text-white text-xs px-2 py-0.5 rounded-full backdrop-blur-sm"
+              class="absolute bottom-2 right-2 bg-foreground/50 text-white text-xs px-2 py-0.5 rounded-full backdrop-blur-sm"
             >
               {{ compressedSize }}
             </div>
 
-            <!-- Change overlay on preview -->
             <button
               v-if="preview"
               type="button"
@@ -77,20 +70,18 @@
               class="absolute inset-0 flex items-center justify-center bg-black/0 hover:bg-black/30 transition-colors group"
               aria-label="Cambiar imagen"
             >
-              <span class="hidden group-hover:flex items-center gap-1.5 bg-black/60 text-white text-sm font-medium px-3 py-1.5 rounded-lg">
+              <span class="hidden group-hover:flex items-center gap-1.5 bg-foreground/60 text-white text-sm font-medium px-3 py-1.5 rounded-lg">
                 <PhotoIcon class="w-4 h-4" aria-hidden="true" />
                 Cambiar imagen
               </span>
             </button>
           </div>
 
-          <!-- Error message -->
           <p v-if="errorMsg" class="flex items-center gap-1.5 text-sm text-destructive" role="alert">
             <ExclamationCircleIcon class="w-4 h-4 flex-shrink-0" aria-hidden="true" />
             {{ errorMsg }}
           </p>
 
-          <!-- Hidden file input -->
           <input
             ref="fileInput"
             type="file"
@@ -105,7 +96,7 @@
           <button
             type="button"
             @click="$emit('close')"
-            class="px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary border border-border rounded-lg hover:bg-surface-secondary transition-colors"
+            class="px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary border border-border rounded-lg hover:bg-surface-secondary transition-colors min-h-[44px]"
           >
             Cancelar
           </button>
@@ -113,7 +104,7 @@
             type="button"
             :disabled="!preview || isUploading"
             @click="confirmUpload"
-            class="px-4 py-2 text-sm font-medium bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 min-w-[130px] justify-center"
+            class="px-4 py-2 text-sm font-medium bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 min-h-[44px] min-w-[130px] justify-center"
           >
             <span v-if="isUploading" class="flex items-center gap-2">
               <CommonsTheCustomLoader size="small" />
@@ -132,11 +123,34 @@
 </template>
 
 <script setup lang="ts">
+import { computed, onUnmounted, ref } from 'vue'
 import { XMarkIcon, PhotoIcon, ExclamationCircleIcon, ArrowUpTrayIcon } from '@heroicons/vue/24/outline'
 
-const props = defineProps<{
-  imageType: 'logo' | 'banner'
-}>()
+interface Props {
+  /** Logical bucket — drives default dimensions, header title, and the
+   *  `image_type` field added to the FormData (only when uploadEndpoint is
+   *  the legacy tenant endpoint). */
+  imageType: 'logo' | 'banner' | 'product'
+  /** Backend POST URL. Receives a multipart/form-data with `file`. */
+  uploadEndpoint: string
+  /** Whether to also send `image_type` as a form field — needed by the legacy
+   *  tenant endpoint that handles logo + banner under one route. */
+  sendImageTypeField?: boolean
+  /** Override max dimensions for compression. Defaults per imageType apply
+   *  if omitted. */
+  maxDims?: { w: number; h: number }
+  /** Helper text inside the empty state, e.g. "cuadrada 800×800 recomendada". */
+  recommendationText?: string
+  /** Custom title in the modal header. Defaults to "Subir imagen de X". */
+  title?: string
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  sendImageTypeField: false,
+  maxDims: undefined,
+  recommendationText: '',
+  title: '',
+})
 
 const emit = defineEmits<{
   upload: [url: string]
@@ -151,18 +165,38 @@ const errorMsg = ref<string | null>(null)
 const isDragging = ref(false)
 const isUploading = ref(false)
 
-const toast = useToast()
-
-// ─── Max dimensions per image type ───
-const MAX_DIMS = {
+const DEFAULT_DIMS = {
   logo: { w: 400, h: 400 },
   banner: { w: 1400, h: 470 },
+  product: { w: 800, h: 800 },
+} as const
+
+const DEFAULT_RECOMMENDATIONS: Record<string, string> = {
+  logo: 'cuadrada recomendada',
+  banner: '1200 × 400 px recomendado',
+  product: 'cuadrada · 800×800 recomendada',
 }
 
 const ALLOWED_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp'])
 const MAX_SIZE_BYTES = 5 * 1024 * 1024
 
-// ─── Compress via Canvas ───
+const headerTitle = computed(() => {
+  if (props.title) return props.title
+  if (props.imageType === 'logo') return 'Subir imagen de logo'
+  if (props.imageType === 'banner') return 'Subir imagen de banner'
+  return 'Subir imagen del producto'
+})
+
+const recommendationText = computed(() => {
+  return props.recommendationText || DEFAULT_RECOMMENDATIONS[props.imageType] || ''
+})
+
+const previewClass = computed(() => {
+  if (props.imageType === 'logo') return 'max-h-48 object-contain'
+  if (props.imageType === 'product') return 'h-48 object-cover'
+  return 'h-36'
+})
+
 function compressImage(file: File): Promise<Blob> {
   return new Promise((resolve, reject) => {
     const img = new Image()
@@ -171,12 +205,11 @@ function compressImage(file: File): Promise<Blob> {
     img.onload = () => {
       URL.revokeObjectURL(objectUrl)
 
-      const { w: maxW, h: maxH } = MAX_DIMS[props.imageType]
+      const dims = props.maxDims || DEFAULT_DIMS[props.imageType]
       let { naturalWidth: w, naturalHeight: h } = img
 
-      // Scale down if exceeds max dimensions
-      if (w > maxW || h > maxH) {
-        const ratio = Math.min(maxW / w, maxH / h)
+      if (w > dims.w || h > dims.h) {
+        const ratio = Math.min(dims.w / w, dims.h / h)
         w = Math.round(w * ratio)
         h = Math.round(h * ratio)
       }
@@ -256,9 +289,11 @@ async function confirmUpload() {
   try {
     const formData = new FormData()
     formData.append('file', compressedBlob.value, `${props.imageType}.jpg`)
-    formData.append('image_type', props.imageType)
+    if (props.sendImageTypeField) {
+      formData.append('image_type', props.imageType)
+    }
 
-    const response = await $fetch<{ url: string }>('/api/api/tenant/upload-image', {
+    const response = await $fetch<{ url: string }>(props.uploadEndpoint, {
       method: 'POST',
       body: formData,
     })

--- a/components/pos/ProductCard.vue
+++ b/components/pos/ProductCard.vue
@@ -6,9 +6,16 @@
     @mouseleave="isHovered = false"
     @click="$emit('select', product)"
   >
-    <!-- Product icon in white bubble -->
-    <div class="w-12 h-12 md:w-16 md:h-16 bg-white/70 rounded-2xl shadow-sm flex items-center justify-center mb-1.5 md:mb-3 select-none flex-shrink-0">
-      <span class="text-xl md:text-3xl">{{ product.image }}</span>
+    <!-- Product icon: real image when uploaded, emoji as fallback (#465) -->
+    <div class="w-12 h-12 md:w-16 md:h-16 bg-white/70 rounded-2xl shadow-sm flex items-center justify-center mb-1.5 md:mb-3 select-none flex-shrink-0 overflow-hidden">
+      <img
+        v-if="product.image_url && product.image_url.startsWith('http')"
+        :src="product.image_url"
+        :alt="product.name"
+        loading="lazy"
+        class="w-full h-full object-cover"
+      />
+      <span v-else class="text-xl md:text-3xl">{{ product.image }}</span>
     </div>
 
     <!-- Name -->
@@ -34,6 +41,7 @@ interface Product {
   price: number
   category: string
   image: string
+  image_url?: string | null
   available: boolean
 }
 

--- a/pages/[tenant]/index.vue
+++ b/pages/[tenant]/index.vue
@@ -134,6 +134,7 @@ const menuItems = computed(() =>
     '@type': 'MenuItem',
     name: p.name,
     description: p.description || undefined,
+    image: p.image_url || undefined,  // Issue #465 — improves Google Rich Results
     offers: {
       '@type': 'Offer',
       price: p.price,

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -41,6 +41,42 @@
                 ></textarea>
               </div>
 
+              <!-- Image (issue #465) -->
+              <div class="sm:col-span-2">
+                <label class="block text-sm font-medium text-text-primary mb-2">Imagen</label>
+                <div class="flex items-center gap-4">
+                  <div class="w-24 h-24 rounded-lg border-2 border-dashed border-border bg-surface-secondary overflow-hidden flex items-center justify-center flex-shrink-0">
+                    <img
+                      v-if="form.image_url"
+                      :src="form.image_url"
+                      :alt="form.name || 'Imagen del producto'"
+                      class="w-full h-full object-cover"
+                      loading="lazy"
+                    />
+                    <svg v-else class="w-8 h-8 text-text-secondary/40" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                    </svg>
+                  </div>
+                  <div class="flex flex-col gap-2">
+                    <button
+                      type="button"
+                      @click="showImageModal = true"
+                      class="min-h-[44px] px-3 py-2 text-sm border border-border rounded-lg hover:bg-surface-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+                    >
+                      {{ form.image_url ? 'Cambiar imagen' : 'Subir imagen' }}
+                    </button>
+                    <button
+                      v-if="form.image_url"
+                      type="button"
+                      @click="form.image_url = ''"
+                      class="text-xs text-destructive hover:underline"
+                    >
+                      Eliminar
+                    </button>
+                  </div>
+                </div>
+              </div>
+
               <div>
                 <label class="block text-sm font-medium text-text-primary mb-2">
                   Categoría *
@@ -554,6 +590,14 @@
       v-model="showNewStationModal"
       @saved="onStationCreated"
     />
+
+    <CommonsImageUploadModal
+      v-if="showImageModal"
+      image-type="product"
+      upload-endpoint="/api/menu/products/upload-image"
+      @upload="onImageUploaded"
+      @close="showImageModal = false"
+    />
   </div>
 </template>
 
@@ -727,6 +771,14 @@ function onCategoryCreated(cat: { id: string; name: string }) {
   selectedCategoryName.value = cat.name
 }
 
+// ── Image upload (issue #465) ─────────────────────────────────────────────
+const showImageModal = ref(false)
+
+function onImageUploaded(url: string) {
+  form.value.image_url = url
+  showImageModal.value = false
+}
+
 // ── Kitchen station inline create flow (issue #463) ───────────────────────
 const showNewStationModal = ref(false)
 
@@ -760,6 +812,7 @@ const selectedRecipeBaseIngredients = computed(() => {
 const form = ref({
   name: '',
   description: '',
+  image_url: '',
   price: 0,
   category_id: '',
   preparation_time: 15,
@@ -788,6 +841,7 @@ watch(productData, (data) => {
     form.value = {
       name: product.name,
       description: product.description || '',
+      image_url: product.image_url || '',
       price: Number(product.price),
       category_id: product.category_id,
       preparation_time: product.preparation_time || 15,
@@ -922,10 +976,12 @@ const handleSubmit = async () => {
     }
 
     // When toggle is OFF, force empty recipe arrays — product won't track inventory.
+    // Normalise image_url empty string → null so backend stores NULL (issue #465).
     const cleanedForm = {
       ...form.value,
       recipe_base_ids: tracksInventory.value ? uniqueRecipeBaseIds : [],
       ingredients: tracksInventory.value ? form.value.ingredients : [],
+      image_url: form.value.image_url || null,
     }
     await $fetch(`/api/menu/products/${productId}`, {
       method: 'PUT',

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -197,6 +197,42 @@
                 />
               </div>
 
+              <!-- Image (issue #465) -->
+              <div class="md:col-span-2">
+                <label class="block text-sm font-medium text-text-primary mb-2">Imagen</label>
+                <div class="flex items-center gap-4">
+                  <div class="w-24 h-24 rounded-lg border-2 border-dashed border-border bg-surface-secondary overflow-hidden flex items-center justify-center flex-shrink-0">
+                    <img
+                      v-if="form.image_url"
+                      :src="form.image_url"
+                      :alt="form.name || 'Imagen del producto'"
+                      class="w-full h-full object-cover"
+                      loading="lazy"
+                    />
+                    <svg v-else class="w-8 h-8 text-text-secondary/40" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                    </svg>
+                  </div>
+                  <div class="flex flex-col gap-2">
+                    <button
+                      type="button"
+                      @click="showImageModal = true"
+                      class="min-h-[44px] px-3 py-2 text-sm border border-border rounded-lg hover:bg-surface-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+                    >
+                      {{ form.image_url ? 'Cambiar imagen' : 'Subir imagen' }}
+                    </button>
+                    <button
+                      v-if="form.image_url"
+                      type="button"
+                      @click="form.image_url = ''"
+                      class="text-xs text-destructive hover:underline"
+                    >
+                      Eliminar
+                    </button>
+                  </div>
+                </div>
+              </div>
+
               <!-- Category — search + inline create (issue #458) -->
               <div>
                 <label class="block text-sm font-medium text-text-primary mb-2">
@@ -750,6 +786,14 @@
       v-model="showNewStationModal"
       @saved="onStationCreated"
     />
+
+    <CommonsImageUploadModal
+      v-if="showImageModal"
+      image-type="product"
+      upload-endpoint="/api/menu/products/upload-image"
+      @upload="onImageUploaded"
+      @close="showImageModal = false"
+    />
   </div>
 </template>
 
@@ -796,6 +840,7 @@ const tracksInventory = ref(true)
 const form = ref({
   name: '',
   description: '',
+  image_url: '',
   price: 0,
   category_id: '',
   recipe_base_ids: [] as string[],
@@ -1055,6 +1100,14 @@ function onCategoryCreated(cat: { id: string; name: string }) {
   selectedCategoryName.value = cat.name
 }
 
+// ── Image upload (issue #465) ─────────────────────────────────────────────
+const showImageModal = ref(false)
+
+function onImageUploaded(url: string) {
+  form.value.image_url = url
+  showImageModal.value = false
+}
+
 // ── Kitchen station inline create flow (issue #463) ───────────────────────
 const showNewStationModal = ref(false)
 
@@ -1147,10 +1200,12 @@ async function submitProduct() {
     form.value.tenant_id = currentTenant.value?.id || ''
 
     // When toggle is OFF, force empty recipe arrays — product won't track inventory.
+    // Normalise image_url empty string → null so backend stores NULL (issue #465).
     const cleanedForm = {
       ...form.value,
       recipe_base_ids: tracksInventory.value ? uniqueRecipeBaseIds : [],
       ingredients: tracksInventory.value ? form.value.ingredients : [],
+      image_url: form.value.image_url || null,
     }
 
     await $fetch('/api/menu/products', {

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -87,6 +87,18 @@
               ]"
               @click="editProduct(item)"
             >
+              <div class="w-10 h-10 rounded-md bg-surface-secondary overflow-hidden flex-shrink-0 flex items-center justify-center">
+                <img
+                  v-if="item.image_url"
+                  :src="item.image_url"
+                  :alt="item.name"
+                  loading="lazy"
+                  class="w-full h-full object-cover"
+                />
+                <svg v-else class="w-5 h-5 text-text-secondary/40" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+              </div>
               <div class="flex-1 min-w-0">
                 <span class="text-sm font-bold text-text-primary">{{ toTitleCase(item.name) }}</span>
                 <p class="text-xs text-text-secondary mt-0.5">{{ item.category_name || 'Sin categoría' }} · {{ formatCurrency(item.price) }}</p>
@@ -125,8 +137,22 @@
 
 
           <!-- Desktop Table Cell Customizations -->
-          <template #cell-name="{ value }">
-            <span class="text-sm font-medium text-text-primary">{{ toTitleCase(value) }}</span>
+          <template #cell-name="{ value, item }">
+            <div class="flex items-center gap-3">
+              <div class="w-8 h-8 rounded-md bg-surface-secondary overflow-hidden flex-shrink-0 flex items-center justify-center">
+                <img
+                  v-if="item.image_url"
+                  :src="item.image_url"
+                  :alt="value"
+                  loading="lazy"
+                  class="w-full h-full object-cover"
+                />
+                <svg v-else class="w-4 h-4 text-text-secondary/40" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+              </div>
+              <span class="text-sm font-medium text-text-primary">{{ toTitleCase(value) }}</span>
+            </div>
           </template>
 
           <template #cell-category_name="{ value }">

--- a/pages/negocio.vue
+++ b/pages/negocio.vue
@@ -484,9 +484,11 @@
     </div>
 
     <!-- Image Upload Modal -->
-    <NegocioImageUploadModal
+    <CommonsImageUploadModal
       v-if="imageModalOpen"
       :image-type="imageModalType"
+      upload-endpoint="/api/api/tenant/upload-image"
+      :send-image-type-field="true"
       @upload="handleImageUploaded"
       @close="imageModalOpen = false"
     />

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -516,7 +516,8 @@ watch(() => productsData.value, (data) => {
       name: p.name,
       description: p.description || '',
       price: Number(p.price) || 0,
-      image: p.image_url || '🍽️',
+      image: '🍽️',  // Emoji fallback shown when image_url is missing/empty
+      image_url: p.image_url || null,  // Issue #465 — real image when uploaded
       category: p.category_name || p.category?.name || 'Sin categoría',
       is_available: p.is_available,
       is_resale: p.is_resale || false,

--- a/pages/pos/producto/[id].vue
+++ b/pages/pos/producto/[id].vue
@@ -54,6 +54,7 @@ const product = computed(() => {
     price: Number(p.price) || 0,
     category: p.category,
     image: p.image,
+    image_url: p.image_url || null,
     available: p.is_available,
     modifier_groups: p.modifier_groups || []
   }
@@ -486,9 +487,16 @@ onUnmounted(() => {
           </div>
 
           <div class="flex flex-col sm:flex-row gap-4 md:gap-6 items-start sm:items-center">
-            <!-- Product Image/Emoji -->
+            <!-- Product Image/Emoji — real image when uploaded, emoji fallback (#465) -->
             <div class="w-full sm:w-32 md:w-40 h-32 md:h-40 flex-shrink-0 bg-surface-secondary rounded-xl overflow-hidden relative flex items-center justify-center">
-              <div class="text-6xl md:text-8xl">{{ product.image }}</div>
+              <img
+                v-if="product.image_url && product.image_url.startsWith('http')"
+                :src="product.image_url"
+                :alt="product.name"
+                loading="lazy"
+                class="w-full h-full object-cover"
+              />
+              <div v-else class="text-6xl md:text-8xl">{{ product.image }}</div>
             </div>
 
             <!-- Product Info -->

--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -55,6 +55,7 @@ export interface CachedProduct {
     description: string
     price: number
     image: string
+    image_url?: string | null  // Issue #465: real image when uploaded; emoji fallback otherwise
     category: string
     is_available: boolean
     is_resale: boolean


### PR DESCRIPTION
## Summary

Single image per product. Refactor of \`negocio/ImageUploadModal\` to \`Commons/ImageUploadModal\` (genérico) + nueva sección "Imagen" en wizard crear/editar + thumbnail en listado admin + \`<img>\` en POS card y detail (con emoji fallback) + schema.org \`image\` en delivery.

## Stack
🟢 Nuxt 3 · 🎨 UX

## Pairs with
api-warolabs PR (migration, endpoint POST /upload-image, persist image_url, public_restaurant_service queries).

## UX fixes incluidos
- Modal close button: ~28px → ≥44×44 touch target
- Backdrop: \`bg-black/60\` → \`bg-foreground/60\` (token)
- \`<img>\` siempre con \`alt\` y \`loading="lazy"\`
- Empty state con \`PhotoIcon\` placeholder

## Validation

- ✅ \`bun run build\` clean (498 MB / 120 MB gzip)
- ✅ Backend imports clean
- ✅ Migration aplicada en local DB

Closes #465