### PR TITLE
chore(operaciones,ventas): cut over to operaciones-context aggregator

### DIFF
--- a/pages/operaciones/comandas.vue
+++ b/pages/operaciones/comandas.vue
@@ -452,13 +452,22 @@ useHead({ title: 'Comandas & Cocina | Operaciones' })
 const { currentTenant } = useTenantReactive()
 const toast = useToast()
 
-// ─── Business profile ───
+// ─── Business profile (operaciones audience aggregator — gated under OPERACIONES) ───
+const cache = useQueryCache()
 const { data: profileData, asyncStatus: profileAsyncStatus, refetch: refreshProfile } = useQuery({
-  key: () => ['tenant', 'negocio-profile', currentTenant.value?.id],
-  query: () => $fetch<{ success: boolean; data: any }>('/api/api/tenant/public-profile'),
+  key: () => ['operaciones', 'restaurant-context', currentTenant.value?.id],
+  query: () => $fetch<{ success: boolean; data: any }>('/api/api/operaciones/restaurant-context'),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })
+
+// Toggle helper — invalidates BOTH audience caches so POS reflects operational
+// changes immediately (POS reads kds_enabled / comandas_enabled / expediter_enabled
+// from /api/pos/restaurant-context which shares no cache key with operaciones).
+const invalidateContextCaches = async () => {
+  await cache.invalidateQueries({ key: ['operaciones', 'restaurant-context'] })
+  await cache.invalidateQueries({ key: ['pos', 'restaurant-context'] })
+}
 const businessProfile = computed(() => profileData.value?.data ?? null)
 
 // ─── Stations & categories ───
@@ -576,8 +585,8 @@ const handleToggleComandas = async (event: Event) => {
   if (isTogglingComandas.value) return
   isTogglingComandas.value = true
   try {
-    await $fetch('/api/api/tenant/public-profile', { method: 'PATCH', body: { comandas_enabled: true } })
-    await refreshProfile()
+    await $fetch('/api/api/operaciones/toggles/comandas', { method: 'PATCH', body: { enabled: true } })
+    await invalidateContextCaches()
     toast.success('Módulo de comandas activado', { title: 'Activado' })
   } catch (error: any) {
     toast.error(error.data?.detail || 'Error al activar comandas', { title: 'Error' })
@@ -591,8 +600,8 @@ const confirmDisableComandas = async () => {
   if (isTogglingComandas.value) return
   isTogglingComandas.value = true
   try {
-    await $fetch('/api/api/tenant/public-profile', { method: 'PATCH', body: { comandas_enabled: false } })
-    await refreshProfile()
+    await $fetch('/api/api/operaciones/toggles/comandas', { method: 'PATCH', body: { enabled: false } })
+    await invalidateContextCaches()
     toast.success('Módulo de comandas desactivado', { title: 'Desactivado' })
   } catch (error: any) {
     toast.error(error.data?.detail || 'Error al desactivar comandas', { title: 'Error' })
@@ -606,8 +615,8 @@ const handleToggleKds = async (event: Event) => {
   const newState = (event.target as HTMLInputElement).checked
   isTogglingKds.value = true
   try {
-    await $fetch('/api/api/tenant/public-profile', { method: 'PATCH', body: { kds_enabled: newState } })
-    await refreshProfile()
+    await $fetch('/api/api/operaciones/toggles/kds', { method: 'PATCH', body: { enabled: newState } })
+    await invalidateContextCaches()
     toast.success(
       newState ? 'Pantallas KDS activadas' : 'Pantallas KDS desactivadas',
       { title: newState ? 'Activado' : 'Desactivado' }
@@ -626,8 +635,8 @@ const handleToggleExpediter = async (event: Event) => {
   const newState = (event.target as HTMLInputElement).checked
   isTogglingExpediter.value = true
   try {
-    await $fetch('/api/api/tenant/public-profile', { method: 'PATCH', body: { expediter_enabled: newState } })
-    await refreshProfile()
+    await $fetch('/api/api/operaciones/toggles/expediter', { method: 'PATCH', body: { enabled: newState } })
+    await invalidateContextCaches()
     toast.success(
       newState
         ? 'El mesero puede avanzar comandas desde el POS'

--- a/pages/operaciones/mesas.vue
+++ b/pages/operaciones/mesas.vue
@@ -18,14 +18,23 @@ const { data: tablesData, status: tablesStatus, asyncStatus: tablesAsyncStatus, 
   staleTime: 30_000,
 })
 
-// Business profile (shared cache key) — declared up here so its asyncStatus
-// can join the layout's progressive-loading indicator (issue #461).
+// Operaciones audience aggregator — gated under OPERACIONES.
+// Migrated from /api/api/tenant/public-profile (now owner-only MI_NEGOCIO).
+const cache = useQueryCache()
 const { data: profileData, asyncStatus: profileAsyncStatus, refetch: refreshProfile } = useQuery({
-  key: () => ['tenant', 'negocio-profile', currentTenant.value?.id],
-  query: () => $fetch<{ success: boolean; data: any }>('/api/api/tenant/public-profile'),
+  key: () => ['operaciones', 'restaurant-context', currentTenant.value?.id],
+  query: () => $fetch<{ success: boolean; data: any }>('/api/api/operaciones/restaurant-context'),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })
+
+// Cross-audience cache invalidation — POS reads tables_enabled from its own
+// /pos/restaurant-context aggregator; flipping the toggle here must invalidate
+// that key too so /pos/index reflects the change immediately.
+const invalidateContextCaches = async () => {
+  await cache.invalidateQueries({ key: ['operaciones', 'restaurant-context'] })
+  await cache.invalidateQueries({ key: ['pos', 'restaurant-context'] })
+}
 const businessProfile = computed(() => profileData.value?.data ?? null)
 
 const loadingTables = computed(() => !tablesData.value)
@@ -194,11 +203,11 @@ const toggleTablesEnabled = async () => {
   isTogglingTables.value = true
   const newState = !businessProfile.value.tables_enabled
   try {
-    await $fetch('/api/api/tenant/public-profile', {
+    await $fetch('/api/api/operaciones/toggles/tables', {
       method: 'PATCH',
-      body: { tables_enabled: newState },
+      body: { enabled: newState },
     })
-    await refreshProfile()
+    await invalidateContextCaches()
     posStore.tablesEnabled = newState
     toast.success(
       newState ? 'Gestión de mesas activada para el POS' : 'Gestión de mesas desactivada',

--- a/pages/operaciones/personalizar.vue
+++ b/pages/operaciones/personalizar.vue
@@ -10,11 +10,12 @@ useHead({ title: 'Personalizar | Operaciones' })
 const { currentTenant } = useTenantReactive()
 const cache = useQueryCache()
 
-// Shared cache key with /operaciones/mesas and /operaciones/comandas so a
-// PATCH from any of these pages refreshes the others on next visit.
+// Operaciones audience aggregator — gated under OPERACIONES.
+// Migrated from /api/api/tenant/public-profile (now owner-only MI_NEGOCIO).
+// Shared cache key with /operaciones/mesas and /operaciones/comandas.
 const { data: profileData, asyncStatus: profileAsyncStatus, refetch: refreshProfile } = useQuery({
-  key: () => ['tenant', 'negocio-profile', currentTenant.value?.id],
-  query: () => $fetch<{ success: boolean; data: any }>('/api/api/tenant/public-profile'),
+  key: () => ['operaciones', 'restaurant-context', currentTenant.value?.id],
+  query: () => $fetch<{ success: boolean; data: any }>('/api/api/operaciones/restaurant-context'),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })
@@ -39,15 +40,15 @@ const toggleAutoSelectGeneric = async () => {
   isToggling.value = true
   const newState = !businessProfile.value.auto_select_generic_enabled
   try {
-    await $fetch('/api/api/tenant/public-profile', {
+    await $fetch('/api/api/operaciones/toggles/auto-select-generic', {
       method: 'PATCH',
-      body: { auto_select_generic_enabled: newState },
+      body: { enabled: newState },
     })
-    // Invalidate both cache entries that hold the public profile:
-    //  - local 'negocio-profile' (this page + mesas/comandas)
-    //  - tenants store 'business-profile' (read by useTenantReactive in checkout)
-    await cache.invalidateQueries({ key: ['tenant'] })
-    await refreshProfile()
+    // Cross-audience invalidation: operaciones (this page + mesas/comandas)
+    // AND pos (read in /pos/index + /pos/checkout). The previous broad
+    // ['tenant'] invalidation no longer matches the audience-scoped keys.
+    await cache.invalidateQueries({ key: ['operaciones', 'restaurant-context'] })
+    await cache.invalidateQueries({ key: ['pos', 'restaurant-context'] })
     toast.success(
       newState
         ? 'El cobro abrirá con cliente Genérico ya seleccionado'

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -6,7 +6,6 @@ import { useQuery } from '@pinia/colada'
 import QRCode from 'qrcode'
 import { usePOSStore } from '~/stores/usePOSStore'
 import { useAddressStore, type AddressCreate } from '~/stores/address'
-import { useInvoicingReadiness } from '~/composables/useInvoicingReadiness'
 import { PAYMENT_DEFAULTS, type PosPaymentGroup, type PosPaymentMethod } from '~/utils/paymentDefaults'
 import DeliveryAddressPicker from '~/components/pos/checkout/DeliveryAddressPicker.vue'
 import DeliveryAddressForm from '~/components/pos/checkout/DeliveryAddressForm.vue'
@@ -65,10 +64,12 @@ const emailFromProfile = ref(false)
 const isSendingEmail = ref(false)
 const cartItemsSnapshot = ref<any[]>([])
 
-// Invoicing readiness gate (issue #450) — backend tells us if this tenant is
-// fully configured to emit electronic invoices. Drives whether the
-// "Generar factura electrónica DIAN" button is rendered.
-const { ready: isInvoicingReady, isLoading: isReadinessLoading } = useInvoicingReadiness()
+// Invoicing readiness gate (issue #450) — derived from the POS restaurant
+// context aggregator (`settingsData` below). Backend gates the rich
+// readiness detail under owner-only MI_NEGOCIO; POS only needs the boolean,
+// which is included in /api/pos/restaurant-context.
+const isInvoicingReady = computed(() => settingsData.value?.data?.invoicing_ready === true)
+const isReadinessLoading = computed(() => !settingsData.value)
 
 // Invoice state
 const invoiceLoading = ref(false)
@@ -180,10 +181,11 @@ const refreshTaxPreview = async () => {
   }
 }
 
-// ── KDS / Comandas feature flag — reuses same cache key as index.vue (no extra network request)
+// ── POS restaurant context (BFF aggregator) — reuses same cache key as index.vue (no extra network request)
+// Migrated from /api/api/tenant/public-profile (now owner-only MI_NEGOCIO).
 const { data: settingsData } = useQuery({
-  key: () => ['tenant', 'negocio-profile', currentTenant.value?.id ?? null],
-  query: () => $fetch<{ success: boolean; data: any }>('/api/api/tenant/public-profile'),
+  key: () => ['pos', 'restaurant-context', currentTenant.value?.id ?? null],
+  query: () => $fetch<{ success: boolean; data: any }>('/api/api/pos/restaurant-context'),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })
@@ -965,15 +967,11 @@ const printReceipt = async () => {
   window.print()
 }
 
-// Issue #535 — fetch tenant fiscal data once for the prefactura header
-// (NIT, razón social, fiscal address). Same source as the /facturacion page.
-const { data: fiscalDataRes } = useQuery({
-  key: () => ['tenant', 'fiscal-data', currentTenant.value?.id],
-  query: () => $fetch<{ success: boolean; data: any }>('/api/api/tenant/fiscal-data'),
-  enabled: () => !!currentTenant.value,
-  staleTime: 300_000,
-})
-const fiscalData = computed(() => fiscalDataRes.value?.data ?? null)
+// Issue #535 — tenant fiscal data for the prefactura header.
+// Read from the POS restaurant-context aggregator (settingsData above) so
+// the cashier doesn't need MI_NEGOCIO. The /facturacion owner panel reads
+// /api/api/tenant/fiscal-data directly with its richer write surface.
+const fiscalData = computed(() => settingsData.value?.data?.fiscal_data ?? null)
 
 // Issue #535 — print pre-bill (prefactura) before payment.
 // Toggles a body class so @media print rules switch which printable div is

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -24,11 +24,13 @@ if (typeof window !== 'undefined' && sessionStorage.getItem('posNavigation') !==
   posStore.exitSession()
 }
 
-// ── Table management settings ──────────────────────────────────────────────
-// Reuses the same cached query key as negocio.vue — no extra network request
+// ── POS restaurant context (BFF aggregator) ────────────────────────────────
+// Single endpoint gated under Module.POS; replaces direct /api/tenant/* reads.
+// `tables_enabled` lives on tenant_public_profiles and is included in the
+// aggregator payload. /api/api/tenant/public-profile is now owner-only (MI_NEGOCIO).
 const { data: settingsData, asyncStatus: settingsAsyncStatus } = useQuery({
-  key: () => ['tenant', 'negocio-profile', currentTenant.value?.id],
-  query: () => $fetch<{ success: boolean; data: any }>('/api/api/tenant/public-profile'),
+  key: () => ['pos', 'restaurant-context', currentTenant.value?.id],
+  query: () => $fetch<{ success: boolean; data: any }>('/api/api/pos/restaurant-context'),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
-import { useInvoicingReadiness } from '~/composables/useInvoicingReadiness'
 
 definePageMeta({
   layout: 'dashboard'
@@ -78,9 +77,18 @@ const { data: invoiceData, refetch: refetchInvoice } = useQuery({
   staleTime: 60_000,
 })
 
-// DIAN invoicing readiness — gates the entire electronic-invoice UI section.
-// Same composable / pattern used by the POS checkout (pages/pos/checkout.vue:71).
-const { ready: isInvoicingReady, isLoading: isReadinessLoading } = useInvoicingReadiness()
+// DIAN invoicing readiness — read from the POS restaurant-context aggregator.
+// /api/api/tenant/invoicing-readiness (the richer detail) is owner-only MI_NEGOCIO;
+// this page is cashier-accessible, so we use the POS-gated boolean instead.
+// Shares the cache key with /pos/index + /pos/checkout — no extra request.
+const { data: posContextRes, asyncStatus: posContextAsyncStatus } = useQuery({
+  key: () => ['pos', 'restaurant-context', currentTenant.value?.id ?? null],
+  query: () => $fetch<{ success: boolean; data: { invoicing_ready: boolean } }>('/api/api/pos/restaurant-context'),
+  enabled: () => !!currentTenant.value,
+  staleTime: 60_000,
+})
+const isInvoicingReady = computed(() => posContextRes.value?.data?.invoicing_ready === true)
+const isReadinessLoading = computed(() => posContextAsyncStatus.value === 'loading' && !posContextRes.value)
 
 // Invoice emit state
 const isEmittingInvoice = ref(false)


### PR DESCRIPTION
## Summary

Paired with api-warolabs#211 (operaciones-context aggregator + 5 toggle endpoints). Migrates the last 4 frontend pages that still read `/api/tenant/*` so enforce mode can be flipped without breaking supervisor/admin/cashier flows.

## Base branch
Targets **`chore/pos-restaurant-context`** (warocol.com#551) — depends on the POS aggregator cutover landing first. After both PRs merge to main, this can retarget.

## Stack
🟢 Nuxt 3

## Pages cut over

| Page | Audience | Before | After |
|---|---|---|---|
| `pages/operaciones/comandas.vue` | supervisor, admin | `/api/api/tenant/public-profile` + 3 PATCHes (comandas/kds/expediter) | `/api/api/operaciones/restaurant-context` + 3 dedicated `/toggles/*` PATCHes |
| `pages/operaciones/mesas.vue` | supervisor, admin | `/api/api/tenant/public-profile` + PATCH tables_enabled | Same aggregator + `/toggles/tables` |
| `pages/operaciones/personalizar.vue` | supervisor, admin | `/api/api/tenant/public-profile` + PATCH auto_select_generic_enabled | Same aggregator + `/toggles/auto-select-generic` |
| `pages/ventas/[id].vue` | cashier, supervisor | `useInvoicingReadiness()` → `/api/tenant/invoicing-readiness` | Reads `invoicing_ready` from `/api/api/pos/restaurant-context` (already POS-gated) |

## Cache strategy

All 3 operaciones pages share `['operaciones', 'restaurant-context', tenantId]`. Toggle handlers invalidate BOTH operaciones AND pos restaurant-context caches so a toggle from `/operaciones/comandas` is reflected immediately on `/pos/index`.

`useInvoicingReadiness` composable is **kept** — its only remaining consumer is `pages/facturacion.vue` (owner panel, MI_NEGOCIO is fine there).

## Verification

```bash
$ grep -rn '/api/api/tenant/' pages/operaciones pages/ventas pages/pos
# Only doc comments — no actual fetches
```

## Test plan
- [x] No fetch to `/api/api/tenant/*` remains in operaciones, ventas, or pos pages (grep confirms)
- [ ] After both PRs merge: supervisor can use `/operaciones/{comandas,mesas,personalizar}` and toggle features
- [ ] After both PRs merge: toggling KDS in `/operaciones/comandas` reflects on `/pos/index` (cross-cache invalidation)
- [ ] After both PRs merge: cashier opening `/ventas/{id}` sees the factura electrónica section gated by `invoicing_ready` boolean (no 403 in network tab)
- [ ] Owner panel `/negocio` + `/facturacion` unchanged

Refs api-warolabs#210