### PR TITLE
feat(metodos-pago, ventas, facturacion): auto-create PUC sub-account + dynamic dropdown + invoice gate + tz fix (#533)

### DIFF
--- a/composables/useChartOfAccounts.ts
+++ b/composables/useChartOfAccounts.ts
@@ -1,0 +1,36 @@
+/**
+ * Chart-of-accounts helpers shared across finance pages.
+ *
+ * Issue #533 — extracted from `pages/finanzas/contabilidad/cuentas/[id].vue` so
+ * both the create-sub-account flow (cuentas page) and the auto-create-on-method
+ * flow (`pages/finanzas/metodos-pago/[groupId].vue`) compute the next sub-aux
+ * suffix using the same logic. Avoids divergence as the convention evolves.
+ */
+
+interface AccountLike {
+  code: string
+}
+
+/**
+ * Suggest the next available 2-digit sub-aux suffix under a given parent code.
+ *
+ * Convention used across the project (Colombian PUC):
+ *   - Increments of 5 ('05', '10', '15', '20'…) so there's room to insert
+ *     codes manually later without renumbering existing ones.
+ *   - Returns '05' when the parent has no children yet.
+ *   - Operates on the cached list of accounts already loaded in the page.
+ *
+ * Example: parent 1110 with existing children 111005, 111010 → returns '15'.
+ */
+export const suggestSubAccountSuffix = (
+  parentCode: string,
+  allAccounts: AccountLike[],
+): string => {
+  const existing = allAccounts
+    .filter(a => a.code.startsWith(parentCode) && a.code.length === parentCode.length + 2)
+    .map(a => parseInt(a.code.slice(parentCode.length)))
+    .filter(n => !isNaN(n))
+  if (!existing.length) return '05'
+  const next = Math.max(...existing) + 5
+  return String(next).padStart(2, '0')
+}

--- a/pages/facturacion.vue
+++ b/pages/facturacion.vue
@@ -440,15 +440,25 @@ const taxLevels = [
               >
                 <svg class="w-4 h-4 text-text-tertiary" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" /></svg>
               </button>
-              <button
-                @click="toggleResolution(res.id)"
-                class="inline-flex items-center gap-1 text-xs font-bold px-2.5 py-1 rounded-full cursor-pointer transition-colors"
-                :class="res.is_active ? 'bg-green-100 text-green-700 hover:bg-green-200' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+              <!-- Toggle switch — mismo patrón que /operaciones/mesas y /operaciones/personalizar -->
+              <span
+                class="text-xs font-semibold tabular-nums"
+                :class="res.is_active ? 'text-emerald-700 dark:text-emerald-400' : 'text-text-secondary'"
+              >
+                {{ res.is_active ? 'Activa' : 'Inactiva' }}
+              </span>
+              <label
+                class="relative inline-flex items-center cursor-pointer flex-shrink-0"
                 :aria-label="res.is_active ? 'Desactivar resolución' : 'Activar resolución'"
               >
-                <svg v-if="res.is_active" class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m4.5 12.75 6 6 9-13.5" /></svg>
-                {{ res.is_active ? 'Activa' : 'Inactiva' }}
-              </button>
+                <input
+                  type="checkbox"
+                  class="sr-only peer"
+                  :checked="res.is_active"
+                  @change="toggleResolution(res.id)"
+                />
+                <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+              </label>
             </div>
           </div>
 

--- a/pages/finanzas/contabilidad/cuentas/[id].vue
+++ b/pages/finanzas/contabilidad/cuentas/[id].vue
@@ -167,16 +167,9 @@ const codeInput        = ref<HTMLInputElement | null>(null)
 // Full code = parent prefix + user-typed suffix
 const createFullCode = computed(() => (account.value?.code ?? '') + createSuffix.value.trim())
 
-const suggestSuffix = (parentCode: string): string => {
-  // Suggest next available suffix digits: '05', '10', '15'…
-  const existing = (accountsData.value?.data ?? [])
-    .filter(a => a.code.startsWith(parentCode) && a.code.length === parentCode.length + 2)
-    .map(a => parseInt(a.code.slice(parentCode.length)))
-    .filter(n => !isNaN(n))
-  if (!existing.length) return '05'
-  const next = Math.max(...existing) + 5
-  return String(next).padStart(2, '0')
-}
+// Issue #533 — shared with /finanzas/metodos-pago for the auto-create flow.
+const suggestSuffix = (parentCode: string): string =>
+  suggestSubAccountSuffix(parentCode, accountsData.value?.data ?? [])
 
 const openCreatePanel = async () => {
   createSuffix.value   = account.value ? suggestSuffix(account.value.code) : ''

--- a/pages/finanzas/metodos-pago/[groupId].vue
+++ b/pages/finanzas/metodos-pago/[groupId].vue
@@ -250,7 +250,7 @@
         </div>
 
         <!-- Body -->
-        <div class="flex-1 overflow-y-auto px-6 py-5">
+        <div class="flex-1 overflow-y-auto px-6 py-5 space-y-4">
           <div class="flex flex-col gap-1.5">
             <label for="panel-method-name" class="text-sm font-medium text-text-primary">
               Nombre del método
@@ -266,6 +266,65 @@
               @keydown.escape="closePanel"
             />
           </div>
+
+          <!-- Issue #533 — Auto-create PUC sub-account on method creation -->
+          <!-- Checkbox: only on create + when group supports it -->
+          <label
+            v-if="panelMode === 'create' && canAutoCreate"
+            class="flex items-start gap-3 px-4 py-3 rounded-lg border-2 border-border bg-surface cursor-pointer hover:border-primary/40 transition-colors"
+          >
+            <input
+              v-model="autoCreateAccount"
+              type="checkbox"
+              :disabled="saving"
+              class="mt-1 h-4 w-4 text-primary focus:ring-2 focus:ring-primary/30"
+              aria-describedby="auto-create-help"
+            />
+            <div class="min-w-0 flex-1">
+              <p class="text-sm font-semibold text-text-primary leading-snug">
+                Crear sub-cuenta contable automáticamente
+              </p>
+              <p id="auto-create-help" class="text-xs text-text-secondary leading-snug mt-0.5">
+                Se crea una cuenta dedicada en tu plan de cuentas para que las ventas con este método se registren separadas en los reportes.
+              </p>
+            </div>
+          </label>
+
+          <!-- Preview line -->
+          <div
+            v-if="panelMode === 'create' && autoCreateAccount && canAutoCreate && panelName.trim()"
+            class="rounded-lg border border-primary/30 bg-primary/5 px-4 py-3"
+          >
+            <p class="text-xs uppercase tracking-wider text-primary font-medium mb-1">
+              Vista previa
+            </p>
+            <p class="text-sm text-text-primary leading-snug">
+              Se creará la cuenta
+              <span class="font-mono font-semibold">{{ previewCode }} "{{ panelName.trim() }}"</span>
+              bajo
+              <span class="font-mono">{{ parentAccount!.code }} {{ parentAccount!.name }}</span>.
+            </p>
+          </div>
+
+          <!-- Warning: group has no default account configured -->
+          <div
+            v-else-if="panelMode === 'create' && group?.slug !== 'cash' && !group?.glAccountCode"
+            class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-800/40 dark:bg-amber-950/20"
+          >
+            <p class="text-xs text-amber-700 dark:text-amber-400 leading-snug flex items-start gap-1.5">
+              <svg class="w-3.5 h-3.5 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+              <span>
+                Para crear sub-cuentas automáticamente, primero asigna una cuenta contable al grupo desde el selector de arriba.
+              </span>
+            </p>
+          </div>
+
+          <!-- Submit error -->
+          <div v-if="panelError" class="rounded-lg border border-destructive/40 bg-destructive/8 px-4 py-3">
+            <p class="text-sm text-destructive font-medium">{{ panelError }}</p>
+          </div>
         </div>
 
         <!-- Footer -->
@@ -275,11 +334,8 @@
             class="flex-1 min-h-[44px] rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
             @click="savePanel"
           >
-            <svg v-if="saving" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-            </svg>
-            {{ saving ? 'Guardando…' : panelMode === 'create' ? 'Agregar' : 'Guardar' }}
+            <UiLoadingDots v-if="saving" size="8px" color="currentColor" />
+            <template v-else>{{ panelMode === 'create' ? 'Agregar' : 'Guardar' }}</template>
           </button>
           <button
             class="min-h-[44px] px-5 rounded-lg border border-border text-sm text-text-secondary hover:text-text-primary hover:border-primary transition-colors"
@@ -320,8 +376,14 @@ interface TenantAccount {
   id: string
   code: string
   name: string
-  is_detail: boolean
-  is_active: boolean
+  // FastAPI default response_model_by_alias=True → API emits camelCase.
+  isDetail: boolean
+  isActive: boolean
+  accountClass: string
+  accountType: string
+  normalBalance: 'debit' | 'credit'
+  level: number
+  parentId: string | null
 }
 
 interface PaymentMethod {
@@ -382,7 +444,7 @@ const fetchError   = computed(() => groupsError.value || methodsError.value)
 
 // ── Accounts (for GL selector) ────────────────────────────────────────────
 
-const { data: accountsData } = useQuery({
+const { data: accountsData, refetch: refetchAccounts } = useQuery({
   key: () => ['accounting', 'accounts', currentTenant.value?.id],
   query: () => $fetch<{ success: boolean; data: TenantAccount[] }>('/api/accounting/accounts'),
   enabled: () => !!currentTenant.value && group.value?.tenantId !== null,
@@ -390,7 +452,7 @@ const { data: accountsData } = useQuery({
 })
 
 const leafAccounts = computed<TenantAccount[]>(() =>
-  (accountsData.value?.data ?? []).filter(a => a.is_detail && a.is_active)
+  (accountsData.value?.data ?? []).filter(a => a.isDetail && a.isActive)
 )
 
 const currentGlAccount = computed(() =>
@@ -465,11 +527,35 @@ const panelMethod = ref<PaymentMethod | null>(null)
 const panelName  = ref('')
 const saving     = ref(false)
 const panelInput = ref<HTMLInputElement | null>(null)
+// Issue #533 — auto-create PUC sub-account state
+const autoCreateAccount = ref(true)
+const panelError = ref('')
+
+const parentAccount = computed<TenantAccount | null>(() =>
+  group.value?.glAccountCode
+    ? leafAccounts.value.find(a => a.code === group.value!.glAccountCode) ?? null
+    : null,
+)
+const previewSuffix = computed(() =>
+  parentAccount.value
+    ? suggestSubAccountSuffix(parentAccount.value.code, accountsData.value?.data ?? [])
+    : '',
+)
+const previewCode = computed(() =>
+  parentAccount.value ? parentAccount.value.code + previewSuffix.value : '',
+)
+const canAutoCreate = computed(() =>
+  group.value?.slug !== 'cash'
+  && !!group.value?.glAccountCode
+  && !!parentAccount.value,
+)
 
 const openCreate = async () => {
   panelMode.value = 'create'
   panelMethod.value = null
   panelName.value = ''
+  autoCreateAccount.value = true
+  panelError.value = ''
   showPanel.value = true
   await nextTick()
   panelInput.value?.focus()
@@ -479,6 +565,8 @@ const openEdit = async (method: PaymentMethod) => {
   panelMode.value = 'edit'
   panelMethod.value = method
   panelName.value = method.name
+  autoCreateAccount.value = false
+  panelError.value = ''
   showPanel.value = true
   await nextTick()
   panelInput.value?.focus()
@@ -488,16 +576,70 @@ const closePanel = () => {
   showPanel.value = false
   panelMethod.value = null
   panelName.value = ''
+  panelError.value = ''
+}
+
+const createAccountForMethod = async (
+  parent: TenantAccount,
+  desiredCode: string,
+  methodName: string,
+): Promise<string> => {
+  // Helper that POSTs the sub-account; on uniqueness conflict (race condition)
+  // it refetches the chart and retries once with a recomputed code.
+  const buildBody = (code: string) => ({
+    code,
+    name: methodName,
+    parentId: parent.id,
+    isDetail: true,
+    isActive: true,
+    accountClass: parent.accountClass,
+    accountType: parent.accountType,
+    normalBalance: parent.normalBalance,
+    level: parent.level + 1,
+  })
+  try {
+    await $fetch('/api/accounting/accounts', { method: 'POST', body: buildBody(desiredCode) })
+    return desiredCode
+  } catch (err: any) {
+    const msg = err?.data?.detail ?? err?.data?.message ?? ''
+    if (/Ya existe/.test(msg)) {
+      // Race-condition retry: someone else just took this code.
+      await refetchAccounts()
+      const retrySuffix = suggestSubAccountSuffix(parent.code, accountsData.value?.data ?? [])
+      const retryCode = parent.code + retrySuffix
+      await $fetch('/api/accounting/accounts', { method: 'POST', body: buildBody(retryCode) })
+      return retryCode
+    }
+    throw err
+  }
 }
 
 const savePanel = async () => {
   if (!panelName.value.trim() || saving.value) return
   saving.value = true
+  panelError.value = ''
   try {
     if (panelMode.value === 'create') {
+      let glAccountCode: string | null = null
+
+      // Issue #533 — optionally auto-create the PUC sub-account first.
+      if (autoCreateAccount.value && canAutoCreate.value && parentAccount.value) {
+        glAccountCode = await createAccountForMethod(
+          parentAccount.value,
+          previewCode.value,
+          panelName.value.trim(),
+        )
+      }
+
+      // Create the method (now with glAccountCode if auto-created).
       await $fetch('/api/finanzas/metodos-pago', {
         method: 'POST',
-        body: { groupId, name: panelName.value.trim(), sortOrder: 0 },
+        body: {
+          groupId,
+          name: panelName.value.trim(),
+          sortOrder: 0,
+          glAccountCode,
+        },
       })
     } else {
       await $fetch(`/api/finanzas/metodos-pago/${panelMethod.value!.id}`, {
@@ -506,7 +648,9 @@ const savePanel = async () => {
       })
     }
     closePanel()
-    await refetchMethods()
+    await Promise.all([refetchMethods(), refetchAccounts()])
+  } catch (err: any) {
+    panelError.value = err?.data?.detail || err?.data?.message || err?.message || 'Error al guardar el método'
   } finally {
     saving.value = false
   }

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
+import { useInvoicingReadiness } from '~/composables/useInvoicingReadiness'
 
 definePageMeta({
   layout: 'dashboard'
@@ -76,6 +77,10 @@ const { data: invoiceData, refetch: refetchInvoice } = useQuery({
   enabled: () => !!currentTenant.value && !!orderId.value,
   staleTime: 60_000,
 })
+
+// DIAN invoicing readiness — gates the entire electronic-invoice UI section.
+// Same composable / pattern used by the POS checkout (pages/pos/checkout.vue:71).
+const { ready: isInvoicingReady, isLoading: isReadinessLoading } = useInvoicingReadiness()
 
 // Invoice emit state
 const isEmittingInvoice = ref(false)
@@ -523,8 +528,14 @@ onUnmounted(() => {
         </div>
       </div>
 
-      <!-- Electronic Invoice Section -->
-      <div class="bg-surface border border-border rounded-2xl overflow-hidden">
+      <!-- Electronic Invoice Section — visible when:
+           (a) the order already has an emitted invoice (historical data), OR
+           (b) the tenant has DIAN invoicing configured and ready.
+           Otherwise hidden entirely (matches the POS checkout guard pattern). -->
+      <div
+        v-if="invoiceData || (isInvoicingReady && !isReadinessLoading)"
+        class="bg-surface border border-border rounded-2xl overflow-hidden"
+      >
         <!-- Invoice exists -->
         <template v-if="invoiceData">
           <!-- Header -->

--- a/pages/ventas/crear.vue
+++ b/pages/ventas/crear.vue
@@ -34,9 +34,25 @@ interface LineItem {
 const loading = ref(false)
 const activeItemIndex = ref<number | null>(null)
 
+// Pre-fill the datetime-local input with the user's LOCAL time, not UTC.
+// `Date.prototype.toISOString()` returns UTC, which the input then renders
+// AS IF it were local — so a user in Bogota (UTC-5) at 2:30 PM would see
+// the input showing "8:30 PM" of the wrong date and submit a 5-hour-skewed
+// timestamp without noticing. Build the local-time string manually instead.
+const localNowISO = (): string => {
+  const d = new Date()
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+// Form state stores BOTH the group slug AND the method UUID. The slug is
+// what /api/orders/manual has historically accepted; payment_method_id is
+// the specific method (Nequi / PSE / Daviplata...) so the GL posting can
+// resolve to the right sub-account when manual orders also auto-post.
 const form = ref({
-  order_date: new Date().toISOString().slice(0, 16),
+  order_date: localNowISO(),
   payment_method: 'cash',
+  payment_method_id: null as string | null,
   items: [] as LineItem[]
 })
 
@@ -47,6 +63,29 @@ const { data: productsData, pending: loadingProducts } = useFetch('/api/menu/pro
 })
 
 const products = computed(() => productsData.value?.data ?? [])
+
+// ─── Payment methods (dynamic, same source as POS) ──────────────────────────
+interface PaymentMethodLite { id: string; name: string }
+interface PaymentGroupLite { id: string; slug: string; name: string; methods?: PaymentMethodLite[] }
+
+const { data: paymentGroupsData } = useFetch<{ success: boolean; data: PaymentGroupLite[] }>(
+  '/api/pos/payment-methods',
+)
+const paymentGroups = computed(() => paymentGroupsData.value?.data ?? [])
+
+// Single composed value for the v-model: "groupSlug:methodId" or "groupSlug:".
+// "cash:" means group "cash" without a specific method (group default).
+// "digital:b523-…" means group "digital" + that specific method UUID.
+const paymentSelectValue = computed({
+  get: () => `${form.value.payment_method}:${form.value.payment_method_id ?? ''}`,
+  set: (v: string) => {
+    const idx = v.indexOf(':')
+    const slug = idx === -1 ? v : v.slice(0, idx)
+    const methodId = idx === -1 ? '' : v.slice(idx + 1)
+    form.value.payment_method = slug
+    form.value.payment_method_id = methodId || null
+  },
+})
 
 // ─── Computed helpers ─────────────────────────────────────────────────────────
 
@@ -160,11 +199,20 @@ async function submit() {
   if (!canSubmit.value) return
   loading.value = true
   try {
-    const res = await $fetch<any>('/api/orders/manual', {
+    // Convert the local-time input value (e.g. "2026-05-07T14:30") to a UTC
+     // ISO string with explicit "+00:00" offset so the backend stores the
+     // right moment. new Date(localStr) interprets the string as local time;
+     // toISOString emits UTC with a "Z" suffix that Python 3.9 fromisoformat
+     // does NOT accept — strip the "Z" + ms and append "+00:00".
+     const orderDateUtc =
+       new Date(form.value.order_date).toISOString().slice(0, 19) + '+00:00'
+
+     const res = await $fetch<any>('/api/orders/manual', {
       method: 'POST',
       body: {
-        order_date: form.value.order_date,
+        order_date: orderDateUtc,
         payment_method: form.value.payment_method,
+        payment_method_id: form.value.payment_method_id,
         items: form.value.items.map(i => ({
           product_id: i.product_id,
           quantity: i.quantity,
@@ -230,14 +278,21 @@ async function submit() {
           />
           <select
             id="payment_method"
-            v-model="form.payment_method"
+            v-model="paymentSelectValue"
             required
             aria-label="Método de pago"
             class="h-9 w-full px-3 rounded-lg border border-border bg-background text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary cursor-pointer"
           >
-            <option value="cash">Efectivo</option>
-            <option value="card">Tarjeta</option>
-            <option value="digital">Digital</option>
+            <template v-for="g in paymentGroups" :key="g.id">
+              <!-- Group default option (when no specific method picked) -->
+              <option :value="`${g.slug}:`">{{ g.name }}</option>
+              <!-- Specific methods nested under the group -->
+              <optgroup v-if="g.methods && g.methods.length > 0" :label="g.name">
+                <option v-for="m in g.methods" :key="m.id" :value="`${g.slug}:${m.id}`">
+                  {{ g.name }} · {{ m.name }}
+                </option>
+              </optgroup>
+            </template>
           </select>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Closes #533. Bundle of UX work on the payment-methods page (auto-create PUC sub-account) plus adjacent fixes surfaced during testing.

## Stack

🟢 Nuxt 3 + 🎨 UX

## Changes

### Auto-create PUC sub-account on method creation (#533 core)
- \`composables/useChartOfAccounts.ts\` (new) — shared \`suggestSubAccountSuffix\` helper, extracted from \`cuentas/[id].vue\` so both forward and reverse flows compute the same suffix sequence.
- \`pages/finanzas/metodos-pago/[groupId].vue\` — added auto-create checkbox (default checked), preview line (\`Se creará la cuenta 111020 'Bancolombia App' bajo 1110 Bancos\`), amber warning when group has no default account, conflict-retry on uniqueness collisions, \`UiLoadingDots\` in submit. Fixed latent bug: \`TenantAccount\` interface used snake_case (\`is_detail\`, \`is_active\`) but FastAPI emits camelCase by default — \`leafAccounts\` filter was returning empty.
- \`pages/finanzas/contabilidad/cuentas/[id].vue\` — replaced inline \`suggestSuffix\` with composable import (zero behavior change, prevents drift).

### Dynamic payment dropdown on /ventas/crear
- Replaced hardcoded \`<option>\`s (cash / card / digital) with a dynamic \`<select>\` pulling from \`/api/pos/payment-methods\` — same source as the POS. Now shows all groups + their methods nested via \`<optgroup>\`. Form state holds both group slug and \`payment_method_id\`; both sent to \`/api/orders/manual\`.

### Timezone fix on /ventas/crear
- Pre-fill used \`new Date().toISOString()\` (UTC) but \`<input type=\"datetime-local\">\` renders local. Bogota users were saving order_date 5h skewed without noticing. Now pre-fills with local time and converts to UTC on submit using \"+00:00\" offset (Python 3.9 \`fromisoformat\` compatible).

### Invoice readiness gate on /ventas/[id]
- Wraps the entire electronic-invoice section with \`v-if=\"invoiceData || (isInvoicingReady && !isReadinessLoading)\"\` using the same \`useInvoicingReadiness\` composable as the POS. When the tenant has no DIAN configured, the section is hidden entirely. Existing emitted invoices remain visible regardless (historical data).

### Toggle switch on /facturacion DIAN resolutions
- Replaced the pill-style activate/deactivate button with a toggle switch matching the project pattern (mesas, personalizar, comandas). State label rendered alongside.

## Dependencies

Needs the API PR (uno0uno/api-warolabs#TBD) merged + deployed first — backend changes are required for:
- Auto-create flow chain (\`POST /finanzas/metodos-pago\` accepting \`glAccountCode\`).
- Manual orders persisting \`payment_method_id\`.
- DIAN resolution date parsing fix.

## Testing manual

- [ ] Create method in /finanzas/metodos-pago/digital → preview shows next code → submit → method + sub-account both created and linked.
- [ ] /ventas/crear dropdown shows all groups + methods + Crédito → submit with specific method → order registers payment_method_id.
- [ ] /ventas/crear pre-filled time matches local Bogota time (not 5h ahead).
- [ ] /ventas/[id] invoice section visible only when DIAN ready or invoice exists.
- [ ] /facturacion DIAN resolution toggle switches activation cleanly.

Closes #533