### PR TITLE
fix(kds): chime fires for the very first comanda after authorize

### DIFF
--- a/pages/cocina/[id].vue
+++ b/pages/cocina/[id].vue
@@ -114,6 +114,12 @@ const soundEnabled = ref(
   typeof window !== 'undefined' ? localStorage.getItem('kds_sound_enabled') !== 'false' : true
 )
 const knownIds = ref<Set<string>>(new Set())
+// Track whether the first poll has settled. The previous size-based guard
+// (knownIds.size > 0) silently swallowed the chime for the first comanda
+// when the page loaded with zero existing comandas — that comanda was
+// genuinely new but the guard treated the empty initial state as
+// "uninitialized" forever.
+const hasSeenFirstPoll = ref(false)
 
 // Audio gate — explicit user click required (browser autoplay policy).
 // Once authorized in this tab, the AudioContext is unlocked for the session.
@@ -207,8 +213,9 @@ const checkNewComandas = () => {
   // doesn't unleash a chime burst for everything seen during the mute window.
   const currentIds = new Set<string>(allComandas.value.map((c: any) => String(c.id)))
   const hasNew = [...currentIds].some((id) => !knownIds.value.has(id as string))
-  if (hasNew && knownIds.value.size > 0 && soundEnabled.value) playChime()
+  if (hasNew && hasSeenFirstPoll.value && soundEnabled.value) playChime()
   knownIds.value = currentIds
+  hasSeenFirstPoll.value = true
 }
 
 watch(allComandas, checkNewComandas)


### PR DESCRIPTION
## Summary
The first comanda after authorizing audio never played a chime; the second one onwards did.

## Root cause
The "skip-first-poll" guard used \`knownIds.size > 0\`, which works when the page loads with existing comandas (size becomes > 0 after the first poll) but breaks when the page loads with zero comandas. In that case \`knownIds\` stays empty until a new comanda arrives, and that comanda is then mistakenly treated as part of the initial state.

## Fix
Replace the size-based heuristic with an explicit \`hasSeenFirstPoll\` flag that flips to \`true\` at the end of the first \`checkNewComandas\` run, regardless of whether comandas were present.

| Scenario | Before | After |
|---|---|---|
| Page loads w/ 0 comandas, then 1 arrives | silent | chime ✓ |
| Page loads w/ 3 existing, then 4th arrives | chime ✓ | chime ✓ |
| Page loads w/ 3 existing, no new ones | silent ✓ | silent ✓ |

## Test plan
- [ ] Open KDS on a fresh station with 0 comandas → click "Activar sonido"
- [ ] Generate a comanda from POS → chime fires within 10s
- [ ] Open KDS on a station with existing comandas → no initial chime burst
- [ ] Generate a new comanda → chime fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)