### PR TITLE
fix(kds): allow public access to /cocina via token (skip operator auth)

### DIFF
--- a/middleware/auth.global.js
+++ b/middleware/auth.global.js
@@ -8,6 +8,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   // Check if route uses a layout that doesn't require operator auth
   const isPublicRestaurant = to.meta?.layout === 'public-restaurant'
   const isCustomerPortal = to.meta?.layout === 'customer-portal'
+  const isKds = to.meta?.layout === 'kds'
 
   const authStore = useAuthStore()
 
@@ -25,7 +26,8 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
       to.path.startsWith('/blog') ||
       to.path.startsWith('/docs') ||
       isPublicRestaurant ||
-      isCustomerPortal) {
+      isCustomerPortal ||
+      isKds) {
     return
   }
 

--- a/middleware/billing-gate.global.ts
+++ b/middleware/billing-gate.global.ts
@@ -28,7 +28,8 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
     skipExact.includes(to.path) ||
     skipPrefixes.some(p => to.path.startsWith(p)) ||
     to.meta?.layout === 'public-restaurant' ||
-    to.meta?.layout === 'customer-portal'
+    to.meta?.layout === 'customer-portal' ||
+    to.meta?.layout === 'kds'
   ) return
 
   const authStore = useAuthStore()

--- a/middleware/tenants.global.js
+++ b/middleware/tenants.global.js
@@ -5,6 +5,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   // Skip on auth routes, public routes, and non-operator layouts
   const isPublicRestaurant = to.meta?.layout === 'public-restaurant'
   const isCustomerPortal = to.meta?.layout === 'customer-portal'
+  const isKds = to.meta?.layout === 'kds'
   if (
     to.path.startsWith('/auth') ||
     to.path === '/' ||
@@ -14,7 +15,8 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
     to.path.startsWith('/blog') ||
     to.path.startsWith('/docs') ||
     isPublicRestaurant ||
-    isCustomerPortal
+    isCustomerPortal ||
+    isKds
   ) return
 
   const authStore = useAuthStore()


### PR DESCRIPTION
## Summary
The KDS URL `/cocina/[id]?token=...` is meant to be opened on shared kitchen displays that are not logged into an operator account. Token validation already happens server-side, but three global middlewares (auth, tenants, billing-gate) were redirecting unauthenticated visitors to `/auth/login`.

Adds the `kds` layout to the bypass list of all three globals, matching the existing pattern used for `public-restaurant` and `customer-portal` layouts.

## Test plan
- [ ] Open `/cocina/<station-id>?token=<valid-token>` in incognito → page loads, no login redirect
- [ ] Open same URL with invalid/missing token → in-page error (handled by the page itself, not a redirect)
- [ ] Confirm `/pos`, `/ventas`, etc. still require auth as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)