### PR TITLE
feat(operaciones-comandas): persist KDS URLs across page loads

### DIFF
--- a/pages/operaciones/comandas.vue
+++ b/pages/operaciones/comandas.vue
@@ -609,6 +609,25 @@ const kdsTokens = ref<Record<string, string>>({})
 const generatingToken = ref<string | null>(null)
 const revokingToken = ref<string | null>(null)
 
+// Hydrate existing tokens whenever the active stations list resolves so the
+// operator sees the persistent KDS URL without having to regenerate it.
+watch(stations, async (list) => {
+  if (!Array.isArray(list) || list.length === 0) return
+  await Promise.all(
+    list
+      .filter((st: any) => st.is_active)
+      .map(async (st: any) => {
+        if (kdsTokens.value[st.id]) return
+        try {
+          const res = await $fetch<any>(`/api/api/stations/${st.id}/kds-token`)
+          if (res?.data?.token) kdsTokens.value[st.id] = res.data.token
+        } catch {
+          // No token yet for this station — operator will see "Generar enlace"
+        }
+      }),
+  )
+}, { immediate: true })
+
 const generateKdsToken = async (stationId: string) => {
   generatingToken.value = stationId
   try {


### PR DESCRIPTION
## Summary
The Operaciones > Comandas page used to forget the KDS token on every load — operators had to click "Generar enlace" each time even though a valid token already existed in the database. Now hydrates \`kdsTokens\` for every active station from \`GET /api/api/stations/{id}/kds-token\` (full token returned by the paired backend change uno0uno/api-warolabs#183), so the operator sees the "Copiar" / "Revocar" pair immediately and the persistent URL stays visible.

The hydration uses a \`watch\` on the \`stations\` computed with \`immediate: true\`, which covers both the initial mount and any later refetch (e.g. after creating a new station). Stations with no token keep the "Generar enlace" button.

## Test plan
- [ ] Reload Operaciones > Comandas → existing tokens render the KDS URL inline immediately
- [ ] Stations with no token still show "Generar enlace"
- [ ] After clicking "Revocar" the URL disappears and the button reverts to "Generar enlace"
- [ ] Generating a new token on a station persists across reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)