### PR TITLE
chore(pos): cut POS pages over to /api/pos/restaurant-context

### DIFF
--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -6,7 +6,6 @@ import { useQuery } from '@pinia/colada'
 import QRCode from 'qrcode'
 import { usePOSStore } from '~/stores/usePOSStore'
 import { useAddressStore, type AddressCreate } from '~/stores/address'
-import { useInvoicingReadiness } from '~/composables/useInvoicingReadiness'
 import { PAYMENT_DEFAULTS, type PosPaymentGroup, type PosPaymentMethod } from '~/utils/paymentDefaults'
 import DeliveryAddressPicker from '~/components/pos/checkout/DeliveryAddressPicker.vue'
 import DeliveryAddressForm from '~/components/pos/checkout/DeliveryAddressForm.vue'
@@ -65,10 +64,12 @@ const emailFromProfile = ref(false)
 const isSendingEmail = ref(false)
 const cartItemsSnapshot = ref<any[]>([])
 
-// Invoicing readiness gate (issue #450) — backend tells us if this tenant is
-// fully configured to emit electronic invoices. Drives whether the
-// "Generar factura electrónica DIAN" button is rendered.
-const { ready: isInvoicingReady, isLoading: isReadinessLoading } = useInvoicingReadiness()
+// Invoicing readiness gate (issue #450) — derived from the POS restaurant
+// context aggregator (`settingsData` below). Backend gates the rich
+// readiness detail under owner-only MI_NEGOCIO; POS only needs the boolean,
+// which is included in /api/pos/restaurant-context.
+const isInvoicingReady = computed(() => settingsData.value?.data?.invoicing_ready === true)
+const isReadinessLoading = computed(() => !settingsData.value)
 
 // Invoice state
 const invoiceLoading = ref(false)
@@ -180,10 +181,11 @@ const refreshTaxPreview = async () => {
   }
 }
 
-// ── KDS / Comandas feature flag — reuses same cache key as index.vue (no extra network request)
+// ── POS restaurant context (BFF aggregator) — reuses same cache key as index.vue (no extra network request)
+// Migrated from /api/api/tenant/public-profile (now owner-only MI_NEGOCIO).
 const { data: settingsData } = useQuery({
-  key: () => ['tenant', 'negocio-profile', currentTenant.value?.id ?? null],
-  query: () => $fetch<{ success: boolean; data: any }>('/api/api/tenant/public-profile'),
+  key: () => ['pos', 'restaurant-context', currentTenant.value?.id ?? null],
+  query: () => $fetch<{ success: boolean; data: any }>('/api/api/pos/restaurant-context'),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })
@@ -965,15 +967,11 @@ const printReceipt = async () => {
   window.print()
 }
 
-// Issue #535 — fetch tenant fiscal data once for the prefactura header
-// (NIT, razón social, fiscal address). Same source as the /facturacion page.
-const { data: fiscalDataRes } = useQuery({
-  key: () => ['tenant', 'fiscal-data', currentTenant.value?.id],
-  query: () => $fetch<{ success: boolean; data: any }>('/api/api/tenant/fiscal-data'),
-  enabled: () => !!currentTenant.value,
-  staleTime: 300_000,
-})
-const fiscalData = computed(() => fiscalDataRes.value?.data ?? null)
+// Issue #535 — tenant fiscal data for the prefactura header.
+// Read from the POS restaurant-context aggregator (settingsData above) so
+// the cashier doesn't need MI_NEGOCIO. The /facturacion owner panel reads
+// /api/api/tenant/fiscal-data directly with its richer write surface.
+const fiscalData = computed(() => settingsData.value?.data?.fiscal_data ?? null)
 
 // Issue #535 — print pre-bill (prefactura) before payment.
 // Toggles a body class so @media print rules switch which printable div is

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -24,11 +24,13 @@ if (typeof window !== 'undefined' && sessionStorage.getItem('posNavigation') !==
   posStore.exitSession()
 }
 
-// ── Table management settings ──────────────────────────────────────────────
-// Reuses the same cached query key as negocio.vue — no extra network request
+// ── POS restaurant context (BFF aggregator) ────────────────────────────────
+// Single endpoint gated under Module.POS; replaces direct /api/tenant/* reads.
+// `tables_enabled` lives on tenant_public_profiles and is included in the
+// aggregator payload. /api/api/tenant/public-profile is now owner-only (MI_NEGOCIO).
 const { data: settingsData, asyncStatus: settingsAsyncStatus } = useQuery({
-  key: () => ['tenant', 'negocio-profile', currentTenant.value?.id],
-  query: () => $fetch<{ success: boolean; data: any }>('/api/api/tenant/public-profile'),
+  key: () => ['pos', 'restaurant-context', currentTenant.value?.id],
+  query: () => $fetch<{ success: boolean; data: any }>('/api/api/pos/restaurant-context'),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })


### PR DESCRIPTION
## Summary

Paired with api-warolabs#209 (Epic 2: E2.7 OPERACIONES + E2.15 MI_NEGOCIO). Migrates `pos/index.vue` and `pos/checkout.vue` off direct `/api/tenant/*` reads onto the new BFF-style aggregator `GET /api/pos/restaurant-context` so cashiers continue to work after MI_NEGOCIO is tightened to owner-only.

## Stack
🟢 Nuxt 3

## Changes

| File | Change |
|---|---|
| `pages/pos/index.vue` | `settingsData` repointed: `/api/api/tenant/public-profile` → `/api/api/pos/restaurant-context`. Cache key changed to `['pos', 'restaurant-context', tenantId]`. |
| `pages/pos/checkout.vue` | Same settings repoint. `fiscalData` derived from `settingsData.fiscal_data` (was a separate `/api/api/tenant/fiscal-data` fetch). `isInvoicingReady` derived from `settingsData.invoicing_ready` (no more `useInvoicingReadiness()` call). |

## Backend support (api-warolabs#209)
The aggregator returns the full POS-relevant payload in a single request:
```json
{
  "display_name": "...",
  "kds_enabled": true,
  "comandas_enabled": true,
  "expediter_enabled": false,
  "tables_enabled": true,
  "accepts_online_orders": false,
  "auto_select_generic_enabled": false,
  "fiscal_data": { "nit": "...", "business_name": "...", ... },
  "tax_config": { "iva_applicable": false, "inc_applicable": false, ... },
  "invoicing_ready": false
}
```

## Not in scope (flagged for follow-up)
These pages also read `/api/tenant/public-profile` and will 403 for non-owner roles once enforce is flipped. They are not POS-flow critical; left for separate work:

- `pages/operaciones/comandas.vue:457`
- `pages/operaciones/mesas.vue:24`
- `pages/operaciones/personalizar.vue:16`
- `pages/ventas/[id].vue:83` (uses `useInvoicingReadiness`, accessible by cashier)
- `composables/useInvoicingReadiness.ts` (kept; still used by owner-only `/facturacion`)

These are OPERACIONES module — they need a similar BFF aggregator under OPERACIONES, or the operational toggles need dedicated endpoints (audit doc §4 follow-up). Will track separately if breakage is observed during shadow-mode rollout.

## Test plan
- [x] Frontend changes compile (TypeScript clean — same shape, just different endpoint URL)
- [ ] Manual after both PRs merge: cashier logs into `/pos` → page renders, no 403 in network tab
- [ ] Manual: cashier completes a sale through `/pos/checkout` → prefactura shows fiscal data from new payload, factura electrónica button respects `invoicing_ready`
- [ ] Manual: owner can still edit `/negocio` and `/facturacion` (those keep using `/api/tenant/*`)

Refs api-warolabs#191
Refs api-warolabs#192