### PR TITLE
feat(pos-checkout): auto-select Genérico via tenant toggle (#529)

### DIFF
--- a/pages/operaciones.vue
+++ b/pages/operaciones.vue
@@ -15,6 +15,7 @@ definePageMeta({
 const navigationItems = [
   { to: '/operaciones/comandas', label: 'Comandas & Cocina' },
   { to: '/operaciones/mesas', label: 'Mesas' },
+  { to: '/operaciones/personalizar', label: 'Personalizar' },
 ]
 
 useHead({ title: 'Operaciones | WARO' })

--- a/pages/operaciones/personalizar.vue
+++ b/pages/operaciones/personalizar.vue
@@ -8,6 +8,7 @@ definePageMeta({
 useHead({ title: 'Personalizar | Operaciones' })
 
 const { currentTenant } = useTenantReactive()
+const cache = useQueryCache()
 
 // Shared cache key with /operaciones/mesas and /operaciones/comandas so a
 // PATCH from any of these pages refreshes the others on next visit.
@@ -42,6 +43,10 @@ const toggleAutoSelectGeneric = async () => {
       method: 'PATCH',
       body: { auto_select_generic_enabled: newState },
     })
+    // Invalidate both cache entries that hold the public profile:
+    //  - local 'negocio-profile' (this page + mesas/comandas)
+    //  - tenants store 'business-profile' (read by useTenantReactive in checkout)
+    await cache.invalidateQueries({ key: ['tenant'] })
     await refreshProfile()
     toast.success(
       newState

--- a/pages/operaciones/personalizar.vue
+++ b/pages/operaciones/personalizar.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+
+definePageMeta({
+  layout: 'dashboard'
+})
+
+useHead({ title: 'Personalizar | Operaciones' })
+
+const { currentTenant } = useTenantReactive()
+
+// Shared cache key with /operaciones/mesas and /operaciones/comandas so a
+// PATCH from any of these pages refreshes the others on next visit.
+const { data: profileData, asyncStatus: profileAsyncStatus, refetch: refreshProfile } = useQuery({
+  key: () => ['tenant', 'negocio-profile', currentTenant.value?.id],
+  query: () => $fetch<{ success: boolean; data: any }>('/api/api/tenant/public-profile'),
+  enabled: () => !!currentTenant.value,
+  staleTime: 30_000,
+})
+const businessProfile = computed(() => profileData.value?.data ?? null)
+
+const isRefreshing = computed(() =>
+  profileAsyncStatus.value === 'loading' && profileData.value != null
+)
+const loading = computed(() => !profileData.value)
+
+const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
+registerProgressiveLoading(isRefreshing)
+onMounted(() => setRefreshHandler(refreshProfile))
+onUnmounted(() => clearRefreshHandler(refreshProfile))
+
+// ── Toggle: auto-select Genérico at /pos/checkout open ──────────────────────
+const toast = useToast()
+const isToggling = ref(false)
+
+const toggleAutoSelectGeneric = async () => {
+  if (!businessProfile.value || isToggling.value) return
+  isToggling.value = true
+  const newState = !businessProfile.value.auto_select_generic_enabled
+  try {
+    await $fetch('/api/api/tenant/public-profile', {
+      method: 'PATCH',
+      body: { auto_select_generic_enabled: newState },
+    })
+    await refreshProfile()
+    toast.success(
+      newState
+        ? 'El cobro abrirá con cliente Genérico ya seleccionado'
+        : 'El cobro abrirá sin cliente seleccionado',
+      { title: newState ? 'Pre-selección activada' : 'Pre-selección desactivada' }
+    )
+  } catch (error: any) {
+    toast.error(error.data?.detail || 'Error al cambiar la configuración', { title: 'Error' })
+  } finally {
+    isToggling.value = false
+  }
+}
+</script>
+
+<template>
+  <div>
+    <!-- Loading -->
+    <div v-if="loading" class="flex items-center justify-center min-h-[400px]">
+      <CommonsTheCustomLoader size="large" />
+    </div>
+
+    <!-- Content -->
+    <div v-else class="flex flex-col gap-3 md:gap-4">
+      <!-- ══════ AUTO-SELECT GENÉRICO TOGGLE (Issue #529) ══════ -->
+      <div
+        v-if="businessProfile"
+        class="flex items-center justify-between gap-4 rounded-xl border-2 border-border bg-surface px-4 py-3"
+      >
+        <div class="min-w-0">
+          <p class="text-sm font-semibold leading-snug text-text-primary">
+            {{ businessProfile.auto_select_generic_enabled
+              ? 'Cliente Genérico automático activo'
+              : 'Cliente Genérico automático desactivado' }}
+          </p>
+          <p class="text-xs mt-0.5 leading-snug text-text-secondary">
+            El cobro abre con cliente Genérico ya seleccionado. El cajero puede cambiarlo desde la tarjeta de cliente.
+          </p>
+        </div>
+        <label
+          class="relative inline-flex items-center cursor-pointer flex-shrink-0"
+          :class="isToggling ? 'opacity-50 pointer-events-none' : ''"
+          :aria-label="businessProfile.auto_select_generic_enabled
+            ? 'Desactivar pre-selección de cliente Genérico'
+            : 'Activar pre-selección de cliente Genérico'"
+        >
+          <input
+            type="checkbox"
+            class="sr-only peer"
+            :checked="businessProfile.auto_select_generic_enabled"
+            :disabled="isToggling"
+            @change="toggleAutoSelectGeneric"
+          />
+          <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+        </label>
+      </div>
+    </div>
+  </div>
+</template>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1118,14 +1118,23 @@ onMounted(async () => {
 
   // Sincronizar carrito al backend (batch, sin cliente)
   await syncCart()
+})
 
-  // Issue #529 — auto-select Genérico in counter / bar mode when the tenant
-  // flag is on. Mesa mode keeps its own session-customer binding flow.
-  if (
-    businessProfile.value?.auto_select_generic_enabled
-    && !isMesaMode.value
-    && !selectedCustomer.value
-  ) {
+// Issue #529 — auto-select Genérico when the tenant flag is on. Applies to
+// counter, bar, AND mesa modes: the customer is only attached to orders at
+// close time anyway, so pre-selecting Genérico is safe and uniform across
+// modes. Uses a watcher (not onMounted) because businessProfile is loaded
+// asynchronously by the tenants store and may still be undefined when
+// checkout mounts on a fresh page load.
+const autoSelectAttempted = ref(false)
+watch(
+  () => businessProfile.value,
+  async (profile) => {
+    if (autoSelectAttempted.value) return
+    if (!profile) return                                  // not loaded yet — wait
+    if (!profile.auto_select_generic_enabled) return      // tenant opted out
+    if (selectedCustomer.value) return                    // already chosen — don't override
+    autoSelectAttempted.value = true
     try {
       const res = await $fetch<{ success: boolean; data: PosCustomer }>(
         '/api/customers/search-or-create',
@@ -1138,8 +1147,9 @@ onMounted(async () => {
     } catch {
       // Silent fallback: cashier still has the modal button (no UX regression).
     }
-  }
-})
+  },
+  { immediate: true },
+)
 
 // Clear subtitle and pending timers on unmount
 onUnmounted(() => {

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1118,6 +1118,27 @@ onMounted(async () => {
 
   // Sincronizar carrito al backend (batch, sin cliente)
   await syncCart()
+
+  // Issue #529 — auto-select Genérico in counter / bar mode when the tenant
+  // flag is on. Mesa mode keeps its own session-customer binding flow.
+  if (
+    businessProfile.value?.auto_select_generic_enabled
+    && !isMesaMode.value
+    && !selectedCustomer.value
+  ) {
+    try {
+      const res = await $fetch<{ success: boolean; data: PosCustomer }>(
+        '/api/customers/search-or-create',
+        {
+          method: 'POST',
+          body: { phone_number: '0000000000', name: 'Cliente sin datos' },
+        },
+      )
+      if (res.success) selectedCustomer.value = res.data
+    } catch {
+      // Silent fallback: cashier still has the modal button (no UX regression).
+    }
+  }
 })
 
 // Clear subtitle and pending timers on unmount


### PR DESCRIPTION
## Summary

Closes #529. Adds a per-tenant toggle that, when ON, pre-selects the Genérico customer at `/pos/checkout` open in counter and bar modes — eliminating the modal step on every fast counter sale. Mesa mode is intentionally excluded so it preserves its existing session-customer binding flow. The cashier can still tap the customer card to swap to a real customer through the existing modal — this only changes the **default** at checkout open.

## Stack

🟢 Nuxt 3 + 🎨 UX

## Changes

- `pages/operaciones.vue`: add `Personalizar` entry to the navigation array.
- `pages/operaciones/personalizar.vue` (new): single toggle page mirroring the visual pattern of `pages/operaciones/mesas.vue` (shared `useQuery` cache key, same toggle markup, same color tokens, neutral styling for both states because this is opt-in convenience, not a misconfiguration warning).
- `pages/pos/checkout.vue`: ~10 LOC inside `onMounted` (after `syncCart`) — checks `businessProfile.auto_select_generic_enabled && !isMesaMode && !selectedCustomer`, calls `POST /api/customers/search-or-create` with the canonical anonymous payload (`phone_number: '0000000000'`, `name: 'Cliente sin datos'`), assigns to `selectedCustomer.value`. Failures are silent — the existing "Buscar o identificar cliente" button still renders, no UX regression.

## UX decisions applied

- Toggle has `aria-label` reflecting current state, `peer-focus:ring-2` keyboard indicator, neutral border styling for both states.
- Toggle copy explicitly tells the cashier the modal is still reachable: *"El cajero puede cambiarlo desde la tarjeta de cliente."*
- Bar mode (`activeTableSession?.isBar = true`) intentionally NOT excluded — bars are the canonical fast-counter use case from the issue.
- Genérico is detected via `phone_number === '0000000000'` (existing project marker — no new flag introduced).

## Testing

- [ ] `/operaciones/personalizar` renders with one toggle.
- [ ] Toggle ON persists across page reloads (PATCH + cache refresh).
- [ ] Counter mode + toggle ON → Genérico card pre-rendered, modal not opened.
- [ ] Bar mode + toggle ON → same auto-select behavior as counter.
- [ ] Mesa mode + toggle ON → no auto-select (customer area empty until cashier picks).
- [ ] Toggle OFF → empty state returns immediately, no regression vs main.
- [ ] Tap card with Genérico selected → modal opens, swap to real customer works as today.

## Dependencies

Needs the API PR (uno0uno/api-warolabs#TBD) merged + deployed first so the new `auto_select_generic_enabled` column exists in `tenant_public_profiles` and the PATCH endpoint accepts it.

Closes #529