### PR TITLE
fix(pos-card): contain image inside the icon slot

### DIFF
--- a/components/pos/ProductCard.vue
+++ b/components/pos/ProductCard.vue
@@ -7,13 +7,13 @@
     @click="$emit('select', product)"
   >
     <!-- Product icon: real image when uploaded, emoji as fallback (#465) -->
-    <div class="w-12 h-12 md:w-16 md:h-16 bg-white/70 rounded-2xl shadow-sm flex items-center justify-center mb-1.5 md:mb-3 select-none flex-shrink-0 overflow-hidden">
+    <div class="w-12 h-12 md:w-16 md:h-16 bg-white/70 rounded-2xl shadow-sm flex items-center justify-center mb-1.5 md:mb-3 select-none flex-shrink-0 overflow-hidden p-1">
       <img
         v-if="product.image_url && product.image_url.startsWith('http')"
         :src="product.image_url"
         :alt="product.name"
         loading="lazy"
-        class="w-full h-full object-cover"
+        class="max-w-full max-h-full w-auto h-auto object-contain"
       />
       <span v-else class="text-xl md:text-3xl">{{ product.image }}</span>
     </div>


### PR DESCRIPTION
## Summary
- The POS grid card icon container is a fixed 48×48 / 64×64 box. The previous `w-full h-full object-cover` cropped portrait/landscape uploads aggressively to fill it.
- Switched to `max-w-full max-h-full w-auto h-auto object-contain` plus a `p-1` inset on the wrapper, so the photo is visually contained, never exceeds the parent, and keeps its natural aspect.

## Stack
🟢 Nuxt 3

## Testing
- [ ] Portrait product photo renders centered inside the icon, with subtle inset, no crop.
- [ ] Landscape photo renders centered, no vertical squish.
- [ ] Square photo behaves like before (visually fills the slot).
- [ ] Emoji fallback unchanged.