### PR TITLE
feat(pos-checkout): cash tender input + change calculation in UI

### DIFF
--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -729,13 +729,9 @@ const cashIsValid = computed(() =>
 
 // Issue #524 — quick-tap presets. "Sin vuelto" is the friendly equivalent of
 // the industry term "exact tender" — it tells the cashier what happens
-// (no change to give) instead of generic POS jargon.
-//
-// The four "extra-amount" presets are split off from "Sin vuelto" because
-// they semantically mean "customer paid more, give change". Visually treated
-// in a 2x2 grid (see template), with "Siguiente" as a separate full-width
-// action below — the round-up to next thousand is a one-tap shortcut for
-// the most common Colombian cash bills.
+// (no change to give) instead of generic POS jargon. The three +amount
+// shortcuts cover the most common Colombian bill denominations the customer
+// hands over above the total.
 const cashPresetsExtra = computed(() => {
   const a = cashAmountToCharge.value
   return [
@@ -743,10 +739,6 @@ const cashPresetsExtra = computed(() => {
     { label: '+ $10.000', value: a + 10000 },
     { label: '+ $20.000', value: a + 20000 },
   ]
-})
-const cashSiguienteValue = computed(() => {
-  const a = cashAmountToCharge.value
-  return Math.floor(a / 1000) * 1000 + 1000
 })
 
 // Re-prefill the input whenever the cash amount changes (method switch, split
@@ -1862,7 +1854,7 @@ onUnmounted(() => {
                 />
                 <span class="absolute right-4 top-1/2 -translate-y-1/2 text-2xl font-bold text-green-600 pointer-events-none">$</span>
               </div>
-              <!-- 2×2 grid of presets — "Sin vuelto" is gray (different semantic), the +amount ones are green -->
+              <!-- 2×2 grid of presets — uniform neutral treatment -->
               <div class="grid grid-cols-2 gap-3">
                 <button
                   type="button"
@@ -1877,23 +1869,11 @@ onUnmounted(() => {
                   :key="preset.label"
                   type="button"
                   @click="cashReceivedInput = preset.value"
-                  class="min-h-[56px] px-4 py-3 rounded-lg bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400 text-base font-semibold hover:bg-green-100 dark:hover:bg-green-900/40 transition-colors focus:outline-none focus:ring-2 focus:ring-green-500"
+                  class="min-h-[56px] px-4 py-3 rounded-lg bg-surface-secondary dark:bg-surface text-text-primary text-base font-semibold hover:bg-border/50 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
                 >
                   {{ preset.label }}
                 </button>
               </div>
-              <!-- Siguiente $ — solid green primary CTA -->
-              <button
-                type="button"
-                @click="cashReceivedInput = cashSiguienteValue"
-                :aria-label="`Redondear al siguiente mil, ${formatCurrency(cashSiguienteValue)}`"
-                class="min-h-[52px] px-4 py-3 rounded-lg bg-green-600 hover:bg-green-700 text-white text-base font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 flex items-center justify-center gap-2"
-              >
-                <span>Siguiente</span>
-                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
-                </svg>
-              </button>
               <!-- Vuelto card -->
               <div
                 v-if="cashShortfall <= 0.01"
@@ -1975,18 +1955,6 @@ onUnmounted(() => {
               {{ preset.label }}
             </button>
           </div>
-          <!-- Siguiente — solid green CTA -->
-          <button
-            type="button"
-            @click="cashReceivedInput = cashSiguienteValue"
-            :aria-label="`Redondear al siguiente mil, ${formatCurrency(cashSiguienteValue)}`"
-            class="min-h-[52px] px-4 py-3 rounded-lg bg-green-600 hover:bg-green-700 text-white text-base font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 flex items-center justify-center gap-2"
-          >
-            <span>Siguiente</span>
-            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
-            </svg>
-          </button>
           <!-- Vuelto card -->
           <div
             v-if="cashShortfall <= 0.01"

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -735,6 +735,7 @@ const cashIsValid = computed(() =>
 const cashPresetsExtra = computed(() => {
   const a = cashAmountToCharge.value
   return [
+    { label: '+ $1.000',  value: a + 1000 },
     { label: '+ $5.000',  value: a + 5000 },
     { label: '+ $10.000', value: a + 10000 },
     { label: '+ $20.000', value: a + 20000 },
@@ -1854,16 +1855,16 @@ onUnmounted(() => {
                 />
                 <span class="absolute right-4 top-1/2 -translate-y-1/2 text-2xl font-bold text-green-600 pointer-events-none">$</span>
               </div>
-              <!-- 2×2 grid of presets — uniform neutral treatment -->
+              <!-- "Sin vuelto" full-width on top, then 4 amount presets in 2×2 — all neutral gray -->
+              <button
+                type="button"
+                @click="cashReceivedInput = cashAmountToCharge"
+                aria-label="Pagar exacto, sin vuelto"
+                class="w-full min-h-[56px] px-4 py-3 rounded-lg bg-surface-secondary dark:bg-surface text-text-primary text-base font-semibold hover:bg-border/50 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
+              >
+                Sin vuelto
+              </button>
               <div class="grid grid-cols-2 gap-3">
-                <button
-                  type="button"
-                  @click="cashReceivedInput = cashAmountToCharge"
-                  aria-label="Pagar exacto, sin vuelto"
-                  class="min-h-[56px] px-4 py-3 rounded-lg bg-surface-secondary dark:bg-surface text-text-primary text-base font-semibold hover:bg-border/50 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
-                >
-                  Sin vuelto
-                </button>
                 <button
                   v-for="preset in cashPresetsExtra"
                   :key="preset.label"
@@ -1950,7 +1951,7 @@ onUnmounted(() => {
               :key="preset.label"
               type="button"
               @click="cashReceivedInput = preset.value"
-              class="min-h-[56px] px-4 py-3 rounded-lg bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400 text-base font-semibold hover:bg-green-100 dark:hover:bg-green-900/40 transition-colors focus:outline-none focus:ring-2 focus:ring-green-500"
+              class="min-h-[56px] px-4 py-3 rounded-lg bg-surface-secondary dark:bg-surface text-text-primary text-base font-semibold hover:bg-border/50 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
             >
               {{ preset.label }}
             </button>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -278,6 +278,10 @@ const addSplitPayment = async () => {
               : {}),
             split_mode: true,
             split_first_amount: amountToCharge,
+            // Issue #524 — cash tender on the first split when method is cash
+            ...(isCashMethod.value
+              ? { split_first_cash_received: Number(cashReceivedInput.value) }
+              : {}),
           }
         }) as any
         paidTotal = response.data.paid_total ?? amountToCharge
@@ -292,6 +296,9 @@ const addSplitPayment = async () => {
             amount: amountToCharge,
             payment_method: selectedPaymentMethod.value,
             payment_method_id: selectedPaymentMethodId.value ?? null,
+            ...(isCashMethod.value
+              ? { cash_received: Number(cashReceivedInput.value) }
+              : {}),
           }
         }) as any
         paidTotal = response.data.paid_total
@@ -314,6 +321,10 @@ const addSplitPayment = async () => {
               : {}),
             split_mode: true,
             split_first_amount: amountToCharge,
+            // Issue #524 — cash tender on the first split when method is cash
+            ...(isCashMethod.value
+              ? { split_first_cash_received: Number(cashReceivedInput.value) }
+              : {}),
           }
         }) as any
         paidTotal = response.data.paid_total ?? amountToCharge
@@ -328,6 +339,9 @@ const addSplitPayment = async () => {
             amount: amountToCharge,
             payment_method: selectedPaymentMethod.value,
             payment_method_id: selectedPaymentMethodId.value ?? undefined,
+            ...(isCashMethod.value
+              ? { cash_received: Number(cashReceivedInput.value) }
+              : {}),
           }
         }) as any
         paidTotal = response.data.paid_total
@@ -524,6 +538,10 @@ const processOrder = async () => {
           ...(discountEnabled.value && _discountAmt > 0
             ? { discount_type: discountType.value, discount_value: Number(discountInput.value) }
             : {}),
+          // Issue #524 — single-payment cash close: capture cash_received
+          ...(isCashMethod.value
+            ? { cash_received: Number(cashReceivedInput.value) }
+            : {}),
         },
       }) as any
 
@@ -601,6 +619,10 @@ const processOrder = async () => {
           : {}),
         ...(posStore.activeTableSession?.isBar
           ? { table_session_id: posStore.activeTableSession.sessionId }
+          : {}),
+        // Issue #524 — single-payment cash sale: capture cash_received on the order
+        ...(isCashMethod.value
+          ? { cash_received: Number(cashReceivedInput.value) }
           : {}),
         ...(deliveryEnabled.value && addressStore.selectedAddressId
           ? {
@@ -681,6 +703,52 @@ watch(selectedPaymentMethod, () => {
   selectedPaymentMethodId.value = null
   methodSearch.value = ''
 })
+
+// ── Issue #524 — Cash tender + change calculation ────────────────────────────
+// Active only when the selected payment group is "cash". Cashier types how
+// much cash the customer handed over and the system shows the change live.
+// In split mode the input applies to splitAmountToCharge; in single payment
+// it applies to discountedTotal. Backend persists cash_received on
+// order_payments (split lines) or orders (single payment).
+const isCashMethod = computed(() => selectedGroup.value?.slug === 'cash')
+const cashReceivedInput = ref<number>(0)
+
+const cashAmountToCharge = computed(() =>
+  splitMode.value ? splitAmountToCharge.value : discountedTotal.value
+)
+
+const cashChange = computed(() =>
+  Math.max(0, (cashReceivedInput.value || 0) - cashAmountToCharge.value)
+)
+const cashShortfall = computed(() =>
+  Math.max(0, cashAmountToCharge.value - (cashReceivedInput.value || 0))
+)
+const cashIsValid = computed(() =>
+  !isCashMethod.value || (cashReceivedInput.value > 0 && cashShortfall.value <= 0.01)
+)
+
+const cashPresets = computed(() => {
+  const a = cashAmountToCharge.value
+  // Round-up to next thousand (always go up — even on exact thousands)
+  const nextThousand = Math.floor(a / 1000) * 1000 + 1000
+  return [
+    { label: 'Justo',          value: a },
+    { label: '+$5.000',        value: a + 5000 },
+    { label: '+$10.000',       value: a + 10000 },
+    { label: '+$20.000',       value: a + 20000 },
+    { label: 'Siguiente $',    value: nextThousand > a ? nextThousand : a + 1000 },
+  ]
+})
+
+// Re-prefill the input whenever the cash amount changes (method switch, split
+// remainder updates, etc.) so cashier doesn't have to re-type the default.
+watch(
+  [cashAmountToCharge, isCashMethod],
+  ([newAmount, isCash]) => {
+    cashReceivedInput.value = isCash ? Number(newAmount) : 0
+  },
+  { immediate: true }
+)
 
 const filteredMethods = computed(() => {
   const methods = selectedGroup.value?.methods ?? []
@@ -1753,11 +1821,62 @@ onUnmounted(() => {
               </div>
             </div>
 
+            <!-- Issue #524 — Cash tender + change calculation (only when method is cash) -->
+            <div v-if="isCashMethod && !splitIsComplete" class="flex flex-col gap-2 p-3 rounded-xl bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800/40">
+              <label for="cash-received-input" class="text-sm font-medium text-text-primary">
+                Efectivo recibido
+              </label>
+              <div class="relative">
+                <span class="absolute left-3 top-1/2 -translate-y-1/2 text-sm font-semibold text-text-secondary pointer-events-none">$</span>
+                <input
+                  id="cash-received-input"
+                  v-model.number="cashReceivedInput"
+                  type="number"
+                  min="0"
+                  step="any"
+                  inputmode="decimal"
+                  :aria-label="`Efectivo recibido por el cliente, monto a cobrar ${formatCurrency(cashAmountToCharge)}`"
+                  class="w-full min-h-[44px] pl-7 pr-3 py-3 bg-white dark:bg-surface border border-border rounded-xl text-lg font-semibold text-text-primary focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500 tabular-nums"
+                />
+              </div>
+              <!-- Quick-tap presets -->
+              <div class="flex flex-wrap gap-2">
+                <button
+                  v-for="preset in cashPresets"
+                  :key="preset.label"
+                  type="button"
+                  @click="cashReceivedInput = preset.value"
+                  class="min-h-[44px] min-w-[80px] px-3 py-2 rounded-lg border border-border bg-white dark:bg-surface text-sm font-medium text-text-primary hover:bg-green-100 dark:hover:bg-green-900/30 hover:border-green-400 transition-colors focus:outline-none focus:ring-2 focus:ring-green-500"
+                >
+                  {{ preset.label }}
+                </button>
+              </div>
+              <!-- Vuelto display (large green) when received >= amount -->
+              <div
+                v-if="cashShortfall <= 0.01"
+                class="flex items-center justify-between p-3 rounded-lg bg-white dark:bg-surface border-2 border-green-500"
+                role="status"
+                aria-live="polite"
+              >
+                <span class="text-sm font-medium text-green-700 dark:text-green-400">Vuelto</span>
+                <span class="text-2xl font-bold text-green-700 dark:text-green-400 tabular-nums">
+                  {{ formatCurrency(cashChange) }}
+                </span>
+              </div>
+              <!-- Inline shortfall error -->
+              <p v-else class="flex items-center gap-2 text-sm text-destructive">
+                <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+                Falta cobrar {{ formatCurrency(cashShortfall) }}
+              </p>
+            </div>
+
             <!-- Add payment button -->
             <button
               v-if="!splitIsComplete"
               type="button"
-              :disabled="isAddingPayment || !selectedPaymentMethod || requiresMethodSelection || !splitAmountToCharge || splitAmountToCharge <= 0 || !selectedCustomer || (!isMesaMode && !posStore.cartId)"
+              :disabled="isAddingPayment || !selectedPaymentMethod || requiresMethodSelection || !splitAmountToCharge || splitAmountToCharge <= 0 || !selectedCustomer || (!isMesaMode && !posStore.cartId) || !cashIsValid"
               @click="addSplitPayment"
               class="w-full min-h-[44px] px-4 py-3 bg-primary text-primary-foreground text-sm font-semibold rounded-xl transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
             >
@@ -1773,6 +1892,54 @@ onUnmounted(() => {
             <span class="text-xl">⚠️</span>
             <p class="text-sm text-red-800 dark:text-red-200">{{ processingError }}</p>
           </div>
+        </div>
+
+        <!-- Issue #524 — Cash tender + change calculation (single-payment mode) -->
+        <div v-if="!splitMode && isCashMethod && selectedCustomer" class="flex flex-col gap-2 p-4 rounded-xl bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800/40">
+          <label for="cash-received-input-single" class="text-sm font-medium text-text-primary">
+            Efectivo recibido
+          </label>
+          <div class="relative">
+            <span class="absolute left-3 top-1/2 -translate-y-1/2 text-sm font-semibold text-text-secondary pointer-events-none">$</span>
+            <input
+              id="cash-received-input-single"
+              v-model.number="cashReceivedInput"
+              type="number"
+              min="0"
+              step="any"
+              inputmode="decimal"
+              :aria-label="`Efectivo recibido por el cliente, monto a cobrar ${formatCurrency(cashAmountToCharge)}`"
+              class="w-full min-h-[44px] pl-7 pr-3 py-3 bg-white dark:bg-surface border border-border rounded-xl text-lg font-semibold text-text-primary focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500 tabular-nums"
+            />
+          </div>
+          <div class="flex flex-wrap gap-2">
+            <button
+              v-for="preset in cashPresets"
+              :key="preset.label"
+              type="button"
+              @click="cashReceivedInput = preset.value"
+              class="min-h-[44px] min-w-[80px] px-3 py-2 rounded-lg border border-border bg-white dark:bg-surface text-sm font-medium text-text-primary hover:bg-green-100 dark:hover:bg-green-900/30 hover:border-green-400 transition-colors focus:outline-none focus:ring-2 focus:ring-green-500"
+            >
+              {{ preset.label }}
+            </button>
+          </div>
+          <div
+            v-if="cashShortfall <= 0.01"
+            class="flex items-center justify-between p-3 rounded-lg bg-white dark:bg-surface border-2 border-green-500"
+            role="status"
+            aria-live="polite"
+          >
+            <span class="text-sm font-medium text-green-700 dark:text-green-400">Vuelto</span>
+            <span class="text-2xl font-bold text-green-700 dark:text-green-400 tabular-nums">
+              {{ formatCurrency(cashChange) }}
+            </span>
+          </div>
+          <p v-else class="flex items-center gap-2 text-sm text-destructive">
+            <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+            Falta cobrar {{ formatCurrency(cashShortfall) }}
+          </p>
         </div>
 
         <!-- Pre-checkout banner: items will fire to kitchen on checkout (counter mode only) -->
@@ -1795,7 +1962,7 @@ onUnmounted(() => {
           <button
             @click="processOrder"
             v-if="!splitMode"
-            :disabled="isProcessing || !selectedCustomer || isLoadingEstimate || requiresMethodSelection"
+            :disabled="isProcessing || !selectedCustomer || isLoadingEstimate || requiresMethodSelection || !cashIsValid"
             class="w-full bg-primary hover:bg-primary/90 text-primary-foreground font-bold py-4 px-6 rounded-xl shadow-lg transition-all flex items-center justify-center gap-2 active:scale-95 group disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <UiLoadingDots v-if="isProcessing" size="9px" />

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -112,7 +112,9 @@ const fiscalWizardCanSubmit = computed(() => Boolean(
 // Customer insights
 const customerInsights = ref<CustomerInsights | null>(null)
 const insightsLoading = ref(false)
-const activeAccordion = ref<'insights' | 'summary' | 'waros' | null>('summary')
+// Accordions start closed; the user opens them on demand. Previous behavior
+// auto-opened "summary" / "insights" on customer change — too noisy.
+const activeAccordion = ref<'insights' | 'summary' | 'waros' | null>(null)
 
 // Mesa mode detection — bar sessions behave as normal POS (cart-based, not tab-based)
 const isMesaMode = computed(() => !!posStore.activeTableSession && !posStore.activeTableSession?.isBar)
@@ -458,25 +460,22 @@ const onWarosAssigned = async (_payload: { newBalance: number }) => {
 }
 
 watch(selectedCustomer, async (customer) => {
-  // Reset Waros state on customer change
+  // Reset Waros state on customer change. Accordions stay where the user
+  // last left them — never auto-open on customer change.
   resetSummary()
   resetEstimate()
   customerInsights.value = null
   insightsLoading.value = false
-  activeAccordion.value = 'summary'
   if (!customer || customer.phone_number === '0000000000') return
   insightsLoading.value = true
-  activeAccordion.value = 'insights'
 
   // Fetch insights + Waros in parallel so the right column doesn't fill in step by step.
   const insightsPromise = (async () => {
     try {
       const res = await $fetch<{ data: CustomerInsights }>(`/api/customers/${customer.id}/insights`)
       customerInsights.value = res.data
-      if (res.data.orders_count === 0) activeAccordion.value = 'summary'
     } catch {
       customerInsights.value = null
-      activeAccordion.value = 'summary'
     } finally {
       insightsLoading.value = false
     }
@@ -742,14 +741,15 @@ const cashPresetsExtra = computed(() => {
   ]
 })
 
-// Re-prefill the input whenever the cash amount changes (method switch, split
-// remainder updates, etc.) so cashier doesn't have to re-type the default.
+// Issue #524 — input starts at 0 and stays at 0 until the cashier either
+// taps a preset or types. Auto-prefilling with the amount made it look like
+// "Sin vuelto" was already chosen, which was confusing. Reset to 0 only when
+// the method group changes (so switching methods clears the previous tender).
 watch(
-  [cashAmountToCharge, isCashMethod],
-  ([newAmount, isCash]) => {
-    cashReceivedInput.value = isCash ? Number(newAmount) : 0
+  isCashMethod,
+  () => {
+    cashReceivedInput.value = 0
   },
-  { immediate: true }
 )
 
 // Issue #524 — thousand-separator formatting (Colombian style: "145.000").
@@ -1875,9 +1875,9 @@ onUnmounted(() => {
                   {{ preset.label }}
                 </button>
               </div>
-              <!-- Vuelto card -->
+              <!-- Vuelto card — only when the cashier has typed/picked something -->
               <div
-                v-if="cashShortfall <= 0.01"
+                v-if="cashReceivedInput > 0 && cashShortfall <= 0.01"
                 class="flex items-center justify-between p-4 rounded-xl bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800/40"
                 role="status"
                 aria-live="polite"
@@ -1887,8 +1887,8 @@ onUnmounted(() => {
                   {{ formatCurrency(cashChange) }}
                 </span>
               </div>
-              <!-- Inline shortfall error -->
-              <p v-else class="flex items-center gap-2 text-sm text-destructive">
+              <!-- Inline shortfall error — only when the cashier typed an insufficient amount -->
+              <p v-else-if="cashReceivedInput > 0" class="flex items-center gap-2 text-sm text-destructive">
                 <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                 </svg>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -727,17 +727,26 @@ const cashIsValid = computed(() =>
   !isCashMethod.value || (cashReceivedInput.value > 0 && cashShortfall.value <= 0.01)
 )
 
-const cashPresets = computed(() => {
+// Issue #524 — quick-tap presets. "Sin vuelto" is the friendly equivalent of
+// the industry term "exact tender" — it tells the cashier what happens
+// (no change to give) instead of generic POS jargon.
+//
+// The four "extra-amount" presets are split off from "Sin vuelto" because
+// they semantically mean "customer paid more, give change". Visually treated
+// in a 2x2 grid (see template), with "Siguiente" as a separate full-width
+// action below — the round-up to next thousand is a one-tap shortcut for
+// the most common Colombian cash bills.
+const cashPresetsExtra = computed(() => {
   const a = cashAmountToCharge.value
-  // Round-up to next thousand (always go up — even on exact thousands)
-  const nextThousand = Math.floor(a / 1000) * 1000 + 1000
   return [
-    { label: 'Justo',          value: a },
-    { label: '+$5.000',        value: a + 5000 },
-    { label: '+$10.000',       value: a + 10000 },
-    { label: '+$20.000',       value: a + 20000 },
-    { label: 'Siguiente $',    value: nextThousand > a ? nextThousand : a + 1000 },
+    { label: '+ $5.000',  value: a + 5000 },
+    { label: '+ $10.000', value: a + 10000 },
+    { label: '+ $20.000', value: a + 20000 },
   ]
+})
+const cashSiguienteValue = computed(() => {
+  const a = cashAmountToCharge.value
+  return Math.floor(a / 1000) * 1000 + 1000
 })
 
 // Re-prefill the input whenever the cash amount changes (method switch, split
@@ -749,6 +758,19 @@ watch(
   },
   { immediate: true }
 )
+
+// Issue #524 — thousand-separator formatting (Colombian style: "145.000").
+// Cajero ve el valor con puntos pero la lógica trabaja con un número limpio.
+const cashReceivedDisplay = computed(() =>
+  cashReceivedInput.value > 0 ? cashReceivedInput.value.toLocaleString('es-CO') : ''
+)
+const onCashReceivedInput = (e: Event) => {
+  const input = e.target as HTMLInputElement
+  const raw = Number(input.value.replace(/\./g, '').replace(/\D/g, ''))
+  cashReceivedInput.value = Number.isFinite(raw) ? raw : 0
+  // Reflect the formatted value back into the field so the user sees dots.
+  input.value = raw ? raw.toLocaleString('es-CO') : ''
+}
 
 const filteredMethods = computed(() => {
   const methods = selectedGroup.value?.methods ?? []
@@ -1821,45 +1843,66 @@ onUnmounted(() => {
               </div>
             </div>
 
-            <!-- Issue #524 — Cash tender + change calculation (only when method is cash) -->
-            <div v-if="isCashMethod && !splitIsComplete" class="flex flex-col gap-2 p-3 rounded-xl bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800/40">
+            <!-- Issue #524 — Cash tender + change calculation (split mode) -->
+            <div v-if="isCashMethod && !splitIsComplete" class="flex flex-col gap-3 p-4 rounded-xl bg-surface border border-border">
               <label for="cash-received-input" class="text-sm font-medium text-text-primary">
                 Efectivo recibido
               </label>
+              <!-- Big input with $ on the right (matches mockup) -->
               <div class="relative">
-                <span class="absolute left-3 top-1/2 -translate-y-1/2 text-sm font-semibold text-text-secondary pointer-events-none">$</span>
                 <input
                   id="cash-received-input"
-                  v-model.number="cashReceivedInput"
-                  type="number"
-                  min="0"
-                  step="any"
-                  inputmode="decimal"
+                  type="text"
+                  inputmode="numeric"
+                  :value="cashReceivedDisplay"
+                  @input="onCashReceivedInput"
                   :aria-label="`Efectivo recibido por el cliente, monto a cobrar ${formatCurrency(cashAmountToCharge)}`"
-                  class="w-full min-h-[44px] pl-7 pr-3 py-3 bg-white dark:bg-surface border border-border rounded-xl text-lg font-semibold text-text-primary focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500 tabular-nums"
+                  placeholder="0"
+                  class="w-full min-h-[60px] pl-4 pr-10 py-3 bg-white dark:bg-surface border-2 border-green-500 rounded-xl text-3xl font-bold text-text-primary focus:outline-none focus:ring-2 focus:ring-green-500 tabular-nums placeholder:text-text-tertiary placeholder:font-normal"
                 />
+                <span class="absolute right-4 top-1/2 -translate-y-1/2 text-2xl font-bold text-green-600 pointer-events-none">$</span>
               </div>
-              <!-- Quick-tap presets -->
-              <div class="flex flex-wrap gap-2">
+              <!-- 2×2 grid of presets — "Sin vuelto" is gray (different semantic), the +amount ones are green -->
+              <div class="grid grid-cols-2 gap-3">
                 <button
-                  v-for="preset in cashPresets"
+                  type="button"
+                  @click="cashReceivedInput = cashAmountToCharge"
+                  aria-label="Pagar exacto, sin vuelto"
+                  class="min-h-[56px] px-4 py-3 rounded-lg bg-surface-secondary dark:bg-surface text-text-primary text-base font-semibold hover:bg-border/50 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
+                >
+                  Sin vuelto
+                </button>
+                <button
+                  v-for="preset in cashPresetsExtra"
                   :key="preset.label"
                   type="button"
                   @click="cashReceivedInput = preset.value"
-                  class="min-h-[44px] min-w-[80px] px-3 py-2 rounded-lg border border-border bg-white dark:bg-surface text-sm font-medium text-text-primary hover:bg-green-100 dark:hover:bg-green-900/30 hover:border-green-400 transition-colors focus:outline-none focus:ring-2 focus:ring-green-500"
+                  class="min-h-[56px] px-4 py-3 rounded-lg bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400 text-base font-semibold hover:bg-green-100 dark:hover:bg-green-900/40 transition-colors focus:outline-none focus:ring-2 focus:ring-green-500"
                 >
                   {{ preset.label }}
                 </button>
               </div>
-              <!-- Vuelto display (large green) when received >= amount -->
+              <!-- Siguiente $ — solid green primary CTA -->
+              <button
+                type="button"
+                @click="cashReceivedInput = cashSiguienteValue"
+                :aria-label="`Redondear al siguiente mil, ${formatCurrency(cashSiguienteValue)}`"
+                class="min-h-[52px] px-4 py-3 rounded-lg bg-green-600 hover:bg-green-700 text-white text-base font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 flex items-center justify-center gap-2"
+              >
+                <span>Siguiente</span>
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
+                </svg>
+              </button>
+              <!-- Vuelto card -->
               <div
                 v-if="cashShortfall <= 0.01"
-                class="flex items-center justify-between p-3 rounded-lg bg-white dark:bg-surface border-2 border-green-500"
+                class="flex items-center justify-between p-4 rounded-xl bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800/40"
                 role="status"
                 aria-live="polite"
               >
-                <span class="text-sm font-medium text-green-700 dark:text-green-400">Vuelto</span>
-                <span class="text-2xl font-bold text-green-700 dark:text-green-400 tabular-nums">
+                <span class="text-base font-medium text-green-700 dark:text-green-400">Vuelto</span>
+                <span class="text-3xl font-bold text-green-700 dark:text-green-400 tabular-nums">
                   {{ formatCurrency(cashChange) }}
                 </span>
               </div>
@@ -1895,42 +1938,64 @@ onUnmounted(() => {
         </div>
 
         <!-- Issue #524 — Cash tender + change calculation (single-payment mode) -->
-        <div v-if="!splitMode && isCashMethod && selectedCustomer" class="flex flex-col gap-2 p-4 rounded-xl bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800/40">
+        <div v-if="!splitMode && isCashMethod && selectedCustomer" class="flex flex-col gap-3 p-4 rounded-xl bg-surface border border-border">
           <label for="cash-received-input-single" class="text-sm font-medium text-text-primary">
             Efectivo recibido
           </label>
           <div class="relative">
-            <span class="absolute left-3 top-1/2 -translate-y-1/2 text-sm font-semibold text-text-secondary pointer-events-none">$</span>
             <input
               id="cash-received-input-single"
-              v-model.number="cashReceivedInput"
-              type="number"
-              min="0"
-              step="any"
-              inputmode="decimal"
+              type="text"
+              inputmode="numeric"
+              :value="cashReceivedDisplay"
+              @input="onCashReceivedInput"
               :aria-label="`Efectivo recibido por el cliente, monto a cobrar ${formatCurrency(cashAmountToCharge)}`"
-              class="w-full min-h-[44px] pl-7 pr-3 py-3 bg-white dark:bg-surface border border-border rounded-xl text-lg font-semibold text-text-primary focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500 tabular-nums"
+              placeholder="0"
+              class="w-full min-h-[60px] pl-4 pr-10 py-3 bg-white dark:bg-surface border-2 border-green-500 rounded-xl text-3xl font-bold text-text-primary focus:outline-none focus:ring-2 focus:ring-green-500 tabular-nums placeholder:text-text-tertiary placeholder:font-normal"
             />
+            <span class="absolute right-4 top-1/2 -translate-y-1/2 text-2xl font-bold text-green-600 pointer-events-none">$</span>
           </div>
-          <div class="flex flex-wrap gap-2">
+          <!-- 2×2 grid of presets -->
+          <div class="grid grid-cols-2 gap-3">
             <button
-              v-for="preset in cashPresets"
+              type="button"
+              @click="cashReceivedInput = cashAmountToCharge"
+              aria-label="Pagar exacto, sin vuelto"
+              class="min-h-[56px] px-4 py-3 rounded-lg bg-surface-secondary dark:bg-surface text-text-primary text-base font-semibold hover:bg-border/50 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
+            >
+              Sin vuelto
+            </button>
+            <button
+              v-for="preset in cashPresetsExtra"
               :key="preset.label"
               type="button"
               @click="cashReceivedInput = preset.value"
-              class="min-h-[44px] min-w-[80px] px-3 py-2 rounded-lg border border-border bg-white dark:bg-surface text-sm font-medium text-text-primary hover:bg-green-100 dark:hover:bg-green-900/30 hover:border-green-400 transition-colors focus:outline-none focus:ring-2 focus:ring-green-500"
+              class="min-h-[56px] px-4 py-3 rounded-lg bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400 text-base font-semibold hover:bg-green-100 dark:hover:bg-green-900/40 transition-colors focus:outline-none focus:ring-2 focus:ring-green-500"
             >
               {{ preset.label }}
             </button>
           </div>
+          <!-- Siguiente — solid green CTA -->
+          <button
+            type="button"
+            @click="cashReceivedInput = cashSiguienteValue"
+            :aria-label="`Redondear al siguiente mil, ${formatCurrency(cashSiguienteValue)}`"
+            class="min-h-[52px] px-4 py-3 rounded-lg bg-green-600 hover:bg-green-700 text-white text-base font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 flex items-center justify-center gap-2"
+          >
+            <span>Siguiente</span>
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
+            </svg>
+          </button>
+          <!-- Vuelto card -->
           <div
             v-if="cashShortfall <= 0.01"
-            class="flex items-center justify-between p-3 rounded-lg bg-white dark:bg-surface border-2 border-green-500"
+            class="flex items-center justify-between p-4 rounded-xl bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800/40"
             role="status"
             aria-live="polite"
           >
-            <span class="text-sm font-medium text-green-700 dark:text-green-400">Vuelto</span>
-            <span class="text-2xl font-bold text-green-700 dark:text-green-400 tabular-nums">
+            <span class="text-base font-medium text-green-700 dark:text-green-400">Vuelto</span>
+            <span class="text-3xl font-bold text-green-700 dark:text-green-400 tabular-nums">
               {{ formatCurrency(cashChange) }}
             </span>
           </div>


### PR DESCRIPTION
## Summary
Renders an "Efectivo recibido" input + 5 quick-tap presets + live "Vuelto" display when the active payment method is cash.

## Stack
🟢 Nuxt 3 + 🎨 UX

## Depends on
api-warolabs PR for #524 (backend half) — must ship first so the columns + endpoints are live.

## Changes
- \`pages/pos/checkout.vue\`:
  - Two cash-tender blocks (one for split mode inside the split panel, one for single-payment mode) — keeps the existing flow untouched.
  - 5 quick-tap presets: Justo / +\$5.000 / +\$10.000 / +\$20.000 / Siguiente \$.
  - Live "Vuelto" calculation in large green text (text-2xl bold green-700) for cashier readability.
  - Inline shortfall error: "Falta cobrar \$X".
  - Action button disabled until \`cash_received >= amount\` when cash method is active.
  - Backend POSTs send \`cash_received\` (or \`split_first_cash_received\`) only when method is cash.

## UX (per plan)
- Touch targets ≥ 44px on input + presets.
- Persistent \`<label>\` (never placeholder-only).
- Mobile: \`flex-wrap\` so 5 presets reflow to 2 rows on phones.
- Reuses existing \`green-50/200/700\` tokens (already used by the cash-method icon at line 1285).

## Testing
- [ ] Single cash sale exact change → \`orders.cash_received = total\`.
- [ ] Single cash sale with change → input typed > total, button enabled, vuelto shown, persists on \`orders\`.
- [ ] Single cash sale short → button disabled, inline "Falta cobrar".
- [ ] Split: cash + transfer → \`order_payments\` has 2 rows, only the cash one with \`cash_received\`.
- [ ] Card / Nequi → no input shown, no \`cash_received\` sent.
- [ ] Mobile (375px) reflows correctly.

Closes #524 (frontend half)