### PR TITLE
feat(access): add useModuleAccess composable for Epic 4 (#556)

### DIFF
--- a/composables/useModuleAccess.ts
+++ b/composables/useModuleAccess.ts
@@ -1,0 +1,50 @@
+import type { ComputedRef } from 'vue'
+import type { Module } from '~/stores/access'
+
+/**
+ * useModuleAccess — Epic 4 (warocol.com#489) sub-task #556.
+ *
+ * Thin composable wrapper over `useAccessStore` (#555). Components, the
+ * sidebar (#559), bottom nav (#560), route middleware (#557), and
+ * component-level guards (#563) call this instead of importing the store
+ * directly.
+ *
+ * Pattern mirrors `composables/useTenantReactive.ts`:
+ *   - Function-style (not `defineStore`, not `defineNuxtPlugin`)
+ *   - Returns `computed` refs for reactive state
+ *   - `can()` returns a `ComputedRef<boolean>` so templates auto-re-render
+ *     when the user's access changes (e.g. when polling #562 picks up an
+ *     owner-edited matrix)
+ *
+ * The composable is read-only by design. Mutation (`load`, `clear`) lives
+ * on the store and is triggered by the auth middleware (#555) and the
+ * polling task (#562). Components do not call mutations directly.
+ */
+export const useModuleAccess = () => {
+  const store = useAccessStore()
+
+  const role = computed(() => store.role)
+  const enforcementMode = computed(() => store.enforcementMode)
+  const isLoaded = computed(() => store.isLoaded)
+
+  /**
+   * Returns a `ComputedRef<boolean>` that's `true` when the current user
+   * can access `module`.
+   *
+   * Fail-open semantics — always `true` when `enforcementMode` is
+   * `'disabled'` or `'shadow'`. Only `'enforce'` mode actually checks
+   * membership. This mirrors the backend's gate behavior so the UI matches
+   * runtime authorization without surprises.
+   *
+   * Usage in templates:
+   *   <button v-if="can('finanzas').value">Ver finanzas</button>
+   *
+   * Usage in script setup:
+   *   const finanzasAccess = can('finanzas')
+   *   watch(finanzasAccess, (newVal) => { ... })
+   */
+  const can = (module: Module): ComputedRef<boolean> =>
+    computed(() => store.can(module))
+
+  return { role, enforcementMode, isLoaded, can }
+}

--- a/middleware/auth.global.js
+++ b/middleware/auth.global.js
@@ -11,6 +11,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   const isKds = to.meta?.layout === 'kds'
 
   const authStore = useAuthStore()
+  const accessStore = useAccessStore()
 
   // If user already has a valid session and tries to access login, redirect to ventas
   if (authStore.isSessionValid && to.path === '/auth/login') {
@@ -33,6 +34,12 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 
   // ✅ Check if we already have a valid session in the store
   if (authStore.isSessionValid) {
+    // Hydrate the access store on first navigation if it wasn't loaded yet
+    // (e.g. page refresh inside an authenticated session). Fire-and-forget —
+    // sidebar / gates fail-open while enforcementMode stays at 'disabled'.
+    if (!accessStore.isLoaded) {
+      accessStore.load()
+    }
     return
   }
 
@@ -53,6 +60,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
     if (error.value || !sessionResponse.value?.user) {
       // No valid session
       authStore.clearAuth()
+      accessStore.clear()
 
       // If not on a public route, redirect to login
 
@@ -69,10 +77,14 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
           // ... other user properties
         }
       })
+
+      // Hydrate access store (role + modules + enforcement_mode for Epic 4)
+      await accessStore.load()
     }
   } catch (err) {
     console.error('Auth middleware error:', err)
     authStore.clearAuth()
+    accessStore.clear()
     return navigateTo('/auth/login')
   } finally {
     authStore.setLoading(false)

--- a/stores/access.ts
+++ b/stores/access.ts
@@ -1,0 +1,98 @@
+/**
+ * Access Store — Epic 4 (warocol.com#489) sub-task #555.
+ *
+ * Single source of truth for the current user's role, module access, and the
+ * tenant's enforcement mode. Hydrates from GET /api/me/access (backend lives
+ * in api-warolabs#200, merged via PR #219).
+ *
+ * Read by sidebar (#559), bottom nav (#560), route middleware (#557), and
+ * page-level guards (#563). Refreshed periodically by polling (#562).
+ *
+ * Module string union is hand-maintained against the backend enum at
+ * api_warocol.com/app/core/permissions.py:Module. If a new module is added
+ * there, mirror it here.
+ */
+import { defineStore } from 'pinia'
+
+export type Module =
+  | 'pos'
+  | 'ventas'
+  | 'despacho'
+  | 'menu'
+  | 'operaciones'
+  | 'abastecimiento'
+  | 'analitica'
+  | 'finanzas'
+  | 'facturacion'
+  | 'equipo'
+  | 'integraciones'
+  | 'mi_plan'
+  | 'mi_negocio'
+  // EVENTOS removed in api-warolabs#212 (PR #212 merged) — Eventos lives in warotickets.com
+
+export type EnforcementMode = 'disabled' | 'shadow' | 'enforce'
+
+interface AccessResponse {
+  role: string | null
+  modules: string[]
+  enforcement_mode: EnforcementMode
+}
+
+export const useAccessStore = defineStore('access', () => {
+  const role = ref<string | null>(null)
+  const modules = ref<string[]>([])
+  const enforcementMode = ref<EnforcementMode>('disabled')
+  const isLoaded = ref(false)
+
+  // O(1) membership lookup derived from the array.
+  // Stored as `string[]` (not `Set`) because Pinia SSR serializes state to
+  // the Nuxt payload as JSON, and Sets don't survive the round trip.
+  const modulesSet = computed(() => new Set(modules.value))
+
+  async function load() {
+    try {
+      const data = await $fetch<AccessResponse>('/api/me/access')
+      role.value = data.role
+      modules.value = data.modules ?? []
+      enforcementMode.value = data.enforcement_mode ?? 'disabled'
+      isLoaded.value = true
+    } catch (err) {
+      // Fail-open: keep current state. enforcementMode stays at its current
+      // value (initially 'disabled' which makes can() always return true).
+      // Matches the safety guarantee in Epic 4's body.
+      console.error('useAccessStore.load() failed:', err)
+    }
+  }
+
+  function clear() {
+    role.value = null
+    modules.value = []
+    enforcementMode.value = 'disabled'
+    isLoaded.value = false
+  }
+
+  /**
+   * Returns true if the current user can access `module`.
+   *
+   * Fail-open semantics: when enforcementMode is 'disabled' or 'shadow',
+   * always returns true so the frontend renders today's behavior (no menu
+   * items hidden, no redirects). Backend mirrors this — shadow mode logs
+   * but does not deny.
+   *
+   * Only 'enforce' mode actually checks membership against `modules`.
+   */
+  function can(module: Module): boolean {
+    if (enforcementMode.value !== 'enforce') return true
+    return modulesSet.value.has(module)
+  }
+
+  return {
+    role: readonly(role),
+    modules: readonly(modules),
+    enforcementMode: readonly(enforcementMode),
+    isLoaded: readonly(isLoaded),
+    load,
+    clear,
+    can,
+  }
+})


### PR DESCRIPTION
## Summary

Sub-task **E4.2** of Epic 4 (#489). Thin function-style composable wrapping `useAccessStore()` (from #555 / PR #564). Sidebar (#559), bottom nav (#560), route middleware (#557), and component-level guards (#563) call this instead of importing the store directly.

## Stack
🟢 Nuxt 3 (TypeScript composable, ~30 lines + JSDoc)

## ⚠️ Stacked PR

This branch is based on `gh-555-access-store` (PR #564), **not** `main`. When #564 merges to main, this PR will need to be re-targeted to `main` (GitHub does this automatically when the base branch is deleted).

## Changes

| File | Type | What |
|---|---|---|
| `composables/useModuleAccess.ts` | new | Composable wrapping `useAccessStore` — returns `role`, `enforcementMode`, `isLoaded`, `can()` |

## API

```ts
const { role, enforcementMode, isLoaded, can } = useModuleAccess()

// Template auto-reactivity:
// <button v-if="can('finanzas').value">Ver finanzas</button>

role.value             // string | null
enforcementMode.value  // 'disabled' | 'shadow' | 'enforce'
isLoaded.value         // true after first /api/me/access call
can('finanzas')        // ComputedRef<boolean> — typed parameter
```

## Decisions applied

1. **`can()` returns `ComputedRef<boolean>`** (not plain `boolean`) — wraps store's `can()` in `computed()` so templates auto-re-render when access changes via polling (#562).
2. **`Module` union type** on `can()`'s parameter (not `string`) — compile-time typo catching. Inherited from `stores/access.ts`.
3. **Exposes `isLoaded`** — useful for sidebar skeleton during first hydration.
4. **Does NOT expose `load()` / `clear()`** — those are middleware (#555 / #555 merged in PR #564) and polling (#562) responsibilities. Read-only ergonomics.

## Pattern reference

Mirrors `composables/useTenantReactive.ts` exactly (function-style, no `defineStore`, returns `computed` refs).

## Testing

- ✅ Nuxt typecheck: zero new errors in `composables/useModuleAccess.ts` (pre-existing errors in other files unrelated)
- ⏳ Manual integration QA pending: happens when sidebar (#559) and middleware (#557) consume this

## Out of scope

- Sidebar / bottom nav consumers — #559, #560
- Route middleware using `enforcementMode` + `can()` — #557
- Polling — #562
- Component-level guard composable — #563

Closes #556