### PR TITLE
fix(negocio): use public profile slug for the storefront URL

### DIFF
--- a/pages/negocio.vue
+++ b/pages/negocio.vue
@@ -705,7 +705,9 @@ const cancelEdit = () => {
 // ─── Public link (URL + copy + share) ───
 const runtimeConfig = useRuntimeConfig()
 const publicUrl = computed(() => {
-  const slug = currentTenant.value?.slug || businessProfile.value?.slug
+  // Prefer the public profile slug (storefront URL slug, e.g. "sandwichito-monroy"),
+  // not the internal tenant slug (e.g. "warocolombia"). They can differ.
+  const slug = businessProfile.value?.slug || currentTenant.value?.slug
   if (!slug) return ''
   const base = (runtimeConfig.public.siteUrl as string | undefined) || 'https://warocol.com'
   return `${base.replace(/\/$/, '')}/${slug}`


### PR DESCRIPTION
## Summary
The "Tu enlace público" card (added in #514) was rendering `https://warocol.com/<tenant.slug>` (e.g. `warocolombia`), which is the **internal** tenant identifier — not the public storefront slug. Switch the priority so the card uses `businessProfile.slug` (the slug stored on `tenant_public_profiles`), falling back to the tenant slug only when there is no public profile.

## Stack
🟢 Nuxt 3

## Changes
- `pages/negocio.vue`: invert the `publicUrl` slug source order (`businessProfile.value?.slug || currentTenant.value?.slug`).

## Testing
- [ ] `/negocio` for a tenant whose public slug differs from its tenant slug → the card now shows the public-profile URL.
- [ ] Tenants with no public profile yet → still falls back to the tenant slug.

Refs #504