### PR TITLE
fix(pos-card): icon slot uses surface token + border for contrast

### DIFF
--- a/components/pos/ProductCard.vue
+++ b/components/pos/ProductCard.vue
@@ -7,7 +7,7 @@
     @click="$emit('select', product)"
   >
     <!-- Product icon: real image when uploaded, emoji as fallback (#465) -->
-    <div class="w-full aspect-[3/2] bg-white/70 rounded-2xl shadow-sm flex items-center justify-center mb-1.5 md:mb-3 select-none flex-shrink-0 overflow-hidden">
+    <div class="w-full aspect-[3/2] bg-surface-secondary border border-border/40 rounded-2xl shadow-sm flex items-center justify-center mb-1.5 md:mb-3 select-none flex-shrink-0 overflow-hidden">
       <img
         v-if="product.image_url && product.image_url.startsWith('http')"
         :src="product.image_url"


### PR DESCRIPTION
## Summary
The icon slot (`bg-white/70`) was invisible on white-background product cards (Sin categoría / unmatched color entries) — the slot blended into the card surface, see screenshot in #481 follow-up.

## Stack
🟢 Nuxt 3 · 🎨 Color · 🎨 UX

## Change
- `components/pos/ProductCard.vue` icon wrapper: `bg-white/70` → `bg-surface-secondary border border-border/40`
- Token-based: aligns with the codebase's `--surface`/`--surface-secondary`/`--border` tokens.
- Always-visible affordance regardless of card category color.

## Testing
- [ ] White-bg cards (Sin categoría) — icon slot visible with subtle gray fill + border.
- [ ] Colored-bg cards (pizza red, drinks blue, etc.) — slot still distinct from card.
- [ ] Selected card — slot keeps contrast against the active state.