### PR TITLE
feat(pos-expediter): waiter-facing comandas state panel (#537)

### DIFF
--- a/components/pos/ComandasEstadoPanel.vue
+++ b/components/pos/ComandasEstadoPanel.vue
@@ -1,0 +1,443 @@
+<script setup lang="ts">
+import { ref, computed, watch, onUnmounted } from 'vue'
+import {
+  XMarkIcon,
+  ClipboardDocumentListIcon,
+  CheckCircleIcon,
+  BellAlertIcon,
+  BellSlashIcon,
+  ClockIcon,
+  MapPinIcon,
+} from '@heroicons/vue/24/outline'
+
+interface ComandaItem {
+  id: string
+  kitchen_name: string
+  quantity: number
+  notes?: string | null
+}
+
+interface Comanda {
+  id: string
+  comanda_number: number
+  status: 'pending' | 'preparing' | 'ready' | 'delivered' | 'cancelled'
+  source_type: 'table' | 'pos' | 'delivery' | 'pickup'
+  table_display_name?: string | null
+  fired_at: string
+  preparing_at?: string | null
+  ready_at?: string | null
+  items?: ComandaItem[]
+}
+
+const props = defineProps<{
+  modelValue: boolean
+  tableSessionId?: string | null
+  tableDisplayName?: string | null
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+  'success': []
+}>()
+
+const close = () => emit('update:modelValue', false)
+
+const toast = useToast()
+const { enabled: audioEnabled, setEnabled: setAudioEnabled, playReadyChime } = useExpediterAudio()
+
+// ── Fetch comandas — only while panel is open, polling every 10s ─────────
+const comandas = ref<Comanda[]>([])
+const isLoading = ref(false)
+const submitting = ref(false)
+let pollInterval: ReturnType<typeof setInterval> | null = null
+let previousReadyIds = new Set<string>()
+
+const fetchComandas = async () => {
+  if (!props.modelValue) return
+  try {
+    const res = await $fetch<{ success: boolean; data: Comanda[] }>(
+      '/api/api/comandas',
+      { params: { status: 'pending,preparing,ready' } },
+    )
+    let list = (res?.data ?? []).filter(c => c.source_type === 'table' || c.source_type === 'pos')
+    if (props.tableSessionId) {
+      list = list.filter(c => (c as any).table_session_id === props.tableSessionId
+        || (c.source_type === 'table' && c.table_display_name === props.tableDisplayName))
+    }
+    const currentReady = new Set(list.filter(c => c.status === 'ready').map(c => c.id))
+    const newReady = [...currentReady].filter(id => !previousReadyIds.has(id))
+    if (newReady.length > 0 && previousReadyIds.size > 0) {
+      playReadyChime()
+      flashIds.value = new Set(newReady)
+      setTimeout(() => { flashIds.value = new Set() }, 2000)
+    }
+    previousReadyIds = currentReady
+    comandas.value = list
+  } catch {
+    // Silent — non-critical, will retry on next poll
+  }
+}
+
+const flashIds = ref<Set<string>>(new Set())
+
+watch(() => props.modelValue, (open) => {
+  if (open) {
+    selectedIds.value = new Set()
+    activeTab.value = 'ready'
+    isLoading.value = true
+    previousReadyIds = new Set()
+    fetchComandas().finally(() => { isLoading.value = false })
+    pollInterval = setInterval(fetchComandas, 10_000)
+  } else {
+    if (pollInterval) {
+      clearInterval(pollInterval)
+      pollInterval = null
+    }
+  }
+})
+
+onUnmounted(() => {
+  if (pollInterval) clearInterval(pollInterval)
+})
+
+// ── Tabs ─────────────────────────────────────────────────────────────────
+const activeTab = ref<'ready' | 'preparing'>('ready')
+const readyComandas = computed(() => comandas.value.filter(c => c.status === 'ready'))
+const preparingComandas = computed(() =>
+  comandas.value.filter(c => c.status === 'preparing' || c.status === 'pending'),
+)
+const visibleComandas = computed(() =>
+  activeTab.value === 'ready' ? readyComandas.value : preparingComandas.value,
+)
+
+// ── Selection ────────────────────────────────────────────────────────────
+const selectedIds = ref<Set<string>>(new Set())
+watch(activeTab, () => { selectedIds.value = new Set() })
+
+const toggleSelected = (id: string) => {
+  const next = new Set(selectedIds.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  selectedIds.value = next
+}
+const allSelected = computed(() =>
+  visibleComandas.value.length > 0
+  && visibleComandas.value.every(c => selectedIds.value.has(c.id)),
+)
+const toggleAll = () => {
+  if (allSelected.value) {
+    selectedIds.value = new Set()
+  } else {
+    selectedIds.value = new Set(visibleComandas.value.map(c => c.id))
+  }
+}
+
+// ── Aging tier (3-tier intensity scale) ──────────────────────────────────
+type AgingTier = 'fresh' | 'warning' | 'urgent'
+const ageMinutes = (firedAt: string): number => {
+  const t = new Date(firedAt).getTime()
+  if (Number.isNaN(t)) return 0
+  return Math.floor((Date.now() - t) / 60_000)
+}
+const agingTier = (firedAt: string): AgingTier => {
+  const m = ageMinutes(firedAt)
+  if (m >= 10) return 'urgent'
+  if (m >= 5)  return 'warning'
+  return 'fresh'
+}
+// 60-30-10: fresh stays neutral, warning gets a soft tint, urgent pops with bg + chip
+const cardClass = (firedAt: string, selected: boolean): string => {
+  const tier = agingTier(firedAt)
+  if (selected) return 'bg-primary/5 border-primary'
+  if (tier === 'urgent')  return 'bg-destructive/5 border-destructive'
+  if (tier === 'warning') return 'bg-amber-50/60 border-amber-300'
+  return 'bg-surface border-emerald-200'
+}
+const chipClass = (firedAt: string): string => {
+  const tier = agingTier(firedAt)
+  if (tier === 'urgent')  return 'bg-destructive/10 text-destructive'
+  if (tier === 'warning') return 'bg-amber-100 text-amber-800'
+  return 'bg-emerald-50 text-emerald-700'
+}
+const ageLabel = (firedAt: string): string => {
+  const m = ageMinutes(firedAt)
+  if (m < 1)   return 'recién'
+  if (m === 1) return '1 min'
+  if (m < 60)  return `${m} min`
+  const h = Math.floor(m / 60)
+  const r = m % 60
+  return r === 0 ? `${h} h` : `${h} h ${r} min`
+}
+
+// ── Submit (bulk advance) ────────────────────────────────────────────────
+const submitTarget = computed<'ready' | 'delivered'>(() =>
+  activeTab.value === 'preparing' ? 'ready' : 'delivered',
+)
+const submitLabel = computed(() => {
+  const n = selectedIds.value.size
+  if (n === 0) {
+    return activeTab.value === 'preparing' ? 'Marcar como listas' : 'Marcar como entregadas'
+  }
+  if (activeTab.value === 'preparing') return `Marcar ${n} como ${n === 1 ? 'lista' : 'listas'}`
+  return `Marcar ${n} como ${n === 1 ? 'entregada' : 'entregadas'}`
+})
+
+const submit = async () => {
+  if (submitting.value || selectedIds.value.size === 0) return
+  submitting.value = true
+  const ids = [...selectedIds.value]
+  const target = submitTarget.value
+  try {
+    const res = await $fetch<{ success_count: number; failed: any[] }>(
+      '/api/api/comandas/bulk-status',
+      { method: 'PATCH', body: { comanda_ids: ids, status: target } },
+    )
+    const ok = res.success_count ?? ids.length
+    const failed = (res.failed ?? []).length
+    if (failed === 0) {
+      toast.success(`${ok} ${ok === 1 ? 'comanda actualizada' : 'comandas actualizadas'}`, {
+        title: 'Estado actualizado',
+      })
+    } else {
+      toast.success(`${ok} actualizadas · ${failed} fallaron`, { title: 'Resultado parcial' })
+    }
+    selectedIds.value = new Set()
+    await fetchComandas()
+    emit('success')
+  } catch (err: any) {
+    toast.error(err?.data?.detail || err?.message || 'Error al actualizar comandas', { title: 'Error' })
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-200"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div v-if="modelValue" class="fixed inset-0 z-40 bg-black/40" aria-hidden="true" @click="close" />
+    </Transition>
+
+    <Transition name="panel">
+      <div
+        v-if="modelValue"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Estado de comandas"
+        class="fixed z-50 flex flex-col bg-surface shadow-2xl
+               inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh]
+               md:inset-y-0 md:right-0 md:bottom-auto md:left-auto md:inset-x-auto md:rounded-none md:w-full md:max-w-lg md:max-h-none md:h-full"
+      >
+        <!-- Mobile drag handle -->
+        <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
+          <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+        </div>
+
+        <!-- Header -->
+        <div class="flex-shrink-0 bg-surface-secondary/40 border-b border-border px-5 py-4">
+          <div class="flex items-start justify-between gap-3">
+            <div class="flex items-center gap-3 min-w-0 flex-1">
+              <div class="flex-shrink-0 w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
+                <ClipboardDocumentListIcon class="w-5 h-5" />
+              </div>
+              <div class="min-w-0">
+                <h2 class="text-base font-bold text-text-primary leading-tight">Estado de comandas</h2>
+                <p class="text-xs text-text-secondary leading-snug mt-0.5 truncate">
+                  {{ tableDisplayName ? `Mesa ${tableDisplayName}` : 'Comandas activas' }}
+                  · {{ comandas.length }} {{ comandas.length === 1 ? 'comanda' : 'comandas' }}
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              aria-label="Cerrar panel"
+              class="flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center text-text-tertiary hover:bg-surface-secondary hover:text-text-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+              @click="close"
+            >
+              <XMarkIcon class="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+
+        <!-- Tabs -->
+        <div class="flex-shrink-0 border-b border-border bg-surface px-2">
+          <div class="flex">
+            <button
+              type="button"
+              class="flex-1 min-h-[44px] px-3 py-2 text-sm font-semibold transition-colors border-b-2 flex items-center justify-center gap-2"
+              :class="activeTab === 'ready'
+                ? 'border-primary text-primary'
+                : 'border-transparent text-text-secondary hover:text-text-primary'"
+              @click="activeTab = 'ready'"
+            >
+              <span>Listas</span>
+              <span
+                class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full text-[11px] font-bold tabular-nums"
+                :class="activeTab === 'ready'
+                  ? 'bg-primary text-white'
+                  : 'bg-surface-secondary text-text-tertiary'"
+              >{{ readyComandas.length }}</span>
+            </button>
+            <button
+              type="button"
+              class="flex-1 min-h-[44px] px-3 py-2 text-sm font-semibold transition-colors border-b-2 flex items-center justify-center gap-2"
+              :class="activeTab === 'preparing'
+                ? 'border-primary text-primary'
+                : 'border-transparent text-text-secondary hover:text-text-primary'"
+              @click="activeTab = 'preparing'"
+            >
+              <span>En preparación</span>
+              <span
+                class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full text-[11px] font-bold tabular-nums"
+                :class="activeTab === 'preparing'
+                  ? 'bg-primary text-white'
+                  : 'bg-surface-secondary text-text-tertiary'"
+              >{{ preparingComandas.length }}</span>
+            </button>
+          </div>
+        </div>
+
+        <!-- Body -->
+        <div class="flex-1 overflow-y-auto px-4 py-4 space-y-2.5">
+          <div v-if="isLoading && comandas.length === 0" class="flex items-center justify-center py-12">
+            <CommonsTheCustomLoader size="medium" />
+          </div>
+
+          <div v-else-if="visibleComandas.length === 0" class="flex flex-col items-center justify-center py-16 text-center">
+            <div class="w-14 h-14 rounded-full bg-surface-secondary flex items-center justify-center mb-3">
+              <CheckCircleIcon class="w-7 h-7 text-text-tertiary" />
+            </div>
+            <p class="text-sm font-semibold text-text-secondary">
+              {{ activeTab === 'ready' ? 'Nada listo aún' : 'Sin comandas en cocina' }}
+            </p>
+            <p class="text-xs text-text-tertiary mt-1 max-w-[14rem]">
+              {{ activeTab === 'ready'
+                ? 'Las comandas aparecerán aquí cuando cocina las marque como listas.'
+                : 'Cuando se generen comandas nuevas las verás aquí.' }}
+            </p>
+          </div>
+
+          <template v-else>
+            <button
+              v-for="c in visibleComandas"
+              :key="c.id"
+              type="button"
+              :aria-pressed="selectedIds.has(c.id)"
+              class="w-full text-left rounded-xl border-2 p-3.5 transition-all"
+              :class="[
+                cardClass(c.fired_at, selectedIds.has(c.id)),
+                flashIds.has(c.id) ? 'animate-pulse ring-2 ring-emerald-400' : '',
+              ]"
+              @click="toggleSelected(c.id)"
+            >
+              <div class="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  :checked="selectedIds.has(c.id)"
+                  class="mt-1 h-4 w-4 rounded text-primary focus:ring-2 focus:ring-primary/30 cursor-pointer"
+                  @click.stop
+                  @change="toggleSelected(c.id)"
+                />
+                <div class="flex-1 min-w-0">
+                  <!-- Row 1 — Comanda # + aging chip -->
+                  <div class="flex items-center justify-between gap-2 mb-1.5">
+                    <span class="text-base font-bold text-text-primary tabular-nums leading-none">
+                      #{{ c.comanda_number }}
+                    </span>
+                    <span
+                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold tabular-nums"
+                      :class="chipClass(c.fired_at)"
+                    >
+                      <ClockIcon class="w-3 h-3" />
+                      {{ ageLabel(c.fired_at) }}
+                    </span>
+                  </div>
+
+                  <!-- Row 2 — Destination (mesa) -->
+                  <div v-if="c.table_display_name" class="flex items-center gap-1 text-sm font-semibold text-text-primary mb-1.5 capitalize">
+                    <MapPinIcon class="w-3.5 h-3.5 text-text-tertiary flex-shrink-0" />
+                    {{ c.table_display_name }}
+                  </div>
+
+                  <!-- Row 3 — Items -->
+                  <ul v-if="c.items?.length" class="text-xs text-text-secondary leading-snug space-y-0.5">
+                    <li v-for="i in c.items" :key="i.id" class="flex gap-1.5">
+                      <span class="font-semibold text-text-primary tabular-nums flex-shrink-0">{{ i.quantity }}×</span>
+                      <span class="truncate">{{ i.kitchen_name }}</span>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </button>
+          </template>
+        </div>
+
+        <!-- Sticky footer -->
+        <div class="flex-shrink-0 border-t border-border bg-surface px-4 py-3 space-y-2">
+          <!-- Audio + select-all row -->
+          <div v-if="visibleComandas.length > 0" class="flex items-center justify-between gap-3">
+            <button
+              type="button"
+              class="text-xs font-medium text-text-secondary hover:text-text-primary transition-colors"
+              @click="toggleAll"
+            >
+              {{ allSelected ? 'Deseleccionar todas' : 'Seleccionar todas' }}
+            </button>
+            <button
+              type="button"
+              :aria-pressed="audioEnabled"
+              :aria-label="audioEnabled ? 'Desactivar aviso sonoro' : 'Activar aviso sonoro'"
+              class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium border transition-colors"
+              :class="audioEnabled
+                ? 'border-primary/30 bg-primary/5 text-primary'
+                : 'border-border bg-surface text-text-tertiary hover:text-text-secondary'"
+              @click="setAudioEnabled(!audioEnabled)"
+            >
+              <BellAlertIcon v-if="audioEnabled" class="w-3.5 h-3.5" />
+              <BellSlashIcon v-else class="w-3.5 h-3.5" />
+              Aviso sonoro
+            </button>
+          </div>
+
+          <!-- Primary action -->
+          <button
+            type="button"
+            :disabled="selectedIds.size === 0 || submitting"
+            class="w-full min-h-[52px] rounded-xl bg-primary text-white text-base font-bold transition-all hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/30 active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            @click="submit"
+          >
+            <UiLoadingDots v-if="submitting" size="9px" color="currentColor" />
+            <template v-else>
+              <CheckCircleIcon class="w-5 h-5" />
+              {{ submitLabel }}
+            </template>
+          </button>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.panel-enter-active,
+.panel-leave-active {
+  transition: transform 0.25s ease;
+}
+.panel-enter-from,
+.panel-leave-to {
+  transform: translateY(100%);
+}
+@media (min-width: 768px) {
+  .panel-enter-from,
+  .panel-leave-to {
+    transform: translateX(100%);
+  }
+}
+</style>

--- a/composables/useExpediterAudio.ts
+++ b/composables/useExpediterAudio.ts
@@ -1,0 +1,78 @@
+/**
+ * Expediter audio cue helper — issue #537.
+ *
+ * Plays a short chime when a comanda transitions to `ready` so the waiter
+ * is alerted without watching the screen. Browser autoplay policy requires
+ * the first user interaction to "unlock" audio playback — this composable
+ * lazily creates the AudioContext on the first user-driven call to play().
+ *
+ * The enabled flag is persisted in localStorage so the operator's choice
+ * survives page reloads.
+ */
+
+const STORAGE_KEY = 'waro:expediter:audio-enabled'
+
+let audioCtx: AudioContext | null = null
+
+const getAudioContext = (): AudioContext | null => {
+  if (typeof window === 'undefined') return null
+  if (audioCtx) return audioCtx
+  try {
+    const Ctx = window.AudioContext || (window as any).webkitAudioContext
+    if (!Ctx) return null
+    audioCtx = new Ctx()
+    return audioCtx
+  } catch {
+    return null
+  }
+}
+
+const playChime = () => {
+  const ctx = getAudioContext()
+  if (!ctx) return
+  // Some browsers start the context in a "suspended" state until the first
+  // user gesture. Resume() inside a click handler is what unlocks it.
+  if (ctx.state === 'suspended') ctx.resume().catch(() => {})
+
+  const now = ctx.currentTime
+  // Two-tone gentle chime (G5 → C6) — pleasant, attention-getting but not alarming.
+  const tones = [
+    { freq: 784, start: 0,    duration: 0.12 },   // G5
+    { freq: 1046, start: 0.13, duration: 0.18 },  // C6
+  ]
+  for (const t of tones) {
+    const osc = ctx.createOscillator()
+    const gain = ctx.createGain()
+    osc.type = 'sine'
+    osc.frequency.setValueAtTime(t.freq, now + t.start)
+    gain.gain.setValueAtTime(0, now + t.start)
+    gain.gain.linearRampToValueAtTime(0.18, now + t.start + 0.02)
+    gain.gain.linearRampToValueAtTime(0, now + t.start + t.duration)
+    osc.connect(gain)
+    gain.connect(ctx.destination)
+    osc.start(now + t.start)
+    osc.stop(now + t.start + t.duration)
+  }
+}
+
+export const useExpediterAudio = () => {
+  const initial =
+    typeof window !== 'undefined'
+      ? window.localStorage.getItem(STORAGE_KEY) !== 'false' // default ON
+      : true
+  const enabled = useState<boolean>('expediter-audio-enabled', () => initial)
+
+  const setEnabled = (value: boolean) => {
+    enabled.value = value
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, value ? 'true' : 'false')
+    }
+  }
+
+  const playReadyChime = () => {
+    if (!enabled.value) return
+    playChime()
+  }
+
+  return { enabled, setEnabled, playReadyChime }
+}

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -41,7 +41,7 @@
               key="pos-link"
               type="button"
               @click="navigateToPOS"
-              class="flex items-center gap-1 md:gap-2 h-11 bg-card border border-border text-foreground px-2 md:px-4 rounded-xl font-medium hover:bg-accent transition-all"
+              class="flex items-center gap-1 md:gap-2 h-11 bg-white border-2 border-surface-secondary text-text-primary px-2 md:px-4 rounded-lg text-sm font-medium hover:bg-surface-secondary transition-colors"
               title="Venta POS"
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg>

--- a/pages/operaciones/comandas.vue
+++ b/pages/operaciones/comandas.vue
@@ -122,6 +122,31 @@
             </div>
           </div>
         </div>
+
+        <!-- Issue #537 — Expediter mode (waiter advances comanda state from POS) -->
+        <div v-if="businessProfile?.comandas_enabled" class="space-y-2 pt-3 border-t border-border">
+          <div class="flex items-center justify-between py-1">
+            <div>
+              <p class="text-sm font-medium text-text-primary">Mesero avanza estado desde POS</p>
+              <p class="text-xs text-text-secondary mt-0.5">
+                Habilita un panel en <span class="font-mono text-[11px]">/pos</span> donde el mesero
+                puede marcar comandas como "lista" o "entregada" sin tocar la pantalla de cocina.
+              </p>
+            </div>
+            <div class="flex-shrink-0 ml-4 flex items-center justify-center w-10 h-6">
+              <UiLoadingDots v-if="isTogglingExpediter" color="var(--color-primary)" size="11px" />
+              <label v-else class="relative inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  class="sr-only peer"
+                  :checked="businessProfile?.expediter_enabled"
+                  @change="handleToggleExpediter"
+                />
+                <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+              </label>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -552,6 +577,28 @@ const handleToggleKds = async (event: Event) => {
     toast.error(error.data?.detail || 'Error al cambiar estado KDS', { title: 'Error' })
   } finally {
     isTogglingKds.value = false
+  }
+}
+
+// Issue #537 — Expediter mode toggle (waiter advances comanda state from POS)
+const isTogglingExpediter = ref(false)
+const handleToggleExpediter = async (event: Event) => {
+  if (isTogglingExpediter.value) return
+  const newState = (event.target as HTMLInputElement).checked
+  isTogglingExpediter.value = true
+  try {
+    await $fetch('/api/api/tenant/public-profile', { method: 'PATCH', body: { expediter_enabled: newState } })
+    await refreshProfile()
+    toast.success(
+      newState
+        ? 'El mesero puede avanzar comandas desde el POS'
+        : 'Solo cocina avanza comandas (desde KDS)',
+      { title: newState ? 'Activado' : 'Desactivado' }
+    )
+  } catch (error: any) {
+    toast.error(error.data?.detail || 'Error al cambiar modo expedidor', { title: 'Error' })
+  } finally {
+    isTogglingExpediter.value = false
   }
 }
 

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -188,6 +188,9 @@ const { data: settingsData } = useQuery({
   staleTime: 30_000,
 })
 const comandasEnabled = computed(() => settingsData.value?.data?.comandas_enabled === true)
+// Issue #537 — expediter mode (waiter advances comanda state from POS)
+const expediterEnabled = computed(() => settingsData.value?.data?.expediter_enabled === true)
+const showExpediterPanel = ref(false)
 const acceptsOnlineOrders = computed(() => settingsData.value?.data?.accepts_online_orders === true)
 
 // Counter mode: not a real table session (no mesa, no bar)
@@ -2128,6 +2131,20 @@ onUnmounted(() => {
             <span>Imprimir prefactura</span>
           </button>
 
+          <!-- Issue #537 — Estado de comandas (expediter) -->
+          <button
+            v-if="expediterEnabled && comandasEnabled && (isMesaMode || posStore.activeTableSession)"
+            type="button"
+            class="w-full bg-surface border-2 border-border hover:border-primary hover:text-primary text-text-secondary font-semibold py-3 px-6 rounded-xl transition-all flex items-center justify-center gap-2 active:scale-95 focus:outline-none focus:ring-2 focus:ring-primary/30"
+            aria-label="Ver estado de comandas"
+            @click="showExpediterPanel = true"
+          >
+            <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.8" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <span>Estado de comandas</span>
+          </button>
+
           <button
             @click="cancelOrder"
             class="w-full bg-surface border border-border hover:bg-destructive/10 hover:text-destructive hover:border-destructive/20 text-text-secondary font-semibold py-3 px-6 rounded-xl transition-all flex items-center justify-center gap-2"
@@ -2761,6 +2778,14 @@ onUnmounted(() => {
       <div class="receipt-divider">================================</div>
     </template>
   </div>
+
+  <!-- Issue #537 — Estado de comandas (expediter) slide-over -->
+  <PosComandasEstadoPanel
+    v-if="expediterEnabled && comandasEnabled"
+    v-model="showExpediterPanel"
+    :table-session-id="posStore.activeTableSession?.tableId ?? null"
+    :table-display-name="posStore.activeTableSession?.tableName ?? null"
+  />
   </div>
 </template>
 

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -99,6 +99,39 @@ const isResolvingSettings = computed(() => {
 // ── KDS / Comandas feature flag ─────────────────────────────────────────────
 const comandasEnabled = computed(() => settingsData.value?.data?.comandas_enabled === true)
 
+// Issue #537 — expediter mode (waiter advances comanda state from POS)
+const expediterEnabled = computed(() => settingsData.value?.data?.expediter_enabled === true)
+const showExpediterPanel = ref(false)
+const readyComandasCount = ref(0)
+let readyCountInterval: ReturnType<typeof setInterval> | null = null
+const refreshReadyComandasCount = async () => {
+  if (!expediterEnabled.value || !comandasEnabled.value) {
+    readyComandasCount.value = 0
+    return
+  }
+  try {
+    const res = await $fetch<{ success: boolean; data: any[] }>(
+      '/api/api/comandas?status=ready&source_type=table,pos',
+    )
+    readyComandasCount.value = (res?.data ?? []).length
+  } catch {
+    // silent — non-critical
+  }
+}
+watch(
+  () => expediterEnabled.value && comandasEnabled.value,
+  (on) => {
+    if (on) {
+      refreshReadyComandasCount()
+      readyCountInterval = setInterval(refreshReadyComandasCount, 30_000)
+    } else if (readyCountInterval) {
+      clearInterval(readyCountInterval)
+      readyCountInterval = null
+    }
+  },
+  { immediate: true },
+)
+
 // ── Unfired items count — items in the tab not yet sent to the KDS ──────────
 // In counter mode (no mesa session), all cart items are "new" — none have been fired yet.
 // In mesa mode, count tab items with fulfillmentStatus === 'new'.
@@ -714,6 +747,7 @@ onMounted(async () => {
 onUnmounted(() => {
   setRefreshHandler(undefined)
   stopFulfillmentPolling()
+  if (readyCountInterval) clearInterval(readyCountInterval)
 })
 </script>
 
@@ -1076,5 +1110,52 @@ onUnmounted(() => {
       </div>
     </Transition>
   </Teleport>
+
+  <!-- Issue #537 — Expediter chip teleported into the dashboard header so it
+       never overlaps content. Icon-only on mobile, icon + label on sm+.
+       Sits just left of the refresh button (header-actions portal renders
+       before the refresh in the layout). -->
+  <ClientOnly>
+    <Teleport to="#dashboard-header-actions">
+      <button
+        v-if="expediterEnabled && comandasEnabled"
+        type="button"
+        :aria-label="readyComandasCount > 0 ? `Estado de comandas — ${readyComandasCount} listas` : 'Estado de comandas'"
+        :title="readyComandasCount > 0 ? `${readyComandasCount} comanda${readyComandasCount === 1 ? '' : 's'} lista${readyComandasCount === 1 ? '' : 's'}` : 'Estado de comandas'"
+        class="relative inline-flex items-center gap-2 h-11 rounded-lg border-2 border-surface-secondary bg-white text-text-primary text-sm font-medium hover:bg-surface-secondary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary mr-1.5 md:mr-2 px-2.5 sm:px-3 md:px-4"
+        :class="readyComandasCount > 0 ? 'ring-1 ring-emerald-300/60' : ''"
+        @click="showExpediterPanel = true"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/>
+          <rect x="8" y="2" width="8" height="4" rx="1" ry="1"/>
+          <path d="m9 14 2 2 4-4"/>
+        </svg>
+        <span class="hidden sm:inline text-sm font-medium">Comandas</span>
+        <!-- Count badge: numeric on sm+, dot indicator on mobile -->
+        <span
+          v-if="readyComandasCount > 0"
+          class="hidden sm:inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full bg-emerald-500 text-white text-[11px] font-bold tabular-nums"
+        >
+          {{ readyComandasCount }}
+        </span>
+        <span
+          v-if="readyComandasCount > 0"
+          class="sm:hidden absolute -top-1 -right-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-emerald-500 px-1 text-[10px] font-bold text-white tabular-nums ring-2 ring-surface"
+          aria-hidden="true"
+        >
+          {{ readyComandasCount > 9 ? '9+' : readyComandasCount }}
+        </span>
+      </button>
+    </Teleport>
+  </ClientOnly>
+
+  <PosComandasEstadoPanel
+    v-if="expediterEnabled && comandasEnabled"
+    v-model="showExpediterPanel"
+    :table-session-id="posStore.activeTableSession?.tableId ?? null"
+    :table-display-name="posStore.activeTableSession?.tableName ?? null"
+    @success="refreshReadyComandasCount"
+  />
 
 </template>


### PR DESCRIPTION
## Summary
- Adds POS expediter mode: a slide-over panel for waiters to advance comanda state (preparing → ready → delivered) without touching the KDS.
- Replaces the floating FAB in /pos with a chip teleported into the dashboard header (matches the tenant-selector hover style; no longer overlaps the floor plan or cart column).
- 3-tier aging visuals (fresh / warning / urgent) with border + tint so overdue tickets pop.
- Toggle gated behind `expediter_enabled` on the tenant profile (uno0uno/api-warolabs#181).

## Bug fixes folded in
- Item names now render `kitchen_name` (was `name` → "undefined").
- Bulk status request switched to PATCH to match the backend route.
- Source-type filter moved client-side (backend takes single value, not comma-separated).

## Test plan
- [ ] Toggle expediter on Operaciones > Comandas → chip appears in header
- [ ] Toggle off → chip disappears (no leftovers)
- [ ] Open panel with active mesa → only that mesa's comandas show
- [ ] Open panel without mesa → all table+pos comandas show
- [ ] Pending + preparing show in "En preparación" tab; ready in "Listas"
- [ ] Bulk-mark works (preparing → ready and ready → delivered)
- [ ] Header chip shows numeric badge on sm+ and dot on mobile
- [ ] Verify no FAB overlap on /pos floor plan or /pos with active cart

🤖 Generated with [Claude Code](https://claude.com/claude-code)