### PR TITLE
fix(negocio): derive public URL from window.location.origin

### DIFF
--- a/pages/negocio.vue
+++ b/pages/negocio.vue
@@ -709,7 +709,12 @@ const publicUrl = computed(() => {
   // not the internal tenant slug (e.g. "warocolombia"). They can differ.
   const slug = businessProfile.value?.slug || currentTenant.value?.slug
   if (!slug) return ''
-  const base = (runtimeConfig.public.siteUrl as string | undefined) || 'https://warocol.com'
+  // Use the live origin so the URL matches the current environment
+  // (localhost in dev, dev.warocol.com on staging, warocol.com in prod).
+  // Fall back to runtime config / the production domain on SSR where window is undefined.
+  const base = (typeof window !== 'undefined' && window.location?.origin)
+    || (runtimeConfig.public.siteUrl as string | undefined)
+    || 'https://warocol.com'
   return `${base.replace(/\/$/, '')}/${slug}`
 })
 


### PR DESCRIPTION
## Summary
The public link card was rendering `https://warocol.com/<slug>` regardless of environment, which is misleading on dev/staging. Switch to `window.location.origin` so the URL reflects the current environment (`localhost:3005` in dev, the dev domain on staging, `warocol.com` in prod). Falls back to `runtimeConfig.public.siteUrl` and finally to the production domain on SSR (where `window` is undefined).

## Stack
🟢 Nuxt 3

## Changes
- `pages/negocio.vue`: `publicUrl` now prefers `window.location.origin`.

## Testing
- [ ] On `localhost:3005` → card shows `http://localhost:3005/<slug>`.
- [ ] On dev domain → card shows the dev URL.
- [ ] On `warocol.com` → card shows `https://warocol.com/<slug>` (unchanged).

Refs #504