### PR TITLE
fix(kds): propagate token to PATCH calls so cooks can advance state

### DIFF
--- a/components/cocina/ComandaCard.vue
+++ b/components/cocina/ComandaCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, inject, onMounted, onUnmounted, type Ref } from 'vue'
 import { formatDistanceToNow, differenceInMinutes } from 'date-fns'
 import { es } from 'date-fns/locale'
 
@@ -11,6 +11,10 @@ const emit = defineEmits(['refresh'])
 
 const toast = useToast()
 const isUpdating = ref(false)
+
+// KDS token (provided by /cocina/[id].vue). Optional so the component
+// keeps working under cookie auth in non-KDS contexts.
+const kdsToken = inject<Ref<string>>('kdsToken')
 
 // ── Timer ──────────────────────────────────────────────────────────────────
 const now = ref(new Date())
@@ -67,6 +71,7 @@ const updateStatus = async (newStatus: string) => {
   try {
     await $fetch(`/api/api/comandas/${props.comanda.id}/status`, {
       method: 'PATCH',
+      params: kdsToken?.value ? { token: kdsToken.value } : undefined,
       body: { status: newStatus }
     })
     emit('refresh')
@@ -74,7 +79,12 @@ const updateStatus = async (newStatus: string) => {
       toast.success('Comanda entregada')
     }
   } catch (error: any) {
-    toast.error('Error al actualizar estado')
+    const status = error?.status ?? error?.statusCode ?? error?.response?.status
+    toast.error(
+      status === 401
+        ? 'Enlace KDS expirado. Recarga la página.'
+        : 'Error al actualizar estado',
+    )
   } finally {
     isUpdating.value = false
   }

--- a/components/cocina/ItemRow.vue
+++ b/components/cocina/ItemRow.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import { inject, type Ref } from 'vue'
+import { ExclamationTriangleIcon } from '@heroicons/vue/24/outline'
+
 const props = defineProps<{
   item: any
   comandaStatus: string
@@ -9,6 +12,10 @@ const emit = defineEmits(['refresh'])
 const toast = useToast()
 const isUpdating = ref(false)
 
+// KDS token (provided by /cocina/[id].vue). Optional so the component
+// keeps working under cookie auth in non-KDS contexts.
+const kdsToken = inject<Ref<string>>('kdsToken')
+
 const toggleStatus = async () => {
   if (props.comandaStatus === 'ready' || isUpdating.value) return
   isUpdating.value = true
@@ -16,11 +23,17 @@ const toggleStatus = async () => {
   try {
     await $fetch(`/api/api/comandas/${props.comandaId}/items/${props.item.id}/status`, {
       method: 'PATCH',
+      params: kdsToken?.value ? { token: kdsToken.value } : undefined,
       body: { status: newStatus }
     })
     emit('refresh')
   } catch (error: any) {
-    toast.error('Error al actualizar ítem')
+    const status = error?.status ?? error?.statusCode ?? error?.response?.status
+    toast.error(
+      status === 401
+        ? 'Enlace KDS expirado. Recarga la página.'
+        : 'Error al actualizar ítem',
+    )
   } finally {
     isUpdating.value = false
   }
@@ -53,8 +66,12 @@ const toggleStatus = async () => {
       </div>
 
       <!-- Item Notes -->
-      <p v-if="item.notes && item.status !== 'cancelled'" class="text-[10px] italic text-destructive font-bold mt-1 uppercase">
-        ⚠️ {{ item.notes }}
+      <p
+        v-if="item.notes && item.status !== 'cancelled'"
+        class="text-[10px] italic text-destructive font-bold mt-1 uppercase flex items-start gap-1"
+      >
+        <ExclamationTriangleIcon class="w-3 h-3 flex-shrink-0 mt-px" aria-hidden="true" />
+        <span>{{ item.notes }}</span>
       </p>
     </div>
 

--- a/pages/cocina/[id].vue
+++ b/pages/cocina/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted, provide, watch } from 'vue'
 
 definePageMeta({
   layout: 'kds',
@@ -8,6 +8,11 @@ definePageMeta({
 const route = useRoute()
 const stationId = computed(() => route.params.id as string)
 const kdsToken = computed(() => (route.query.token as string) || '')
+
+// Make the KDS token available to descendant components (ComandaCard,
+// ItemRow) so their PATCH requests can carry it and satisfy the
+// kds_public middleware bypass on the backend.
+provide('kdsToken', kdsToken)
 
 // ── Token guard ─────────────────────────────────────────────────────────────
 const tokenError = ref(false)


### PR DESCRIPTION
## Summary
The KDS at /cocina/[id] read its access token from the URL but only included it on GET requests. Status-update buttons in ComandaCard and the per-item toggle in ItemRow fired PATCH calls without the token, so the kitchen browser (no operator cookie) hit 401 on every state transition.

The backend middleware already supports PATCH-with-token on /api/comandas (kds_public block) — fix is purely frontend.

## Stack
🟢 Nuxt 3 + 🎨 UX

## Changes
- **pages/cocina/[id].vue**: provide() the kdsToken ref so children can inject.
- **components/cocina/ComandaCard.vue**: inject the token, append it to the PATCH params, branch the toast on 401 ("Enlace KDS expirado. Recarga la página.").
- **components/cocina/ItemRow.vue**: same treatment for the per-item PATCH; also replaced the literal ⚠️ emoji on the note badge with ExclamationTriangleIcon (heroicon outline 24) to match the project's no-emojis rule.

## Testing
1. Open /cocina/<station-id>?token=<valid-token> in incognito (no operator session).
2. Click each action (Empezar, Listo, Entregar, Cancelar) → 200 OK, state transitions visible.
3. Toggle a per-item check → 200 OK, item toggles pending ↔ ready.
4. Use a deliberately bad/revoked token → 401 surfaces the new specific toast.
5. Verify operator dashboard /operaciones/comandas still works via cookie auth (no regression).

Closes #547