### PR TITLE
fix(billing): point all stale /billing links to /gestion/billing

### DIFF
--- a/components/SubscriptionBanner.vue
+++ b/components/SubscriptionBanner.vue
@@ -29,7 +29,7 @@
 
       <!-- CTA -->
       <NuxtLink
-        to="/billing/planes"
+        to="/gestion/billing"
         :class="ctaClass"
         class="flex-shrink-0 text-xs font-semibold px-3 py-1.5 rounded-lg min-h-[44px] flex items-center whitespace-nowrap transition-opacity hover:opacity-80"
       >

--- a/components/ui/ScanUsageBar.vue
+++ b/components/ui/ScanUsageBar.vue
@@ -38,7 +38,7 @@
         </div>
         <NuxtLink
           v-if="showPeriod"
-          to="/billing/"
+          to="/gestion/billing"
           class="text-xs font-bold text-primary hover:text-primary/80 transition-colors py-1.5 px-2.5 -mr-2 bg-primary/5 rounded-lg active:scale-95"
           style="min-height: 44px; display: flex; align-items: center;"
         >

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -1382,7 +1382,7 @@
       </div>
       <div class="flex flex-col gap-2 pt-1">
         <NuxtLink
-          to="/billing/planes"
+          to="/gestion/billing"
           class="btn-primary px-4 py-3 rounded-xl text-sm font-semibold text-center min-h-[44px] flex items-center justify-center"
           @click="showQuotaModal = false"
         >

--- a/pages/billing/confirmacion.vue
+++ b/pages/billing/confirmacion.vue
@@ -29,7 +29,7 @@
             Ya tienes acceso completo a todas las funciones.
           </p>
         </div>
-        <NuxtLink to="/billing" class="btn-primary px-6 py-3 rounded-xl text-sm font-semibold inline-block min-h-[44px] flex items-center justify-center">
+        <NuxtLink to="/gestion/billing" class="btn-primary px-6 py-3 rounded-xl text-sm font-semibold inline-block min-h-[44px] flex items-center justify-center">
           Ver mi suscripción
         </NuxtLink>
       </div>
@@ -50,7 +50,7 @@
             Esto puede tardar unos minutos.
           </p>
         </div>
-        <NuxtLink to="/billing" class="border border-border px-6 py-3 rounded-xl text-sm font-semibold inline-block text-text-primary hover:bg-surface-alt transition-colors min-h-[44px] flex items-center justify-center">
+        <NuxtLink to="/gestion/billing" class="border border-border px-6 py-3 rounded-xl text-sm font-semibold inline-block text-text-primary hover:bg-surface-alt transition-colors min-h-[44px] flex items-center justify-center">
           Ver estado de mi suscripción
         </NuxtLink>
       </div>
@@ -72,10 +72,10 @@
           </p>
         </div>
         <div class="flex flex-col gap-3">
-          <NuxtLink to="/billing/planes" class="btn-primary px-6 py-3 rounded-xl text-sm font-semibold inline-block min-h-[44px] flex items-center justify-center">
+          <NuxtLink to="/gestion/billing" class="btn-primary px-6 py-3 rounded-xl text-sm font-semibold inline-block min-h-[44px] flex items-center justify-center">
             Intentar de nuevo
           </NuxtLink>
-          <NuxtLink to="/billing" class="text-sm text-text-secondary hover:text-text-primary">
+          <NuxtLink to="/gestion/billing" class="text-sm text-text-secondary hover:text-text-primary">
             Volver a mi suscripción
           </NuxtLink>
         </div>


### PR DESCRIPTION
## Summary

Replaces every dead in-app `NuxtLink` targeting `/billing/planes` or the bare `/billing` path with the canonical `/gestion/billing` billing portal. Fixes the 404 reported in #491 (subscription warning banner CTA → `/billing/planes`).

No new `routeRules` redirects are added — links are corrected at the source per direction in #491.

## Stack

🟢 Nuxt 3 (frontend-only, no backend or DB changes)

## Changes

| File | Change |
|------|--------|
| `components/SubscriptionBanner.vue` | "Renovar plan" CTA → `/gestion/billing` |
| `components/ui/ScanUsageBar.vue` | "Ver plan" CTA → `/gestion/billing` |
| `pages/abastecimiento/compras-directas/crear.vue` | Quota-exceeded modal "Actualizar plan" CTA → `/gestion/billing` |
| `pages/billing/confirmacion.vue` | All four state CTAs (success/pending/failure×2) → `/gestion/billing` |

## What is NOT touched

- `pages/billing/confirmacion.vue` itself remains the Wompi callback URL — only its outbound CTAs change.
- `nuxt.config.ts` `routeRules` are unchanged: the existing `/billing/renovar → /gestion/billing` redirect (from #485) and the `/billing/**` SSR-off rule both stay.

## Testing

- [ ] Trigger `accessStatus.level === 'full_with_warning'` or `'read_only'` → click "Renovar plan" in the top banner → lands on `/gestion/billing`.
- [ ] Trigger AI-scan quota-exceeded modal on compras-directas creation → click "Actualizar plan" → lands on `/gestion/billing`.
- [ ] Click "Ver plan" on the scan-usage bar → lands on `/gestion/billing`.
- [ ] Walk through `/billing/confirmacion?id=<tx>` for active / pending / failed Wompi states — every CTA lands on `/gestion/billing`.
- [ ] `/billing/confirmacion?id=...` itself still verifies the Wompi transaction (not swallowed by any redirect).
- [ ] `grep -rn '/billing/planes' .` returns zero hits in `components/` and `pages/`.

Closes #491