### PR TITLE
feat(addresses): make postal_code optional in POS + storefront forms

### DIFF
--- a/components/online/AddressForm.vue
+++ b/components/online/AddressForm.vue
@@ -92,7 +92,7 @@
     <!-- Postal Code -->
     <div class="mb-5">
       <label for="postal_code" class="block text-sm font-semibold text-foreground mb-2">
-        Código Postal *
+        Código Postal (opcional)
       </label>
       <input
         id="postal_code"
@@ -102,7 +102,6 @@
                placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring
                focus:border-ring transition-all"
         placeholder="110111"
-        required
         maxlength="10"
       />
     </div>
@@ -220,7 +219,7 @@ watch(
       formData.address_line2 = address.address_line2 || ''
       formData.city = address.city
       formData.state = address.state
-      formData.postal_code = address.postal_code
+      formData.postal_code = address.postal_code ?? ''
       formData.country = address.country
       formData.is_default = address.is_default
       formData.address_type = address.address_type
@@ -234,8 +233,7 @@ const isFormValid = computed(() => {
   return (
     formData.address_line1.trim().length >= 5 &&
     formData.city.trim().length >= 2 &&
-    formData.state.trim().length >= 2 &&
-    formData.postal_code.trim().length >= 4
+    formData.state.trim().length >= 2
   )
 })
 
@@ -246,6 +244,13 @@ const handleSubmit = () => {
   }
 
   error.value = null
-  emit('submit', { ...formData })
+  // Omit postal_code when empty so the backend stores NULL instead of "".
+  const payload = { ...formData }
+  if (!payload.postal_code?.trim()) {
+    delete payload.postal_code
+  } else {
+    payload.postal_code = payload.postal_code.trim()
+  }
+  emit('submit', payload)
 }
 </script>

--- a/components/pos/checkout/DeliveryAddressForm.vue
+++ b/components/pos/checkout/DeliveryAddressForm.vue
@@ -16,7 +16,7 @@ const emit = defineEmits<{
 // Backend constraints (app/models/address_profile.py):
 // - address_line1: required, min 5 chars
 // - city, state: required, min 2 chars
-// - postal_code: required, min 4 chars
+// - postal_code: optional (DB column nullable; backend coerces empty → NULL)
 // - country: max 2 chars (ISO code, e.g. "CO")
 const form = reactive<AddressCreate>({
   address_line1: '',
@@ -34,7 +34,6 @@ const isValid = computed(
   () => form.address_line1.trim().length >= 5
     && form.city.trim().length >= 2
     && form.state.trim().length >= 2
-    && form.postal_code.trim().length >= 4
 )
 
 const submit = () => {
@@ -43,7 +42,6 @@ const submit = () => {
     address_line1: form.address_line1.trim(),
     city: form.city.trim(),
     state: (form.state ?? '').trim(),
-    postal_code: (form.postal_code ?? '').trim(),
     country: form.country,
     address_type: form.address_type,
     is_default: form.is_default,
@@ -52,6 +50,8 @@ const submit = () => {
   if (addr2) payload.address_line2 = addr2
   const notes = form.delivery_notes?.trim()
   if (notes) payload.delivery_notes = notes
+  const postal = form.postal_code?.trim()
+  if (postal) payload.postal_code = postal
   emit('submit', payload)
 }
 </script>
@@ -140,14 +140,12 @@ const submit = () => {
       </div>
       <div class="flex flex-col gap-1">
         <label for="addr-postal" class="text-sm font-medium text-text-primary">
-          Código postal <span class="text-destructive">*</span>
+          Código postal (opcional)
         </label>
         <input
           id="addr-postal"
           v-model="form.postal_code"
           type="text"
-          minlength="4"
-          required
           placeholder="Ej: 110221"
           autocomplete="postal-code"
           class="input-base w-full px-3 py-2 text-sm"

--- a/stores/address.ts
+++ b/stores/address.ts
@@ -15,7 +15,7 @@ export interface Address {
   address_line2?: string
   city: string
   state: string
-  postal_code: string
+  postal_code: string | null
   country: string
   latitude?: number
   longitude?: number
@@ -31,7 +31,7 @@ export interface AddressCreate {
   address_line2?: string
   city: string
   state: string
-  postal_code: string
+  postal_code?: string
   country?: string
   latitude?: number
   longitude?: number


### PR DESCRIPTION
Closes #510

Companion to uno0uno/api-warolabs#170 (backend).

## Summary

Drops the required `postal_code` field from both the POS delivery form and the storefront checkout form. Customers in Colombia rarely know their ZIP — forcing the field produced abandoned forms or invented values.

Backend (in #170) accepts NULL/empty and coerces empty strings to NULL.

## Stack

🟢 Nuxt 3 + 🎨 UX

## Changes

| File | Change |
|------|--------|
| `components/pos/checkout/DeliveryAddressForm.vue` | label, input attributes, isValid, submit payload omits empty postal_code |
| `components/online/AddressForm.vue` | same + edit-flow null fallback (`?? ''`) |
| `stores/address.ts` | `Address.postal_code: string \| null`, `AddressCreate.postal_code?: string` |

## Deploy order

Backend (`#170`) FIRST. It becomes more permissive, so the existing frontend (which still sends a value) keeps working. Frontend (`this PR`) AFTER — now omits postal_code when empty.

Zero downtime in either order.

## Testing

- [ ] POS form with empty Código postal → save succeeds.
- [ ] Storefront form same.
- [ ] Edit flow on address with NULL postal_code → no crash.
- [ ] Vue-tsc clean on changed files (pre-existing TS warning in stores/address.ts:138 unrelated).
- [ ] Existing addresses with postal_code populated continue to work bidirectionally.

## UX rationale

Source: NN/g — "Don't require fields users can't reasonably know". https://www.nngroup.com/articles/required-fields/