### PR TITLE
fix(pos-checkout): correct address form to match backend constraints

### DIFF
--- a/components/pos/checkout/DeliveryAddressForm.vue
+++ b/components/pos/checkout/DeliveryAddressForm.vue
@@ -13,20 +13,28 @@ const emit = defineEmits<{
   (e: 'cancel'): void
 }>()
 
+// Backend constraints (app/models/address_profile.py):
+// - address_line1: required, min 5 chars
+// - city, state: required, min 2 chars
+// - postal_code: required, min 4 chars
+// - country: max 2 chars (ISO code, e.g. "CO")
 const form = reactive<AddressCreate>({
   address_line1: '',
   address_line2: '',
   city: 'Bogotá',
   state: 'Cundinamarca',
   postal_code: '',
-  country: 'Colombia',
+  country: 'CO',
   address_type: 'home',
   delivery_notes: '',
   is_default: false,
 })
 
 const isValid = computed(
-  () => form.address_line1.trim().length > 0 && form.city.trim().length > 0
+  () => form.address_line1.trim().length >= 5
+    && form.city.trim().length >= 2
+    && form.state.trim().length >= 2
+    && form.postal_code.trim().length >= 4
 )
 
 const submit = () => {
@@ -102,7 +110,7 @@ const submit = () => {
       </div>
       <div class="flex flex-col gap-1">
         <label for="addr-state" class="text-sm font-medium text-text-primary">
-          Departamento (opcional)
+          Departamento <span class="text-destructive">*</span>
         </label>
         <input
           id="addr-state"
@@ -110,6 +118,7 @@ const submit = () => {
           type="text"
           class="input-base w-full px-3 py-2 text-sm"
           :disabled="loading"
+          required
         />
       </div>
     </div>
@@ -131,12 +140,15 @@ const submit = () => {
       </div>
       <div class="flex flex-col gap-1">
         <label for="addr-postal" class="text-sm font-medium text-text-primary">
-          Código postal (opcional)
+          Código postal <span class="text-destructive">*</span>
         </label>
         <input
           id="addr-postal"
           v-model="form.postal_code"
           type="text"
+          minlength="4"
+          required
+          placeholder="Ej: 110221"
           autocomplete="postal-code"
           class="input-base w-full px-3 py-2 text-sm"
           :disabled="loading"


### PR DESCRIPTION
## Bug

When the cashier tried to save a new delivery address from POS checkout, the backend rejected with:

\`\`\`
[
  {\"type\":\"string_too_short\",\"loc\":[\"body\",\"postal_code\"],\"msg\":\"String should have at least 4 characters\"},
  {\"type\":\"string_too_long\",\"loc\":[\"body\",\"country\"],\"msg\":\"String should have at most 2 characters\"}
]
\`\`\`

The form was sending \`country=\"Colombia\"\` (8 chars) when the backend expects ISO code (max 2), and was sending an empty \`postal_code\` while the backend requires min 4 chars.

## Backend constraints (verified in app/models/address_profile.py)

| Field | Rule |
|---|---|
| address_line1 | required, min 5, max 200 |
| city | required, min 2, max 100 |
| state | required, min 2, max 100 |
| **postal_code** | **required, min 4, max 20** |
| **country** | **default \"CO\", max 2 (ISO code)** |

## Fixes

- \`country\` default changed from \`\"Colombia\"\` to \`\"CO\"\`. Field stays hidden — ISO code is fixed and shouldn't be edited from POS.
- \`postal_code\` marked required in UI: \`*\` indicator + \`minlength=\"4\"\` + \`required\` + placeholder \`\"Ej: 110221\"\`.
- \`state\` (Departamento) marked required: \`*\` indicator + \`required\` on the input.
- \`isValid\` computed enforces 5/2/2/4 minimums, keeping the submit button disabled until the form would actually pass backend validation.

Pattern mirrors the storefront's \`components/online/AddressForm.vue\` which was already correct.

## Stack

🟢 Nuxt 3 + 🎨 UX

## Testing

- [ ] Open POS, identify customer, enable Domicilio toggle, click \"Agregar nueva dirección\".
- [ ] Confirm \"Departamento *\" and \"Código postal *\" are now marked required.
- [ ] Submit button disabled until all required fields meet min lengths.
- [ ] Save → no backend rejection. Address appears selected in the picker.
- [ ] Country is sent as \"CO\" (verify in Network tab).

Visual-only on the form's two label/required attribute changes; behavior change on submit guard.