### PR TITLE
feat(access): add module-access global middleware for Epic 4 (#557)

### DIFF
--- a/composables/useModuleAccess.ts
+++ b/composables/useModuleAccess.ts
@@ -1,0 +1,50 @@
+import type { ComputedRef } from 'vue'
+import type { Module } from '~/stores/access'
+
+/**
+ * useModuleAccess — Epic 4 (warocol.com#489) sub-task #556.
+ *
+ * Thin composable wrapper over `useAccessStore` (#555). Components, the
+ * sidebar (#559), bottom nav (#560), route middleware (#557), and
+ * component-level guards (#563) call this instead of importing the store
+ * directly.
+ *
+ * Pattern mirrors `composables/useTenantReactive.ts`:
+ *   - Function-style (not `defineStore`, not `defineNuxtPlugin`)
+ *   - Returns `computed` refs for reactive state
+ *   - `can()` returns a `ComputedRef<boolean>` so templates auto-re-render
+ *     when the user's access changes (e.g. when polling #562 picks up an
+ *     owner-edited matrix)
+ *
+ * The composable is read-only by design. Mutation (`load`, `clear`) lives
+ * on the store and is triggered by the auth middleware (#555) and the
+ * polling task (#562). Components do not call mutations directly.
+ */
+export const useModuleAccess = () => {
+  const store = useAccessStore()
+
+  const role = computed(() => store.role)
+  const enforcementMode = computed(() => store.enforcementMode)
+  const isLoaded = computed(() => store.isLoaded)
+
+  /**
+   * Returns a `ComputedRef<boolean>` that's `true` when the current user
+   * can access `module`.
+   *
+   * Fail-open semantics — always `true` when `enforcementMode` is
+   * `'disabled'` or `'shadow'`. Only `'enforce'` mode actually checks
+   * membership. This mirrors the backend's gate behavior so the UI matches
+   * runtime authorization without surprises.
+   *
+   * Usage in templates:
+   *   <button v-if="can('finanzas').value">Ver finanzas</button>
+   *
+   * Usage in script setup:
+   *   const finanzasAccess = can('finanzas')
+   *   watch(finanzasAccess, (newVal) => { ... })
+   */
+  const can = (module: Module): ComputedRef<boolean> =>
+    computed(() => store.can(module))
+
+  return { role, enforcementMode, isLoaded, can }
+}

--- a/middleware/auth.global.js
+++ b/middleware/auth.global.js
@@ -11,6 +11,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   const isKds = to.meta?.layout === 'kds'
 
   const authStore = useAuthStore()
+  const accessStore = useAccessStore()
 
   // If user already has a valid session and tries to access login, redirect to ventas
   if (authStore.isSessionValid && to.path === '/auth/login') {
@@ -33,6 +34,12 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 
   // ✅ Check if we already have a valid session in the store
   if (authStore.isSessionValid) {
+    // Hydrate the access store on first navigation if it wasn't loaded yet
+    // (e.g. page refresh inside an authenticated session). Fire-and-forget —
+    // sidebar / gates fail-open while enforcementMode stays at 'disabled'.
+    if (!accessStore.isLoaded) {
+      accessStore.load()
+    }
     return
   }
 
@@ -53,6 +60,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
     if (error.value || !sessionResponse.value?.user) {
       // No valid session
       authStore.clearAuth()
+      accessStore.clear()
 
       // If not on a public route, redirect to login
 
@@ -69,10 +77,14 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
           // ... other user properties
         }
       })
+
+      // Hydrate access store (role + modules + enforcement_mode for Epic 4)
+      await accessStore.load()
     }
   } catch (err) {
     console.error('Auth middleware error:', err)
     authStore.clearAuth()
+    accessStore.clear()
     return navigateTo('/auth/login')
   } finally {
     authStore.setLoading(false)

--- a/middleware/module-access.global.ts
+++ b/middleware/module-access.global.ts
@@ -1,0 +1,63 @@
+import type { Module } from '~/stores/access'
+
+/**
+ * module-access.global.ts — Epic 4 (warocol.com#489) sub-task #557.
+ *
+ * Route-level enforcement of module access. Activates only when:
+ *   1. The destination page declares `definePageMeta({ module: 'X' })` (#558).
+ *   2. The tenant's `enforcement_mode` is `'enforce'` (flipped per-tenant in
+ *      Epic 6).
+ *
+ * Otherwise no-op (fail-open). Mirrors the backend's behavior — backend's
+ * `require_module()` also passes through on `'disabled'` / `'shadow'` modes,
+ * so the frontend gate matches what the API would actually return.
+ *
+ * Execution order: runs after `auth.global.js` (which hydrates
+ * `useAccessStore`) and after `billing-gate.global.ts` (no point gating
+ * modules for a user who's about to be redirected to billing).
+ *
+ * Redirect target `/403` ships in #561. Until that lands, a denial would
+ * hit a 404 — but denial only triggers when `enforcement_mode === 'enforce'`
+ * AND a page has `module` meta, neither of which exists in production
+ * today. The coordination requirement: #561 must merge BEFORE any tenant
+ * is flipped to `'enforce'`.
+ */
+export default defineNuxtRouteMiddleware((to) => {
+  if (process.server) return
+
+  // Skip-list: routes that never require module gating. Mirrors the lists
+  // in auth.global.js and billing-gate.global.ts. If this list drifts,
+  // extract to utils/route-helpers.ts as a follow-up.
+  const skipExact = ['/', '/bogota']
+  const skipPrefixes = [
+    '/auth/',
+    '/proveedor/',
+    '/blog',
+    '/docs',
+    '/403', // prevent infinite redirect loop if /403 itself gets gated
+  ]
+  const skipLayouts = ['public-restaurant', 'customer-portal', 'kds']
+
+  if (
+    skipExact.includes(to.path) ||
+    skipPrefixes.some((p) => to.path.startsWith(p)) ||
+    skipLayouts.includes(to.meta?.layout as string)
+  ) return
+
+  // Page didn't opt in to module gating → pass through.
+  // Type augmentation of PageMeta lives in #558 (where pages add the meta).
+  // Until then, cast to keep this middleware self-contained.
+  const moduleKey = (to.meta as { module?: string })?.module
+  if (!moduleKey) return
+
+  const { can, enforcementMode } = useModuleAccess()
+
+  // Fail-open: only 'enforce' mode actually denies. 'disabled' and 'shadow'
+  // let the request through (backend behavior matches).
+  if (enforcementMode.value !== 'enforce') return
+
+  // Denied → redirect to /403 (page ships in #561).
+  if (!can(moduleKey as Module).value) {
+    return navigateTo('/403')
+  }
+})

--- a/stores/access.ts
+++ b/stores/access.ts
@@ -1,0 +1,98 @@
+/**
+ * Access Store — Epic 4 (warocol.com#489) sub-task #555.
+ *
+ * Single source of truth for the current user's role, module access, and the
+ * tenant's enforcement mode. Hydrates from GET /api/me/access (backend lives
+ * in api-warolabs#200, merged via PR #219).
+ *
+ * Read by sidebar (#559), bottom nav (#560), route middleware (#557), and
+ * page-level guards (#563). Refreshed periodically by polling (#562).
+ *
+ * Module string union is hand-maintained against the backend enum at
+ * api_warocol.com/app/core/permissions.py:Module. If a new module is added
+ * there, mirror it here.
+ */
+import { defineStore } from 'pinia'
+
+export type Module =
+  | 'pos'
+  | 'ventas'
+  | 'despacho'
+  | 'menu'
+  | 'operaciones'
+  | 'abastecimiento'
+  | 'analitica'
+  | 'finanzas'
+  | 'facturacion'
+  | 'equipo'
+  | 'integraciones'
+  | 'mi_plan'
+  | 'mi_negocio'
+  // EVENTOS removed in api-warolabs#212 (PR #212 merged) — Eventos lives in warotickets.com
+
+export type EnforcementMode = 'disabled' | 'shadow' | 'enforce'
+
+interface AccessResponse {
+  role: string | null
+  modules: string[]
+  enforcement_mode: EnforcementMode
+}
+
+export const useAccessStore = defineStore('access', () => {
+  const role = ref<string | null>(null)
+  const modules = ref<string[]>([])
+  const enforcementMode = ref<EnforcementMode>('disabled')
+  const isLoaded = ref(false)
+
+  // O(1) membership lookup derived from the array.
+  // Stored as `string[]` (not `Set`) because Pinia SSR serializes state to
+  // the Nuxt payload as JSON, and Sets don't survive the round trip.
+  const modulesSet = computed(() => new Set(modules.value))
+
+  async function load() {
+    try {
+      const data = await $fetch<AccessResponse>('/api/me/access')
+      role.value = data.role
+      modules.value = data.modules ?? []
+      enforcementMode.value = data.enforcement_mode ?? 'disabled'
+      isLoaded.value = true
+    } catch (err) {
+      // Fail-open: keep current state. enforcementMode stays at its current
+      // value (initially 'disabled' which makes can() always return true).
+      // Matches the safety guarantee in Epic 4's body.
+      console.error('useAccessStore.load() failed:', err)
+    }
+  }
+
+  function clear() {
+    role.value = null
+    modules.value = []
+    enforcementMode.value = 'disabled'
+    isLoaded.value = false
+  }
+
+  /**
+   * Returns true if the current user can access `module`.
+   *
+   * Fail-open semantics: when enforcementMode is 'disabled' or 'shadow',
+   * always returns true so the frontend renders today's behavior (no menu
+   * items hidden, no redirects). Backend mirrors this — shadow mode logs
+   * but does not deny.
+   *
+   * Only 'enforce' mode actually checks membership against `modules`.
+   */
+  function can(module: Module): boolean {
+    if (enforcementMode.value !== 'enforce') return true
+    return modulesSet.value.has(module)
+  }
+
+  return {
+    role: readonly(role),
+    modules: readonly(modules),
+    enforcementMode: readonly(enforcementMode),
+    isLoaded: readonly(isLoaded),
+    load,
+    clear,
+    can,
+  }
+})


### PR DESCRIPTION
## Summary

Sub-task **E4.3** of Epic 4 (#489). Adds the global Nuxt route middleware that redirects to `/403` when a user navigates to a page tagged with `definePageMeta({ module: 'X' })` and doesn't have access — but **only** under `enforcement_mode === 'enforce'`. Fail-open in every other mode.

## Stack
🟢 Nuxt 3 (TypeScript middleware, ~55 lines with JSDoc)

## ⚠️ Stacked PR (3rd in the chain)

```
#564 (#555 store)
  └─ #565 (#556 composable)
       └─ THIS PR (#557 middleware)
```

When #564 / #565 merge to main, GitHub auto-retargets this PR to the new base. If branches get deleted mid-merge, the PR may need recreating (like the earlier #211 → #226 incident).

## Changes

| File | Type | What |
|---|---|---|
| `middleware/module-access.global.ts` | new | Global route middleware; reads `to.meta.module`, gates via `useModuleAccess()` |

## Behavior matrix

| Condition | Result |
|---|---|
| `process.server` | early return |
| Path in skip-list (`/auth/*`, `/blog`, `/docs`, `/403`, `/`, `/bogota`, layout = `public-restaurant`/`customer-portal`/`kds`) | pass through |
| Page has no `module` meta | pass through |
| Page has `module` meta + `enforcementMode !== 'enforce'` | pass through (fail-open) |
| Page has `module` meta + `enforcementMode === 'enforce'` + access granted | pass through |
| Page has `module` meta + `enforcementMode === 'enforce'` + access denied | `navigateTo('/403')` |

## Coordination requirements

| Dep | Notes |
|---|---|
| #564 / #565 | Must merge before this PR can land on main |
| #558 (page meta) | Until pages declare `module:` meta, this middleware no-ops |
| #561 (`/403` page) | **MUST merge BEFORE any tenant is flipped to `enforce`** in Epic 6 — otherwise denials would 404 |

Today none of the trigger conditions are met (no tenant in `enforce`; no page has `module` meta), so this middleware is invisible in production until the rest of Epic 4 + Epic 6 line up.

## Decisions applied (per plan)

1. **`useModuleAccess()` not `useAccessStore()`** — honors #556's abstraction
2. **`/403` added to skip-list** — prevents infinite redirect loop
3. **Type cast `(to.meta as { module?: string })?.module`** — full `PageMeta` augmentation belongs in #558
4. **Skip-list duplicated** from `auth.global.js` + `billing-gate.global.ts` — refactor to `utils/route-helpers.ts` tracked separately
5. **No automated tests** — consistent with #555, #556 (no test infra in repo)

## Testing

- ✅ Nuxt typecheck: zero new errors in `middleware/module-access.global.ts`
- ⏳ Manual integration QA pending:
  - Path A — Page without module meta (today's state): navigate → no redirect, no console errors
  - Path B — Page with module meta + enforcement=disabled (after #558): navigate as any role → no redirect
  - Path C — Page with module meta + enforcement=enforce (after Epic 6): cashier hits `/finanzas` → redirect to `/403`

## Out of scope

- Page meta rollout (`definePageMeta({ module })`) — #558
- `/403` page itself — #561
- Sidebar / nav dynamic filter — #559 / #560
- Polling — #562
- Component-level guard — #563

Closes #557