### PR TITLE
fix(address-store): make fetchAddresses await the underlying query

### DIFF
--- a/stores/address.ts
+++ b/stores/address.ts
@@ -50,7 +50,7 @@ export const useAddressStore = defineStore('address', () => {
   const _customerId = ref<string | null>(null)
 
   // ── Query — reactive on _customerId ──────────────────────────────────────────
-  const { data: _addressesQueryData, status } = useQuery({
+  const { data: _addressesQueryData, status, refetch: _refetchAddresses } = useQuery({
     key: () => ['addresses', _customerId.value],
     query: () =>
       $fetch<{ addresses: Address[]; total: number; default_address_id: string | null }>(
@@ -145,9 +145,15 @@ export const useAddressStore = defineStore('address', () => {
 
   // ── Public action wrappers (preserve original signatures) ─────────────────────
 
-  /** Fetch addresses for authenticated customer (post-OTP) */
-  const fetchAddresses = (customerId: string) => {
+  /** Fetch addresses for authenticated customer (post-OTP).
+   * Returns a promise that resolves AFTER the underlying Pinia Colada query
+   * has actually loaded — so callers that `await fetchAddresses(...)` can
+   * safely render UI that depends on `addresses` / `hasAddresses` without
+   * showing the empty/new-customer state during the split-second it takes
+   * the request to come back. */
+  const fetchAddresses = async (customerId: string): Promise<void> => {
     _customerId.value = customerId
+    await _refetchAddresses()
   }
 
   const createAddress = (customerId: string, data: AddressCreate) =>


### PR DESCRIPTION
## Summary
Returning customers in the public checkout flow (\`/<slug>/checkout\`) saw their saved addresses flicker as a fresh \"new customer\" address form because \`addressStore.fetchAddresses(customerId)\` only set the Pinia Colada query key without waiting for the response. The wizard advanced to the delivery step before \`addresses\` was populated, so \`hasAddresses\` was false during initial render and the form branch was rendered instead of the selector.

Make \`fetchAddresses\` actually awaitable: pull the \`refetch\` handle from \`useQuery\`, await it inside the wrapper. Callers that already \`await\` the function (\`pages/[tenant]/checkout/index.vue\` lines 99 and 190) now actually wait for the data to arrive before advancing.

## Stack
🟢 Nuxt 3 + Pinia Colada

## Changes
- \`stores/address.ts\`: destructure \`refetch\` from \`useQuery\`; \`fetchAddresses\` is now async and awaits \`_refetchAddresses()\` before resolving.

## Testing
- [ ] Returning customer (cookie session, has saved addresses) opens \`/<slug>/checkout\` → wizard skips to Entrega → AddressSelector renders with saved addresses on first paint, no form flicker.
- [ ] New customer (no saved addresses) → form branch still renders correctly.
- [ ] After OTP verification (\`handleVerified\`) for a returning user without cookie → addresses load before the wizard advances.

Closes the user report from the public checkout: \"guardé una dirección y no me salió de nuevo\".