### PR TITLE
fix(despacho-detail): show refresh in dashboard header (progressive loader)

### DIFF
--- a/pages/despacho/domicilios/[id].vue
+++ b/pages/despacho/domicilios/[id].vue
@@ -77,16 +77,24 @@ watch(order, (newOrder) => {
   }
 }, { immediate: true })
 
+// Header refresh button + progressive loader (parity with /ventas/ordenes)
+const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
+const refreshAll = async () => {
+  await Promise.all([refetchOrder(), refetchHistory()])
+}
 onMounted(() => {
   setShowBackButton?.(true)
   setBackHandler?.(goBack)
+  setRefreshHandler(refreshAll)
 })
+registerProgressiveLoading(isRefreshing)
 
 onUnmounted(() => {
   setPageTitle?.(undefined)
   setPageSubtitle?.(undefined)
   setShowBackButton?.(false)
   setBackHandler?.(undefined)
+  clearRefreshHandler(refreshAll)
 })
 </script>
 
@@ -102,10 +110,6 @@ onUnmounted(() => {
 
     <!-- Main Content -->
     <div v-else-if="order" class="space-y-6">
-      <div v-if="isRefreshing" class="flex justify-end -mb-4">
-        <UiLoadingDots size="10px" class="text-text-secondary" />
-      </div>
-
       <!-- ── Section 1: Info Cards ── -->
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         <!-- Card 1: Cliente -->


### PR DESCRIPTION
## Summary
The order detail page at \`/despacho/domicilios/<id>\` was the only dashboard page rendering its refresh indicator inline (a small dots indicator above the content). Every other page in the dashboard registers refresh state via \`useLayoutActions()\` so the indicator and button live in the page header. This PR brings the detail page to parity with the rest of the dashboard.

## Stack
🟢 Nuxt 3 + 🎨 UX

## Changes
- \`pages/despacho/domicilios/[id].vue\`:
  - Add \`useLayoutActions().setRefreshHandler(refreshAll)\` so the header refresh button refetches both the order and its status history.
  - Add \`registerProgressiveLoading(isRefreshing)\` so the header shows the subtle progressive loader during refresh.
  - Drop the inline \`UiLoadingDots\` block at the top of the content area.
  - \`clearRefreshHandler\` on unmount.

## Testing
- [ ] \`/despacho/domicilios/<id>\` shows the refresh button in the header.
- [ ] Clicking the refresh button refetches order + history.
- [ ] During refetch, header shows the progressive loader (matches \`/ventas/ordenes\` UX).
- [ ] No inline loader-dots block above the cards.