### PR TITLE
feat(storefront): wire accepts_online_orders into catalog + checkout UI

### DIFF
--- a/components/online/CartBottomBar.vue
+++ b/components/online/CartBottomBar.vue
@@ -1,7 +1,7 @@
 <template>
   <Teleport to="body">
     <Transition name="bar-slide">
-      <div v-if="cartStore.itemCount > 0" class="cart-bottom-bar bg-white border-t border-border shadow-2xl">
+      <div v-if="cartStore.itemCount > 0 && acceptsOnlineOrders" class="cart-bottom-bar bg-white border-t border-border shadow-2xl">
         <!-- Inner container — matches layout padding -->
         <div class="px-4 md:px-16 2xl:px-[30rem] py-3">
           <div class="flex items-center justify-between gap-3">
@@ -71,6 +71,12 @@
 
 <script setup lang="ts">
 import { useOnlineCartStore } from '~/stores/online_cart'
+
+withDefaults(defineProps<{
+  acceptsOnlineOrders?: boolean
+}>(), {
+  acceptsOnlineOrders: true,
+})
 
 defineEmits<{
   (e: 'open-cart'): void

--- a/components/online/CartDrawer.vue
+++ b/components/online/CartDrawer.vue
@@ -113,6 +113,7 @@
                 :delivery-fee="deliveryFee"
                 :minimum-order="minimumOrder"
                 :restaurant-open="props.restaurantOpen"
+                :accepts-online-orders="props.acceptsOnlineOrders"
                 @checkout="handleCheckout"
               />
             </div>
@@ -163,6 +164,7 @@ import CartSummary from './CartSummary.vue'
 const props = defineProps<{
   modelValue: boolean
   restaurantOpen?: boolean
+  acceptsOnlineOrders?: boolean
 }>()
 
 const emit = defineEmits<{

--- a/components/online/CartSummary.vue
+++ b/components/online/CartSummary.vue
@@ -43,8 +43,16 @@
       <small class="font-semibold mt-0.5">Faltan {{ formatPrice(minimumOrder - subtotal) }}</small>
     </div>
 
+    <!-- Online orders disabled notice — takes priority over closed notice -->
+    <div v-if="showCheckoutButton && !acceptsOnlineOrders" class="flex items-center gap-2 p-3 mb-2 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-sm">
+      <svg class="w-4 h-4 flex-shrink-0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2Z" />
+      </svg>
+      Este restaurante no recibe pedidos en línea actualmente
+    </div>
+
     <!-- Restaurant closed notice -->
-    <div v-if="showCheckoutButton && !restaurantOpen" class="flex items-center gap-2 p-3 mb-2 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-sm">
+    <div v-else-if="showCheckoutButton && !restaurantOpen" class="flex items-center gap-2 p-3 mb-2 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-sm">
       <svg class="w-4 h-4 flex-shrink-0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
       </svg>
@@ -62,7 +70,8 @@
       :disabled="isCheckoutDisabled"
       @click="$emit('checkout')"
     >
-      <span v-if="!restaurantOpen">Restaurante cerrado</span>
+      <span v-if="!acceptsOnlineOrders">Pedidos en línea no disponibles</span>
+      <span v-else-if="!restaurantOpen">Restaurante cerrado</span>
       <span v-else-if="minimumOrder > subtotal">Pedido mínimo no alcanzado</span>
       <span v-else>Continuar a Checkout</span>
     </button>
@@ -82,6 +91,7 @@ const props = withDefaults(
     minimumOrder?: number
     showCheckoutButton?: boolean
     restaurantOpen?: boolean
+    acceptsOnlineOrders?: boolean
   }>(),
   {
     orderType: 'delivery',
@@ -90,6 +100,7 @@ const props = withDefaults(
     minimumOrder: 0,
     showCheckoutButton: true,
     restaurantOpen: true,
+    acceptsOnlineOrders: true,
   }
 )
 
@@ -102,6 +113,7 @@ const total = computed(() => {
 })
 
 const isCheckoutDisabled = computed(() => {
+  if (!props.acceptsOnlineOrders) return true
   if (!props.restaurantOpen) return true
   return props.minimumOrder > 0 && props.subtotal < props.minimumOrder
 })

--- a/components/public/PublicMenu.vue
+++ b/components/public/PublicMenu.vue
@@ -29,8 +29,16 @@
       </div>
     </div>
 
-    <!-- Closed Banner -->
-    <div v-if="!restaurantOpen" class="max-w-7xl mx-auto px-4 pt-6">
+    <!-- Online ordering disabled banner — takes priority over closed banner -->
+    <div v-if="!acceptsOnlineOrders" class="max-w-7xl mx-auto px-4 pt-6">
+      <div class="flex items-center gap-3 px-4 py-3 rounded-xl bg-destructive/10 border border-destructive/20 text-destructive text-sm font-medium">
+        <span>📋</span>
+        <span>Este restaurante no recibe pedidos en línea actualmente. Puedes ver el menú o contactar al restaurante.</span>
+      </div>
+    </div>
+
+    <!-- Closed Banner — only shown when accepting orders but currently closed -->
+    <div v-else-if="!restaurantOpen" class="max-w-7xl mx-auto px-4 pt-6">
       <div class="flex items-center gap-3 px-4 py-3 rounded-xl bg-destructive/10 border border-destructive/20 text-destructive text-sm font-medium">
         <span>🔒</span>
         <span>El restaurante está cerrado temporalmente. Puedes explorar el menú pero no se pueden realizar pedidos.</span>
@@ -50,7 +58,7 @@
             v-for="product in category.products"
             :key="product.id"
             :product="product"
-            :restaurant-closed="!restaurantOpen"
+            :restaurant-closed="!ordersAvailable"
             @click="handleProductClick"
           />
         </div>
@@ -88,12 +96,20 @@ const props = defineProps({
   restaurantOpen: {
     type: Boolean,
     default: true
+  },
+  acceptsOnlineOrders: {
+    type: Boolean,
+    default: true
   }
 })
 
 const emit = defineEmits(['product-click'])
 
 const selectedCategory = ref('all')
+
+// Combined gate: orders are available only when restaurant is open AND accepts online orders.
+// Used to disable add-to-cart buttons in product cards.
+const ordersAvailable = computed(() => props.restaurantOpen && props.acceptsOnlineOrders)
 
 // All categories including "Todos"
 const allCategories = computed(() => {

--- a/pages/[tenant]/index.vue
+++ b/pages/[tenant]/index.vue
@@ -223,6 +223,10 @@ const handleOpenProductFromCart = (product: { id: string; name: string; price: n
 // Handle checkout - refresh profile + menu, purge unavailable items, block if closed or cart empty
 const handleCheckout = async () => {
   await Promise.all([refetchProfile(), refetchMenu()])
+  if (!(restaurant.value?.accepts_online_orders ?? false)) {
+    toast.error('Este restaurante no recibe pedidos en línea actualmente.')
+    return
+  }
   if (!(restaurant.value?.is_currently_open ?? true)) return
 
   // Purge items that are no longer available online (same logic as handleCartOpen)
@@ -328,17 +332,22 @@ const cancelSwitch = () => {
           :products="products"
           :is-loading="menuStatus === 'pending'"
           :restaurant-open="restaurant.is_currently_open ?? true"
+          :accepts-online-orders="restaurant.accepts_online_orders ?? false"
           @product-click="handleProductClick"
         />
       </div>
 
       <!-- Cart Bottom Bar -->
-      <CartBottomBar @open-cart="handleCartOpen" />
+      <CartBottomBar
+        :accepts-online-orders="restaurant.accepts_online_orders ?? false"
+        @open-cart="handleCartOpen"
+      />
 
       <!-- Cart Drawer -->
       <CartDrawer
         v-model="isCartOpen"
         :restaurant-open="restaurant.is_currently_open ?? true"
+        :accepts-online-orders="restaurant.accepts_online_orders ?? false"
         @checkout="handleCheckout"
         @open-product="handleOpenProductFromCart"
       />


### PR DESCRIPTION
Closes #496

## Summary

Mirror the backend gate landing in [api-warolabs#168](https://github.com/uno0uno/api-warolabs/pull/168) at the storefront UI layer. When the dueña flips "Pedidos en línea" off in `/negocio`, customers now see a clear browse-only state instead of hitting a 403 at checkout.

## Stack

🟢 Nuxt 3 + 🎨 UX

## Changes

- **`pages/[tenant]/index.vue`** — pass `accepts-online-orders` prop to `PublicMenu`, `CartBottomBar`, `CartDrawer`. `handleCheckout` short-circuits with a toast when off.
- **`components/public/PublicMenu.vue`** — new prop, computed `ordersAvailable = restaurantOpen && acceptsOnlineOrders`. New banner with explicit copy ("Este restaurante no recibe pedidos en línea actualmente. Puedes ver el menú o contactar al restaurante.") that takes priority over the existing closed banner. `PublicProductCard` reuses its existing `restaurantClosed` prop, now bound to `!ordersAvailable`.
- **`components/online/CartBottomBar.vue`** — new prop, hide bar entirely when `!acceptsOnlineOrders`.
- **`components/online/CartDrawer.vue`** — new prop, forwarded to `CartSummary`.
- **`components/online/CartSummary.vue`** — new prop, new "not accepting" notice (priority over "closed"), checkout button disabled with appropriate label ("Pedidos en línea no disponibles").

## UX decisions

- **Banner stacking avoided**: when both `!acceptsOnlineOrders` AND `!restaurantOpen`, only the not-accepting banner shows. Same priority applied to the in-cart notice and the checkout button label.
- **Hide vs disable for `CartBottomBar`**: chose hide entirely. Aligns with browse-only intent — items can persist in the cart store but the bar doesn't tease an unreachable checkout.
- **Catalog stays browseable**: customers can still see the menu and prices. Only the ordering actions are gated.
- **Defense-in-depth**: backend rejects with 403 if the frontend is bypassed. Frontend short-circuit + backend guard.

## Testing

### Manual smoke
- [ ] Tenant with `accepts_online_orders=true`: cart UI visible, `+` buttons work, checkout works (no regression).
- [ ] Tenant with `accepts_online_orders=false`: banner shown, `+` buttons disabled, `CartBottomBar` hidden, `CartDrawer` checkout button disabled with "Pedidos en línea no disponibles" label.
- [ ] Compose: tenant `accepts_online_orders=false` AND `is_manually_open=false` → only the not-accepting banner is visible.
- [ ] Flip toggle in `/negocio` from true → false, reload storefront → state changes correctly.

### Static
- [ ] Lint clean.
- [ ] Build clean.

## Companion PR (deploy first)

Backend gate: https://github.com/uno0uno/api-warolabs/pull/168

Suggested deploy order: backend first (frontend without the gate still works — backend will return 403 + Spanish error which the existing toast handler shows), then frontend.

## Out of scope

- POS delivery toggle visibility (#497) — will read the same `accepts_online_orders` field once shipped.
- Admin UI for the toggle — already exists at `/negocio`.