### PR TITLE
feat(menu-productos): add page subtitle for context

### DIFF
--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -11,6 +11,9 @@
     <!-- Main Content -->
     <div v-else class="page-layout">
       <div class="flex flex-col gap-3 md:gap-4">
+        <!-- Page subtitle -->
+        <p class="text-sm text-text-secondary">Catálogo y rentabilidad de productos</p>
+
         <!-- Cost Warning Banner -->
         <div
           v-if="costIssueCount > 0 && !bannerDismissed"


### PR DESCRIPTION
## Summary
- `pages/menu/productos/index.vue`: added `<p class="text-sm text-text-secondary">Catálogo y rentabilidad de productos</p>` at the top of the page content, above the cost-warning banner and filters bar.
- Uses existing typography tokens — no hardcoded sizes, design system respected.

## Stack
🟢 Nuxt 3

## Testing
- [ ] Subtitle visible on `/menu/productos` desktop and mobile.
- [ ] Mobile: text wraps cleanly, no overflow.
- [ ] No layout shift in the rest of the page header.

Closes #470