### PR TITLE
fix(billing-gate): redirect blocked subscriptions to /gestion/billing (was 404)

### DIFF
--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -1011,10 +1011,10 @@ const updateDateTime = () => {
 // Update time immediately and then every minute
 let dateTimeInterval: ReturnType<typeof setInterval> | null = null
 
-// Redirect to blocked page when subscription is expired
+// Redirect to billing portal when subscription is expired
 watch(accessStatus, (status) => {
-  if (status?.level === 'blocked' && !route.path.startsWith('/billing/')) {
-    navigateTo('/billing/renovar')
+  if (status?.level === 'blocked' && !route.path.startsWith('/gestion/billing')) {
+    navigateTo('/gestion/billing')
   }
 }, { immediate: true })
 


### PR DESCRIPTION
Replaces a hardcoded `navigateTo('/billing/renovar')` (404) with the actual billing portal route `/gestion/billing`. Also fixes the redirect-loop guard which checked the wrong path prefix.