### PR TITLE
feat(access): add useAccessStore Pinia store for Epic 4 frontend gating (#555)

### DIFF
--- a/middleware/auth.global.js
+++ b/middleware/auth.global.js
@@ -11,6 +11,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   const isKds = to.meta?.layout === 'kds'
 
   const authStore = useAuthStore()
+  const accessStore = useAccessStore()
 
   // If user already has a valid session and tries to access login, redirect to ventas
   if (authStore.isSessionValid && to.path === '/auth/login') {
@@ -33,6 +34,12 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 
   // ✅ Check if we already have a valid session in the store
   if (authStore.isSessionValid) {
+    // Hydrate the access store on first navigation if it wasn't loaded yet
+    // (e.g. page refresh inside an authenticated session). Fire-and-forget —
+    // sidebar / gates fail-open while enforcementMode stays at 'disabled'.
+    if (!accessStore.isLoaded) {
+      accessStore.load()
+    }
     return
   }
 
@@ -53,6 +60,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
     if (error.value || !sessionResponse.value?.user) {
       // No valid session
       authStore.clearAuth()
+      accessStore.clear()
 
       // If not on a public route, redirect to login
 
@@ -69,10 +77,14 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
           // ... other user properties
         }
       })
+
+      // Hydrate access store (role + modules + enforcement_mode for Epic 4)
+      await accessStore.load()
     }
   } catch (err) {
     console.error('Auth middleware error:', err)
     authStore.clearAuth()
+    accessStore.clear()
     return navigateTo('/auth/login')
   } finally {
     authStore.setLoading(false)

--- a/stores/access.ts
+++ b/stores/access.ts
@@ -1,0 +1,98 @@
+/**
+ * Access Store — Epic 4 (warocol.com#489) sub-task #555.
+ *
+ * Single source of truth for the current user's role, module access, and the
+ * tenant's enforcement mode. Hydrates from GET /api/me/access (backend lives
+ * in api-warolabs#200, merged via PR #219).
+ *
+ * Read by sidebar (#559), bottom nav (#560), route middleware (#557), and
+ * page-level guards (#563). Refreshed periodically by polling (#562).
+ *
+ * Module string union is hand-maintained against the backend enum at
+ * api_warocol.com/app/core/permissions.py:Module. If a new module is added
+ * there, mirror it here.
+ */
+import { defineStore } from 'pinia'
+
+export type Module =
+  | 'pos'
+  | 'ventas'
+  | 'despacho'
+  | 'menu'
+  | 'operaciones'
+  | 'abastecimiento'
+  | 'analitica'
+  | 'finanzas'
+  | 'facturacion'
+  | 'equipo'
+  | 'integraciones'
+  | 'mi_plan'
+  | 'mi_negocio'
+  // EVENTOS removed in api-warolabs#212 (PR #212 merged) — Eventos lives in warotickets.com
+
+export type EnforcementMode = 'disabled' | 'shadow' | 'enforce'
+
+interface AccessResponse {
+  role: string | null
+  modules: string[]
+  enforcement_mode: EnforcementMode
+}
+
+export const useAccessStore = defineStore('access', () => {
+  const role = ref<string | null>(null)
+  const modules = ref<string[]>([])
+  const enforcementMode = ref<EnforcementMode>('disabled')
+  const isLoaded = ref(false)
+
+  // O(1) membership lookup derived from the array.
+  // Stored as `string[]` (not `Set`) because Pinia SSR serializes state to
+  // the Nuxt payload as JSON, and Sets don't survive the round trip.
+  const modulesSet = computed(() => new Set(modules.value))
+
+  async function load() {
+    try {
+      const data = await $fetch<AccessResponse>('/api/me/access')
+      role.value = data.role
+      modules.value = data.modules ?? []
+      enforcementMode.value = data.enforcement_mode ?? 'disabled'
+      isLoaded.value = true
+    } catch (err) {
+      // Fail-open: keep current state. enforcementMode stays at its current
+      // value (initially 'disabled' which makes can() always return true).
+      // Matches the safety guarantee in Epic 4's body.
+      console.error('useAccessStore.load() failed:', err)
+    }
+  }
+
+  function clear() {
+    role.value = null
+    modules.value = []
+    enforcementMode.value = 'disabled'
+    isLoaded.value = false
+  }
+
+  /**
+   * Returns true if the current user can access `module`.
+   *
+   * Fail-open semantics: when enforcementMode is 'disabled' or 'shadow',
+   * always returns true so the frontend renders today's behavior (no menu
+   * items hidden, no redirects). Backend mirrors this — shadow mode logs
+   * but does not deny.
+   *
+   * Only 'enforce' mode actually checks membership against `modules`.
+   */
+  function can(module: Module): boolean {
+    if (enforcementMode.value !== 'enforce') return true
+    return modulesSet.value.has(module)
+  }
+
+  return {
+    role: readonly(role),
+    modules: readonly(modules),
+    enforcementMode: readonly(enforcementMode),
+    isLoaded: readonly(isLoaded),
+    load,
+    clear,
+    can,
+  }
+})


### PR DESCRIPTION
## Summary

Sub-task **E4.1** of Epic 4 (#489). Adds the foundation Pinia store that the rest of Epic 4 will read from — sidebar (#559), bottom nav (#560), route middleware (#557), component guards (#563), polling (#562).

Consumes the backend endpoint \`GET /api/me/access\` (built in api-warolabs#200, merged via PR #219 on main).

## Stack
🟢 Nuxt 3 (TypeScript Pinia store + JS middleware modification)

## Changes

| File | Type | What |
|---|---|---|
| \`stores/access.ts\` | new | Pinia store with state + load/clear/can + Module type union (~95 lines) |
| \`middleware/auth.global.js\` | modify | +12 lines — call \`load()\` on session init success and cached path, \`clear()\` on failure |

## API surface
\`\`\`ts
const access = useAccessStore()

access.role            // Readonly<Ref<string | null>>
access.modules         // Readonly<Ref<string[]>>
access.enforcementMode // Readonly<Ref<'disabled' | 'shadow' | 'enforce'>>
access.isLoaded        // Readonly<Ref<boolean>>

await access.load()    // fetch from /api/me/access
access.clear()         // reset on signout
access.can('finanzas') // typed boolean check, fail-open if not enforced
\`\`\`

## Decisions taken

1. **\`modules: string[]\`** instead of \`Set<string>\` — Pinia SSR serializes state as JSON; Sets get lost across the hydration boundary. Computed \`modulesSet\` derives the lookup-friendly Set internally for O(1) \`has()\`.

2. **No automated tests in this PR** — repo has no vitest / \`@pinia/testing\` configured. Setting up test infrastructure is its own scope. Manual QA: owner sees all 13 modules; cashier sees \`[pos, ventas]\`.

3. **Init hook in \`middleware/auth.global.js\`** — not a new \`auth.client.ts\` plugin. The middleware already runs on every authenticated navigation with session context; reuse that lifecycle. Single source of access store hydration.

## Fail-open safety

\`can(module)\` returns \`true\` whenever \`enforcementMode !== 'enforce'\`. Backend mirrors this (disabled/shadow modes don't deny). Until a tenant flips to enforce (Epic 6 operational task), sidebar/middleware/components render exactly today's UI.

If \`/api/me/access\` ever fails or returns garbage, the store keeps its prior state (initial: \`{role: null, modules: [], enforcementMode: 'disabled'}\`), so \`can()\` keeps returning \`true\` for everything. No menu items go missing on backend errors.

## Module union maintenance

The frontend \`Module\` type is hand-maintained. If a new module is added to the backend enum at \`app/core/permissions.py:Module\`, this union must be mirrored. Reference comment in the file points at the backend file as source of truth. Long-term fix: generate types from OpenAPI in Epic 6.

\`EVENTOS\` already excluded — removed from backend enum in api-warolabs#212.

## Testing

- ✅ Nuxt typecheck: no errors in \`stores/access.ts\` or \`middleware/auth.global.js\` (errors shown by \`nuxi typecheck\` are pre-existing in other files: \`online_cart.ts\`, \`purchases.ts\`, \`tenants.ts\`)
- ✅ \`node --check middleware/auth.global.js\` passes
- ⏳ Manual QA pending post-merge:
  - Sign in as owner → DevTools \`Pinia\` panel should show \`access\` store with all 13 modules
  - Sign in as cashier → \`modules: [pos, ventas]\`
  - Network tab: one \`GET /api/me/access\` per authenticated navigation (no flood)

## Out of scope

- Composable wrapper \`useModuleAccess()\` — #556
- Route middleware enforcement — #557
- \`definePageMeta({ module })\` rollout — #558
- Sidebar / bottom nav dynamic filter — #559 / #560
- \`/403\` page — #561
- Polling — #562
- Component guard composable — #563
- Test infrastructure setup — separate follow-up issue

Closes #555