### PR TITLE
chore(sidebar): condition data-quality polling on role

### DIFF
--- a/composables/useDataQualityStatus.ts
+++ b/composables/useDataQualityStatus.ts
@@ -5,9 +5,30 @@
  * defineQuery ensures all callers share the same data ref and a single interval timer.
  * Pinia Colada deduplicates requests by key automatically.
  * Tenant switching handled by reactive key. Polling lifecycle managed by Pinia Colada.
+ *
+ * RBAC: `/api/analytics/data-quality` is gated under Module.ANALITICA
+ * (api-warolabs#193). Only owner / admin / supervisor roles have access; cashier
+ * and kitchen do not. The polling is fired by the sidebar for EVERY authenticated
+ * user, so without a role check non-ANALITICA sessions would generate 403 spam
+ * every 5 minutes. We gate the `enabled` flag on role to avoid that — the badge
+ * simply doesn't appear for staff that wouldn't be able to act on alerts anyway.
+ *
+ * Session role is read from /api/auth/session (already returns user.role joined
+ * from tenant_members.role; no backend change needed).
  */
 export const useDataQualityStatus = defineQuery(() => {
   const { currentTenant } = useTenantReactive()
+
+  const { data: sessionData } = useAsyncData(
+    'data-quality-current-session-role',
+    () => $fetch<{ user?: { role?: string | null } }>('/api/auth/session'),
+    { server: false },
+  )
+
+  const hasAnaliticaAccess = computed(() => {
+    const role = sessionData.value?.user?.role
+    return role === 'owner' || role === 'admin' || role === 'supervisor'
+  })
 
   const { data, status } = useQuery({
     key: () => ['analytics', 'data-quality-status', currentTenant.value?.id ?? 'default'],
@@ -17,7 +38,7 @@ export const useDataQualityStatus = defineQuery(() => {
       return (res?.data?.critical ?? res?.critical ?? 0) as number
     },
     refetchInterval: 5 * 60_000, // 5 minutes — replaces setInterval
-    enabled: () => !!currentTenant.value,
+    enabled: () => !!currentTenant.value && hasAnaliticaAccess.value,
   })
 
   const hasCritical = computed(() => (data.value ?? 0) > 0)


### PR DESCRIPTION
## Summary

Paired with api-warolabs#213 (E2.9 ANALITICA). Conditions the sidebar's data-quality status composable on user role so cashier/kitchen sessions don't generate 403 spam after `/api/analytics/data-quality` gets gated under `Module.ANALITICA`.

## Stack
🟢 Nuxt 3

## Problem

`composables/useDataQualityStatus.ts` is consumed by `components/DashboardSidebar.vue:163` and fires for every authenticated user, polling `/api/analytics/data-quality` every 5 minutes for the critical-alerts badge next to the Abastecimiento item.

Once api-warolabs#213 gates that endpoint under Module.ANALITICA, only owner/admin/supervisor have access. Without this change, cashier and kitchen sessions would generate one 403 per 5 minutes during the entire session — noise in logs/network/observability.

## Change

`composables/useDataQualityStatus.ts`:
- Reads `user.role` from `/api/auth/session` via `useAsyncData` (endpoint already returns role; same pattern as PR #553).
- Computed `hasAnaliticaAccess` = role ∈ {owner, admin, supervisor}.
- `useQuery.enabled` gated: `!!currentTenant.value && hasAnaliticaAccess.value`.

For cashier/kitchen: query never fires, badge doesn't render. For admin/supervisor/owner: behavior unchanged.

## Why in the composable, not the sidebar

Centralizes role-awareness. Any future consumer of `useDataQualityStatus` automatically inherits the correct gating.

## Test plan
- [ ] Manual after both PRs merge: login as cashier → network tab shows zero `/api/analytics/data-quality` requests
- [ ] Manual: login as kitchen → same
- [ ] Manual: login as admin → request fires + sidebar badge functional

Refs api-warolabs#193