### PR TITLE
feat(pos-checkout): delivery toggle with customer + address selection

### DIFF
--- a/components/pos/checkout/DeliveryAddressForm.vue
+++ b/components/pos/checkout/DeliveryAddressForm.vue
@@ -1,0 +1,185 @@
+<script setup lang="ts">
+import { reactive, computed } from 'vue'
+import type { AddressCreate } from '~/stores/address'
+
+const props = defineProps<{
+  customerId: string
+  loading?: boolean
+  error?: string | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'submit', payload: AddressCreate): void
+  (e: 'cancel'): void
+}>()
+
+const form = reactive<AddressCreate>({
+  address_line1: '',
+  address_line2: '',
+  city: 'Bogotá',
+  state: 'Cundinamarca',
+  postal_code: '',
+  country: 'Colombia',
+  address_type: 'home',
+  delivery_notes: '',
+  is_default: false,
+})
+
+const isValid = computed(
+  () => form.address_line1.trim().length > 0 && form.city.trim().length > 0
+)
+
+const submit = () => {
+  if (!isValid.value || props.loading) return
+  const payload: AddressCreate = {
+    address_line1: form.address_line1.trim(),
+    city: form.city.trim(),
+    state: (form.state ?? '').trim(),
+    postal_code: (form.postal_code ?? '').trim(),
+    country: form.country,
+    address_type: form.address_type,
+    is_default: form.is_default,
+  }
+  const addr2 = form.address_line2?.trim()
+  if (addr2) payload.address_line2 = addr2
+  const notes = form.delivery_notes?.trim()
+  if (notes) payload.delivery_notes = notes
+  emit('submit', payload)
+}
+</script>
+
+<template>
+  <form class="flex flex-col gap-4 p-4 border-2 border-border rounded-xl bg-surface-secondary/30" @submit.prevent="submit">
+    <h4 class="text-sm font-semibold text-text-primary">Nueva dirección</h4>
+
+    <!-- Required: line 1 -->
+    <div class="flex flex-col gap-1">
+      <label for="addr-line1" class="text-sm font-medium text-text-primary">
+        Dirección <span class="text-destructive">*</span>
+      </label>
+      <input
+        id="addr-line1"
+        v-model="form.address_line1"
+        type="text"
+        autocomplete="address-line1"
+        placeholder="Ej: Cra 50 #10-20"
+        class="input-base w-full px-3 py-2 text-sm"
+        :disabled="loading"
+        required
+      />
+    </div>
+
+    <!-- Optional: line 2 -->
+    <div class="flex flex-col gap-1">
+      <label for="addr-line2" class="text-sm font-medium text-text-primary">
+        Apto/Casa (opcional)
+      </label>
+      <input
+        id="addr-line2"
+        v-model="form.address_line2"
+        type="text"
+        autocomplete="address-line2"
+        placeholder="Ej: Apto 305, Torre B"
+        class="input-base w-full px-3 py-2 text-sm"
+        :disabled="loading"
+      />
+    </div>
+
+    <!-- City + state -->
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <div class="flex flex-col gap-1">
+        <label for="addr-city" class="text-sm font-medium text-text-primary">
+          Ciudad <span class="text-destructive">*</span>
+        </label>
+        <input
+          id="addr-city"
+          v-model="form.city"
+          type="text"
+          class="input-base w-full px-3 py-2 text-sm"
+          :disabled="loading"
+          required
+        />
+      </div>
+      <div class="flex flex-col gap-1">
+        <label for="addr-state" class="text-sm font-medium text-text-primary">
+          Departamento (opcional)
+        </label>
+        <input
+          id="addr-state"
+          v-model="form.state"
+          type="text"
+          class="input-base w-full px-3 py-2 text-sm"
+          :disabled="loading"
+        />
+      </div>
+    </div>
+
+    <!-- Type + postal -->
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <div class="flex flex-col gap-1">
+        <label for="addr-type" class="text-sm font-medium text-text-primary">Tipo</label>
+        <select
+          id="addr-type"
+          v-model="form.address_type"
+          class="input-base w-full px-3 py-2 text-sm"
+          :disabled="loading"
+        >
+          <option value="home">Hogar</option>
+          <option value="work">Trabajo</option>
+          <option value="other">Otro</option>
+        </select>
+      </div>
+      <div class="flex flex-col gap-1">
+        <label for="addr-postal" class="text-sm font-medium text-text-primary">
+          Código postal (opcional)
+        </label>
+        <input
+          id="addr-postal"
+          v-model="form.postal_code"
+          type="text"
+          autocomplete="postal-code"
+          class="input-base w-full px-3 py-2 text-sm"
+          :disabled="loading"
+        />
+      </div>
+    </div>
+
+    <!-- Address-level notes -->
+    <div class="flex flex-col gap-1">
+      <label for="addr-notes" class="text-sm font-medium text-text-primary">
+        Notas de la dirección (opcional)
+      </label>
+      <textarea
+        id="addr-notes"
+        v-model="form.delivery_notes"
+        rows="2"
+        maxlength="200"
+        placeholder="Ej: portería en la calle 51, edificio amarillo"
+        class="input-base w-full px-3 py-2 text-sm resize-none"
+        :disabled="loading"
+      />
+    </div>
+
+    <!-- Error -->
+    <p v-if="error" class="text-sm text-destructive">{{ error }}</p>
+
+    <!-- Actions -->
+    <div class="flex items-center gap-2 justify-end">
+      <button
+        type="button"
+        class="min-h-[44px] px-4 py-2 text-sm font-semibold text-text-secondary hover:bg-surface-secondary rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        :disabled="loading"
+        @click="$emit('cancel')"
+      >
+        Cancelar
+      </button>
+      <button
+        type="submit"
+        class="min-h-[44px] px-4 py-2 text-sm font-semibold bg-primary text-primary-foreground rounded-lg disabled:opacity-50 disabled:cursor-not-allowed hover:opacity-90 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+        :disabled="!isValid || loading"
+      >
+        {{ loading ? 'Guardando...' : 'Guardar dirección' }}
+      </button>
+    </div>
+  </form>
+</template>

--- a/components/pos/checkout/DeliveryAddressPicker.vue
+++ b/components/pos/checkout/DeliveryAddressPicker.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import type { Address } from '~/stores/address'
+
+defineProps<{
+  addresses: Address[]
+  selectedId: string | null
+  loading?: boolean
+}>()
+
+defineEmits<{
+  (e: 'update:selectedId', id: string): void
+  (e: 'add-new'): void
+}>()
+
+const ADDRESS_TYPE_LABELS: Record<string, string> = {
+  home: 'Hogar',
+  work: 'Trabajo',
+  other: 'Otro',
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-3">
+    <!-- Loading -->
+    <div v-if="loading && !addresses.length" class="flex items-center justify-center py-4">
+      <CommonsTheCustomLoader size="small" />
+    </div>
+
+    <!-- Empty state -->
+    <p v-else-if="!addresses.length" class="text-sm text-text-secondary py-2">
+      Este cliente no tiene direcciones guardadas. Agrega una nueva para continuar.
+    </p>
+
+    <!-- Address list -->
+    <label
+      v-for="address in addresses"
+      :key="address.id"
+      class="flex items-start gap-3 p-3 rounded-xl border-2 cursor-pointer transition-colors min-h-[60px]"
+      :class="address.id === selectedId
+        ? 'border-primary bg-primary/5'
+        : 'border-border hover:bg-surface-secondary'"
+    >
+      <input
+        type="radio"
+        name="pos-delivery-address"
+        :value="address.id"
+        :checked="address.id === selectedId"
+        class="mt-1 w-5 h-5 accent-primary cursor-pointer"
+        @change="$emit('update:selectedId', address.id)"
+      />
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2 flex-wrap">
+          <span class="text-sm font-semibold text-text-primary">{{ address.address_line1 }}</span>
+          <span class="text-xs px-2 py-0.5 bg-surface-secondary rounded-full text-text-secondary">
+            {{ ADDRESS_TYPE_LABELS[address.address_type] ?? 'Otro' }}
+          </span>
+          <span
+            v-if="address.is_default"
+            class="text-xs px-2 py-0.5 bg-primary/10 text-primary rounded-full font-medium"
+          >
+            Predeterminada
+          </span>
+        </div>
+        <p v-if="address.address_line2" class="text-xs text-text-secondary mt-0.5">
+          {{ address.address_line2 }}
+        </p>
+        <p class="text-xs text-text-secondary mt-0.5">
+          {{ address.city }}{{ address.state ? ', ' + address.state : '' }}
+        </p>
+        <p v-if="address.delivery_notes" class="text-xs text-text-secondary mt-1 italic">
+          "{{ address.delivery_notes }}"
+        </p>
+      </div>
+    </label>
+
+    <!-- Add new button -->
+    <button
+      type="button"
+      class="w-full min-h-[44px] py-2.5 px-4 border-2 border-dashed border-border rounded-xl text-sm font-semibold text-primary hover:bg-primary/5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+      @click="$emit('add-new')"
+    >
+      + Agregar nueva dirección
+    </button>
+  </div>
+</template>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -5,8 +5,11 @@ import { $fetch } from 'ofetch'
 import { useQuery } from '@pinia/colada'
 import QRCode from 'qrcode'
 import { usePOSStore } from '~/stores/usePOSStore'
+import { useAddressStore, type AddressCreate } from '~/stores/address'
 import { useInvoicingReadiness } from '~/composables/useInvoicingReadiness'
 import { PAYMENT_DEFAULTS, type PosPaymentGroup, type PosPaymentMethod } from '~/utils/paymentDefaults'
+import DeliveryAddressPicker from '~/components/pos/checkout/DeliveryAddressPicker.vue'
+import DeliveryAddressForm from '~/components/pos/checkout/DeliveryAddressForm.vue'
 
 interface TopProduct {
   name: string
@@ -156,9 +159,18 @@ const { data: settingsData } = useQuery({
   staleTime: 30_000,
 })
 const comandasEnabled = computed(() => settingsData.value?.data?.comandas_enabled === true)
+const acceptsOnlineOrders = computed(() => settingsData.value?.data?.accepts_online_orders === true)
 
 // Counter mode: not a real table session (no mesa, no bar)
 const isCounterMode = computed(() => !isMesaMode.value && !posStore.activeTableSession?.isBar)
+
+// ── Delivery state ──────────────────────────────────────────────────────────
+const addressStore = useAddressStore()
+const deliveryEnabled = ref(false)
+const deliveryInstructions = ref('')
+const showAddressForm = ref(false)
+const addressFormError = ref<string | null>(null)
+const addressFormLoading = ref(false)
 
 // Computed (must be before any watchers that reference cartTotal)
 const cartItems = computed(() => {
@@ -367,6 +379,53 @@ const showWarosModal = ref(false)
 const warosBalance = computed(() => warosSummary.value?.current_balance ?? 0)
 const isAnonymousCustomer = computed(() => selectedCustomer.value?.phone_number === '0000000000')
 
+// Delivery eligibility — depends on customer + tenant + mode
+const isDeliveryEligible = computed(() =>
+  isCounterMode.value &&
+  acceptsOnlineOrders.value &&
+  !!selectedCustomer.value &&
+  !isAnonymousCustomer.value
+)
+
+// Sync address store with selected customer; reset delivery state when customer cleared
+watch(() => selectedCustomer.value?.id, (customerId, prevId) => {
+  if (customerId && customerId !== prevId) {
+    addressStore.fetchAddresses(customerId)
+  } else if (!customerId) {
+    addressStore.reset()
+    deliveryEnabled.value = false
+    deliveryInstructions.value = ''
+    showAddressForm.value = false
+    addressFormError.value = null
+  }
+}, { immediate: true })
+
+// Auto-disable delivery toggle when eligibility is lost (mesa mode, anon customer, gate flipped off)
+watch(isDeliveryEligible, (eligible) => {
+  if (!eligible) {
+    deliveryEnabled.value = false
+    showAddressForm.value = false
+  }
+})
+
+const handleSaveAddress = async (payload: AddressCreate) => {
+  if (!selectedCustomer.value?.id) return
+  addressFormLoading.value = true
+  addressFormError.value = null
+  try {
+    const created = await addressStore.createAddress(selectedCustomer.value.id, payload)
+    if (created?.id) {
+      addressStore.selectAddress(String(created.id))
+    }
+    showAddressForm.value = false
+  } catch (err: any) {
+    addressFormError.value =
+      err?.data?.detail || err?.data?.message || err?.message || 'No se pudo guardar la dirección'
+  } finally {
+    addressFormLoading.value = false
+  }
+}
+
 let estimateTimer: ReturnType<typeof setTimeout> | null = null
 
 watch(discountedTotal, (total) => {
@@ -512,6 +571,11 @@ const processOrder = async () => {
     return
   }
 
+  if (deliveryEnabled.value && !addressStore.selectedAddressId) {
+    processingError.value = 'Selecciona o crea una dirección de entrega'
+    return
+  }
+
   try {
     isProcessing.value = true
     processingError.value = ''
@@ -535,6 +599,14 @@ const processOrder = async () => {
           : {}),
         ...(posStore.activeTableSession?.isBar
           ? { table_session_id: posStore.activeTableSession.sessionId }
+          : {}),
+        ...(deliveryEnabled.value && addressStore.selectedAddressId
+          ? {
+              delivery_address_id: addressStore.selectedAddressId,
+              ...(deliveryInstructions.value.trim()
+                ? { delivery_instructions: deliveryInstructions.value.trim() }
+                : {}),
+            }
           : {}),
       }
     }) as {
@@ -660,6 +732,12 @@ const closeSuccessModal = () => {
   invoiceProgress.value = ''
   fiscalWizardOpen.value = false
   fiscalWizardError.value = ''
+  // Reset delivery state after successful order
+  deliveryEnabled.value = false
+  deliveryInstructions.value = ''
+  showAddressForm.value = false
+  addressFormError.value = null
+  addressStore.reset()
   if (wasMesaMode.value) {
     cache.invalidateQueries({ key: ['tables', currentTenant.value?.id ?? null] })
     router.push('/pos')
@@ -1075,6 +1153,80 @@ onUnmounted(() => {
               <span class="text-sm font-bold text-primary">-{{ formatCurrency(discountAmount) }}</span>
             </div>
           </div>
+        </div>
+
+        <!-- Section: Domicilio (counter mode only) -->
+        <div v-if="isCounterMode" class="bg-surface rounded-2xl shadow-sm border border-border p-4 md:p-6">
+          <div class="flex items-center justify-between gap-3">
+            <h2 class="font-bold text-text-primary flex items-center gap-2 text-sm md:text-base">
+              <svg class="h-4 w-4 md:h-5 md:w-5 text-primary" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0H15M5.25 18.75a1.5 1.5 0 0 0-3 0m12-13.5V1.5m0 3.75v3.75m0 0h3.75m-3.75 0H10.5m4.5 0V8.625c0-.621-.504-1.125-1.125-1.125h-3.375a1.125 1.125 0 0 0-1.125 1.125v.375M15 9.75h3.75m-3.75 0v9m0 0h-3.75m3.75 0H21m-9 0h-3.75M9 14.25v4.5" />
+              </svg>
+              Domicilio
+            </h2>
+            <label
+              class="relative inline-flex items-center"
+              :class="isDeliveryEligible ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'"
+            >
+              <input
+                v-model="deliveryEnabled"
+                type="checkbox"
+                class="sr-only peer"
+                :disabled="!isDeliveryEligible"
+                aria-label="Activar domicilio para esta orden"
+              />
+              <div class="w-11 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+            </label>
+          </div>
+
+          <!-- Helper messages — explain why the toggle is disabled -->
+          <p v-if="!acceptsOnlineOrders" class="text-xs text-text-secondary mt-2">
+            Activa "Pedidos en línea" en /negocio para habilitar domicilios.
+          </p>
+          <p v-else-if="!selectedCustomer" class="text-xs text-text-secondary mt-2">
+            Selecciona un cliente para habilitar domicilio.
+          </p>
+          <p v-else-if="isAnonymousCustomer" class="text-xs text-text-secondary mt-2">
+            Identifica al cliente (no anónimo) para habilitar domicilio.
+          </p>
+
+          <!-- Expanded delivery details — only when toggle is on -->
+          <Transition name="fade" mode="out-in">
+            <div v-if="deliveryEnabled && selectedCustomer" class="mt-4 space-y-4">
+              <!-- Address picker / form switch -->
+              <DeliveryAddressForm
+                v-if="showAddressForm"
+                :customer-id="selectedCustomer.id"
+                :loading="addressFormLoading"
+                :error="addressFormError"
+                @submit="handleSaveAddress"
+                @cancel="showAddressForm = false"
+              />
+              <DeliveryAddressPicker
+                v-else
+                :addresses="addressStore.addresses"
+                :selected-id="addressStore.selectedAddressId"
+                :loading="addressStore.isLoading"
+                @update:selected-id="addressStore.selectAddress"
+                @add-new="showAddressForm = true"
+              />
+
+              <!-- Delivery instructions (order-level) -->
+              <div class="flex flex-col gap-1">
+                <label for="pos-delivery-instructions" class="text-sm font-medium text-text-primary">
+                  Notas para el repartidor (opcional)
+                </label>
+                <textarea
+                  id="pos-delivery-instructions"
+                  v-model="deliveryInstructions"
+                  rows="3"
+                  maxlength="500"
+                  placeholder="Ej: tocar el timbre, llegar por la entrada lateral…"
+                  class="input-base w-full px-3 py-2 text-sm resize-none"
+                />
+              </div>
+            </div>
+          </Transition>
         </div>
 
         <!-- Section: Payment Method -->


### PR DESCRIPTION
Closes #497

Depends on (must be merged + deployed before this is fully testable end-to-end):
- uno0uno/api-warolabs#167 — backend persistence (delivery_address_id columns + service)
- uno0uno/api-warolabs#168 — accepts_online_orders gate
- #499 — storefront wiring of accepts_online_orders

## Summary

Adds a "Domicilio" section to POS checkout (counter mode only). When the cashier flips the toggle on:
- They pick a saved address (or create one inline) for the selected customer.
- They optionally add notes for the courier.
- The order completes via the same `POST /api/pos/cart/{id}/complete` with three new optional fields.

The order persists with `pos_cart_id IS NOT NULL` (still a POS sale, just with delivery metadata). Comanda fires with `source_type='delivery'` thanks to backend PR #167.

## Stack

🟢 Nuxt 3 + 🎨 UX (frontend-only)

## Changes

- **`pages/pos/checkout.vue`** (+152 lines) — state, eligibility computed, watchers, validation guard, payload extension, new "Domicilio" section template between Discount and Payment Method.
- **`components/pos/checkout/DeliveryAddressPicker.vue`** (new, 85 lines) — radio-style address list with type/default badges and "Agregar nueva" CTA.
- **`components/pos/checkout/DeliveryAddressForm.vue`** (new, 185 lines) — inline form with persistent labels, required markers, inline error placement.

## Visibility & gating

The toggle is rendered only in `isCounterMode` (mesa and bar paths untouched). The input is `disabled` with a contextual helper underneath when:

| Condition | Helper text |
|---|---|
| `accepts_online_orders === false` | "Activa Pedidos en línea en /negocio para habilitar domicilios." |
| no `selectedCustomer` | "Selecciona un cliente para habilitar domicilio." |
| anonymous customer (`phone_number = '0000000000'`) | "Identifica al cliente (no anónimo) para habilitar domicilio." |

Defensive watcher: when `isDeliveryEligible` flips to false (mesa session starts, customer cleared, gate turned off), the toggle auto-resets.

## Submit payload

Only adds the new fields when delivery is on AND an address is selected:

```ts
{
  payment_method, customer_id, payment_method_id,
  ...(creditFields),
  ...(discountFields),
  ...(barSessionField),
  ...(deliveryEnabled && addressStore.selectedAddressId ? {
    delivery_address_id: addressStore.selectedAddressId,
    ...(deliveryInstructions.trim() ? { delivery_instructions } : {}),
  } : {}),
}
```

`scheduled_time` is intentionally NOT sent — v1 is immediate-only.

## v1 scope (locked)

- ✅ Immediate-only (no scheduled time picker)
- ✅ No delivery fee field — cashier adds it manually as a line item
- ✅ No customer notifications from POS
- ✅ Add new address only — no edit/delete from POS (those happen via storefront)

## Testing

### Static
- ✅ `npx vue-tsc --noEmit` — no errors in modified/new files. Pre-existing error in `stores/address.ts:138` is unrelated.
- ✅ AST parse clean.

### Manual smoke (requires #167 + #168 + #499 deployed)
- [ ] Tenant `accepts_online_orders=false` → toggle disabled, helper points to /negocio. Normal POS sale unaffected.
- [ ] Tenant `accepts_online_orders=true`, anonymous customer → toggle disabled, "Identifica al cliente…" helper.
- [ ] Identified customer with NO addresses → empty list shown, "Agregar nueva dirección" CTA visible. Form opens inline. Save persists and selects.
- [ ] Identified customer WITH addresses → list shows with default selected. Switch radio updates selection.
- [ ] Submit delivery → order created with `delivery_address_id`, comanda with `source_type='delivery'`, visible in `/ventas/ordenes`.
- [ ] Submit normal POS (toggle off) → payload unchanged, no regression.
- [ ] Mesa mode → section not rendered.
- [ ] Cancel customer modal mid-flow → toggle auto-resets to off.
- [ ] Switch customer → addresses refetch.
- [ ] After successful order → toggle, instructions, and address store all reset.
- [ ] Mobile + tablet (768x1024) — touch targets ≥44px, form fields don't overflow.

## UX decisions applied

- **Disabled with explanation** (not "mystery disabled") — every blocked state has helper text.
- **Whole row tappable** — radio inside `<label>` so the entire address card responds.
- **Persistent labels** on every input. No placeholder-as-label.
- **Required markers** (`*`) on `address_line1` and `city`; explicit "(opcional)" on the rest.
- **Defensive UX** — watcher auto-reverts toggle when eligibility lost.
- **No state reuse risk** — `addressStore.reset()` only on order success and customer-cleared, not on every modal close.

## Out of scope

- Receipt template changes (delivery info on printed/emailed receipts).
- Status lifecycle UI for POS-originated delivery orders — covered by #498.
- Scheduled delivery (`scheduled_time` UI).
- Driver/courier assignment.