### PR TITLE
fix(pos): show product images in grid (regression after #465)

### DIFF
--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -536,7 +536,8 @@ const products = computed(() => {
     name: p.name,
     price: p.price,
     category: p.category_name || p.category?.name || 'Sin categoría',
-    image: p.image_url || '🍽️',
+    image: '🍽️',
+    image_url: p.image_url || null,
     available: p.is_available,
     is_resale: p.is_resale || false
   }))


### PR DESCRIPTION
## Summary
- The POS grid `products` computed at `pages/pos/index.vue:531-543` collapsed `image_url` into the emoji slot and never emitted a separate `image_url` field, so `ProductCard.vue`'s `v-if="product.image_url && product.image_url.startsWith('http')"` was always falsy and the emoji fallback always won.
- Fix: emit `image: '🍽️'` (constant fallback) and add `image_url: p.image_url || null` — mirrors the `productsToCache` shape directly above.

## Stack
🟢 Nuxt 3

## Changes
- `pages/pos/index.vue` — `products` computed now emits `image_url` separately (parity with the cache mapper).

## Testing
- [x] `bun run build` passes locally.
- [ ] Manual: load `/pos`, verify product `280648ad-9d5b-4bb4-9b96-9198f7af59d6` ("pizza de prueba 34") renders the real photo.
- [ ] Manual: products without `image_url` keep the emoji fallback.
- [ ] Manual: `/pos/producto/280648ad-…` hero still renders.

Closes #467