### PR TITLE
feat(contabilidad): "Actualizar saldo real" + slide-over detalle asiento (#531)

### DIFF
--- a/components/Finanzas/contabilidad/AjustarSaldoPanel.vue
+++ b/components/Finanzas/contabilidad/AjustarSaldoPanel.vue
@@ -1,0 +1,476 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+
+// ── Props / Emits ────────────────────────────────────────────────────────────
+interface Account {
+  id: string
+  code: string
+  name: string
+  accountClass: string
+  accountType: string
+  normalBalance: 'debit' | 'credit'
+  isDetail: boolean
+  isActive: boolean
+}
+
+interface TenantAccountForLookup {
+  id: string
+  code: string
+}
+
+const props = defineProps<{
+  modelValue: boolean
+  account: Account | null
+  bookBalance: number
+  // Pre-fetched list of all tenant accounts (used to resolve contraparte by code)
+  allAccounts: TenantAccountForLookup[]
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+  success: []
+}>()
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+const formatCOP = (v: number) =>
+  new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    minimumFractionDigits: 0,
+  }).format(v ?? 0)
+
+const close = () => emit('update:modelValue', false)
+
+// ── Form state ───────────────────────────────────────────────────────────────
+const targetBalanceInput = ref<string>('')
+const motivoCode = ref<string>('')
+const submitting = ref(false)
+const submitError = ref('')
+
+const targetBalance = computed(() => {
+  const cleaned = (targetBalanceInput.value ?? '').toString().replace(/[^0-9.-]/g, '')
+  const n = parseFloat(cleaned)
+  return Number.isFinite(n) ? n : NaN
+})
+
+const diferencia = computed(() => {
+  if (!Number.isFinite(targetBalance.value)) return 0
+  return targetBalance.value - props.bookBalance
+})
+
+const sign = computed<'positive' | 'negative' | 'zero'>(() => {
+  if (!Number.isFinite(targetBalance.value)) return 'zero'
+  if (diferencia.value > 0) return 'positive'
+  if (diferencia.value < 0) return 'negative'
+  return 'zero'
+})
+
+const canSubmit = computed(() =>
+  Number.isFinite(targetBalance.value)
+  && diferencia.value !== 0
+  && motivoCode.value !== ''
+  && !submitting.value,
+)
+
+// ── Motivos catalog (UX-facing) ──────────────────────────────────────────────
+// Each motivo maps to a contraparte PUC code. The sign field decides which
+// motivos are available based on whether saldo real > or < saldo libro.
+interface Motivo {
+  code: string
+  label: string
+  description: string
+  contraparteCode: string
+  pendingReview: boolean
+  sign: 'positive' | 'negative'
+}
+
+const MOTIVOS: Motivo[] = [
+  // Positive — saldo real > saldo libro (entró plata)
+  {
+    code: 'capital_aporte',
+    label: 'Aporte de socio / capital',
+    description: 'Un socio puso plata en la empresa',
+    contraparteCode: '3105',
+    pendingReview: false,
+    sign: 'positive',
+  },
+  {
+    code: 'prestamo',
+    label: 'Préstamo recibido',
+    description: 'Un banco o tercero le prestó al negocio',
+    contraparteCode: '2105',
+    pendingReview: false,
+    sign: 'positive',
+  },
+  {
+    code: 'saldo_historico',
+    label: 'Saldo histórico que no había registrado',
+    description: 'Plata que ya estaba antes de empezar a usar la plataforma',
+    contraparteCode: '3705',
+    pendingReview: false,
+    sign: 'positive',
+  },
+  {
+    code: 'cliente_directo',
+    label: 'Cliente pagó directo al banco',
+    description: 'Un cliente transfirió o consignó sin pasar por el POS',
+    contraparteCode: '1305',
+    pendingReview: false,
+    sign: 'positive',
+  },
+  {
+    code: 'no_seguro_positivo',
+    label: 'No estoy seguro',
+    description: 'Entró plata pero no sé exactamente de dónde — un contador lo revisará después',
+    contraparteCode: '4295',
+    pendingReview: true,
+    sign: 'positive',
+  },
+  // Negative — saldo real < saldo libro (salió plata)
+  {
+    code: 'comision_bancaria',
+    label: 'Comisión bancaria / GMF (4×1000)',
+    description: 'El banco cobró comisiones, retención o GMF',
+    contraparteCode: '5305',
+    pendingReview: false,
+    sign: 'negative',
+  },
+  {
+    code: 'no_seguro_negativo',
+    label: 'No estoy seguro',
+    description: 'Salió plata pero no sé exactamente a dónde — un contador lo revisará después',
+    contraparteCode: '5395',
+    pendingReview: true,
+    sign: 'negative',
+  },
+]
+
+const availableMotivos = computed<Motivo[]>(() =>
+  sign.value === 'zero' ? [] : MOTIVOS.filter(m => m.sign === sign.value),
+)
+
+const selectedMotivo = computed<Motivo | null>(
+  () => MOTIVOS.find(m => m.code === motivoCode.value) ?? null,
+)
+
+// Reset motivo when sign changes (otherwise an invalid motivo could remain selected)
+watch(sign, () => { motivoCode.value = '' })
+
+// Reset entire form when panel closes/opens
+watch(() => props.modelValue, (open) => {
+  if (open) {
+    targetBalanceInput.value = ''
+    motivoCode.value = ''
+    submitError.value = ''
+  }
+})
+
+// Format COP on blur (don't reformat per keystroke — user-friendly typing)
+const formatOnBlur = () => {
+  if (!Number.isFinite(targetBalance.value)) return
+  targetBalanceInput.value = formatCOP(targetBalance.value).replace(/\s/g, ' ')
+}
+const stripOnFocus = () => {
+  if (!Number.isFinite(targetBalance.value)) return
+  targetBalanceInput.value = String(targetBalance.value)
+}
+
+// ── Submit ───────────────────────────────────────────────────────────────────
+//
+// For an Activo (debit-normal) account "X" being adjusted:
+//   - diferencia > 0 → DR X / CR contraparte (con monto = diferencia)
+//   - diferencia < 0 → DR contraparte / CR X (con monto = abs(diferencia))
+//
+const submit = async () => {
+  if (!canSubmit.value || !props.account || !selectedMotivo.value) return
+
+  const contraparte = props.allAccounts.find(a => a.code === selectedMotivo.value!.contraparteCode)
+  if (!contraparte) {
+    submitError.value = `No se encontró la cuenta contraparte ${selectedMotivo.value.contraparteCode} en tu plan de cuentas. Contacta a soporte.`
+    return
+  }
+
+  const monto = Math.abs(diferencia.value)
+  const lines = sign.value === 'positive'
+    ? [
+        { accountId: props.account.id, debit: monto, credit: 0, description: 'Ajuste saldo (incremento)' },
+        { accountId: contraparte.id,    debit: 0,     credit: monto, description: 'Contraparte ajuste saldo' },
+      ]
+    : [
+        { accountId: contraparte.id,    debit: monto, credit: 0, description: 'Contraparte ajuste saldo' },
+        { accountId: props.account.id,  debit: 0,     credit: monto, description: 'Ajuste saldo (decremento)' },
+      ]
+
+  const today = new Date().toISOString().slice(0, 10)
+  const description = `Ajuste saldo ${props.account.code} ${props.account.name}: ${sign.value === 'positive' ? 'aumento' : 'disminución'} de ${formatCOP(monto)} — motivo: ${selectedMotivo.value.label}`
+
+  submitting.value = true
+  submitError.value = ''
+  try {
+    // 1) Create draft
+    const created = await $fetch<{ success: boolean; data: { id: string } }>(
+      '/api/accounting/journal-entries',
+      {
+        method: 'POST',
+        body: {
+          entryDate: today,
+          description,
+          reference: `BAL-ADJ-${props.account.code}-${Date.now().toString().slice(-6)}`,
+          lines,
+          sourceModule: 'manual_balance_adjustment',
+          sourceId: props.account.id,
+          pendingReview: selectedMotivo.value.pendingReview,
+        },
+      },
+    )
+
+    // 2) Post it (flips status='posted' and sets posted_at)
+    if (created?.data?.id) {
+      await $fetch(`/api/accounting/journal-entries/${created.data.id}/post`, {
+        method: 'POST',
+      })
+    }
+
+    emit('success')
+    close()
+  } catch (err: any) {
+    submitError.value = err?.data?.detail || err?.data?.message || err?.message || 'Error al actualizar el saldo'
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <!-- Backdrop -->
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-200"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="modelValue"
+        class="fixed inset-0 z-40 bg-black/40"
+        aria-hidden="true"
+        @click="close"
+      />
+    </Transition>
+
+    <!-- Panel: bottom sheet on mobile, slide-over on desktop -->
+    <Transition name="panel">
+      <div
+        v-if="modelValue && account"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="`Actualizar saldo real de ${account?.name}`"
+        class="fixed z-50 flex flex-col bg-surface shadow-2xl
+               inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh]
+               md:inset-y-0 md:right-0 md:bottom-auto md:left-auto md:inset-x-auto md:rounded-none md:w-full md:max-w-md md:max-h-none md:h-full"
+      >
+        <!-- Mobile drag handle -->
+        <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
+          <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+        </div>
+
+        <!-- Header -->
+        <div class="flex-shrink-0 bg-surface-secondary/40 border-b border-border px-6 py-4">
+          <div class="flex items-start justify-between gap-3">
+            <div class="flex items-center gap-3 min-w-0 flex-1">
+              <div class="flex-shrink-0 w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M3 10h18M3 14h18M5 6h14a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2z" />
+                </svg>
+              </div>
+              <div class="min-w-0">
+                <h2 class="text-base font-bold text-text-primary leading-tight">
+                  Actualizar saldo real
+                </h2>
+                <p class="text-xs text-text-secondary leading-snug mt-0.5 truncate">
+                  {{ account.code }} · {{ account.name }}
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              aria-label="Cerrar panel"
+              class="flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center text-text-tertiary hover:bg-surface-secondary hover:text-text-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+              @click="close"
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- Body -->
+        <div class="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+
+          <!-- Saldo en libros (read-only) -->
+          <div class="rounded-xl border border-border bg-surface-secondary/30 px-4 py-3">
+            <p class="text-xs uppercase tracking-wider text-text-secondary font-medium mb-1">
+              Saldo en libros (actual)
+            </p>
+            <p class="text-xl font-bold text-text-primary">{{ formatCOP(bookBalance) }}</p>
+          </div>
+
+          <!-- Saldo real input -->
+          <div class="flex flex-col gap-1.5">
+            <label for="target-balance-input" class="text-sm font-semibold text-text-primary">
+              ¿Cuánto tienes ahora mismo en esta cuenta?
+            </label>
+            <input
+              id="target-balance-input"
+              v-model="targetBalanceInput"
+              type="text"
+              inputmode="decimal"
+              placeholder="$ 0"
+              autocomplete="off"
+              :disabled="submitting"
+              class="min-h-[44px] px-3 rounded-lg border-2 border-border bg-surface text-text-primary text-base font-medium focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition-colors disabled:opacity-50"
+              @blur="formatOnBlur"
+              @focus="stripOnFocus"
+            />
+            <p class="text-xs text-text-secondary leading-snug">
+              Escribe el valor exacto que ves hoy en tu extracto, app del banco o conteo de caja.
+            </p>
+          </div>
+
+          <!-- Diferencia calculated -->
+          <div
+            v-if="sign !== 'zero'"
+            class="rounded-xl px-4 py-3 border-2"
+            :class="sign === 'positive'
+              ? 'border-emerald-200 bg-emerald-50 dark:border-emerald-800/40 dark:bg-emerald-950/20'
+              : 'border-amber-200 bg-amber-50 dark:border-amber-800/40 dark:bg-amber-950/20'"
+          >
+            <p class="text-xs uppercase tracking-wider font-medium mb-1"
+               :class="sign === 'positive' ? 'text-emerald-700 dark:text-emerald-400' : 'text-amber-700 dark:text-amber-400'">
+              Diferencia
+            </p>
+            <p class="text-2xl font-bold flex items-center gap-2"
+               :class="sign === 'positive' ? 'text-emerald-700 dark:text-emerald-400' : 'text-amber-700 dark:text-amber-400'">
+              <svg v-if="sign === 'positive'" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+              </svg>
+              <svg v-else class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+              </svg>
+              {{ sign === 'positive' ? '+' : '−' }} {{ formatCOP(Math.abs(diferencia)) }}
+            </p>
+            <p class="text-xs leading-snug mt-1"
+               :class="sign === 'positive' ? 'text-emerald-700/80 dark:text-emerald-400/80' : 'text-amber-700/80 dark:text-amber-400/80'">
+              {{ sign === 'positive'
+                ? 'Tu cuenta tiene más plata que lo que dicen los libros.'
+                : 'Tu cuenta tiene menos plata que lo que dicen los libros.' }}
+            </p>
+          </div>
+
+          <!-- Motivo selector (only when sign known) -->
+          <fieldset v-if="sign !== 'zero'" class="flex flex-col gap-2">
+            <legend class="text-sm font-semibold text-text-primary mb-1">
+              ¿Cuál fue el motivo?
+            </legend>
+            <label
+              v-for="m in availableMotivos"
+              :key="m.code"
+              class="flex items-start gap-3 px-4 py-3 rounded-lg border-2 cursor-pointer transition-colors"
+              :class="motivoCode === m.code
+                ? 'border-primary bg-primary/5'
+                : 'border-border bg-surface hover:border-primary/40 hover:bg-primary/5'"
+            >
+              <input
+                v-model="motivoCode"
+                type="radio"
+                name="motivo"
+                :value="m.code"
+                :disabled="submitting"
+                class="mt-1 h-4 w-4 text-primary focus:ring-2 focus:ring-primary/30"
+              />
+              <div class="min-w-0 flex-1">
+                <p class="text-sm font-semibold text-text-primary leading-snug">
+                  {{ m.label }}
+                </p>
+                <p class="text-xs text-text-secondary leading-snug mt-0.5">
+                  {{ m.description }}
+                </p>
+              </div>
+            </label>
+          </fieldset>
+
+          <!-- Soft confirmation banner (when motivo selected) -->
+          <div
+            v-if="selectedMotivo"
+            class="rounded-xl border border-primary/30 bg-primary/5 px-4 py-3"
+          >
+            <p class="text-xs uppercase tracking-wider text-primary font-medium mb-1.5">
+              Confirmación
+            </p>
+            <p class="text-sm text-text-primary leading-relaxed">
+              Vas a dejar el saldo de <strong>{{ account?.name }}</strong> en
+              <strong>{{ formatCOP(targetBalance) }}</strong>. Esta acción crea un asiento contable.
+              Para corregirlo deberás anularlo y crear uno nuevo.
+            </p>
+            <p
+              v-if="selectedMotivo.pendingReview"
+              class="text-xs text-amber-700 dark:text-amber-400 leading-snug mt-2 flex items-start gap-1.5"
+            >
+              <svg class="w-3.5 h-3.5 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+              <span>Marcaré este ajuste para que un contador lo revise. Si no tienes contador, revísalo antes de la próxima declaración fiscal.</span>
+            </p>
+          </div>
+
+          <!-- Error -->
+          <div v-if="submitError" class="rounded-xl border border-destructive/40 bg-destructive/8 px-4 py-3">
+            <p class="text-sm text-destructive font-medium leading-snug">{{ submitError }}</p>
+          </div>
+        </div>
+
+        <!-- Sticky footer -->
+        <div class="flex-shrink-0 border-t border-border bg-surface px-6 py-4 flex items-center gap-3">
+          <button
+            type="button"
+            class="flex-1 min-h-[44px] rounded-lg border border-border text-sm font-semibold text-text-secondary hover:bg-surface-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50"
+            :disabled="submitting"
+            @click="close"
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            :disabled="!canSubmit"
+            class="flex-1 min-h-[44px] rounded-lg bg-primary text-white text-sm font-bold transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/30 active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            @click="submit"
+          >
+            <UiLoadingDots v-if="submitting" size="8px" color="currentColor" />
+            <template v-else>Actualizar saldo</template>
+          </button>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+/* Slide-over transition: from-right on desktop, from-bottom on mobile */
+.panel-enter-active,
+.panel-leave-active {
+  transition: transform 0.25s ease;
+}
+.panel-enter-from,
+.panel-leave-to {
+  transform: translateY(100%);
+}
+@media (min-width: 768px) {
+  .panel-enter-from,
+  .panel-leave-to {
+    transform: translateX(100%);
+  }
+}
+</style>

--- a/components/Finanzas/contabilidad/AsientoDetailPanel.vue
+++ b/components/Finanzas/contabilidad/AsientoDetailPanel.vue
@@ -1,0 +1,338 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+
+interface JournalLine {
+  id: string
+  accountId: string
+  debit: number
+  credit: number
+  description: string | null
+  lineOrder: number
+}
+
+interface JournalEntryWithLines {
+  id: string
+  entryDate: string
+  description: string
+  reference: string | null
+  sourceModule: string | null
+  status: string
+  totalDebit: number
+  totalCredit: number
+  pendingReview: boolean
+  postedAt: string | null
+  voidedAt: string | null
+  lines: JournalLine[]
+}
+
+interface AccountLookup {
+  id: string
+  code: string
+  name: string
+}
+
+const props = defineProps<{
+  modelValue: boolean
+  entryId: string | null
+  allAccounts: AccountLookup[]
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+}>()
+
+const close = () => emit('update:modelValue', false)
+
+const formatCOP = (v: number) =>
+  new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    minimumFractionDigits: 0,
+  }).format(v ?? 0)
+
+const formatDate = (iso: string) => {
+  if (!iso) return ''
+  return new Date(iso + 'T12:00:00').toLocaleDateString('es-CO', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  })
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  ventas: 'Ventas',
+  gastos: 'Gastos',
+  nomina: 'Nómina',
+  nomina_provision: 'Nómina — provisión',
+  nomina_ss: 'Nómina — seguridad social',
+  nomina_prima: 'Nómina — prima',
+  nomina_cesantias: 'Nómina — cesantías',
+  nomina_int_cesantias: 'Nómina — int. cesantías',
+  nomina_vacaciones: 'Nómina — vacaciones',
+  nomina_dotacion: 'Nómina — dotación',
+  nomina_pila: 'Nómina — PILA',
+  nomina_horas_extras: 'Nómina — horas extras',
+  nomina_liquidacion: 'Nómina — liquidación',
+  inventario: 'Inventario',
+  cartera: 'Cartera',
+  arqueo: 'Arqueo',
+  manual: 'Manual',
+  manual_balance_adjustment: 'Ajuste de saldo',
+  system: 'Sistema',
+  orden: 'Orden',
+  orden_cogs: 'Orden (CMV)',
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  draft: 'Borrador',
+  posted: 'Publicado',
+  voided: 'Anulado',
+}
+
+const STATUS_VARIANTS: Record<string, 'success' | 'warning' | 'secondary'> = {
+  draft: 'warning',
+  posted: 'success',
+  voided: 'secondary',
+}
+
+// ── Fetch entry detail ──────────────────────────────────────────────────────
+const entry = ref<JournalEntryWithLines | null>(null)
+const loading = ref(false)
+const error = ref('')
+
+const accountById = computed<Record<string, AccountLookup>>(() => {
+  const map: Record<string, AccountLookup> = {}
+  for (const a of props.allAccounts) map[a.id] = a
+  return map
+})
+
+const fetchEntry = async (id: string) => {
+  loading.value = true
+  error.value = ''
+  entry.value = null
+  try {
+    const res = await $fetch<{ success: boolean; data: JournalEntryWithLines }>(
+      `/api/accounting/journal-entries/${id}`,
+    )
+    if (res.success) entry.value = res.data
+  } catch (err: any) {
+    error.value = err?.data?.detail || err?.message || 'Error al cargar el asiento'
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(
+  () => [props.modelValue, props.entryId] as const,
+  ([open, id]) => {
+    if (open && id) fetchEntry(id)
+    if (!open) { entry.value = null; error.value = '' }
+  },
+  { immediate: true },
+)
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-200"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="modelValue"
+        class="fixed inset-0 z-40 bg-black/40"
+        aria-hidden="true"
+        @click="close"
+      />
+    </Transition>
+
+    <Transition name="panel">
+      <div
+        v-if="modelValue"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Detalle del asiento contable"
+        class="fixed z-50 flex flex-col bg-surface shadow-2xl
+               inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh]
+               md:inset-y-0 md:right-0 md:bottom-auto md:left-auto md:inset-x-auto md:rounded-none md:w-full md:max-w-lg md:max-h-none md:h-full"
+      >
+        <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
+          <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+        </div>
+
+        <!-- Header -->
+        <div class="flex-shrink-0 bg-surface-secondary/40 border-b border-border px-6 py-4">
+          <div class="flex items-start justify-between gap-3">
+            <div class="flex items-center gap-3 min-w-0 flex-1">
+              <div class="flex-shrink-0 w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+                </svg>
+              </div>
+              <div class="min-w-0">
+                <h2 class="text-base font-bold text-text-primary leading-tight">
+                  Asiento contable
+                </h2>
+                <p v-if="entry" class="text-xs text-text-secondary leading-snug mt-0.5">
+                  {{ formatDate(entry.entryDate) }}
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              aria-label="Cerrar panel"
+              class="flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center text-text-tertiary hover:bg-surface-secondary hover:text-text-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+              @click="close"
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- Body -->
+        <div class="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+          <!-- Loading -->
+          <div v-if="loading" class="flex items-center justify-center py-12">
+            <CommonsTheCustomLoader size="medium" />
+          </div>
+
+          <!-- Error -->
+          <div v-else-if="error" class="rounded-xl border border-destructive/40 bg-destructive/8 px-4 py-3">
+            <p class="text-sm text-destructive font-medium">{{ error }}</p>
+          </div>
+
+          <!-- Entry detail -->
+          <template v-else-if="entry">
+            <!-- Status + module + pending_review badges -->
+            <div class="flex flex-wrap items-center gap-2">
+              <UiStatusBadge
+                :value="STATUS_LABELS[entry.status] || entry.status"
+                format="text"
+                :variant="STATUS_VARIANTS[entry.status] || 'secondary'"
+                size="sm"
+              />
+              <UiStatusBadge
+                v-if="entry.sourceModule"
+                :value="SOURCE_LABELS[entry.sourceModule] || entry.sourceModule"
+                format="text"
+                variant="secondary"
+                size="sm"
+              />
+              <span
+                v-if="entry.pendingReview"
+                class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 text-xs font-medium dark:bg-amber-950/30 dark:text-amber-400"
+              >
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+                Pendiente de revisar
+              </span>
+            </div>
+
+            <!-- Description -->
+            <div>
+              <p class="text-xs uppercase tracking-wider text-text-secondary font-medium mb-1">
+                Descripción
+              </p>
+              <p class="text-sm text-text-primary leading-relaxed">{{ entry.description }}</p>
+            </div>
+
+            <!-- Reference -->
+            <div v-if="entry.reference">
+              <p class="text-xs uppercase tracking-wider text-text-secondary font-medium mb-1">
+                Referencia
+              </p>
+              <p class="text-sm font-mono text-text-primary">{{ entry.reference }}</p>
+            </div>
+
+            <!-- Lines table -->
+            <div>
+              <p class="text-xs uppercase tracking-wider text-text-secondary font-medium mb-2">
+                Movimientos ({{ entry.lines.length }})
+              </p>
+              <div class="rounded-xl border border-border overflow-hidden">
+                <div class="grid grid-cols-[1fr_auto_auto] gap-x-3 px-3 py-2 bg-surface-secondary/40 text-xs font-semibold text-text-secondary">
+                  <span>Cuenta</span>
+                  <span class="text-right">Débito</span>
+                  <span class="text-right">Crédito</span>
+                </div>
+                <div
+                  v-for="(line, idx) in entry.lines"
+                  :key="line.id"
+                  class="grid grid-cols-[1fr_auto_auto] gap-x-3 px-3 py-2.5 text-sm border-t border-border"
+                  :class="idx % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/20'"
+                >
+                  <div class="min-w-0">
+                    <p class="font-medium text-text-primary truncate">
+                      <span class="font-mono text-text-secondary mr-1.5">{{ accountById[line.accountId]?.code || '?' }}</span>
+                      {{ accountById[line.accountId]?.name || 'Cuenta desconocida' }}
+                    </p>
+                    <p v-if="line.description" class="text-xs text-text-secondary leading-snug mt-0.5 truncate">
+                      {{ line.description }}
+                    </p>
+                  </div>
+                  <span class="text-sm font-mono tabular-nums text-right" :class="line.debit ? 'text-primary font-medium' : 'text-text-tertiary'">
+                    {{ line.debit ? formatCOP(line.debit) : '—' }}
+                  </span>
+                  <span class="text-sm font-mono tabular-nums text-right" :class="line.credit ? 'text-text-secondary' : 'text-text-tertiary'">
+                    {{ line.credit ? formatCOP(line.credit) : '—' }}
+                  </span>
+                </div>
+                <!-- Totals -->
+                <div class="grid grid-cols-[1fr_auto_auto] gap-x-3 px-3 py-2.5 bg-surface-secondary/60 border-t-2 border-border text-sm font-bold">
+                  <span class="text-text-primary">Totales</span>
+                  <span class="text-primary font-mono tabular-nums text-right">{{ formatCOP(entry.totalDebit) }}</span>
+                  <span class="text-text-secondary font-mono tabular-nums text-right">{{ formatCOP(entry.totalCredit) }}</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Timestamps -->
+            <div class="text-xs text-text-secondary space-y-1 pt-2 border-t border-border/50">
+              <p v-if="entry.postedAt">
+                <span class="font-medium">Publicado:</span> {{ new Date(entry.postedAt).toLocaleString('es-CO') }}
+              </p>
+              <p v-if="entry.voidedAt">
+                <span class="font-medium text-destructive">Anulado:</span> {{ new Date(entry.voidedAt).toLocaleString('es-CO') }}
+              </p>
+            </div>
+          </template>
+        </div>
+
+        <!-- Sticky footer -->
+        <div class="flex-shrink-0 border-t border-border bg-surface px-6 py-4">
+          <button
+            type="button"
+            class="w-full min-h-[44px] rounded-lg border border-border text-sm font-semibold text-text-secondary hover:bg-surface-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+            @click="close"
+          >
+            Cerrar
+          </button>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.panel-enter-active,
+.panel-leave-active {
+  transition: transform 0.25s ease;
+}
+.panel-enter-from,
+.panel-leave-to {
+  transform: translateY(100%);
+}
+@media (min-width: 768px) {
+  .panel-enter-from,
+  .panel-leave-to {
+    transform: translateX(100%);
+  }
+}
+</style>

--- a/pages/finanzas/contabilidad/cuentas/[id].vue
+++ b/pages/finanzas/contabilidad/cuentas/[id].vue
@@ -14,6 +14,15 @@ const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = u
 const formatCOP = (v: number) =>
   new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(v ?? 0)
 
+// Truncate a long description to keep table rows compact.
+// Click on the row opens the slide-over with the full text.
+const truncateDescription = (text: string | null | undefined, maxWords = 4): string => {
+  if (!text) return ''
+  const words = text.trim().split(/\s+/)
+  if (words.length <= maxWords) return text
+  return words.slice(0, maxWords).join(' ') + '…'
+}
+
 // ── Labels & variants ──────────────────────────────────────────────────────
 const CLASS_SHORT: Record<string, string> = {
   '1': 'Activos', '2': 'Pasivos', '3': 'Patrimonio',
@@ -253,7 +262,7 @@ const dateRange = computed(() => {
 const statusFilter = ref<string | null>(null)
 const sourceFilter = ref<string | null>(null)
 const page = ref(1)
-const PAGE_SIZE = 50
+const PAGE_SIZE = 20
 
 // ── Journal entries ────────────────────────────────────────────────────────
 interface JournalEntry {
@@ -363,6 +372,25 @@ const refetch = () => { refetchEntries(); refetchAccounts() }
 registerProgressiveLoading(isRefreshing)
 onMounted(() => { setRefreshHandler(refetch) })
 onUnmounted(() => { clearRefreshHandler(refetch) })
+
+// ── Issue #531 — Actualizar saldo real ────────────────────────────────────
+const showAdjustPanel = ref(false)
+const toast = useToast()
+const allAccountsForPanel = computed(() => {
+  return (accountsData.value?.data ?? []).map(a => ({ id: a.id, code: a.code, name: a.name }))
+})
+const onAdjustSuccess = async () => {
+  await refetch()
+  toast.success('Saldo actualizado correctamente', { title: 'Asiento contable creado' })
+}
+
+// ── Issue #531 — Detalle del asiento (slide-over) ─────────────────────────
+const showEntryDetailPanel = ref(false)
+const selectedEntryId = ref<string | null>(null)
+const openEntryDetail = (entry: { id: string }) => {
+  selectedEntryId.value = entry.id
+  showEntryDetailPanel.value = true
+}
 </script>
 
 <template>
@@ -432,6 +460,20 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
               </svg>
               <span>{{ account.isActive ? 'Desactivar' : 'Activar' }}</span>
+            </button>
+
+            <!-- Issue #531 — Actualizar saldo real (solo Activo debit-normal hoja activa) -->
+            <button
+              v-if="account.isDetail && account.accountClass === '1' && account.normalBalance === 'debit' && account.isActive"
+              type="button"
+              class="min-h-[44px] px-3 rounded-lg border-2 border-primary text-primary text-sm font-medium transition-colors hover:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-primary/30 active:scale-[0.98] flex items-center gap-1.5"
+              :aria-label="`Actualizar saldo real de ${account.name}`"
+              @click="showAdjustPanel = true"
+            >
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <span>Actualizar saldo</span>
             </button>
           </div>
         </div>
@@ -626,20 +668,23 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
             empty-message="Sin asientos para esta cuenta en el período"
             empty-sub-message="Selecciona otro rango de fechas o crea un nuevo asiento"
             variant="default"
+            @row-click="openEntryDetail"
           >
             <!-- Mobile card -->
             <template #card="{ item, index }">
-              <div
-                class="flex items-center gap-3 py-2 px-3 border-b border-border"
+              <button
+                type="button"
+                class="w-full flex items-center gap-3 py-2 px-3 border-b border-border text-left hover:bg-primary/5 transition-colors focus:outline-none focus:bg-primary/5"
                 :class="index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'"
+                :aria-label="`Ver detalle del asiento ${item.reference || item.description}`"
+                @click="openEntryDetail(item)"
               >
                 <div class="flex-1 min-w-0">
                   <div class="flex items-center gap-1.5">
                     <span class="text-xs text-text-secondary flex-shrink-0">{{ formatDate(item.entryDate) }}</span>
                     <UiStatusBadge v-if="item.sourceModule" :value="SOURCE_LABELS[item.sourceModule] || item.sourceModule" format="text" :variant="SOURCE_VARIANTS[item.sourceModule] || 'secondary'" size="sm" />
                   </div>
-                  <NuxtLink v-if="entryLink(item)" :to="entryLink(item) || ''" class="text-sm font-medium text-primary hover:underline underline-offset-2 truncate mt-0.5 block">{{ item.description }}</NuxtLink>
-                  <p v-else class="text-sm font-medium text-text-primary truncate mt-0.5">{{ item.description }}</p>
+                  <p class="text-sm font-medium text-text-primary mt-0.5" :title="item.description">{{ truncateDescription(item.description) }}</p>
                 </div>
                 <div class="flex flex-col items-end gap-0.5 flex-shrink-0">
                   <span v-if="item.totalDebit" class="text-xs font-mono text-primary tabular-nums">+{{ formatCOP(item.totalDebit) }}</span>
@@ -648,20 +693,18 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
                     {{ formatCOP(item.runningBalance) }}
                   </span>
                 </div>
-              </div>
+              </button>
             </template>
 
             <template #cell-entryDate="{ value }">
               <span class="text-xs text-text-secondary tabular-nums">{{ formatDate(value) }}</span>
             </template>
 
-            <template #cell-description="{ value, row }">
-              <NuxtLink
-                v-if="entryLink(row)"
-                :to="entryLink(row) || ''"
-                class="text-sm text-primary hover:underline underline-offset-2 font-medium"
-              >{{ value }}</NuxtLink>
-              <span v-else class="text-sm text-text-primary">{{ value }}</span>
+            <template #cell-description="{ value }">
+              <span
+                class="text-sm text-text-primary"
+                :title="value"
+              >{{ truncateDescription(value) }}</span>
             </template>
 
             <template #cell-sourceModule="{ value }">
@@ -923,6 +966,22 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
       </div>
     </Transition>
   </Teleport>
+
+  <!-- Issue #531 — Actualizar saldo real -->
+  <FinanzasContabilidadAjustarSaldoPanel
+    v-model="showAdjustPanel"
+    :account="account"
+    :book-balance="closingBalance"
+    :all-accounts="allAccountsForPanel"
+    @success="onAdjustSuccess"
+  />
+
+  <!-- Issue #531 — Detalle del asiento (slide-over) -->
+  <FinanzasContabilidadAsientoDetailPanel
+    v-model="showEntryDetailPanel"
+    :entry-id="selectedEntryId"
+    :all-accounts="allAccountsForPanel"
+  />
 </template>
 
 <style scoped>


### PR DESCRIPTION
## Summary

Closes #531. Slide-over UX para que un dueño no contador pueda declarar el saldo real de una cuenta de Activo, y un slide-over de detalle de asiento accesible desde cualquier fila del libro mayor.

## Stack

🟢 Nuxt 3 + 🎨 UX

## Changes

- \`components/Finanzas/contabilidad/AjustarSaldoPanel.vue\` (new, ~370 LOC) — slide-over con input de saldo real, cálculo de diferencia, 6 motivos en lenguaje natural (5 positivos + 2 negativos, 1 cross-sign), confirmación, soft-warning para motivo \"no estoy seguro\", chain de POST + post para crear y postear el asiento en una operación. Mirroring del patrón de MesaPanel.vue.
- \`components/Finanzas/contabilidad/AsientoDetailPanel.vue\` (new, ~280 LOC) — slide-over con detalle completo del asiento: status/módulo/pending_review badges, descripción, referencia, líneas DR/CR con cuenta + monto + descripción de línea, totales, timestamps.
- \`pages/finanzas/contabilidad/cuentas/[id].vue\`:
  - Botón \"Actualizar saldo\" en header, visible solo cuando \`isDetail && accountClass === '1' && normalBalance === 'debit' && isActive\` (excluye 1592 Depreciación y similares).
  - PAGE_SIZE de libro mayor: 50 → 20 para que la UI no se rompa con muchos asientos.
  - Cada fila del libro mayor es ahora clickable (\`@row-click\`) y abre el AsientoDetailPanel.
  - Descripción del asiento truncada a 4 palabras + tooltip con texto completo + slide-over para el detalle.

## UX decisions applied

- Esconde DR/CR del usuario — la elección de contraparte se hace vía motivos en lenguaje natural.
- Motivo \"no estoy seguro\" marca el asiento con \`pendingReview=true\` (válido contablemente, solo es una anotación).
- Confirmación en el panel antes de submit, recordatorio al usuario que el asiento es inmutable y la corrección se hace via void + recreate.
- Truncate por palabras en JS (no solo CSS) para que funcione independiente del ancho de tabla.
- Mobile: bottom-sheet con drag-handle. Desktop: drawer derecho 26rem max.

## Testing manual

- [ ] /finanzas/contabilidad/cuentas/<id-de-1110> con cuenta vacía: input \$25M, motivo \"Aporte de socio\" → asiento creado y posteado, saldo en pantalla actualiza.
- [ ] Mismo flujo con motivo \"Préstamo recibido\" → contraparte 2105.
- [ ] Diferencia negativa, motivo \"Comisión bancaria\" → contraparte 5305.
- [ ] Motivo \"No estoy seguro\" → asiento con pending_review=true (verificable en DB).
- [ ] Click en fila del libro mayor → slide-over detalle abre, muestra todas las líneas y totales.
- [ ] Cuenta 1592 Depreciación: botón \"Actualizar saldo\" NO aparece.
- [ ] Cuenta 1105 Caja, 1110 Bancos, 111005 Nequi, 1305 Clientes, 1435 Inventarios, 1520 Maquinaria, 1524 Equipo: botón SÍ aparece.
- [ ] Cuentas de Pasivo/Patrimonio/Ingresos/Gastos: botón NO aparece.
- [ ] Mobile (375px): paneles montan como bottom-sheet con drag-handle.

## Dependencies

Necesita el API PR (uno0uno/api-warolabs#TBD) merged + deployed primero — sin las migrations 067/068 el frontend recibirá errors al postear.

Closes #531