### PR TITLE
fix(pos-bar): point local session at rotated bar session id

### DIFF
--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -650,11 +650,12 @@ const processOrder = async () => {
       emailSent.value = false
       emailFromProfile.value = !!emailForReceipt
       posStore.clearAll()
-      // Bar session rotated server-side: point local state at the new session
-      // so the next sale opens a clean tab against the right session ID.
-      if (response.data.next_table_session_id && posStore.activeTableSession?.isBar) {
-        posStore.activeTableSession.sessionId = response.data.next_table_session_id
-        posStore.activeTableSession.runningTotal = 0
+      // After a bar POS sale, drop the local session so /pos shows the floor
+      // plan again (clearAll keeps bar sessions alive on purpose; here we
+      // explicitly exit because the backend already rotated to a new session
+      // and the next entry must come through the floor plan).
+      if (posStore.activeTableSession?.isBar) {
+        posStore.exitSession()
       }
       showSuccessModal.value = true
     }

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -623,6 +623,7 @@ const processOrder = async () => {
         standard_tax?: number
         liquor_tax?: number
         standard_tax_label?: string
+        next_table_session_id?: string | null
       }
     }
 
@@ -649,6 +650,12 @@ const processOrder = async () => {
       emailSent.value = false
       emailFromProfile.value = !!emailForReceipt
       posStore.clearAll()
+      // Bar session rotated server-side: point local state at the new session
+      // so the next sale opens a clean tab against the right session ID.
+      if (response.data.next_table_session_id && posStore.activeTableSession?.isBar) {
+        posStore.activeTableSession.sessionId = response.data.next_table_session_id
+        posStore.activeTableSession.runningTotal = 0
+      }
       showSuccessModal.value = true
     }
   } catch (error: any) {


### PR DESCRIPTION
## Summary
- After `complete_pos_order` rotates the bar `table_session` (see
  api-warolabs#171), pick up the new id from `data.next_table_session_id`
  and update `posStore.activeTableSession.sessionId` so the bar tab UI
  attaches the next items to the right session.
- Also reset the local `runningTotal` to 0 so the header shows a clean
  starting state.

## Stack
🟢 Nuxt 3

## Changes
- `pages/pos/checkout.vue`: extend the response type with
  `next_table_session_id` and apply the rotation in the success branch
  of `processOrder`, after `posStore.clearAll()` (which already keeps
  `activeTableSession` alive when `isBar`).

## Depends on
- api-warolabs PR #171 (backend rotation + new response field)

## Testing
- [ ] Complete a sale on a bar table from POS → bar tab is empty
      afterward and continues to accept new items normally.
- [ ] Counter and mesa flows are unchanged.

Closes #512