### PR TITLE
feat(sidebar): module-based dynamic filtering for Epic 4 (#559)

### DIFF
--- a/components/DashboardSidebar.vue
+++ b/components/DashboardSidebar.vue
@@ -18,90 +18,94 @@
     <template #navigation="{ collapsed }">
 
       <!-- ── OPERACIÓN (frecuente) ── -->
-      <div class="space-y-0.5">
-        <p v-if="!collapsed" class="nav-section-label">Operación</p>
-        <NuxtLink
-          v-for="item in primaryItems"
-          :key="item.to"
-          :to="item.to"
-          :title="item.label"
-          :class="[
-            'nav-item group',
-            collapsed ? 'justify-center' : '',
-            activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
-          ]"
-        >
-          <component :is="item.icon" class="nav-icon" />
-          <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">{{ item.label }}</span>
-        </NuxtLink>
-      </div>
+      <template v-if="visiblePrimaryItems.length">
+        <div class="space-y-0.5">
+          <p v-if="!collapsed" class="nav-section-label">Operación</p>
+          <NuxtLink
+            v-for="item in visiblePrimaryItems"
+            :key="item.to"
+            :to="item.to"
+            :title="item.label"
+            :class="[
+              'nav-item group',
+              collapsed ? 'justify-center' : '',
+              activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
+            ]"
+          >
+            <component :is="item.icon" class="nav-icon" />
+            <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">{{ item.label }}</span>
+          </NuxtLink>
+        </div>
+      </template>
 
-      <!-- ── DIVIDER ── -->
-      <div class="my-1.5 mx-1 border-t nav-divider" />
+      <!-- ── HERRAMIENTAS (with leading divider) ── -->
+      <template v-if="visibleSecondaryItems.length">
+        <div class="my-1.5 mx-1 border-t nav-divider" />
+        <div class="space-y-0.5">
+          <p v-if="!collapsed" class="nav-section-label">Herramientas</p>
+          <NuxtLink
+            v-for="item in visibleSecondaryItems"
+            :key="item.to"
+            :to="item.to"
+            :title="item.label"
+            :class="[
+              'nav-item',
+              collapsed ? 'justify-center' : '',
+              activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
+            ]"
+          >
+            <component :is="item.icon" class="nav-icon" />
+            <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">
+              {{ item.label }}
+              <span
+                v-if="item.page === 'abastecimiento' && hasCriticalAlerts"
+                class="inline-block w-1.5 h-1.5 rounded-full bg-destructive align-middle ml-1.5"
+              />
+            </span>
+          </NuxtLink>
+        </div>
+      </template>
 
-      <!-- ── HERRAMIENTAS ── -->
-      <div class="space-y-0.5">
-        <p v-if="!collapsed" class="nav-section-label">Herramientas</p>
-        <NuxtLink
-          v-for="item in secondaryItems"
-          :key="item.to"
-          :to="item.to"
-          :title="item.label"
-          :class="[
-            'nav-item',
-            collapsed ? 'justify-center' : '',
-            activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
-          ]"
-        >
-          <component :is="item.icon" class="nav-icon" />
-          <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">
-            {{ item.label }}
-            <span
-              v-if="item.page === 'abastecimiento' && hasCriticalAlerts"
-              class="inline-block w-1.5 h-1.5 rounded-full bg-destructive align-middle ml-1.5"
-            />
-          </span>
-        </NuxtLink>
-      </div>
-
-      <!-- ── DIVIDER ── -->
-      <div class="my-1.5 mx-1 border-t nav-divider" />
-
-      <!-- ── APPS ── -->
-      <div class="space-y-0.5">
-        <p v-if="!collapsed" class="nav-section-label">Apps</p>
-        <a
-          href="https://warotickets.com/gestion/eventos"
-          target="_blank"
-          title="Eventos"
-          :class="['nav-item nav-item--idle', collapsed ? 'justify-center' : '']"
-        >
-          <Squares2X2Icon class="nav-icon" />
-          <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">Eventos</span>
-        </a>
-      </div>
+      <!-- ── APPS (with leading divider) — Eventos is owner-only — -->
+      <template v-if="showEventos">
+        <div class="my-1.5 mx-1 border-t nav-divider" />
+        <div class="space-y-0.5">
+          <p v-if="!collapsed" class="nav-section-label">Apps</p>
+          <a
+            href="https://warotickets.com/gestion/eventos"
+            target="_blank"
+            title="Eventos"
+            :class="['nav-item nav-item--idle', collapsed ? 'justify-center' : '']"
+          >
+            <Squares2X2Icon class="nav-icon" />
+            <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">Eventos</span>
+          </a>
+        </div>
+      </template>
 
       <!-- ── SPACER ── -->
       <div class="flex-1" style="min-height: 1rem;" />
 
       <!-- ── CUENTA (fondo) ── -->
-      <div class="space-y-0.5">
-        <p v-if="!collapsed" class="nav-section-label">Cuenta</p>
-        <NuxtLink
-          v-for="item in cuentaItems"
-          :key="item.to"
-          :to="item.to"
-          :title="item.label"
-          :class="[
-            'nav-item',
-            collapsed ? 'justify-center' : '',
-            activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
-          ]"
-        >
-          <component :is="item.icon" class="nav-icon" />
-          <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">{{ item.label }}</span>
-        </NuxtLink>
-      </div>
+      <template v-if="visibleCuentaItems.length">
+        <div class="space-y-0.5">
+          <p v-if="!collapsed" class="nav-section-label">Cuenta</p>
+          <NuxtLink
+            v-for="item in visibleCuentaItems"
+            :key="item.to"
+            :to="item.to"
+            :title="item.label"
+            :class="[
+              'nav-item',
+              collapsed ? 'justify-center' : '',
+              activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
+            ]"
+          >
+            <component :is="item.icon" class="nav-icon" />
+            <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">{{ item.label }}</span>
+          </NuxtLink>
+        </div>
+      </template>
 
     </template>
 
@@ -129,7 +133,9 @@
 defineOptions({ inheritAttrs: false })
 
 import { computed, nextTick, ref } from 'vue'
+import type { FunctionalComponent } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
+import type { Module } from '~/stores/access'
 import {
   AdjustmentsHorizontalIcon,
   ArrowRightOnRectangleIcon,
@@ -157,6 +163,14 @@ interface Props {
 }
 const props = withDefaults(defineProps<Props>(), { activePage: 'financiero' })
 
+interface SidebarItem {
+  to: string
+  page: string
+  label: string
+  icon: FunctionalComponent
+  module: Module
+}
+
 const isLoggingOut = ref(false)
 const router = useRouter()
 
@@ -167,31 +181,50 @@ const authStore = useAuthStore()
 // ── Nav items ──────────────────────────────────────────────
 const { businessProfile } = useTenantReactive()
 
-const primaryItems = computed(() => {
-  const items = [
-    { to: '/pos',               page: 'pos',       label: 'POS',        icon: ComputerDesktopIcon },
-    { to: '/ventas',            page: 'ventas',    label: 'Ventas',     icon: ShoppingCartIcon },
-    { to: '/despacho/domicilios', page: 'despacho', label: 'Despacho', icon: MapPinIcon },
+// Epic 4 (#559): each item declares the backend module it requires.
+// useModuleAccess().can() fails open while enforcementMode !== 'enforce',
+// so today's sidebar (every module visible) is preserved until Epic 6
+// flips a tenant.
+const primaryItems = computed<SidebarItem[]>(() => [
+  { to: '/pos',                 page: 'pos',      label: 'POS',      icon: ComputerDesktopIcon, module: 'pos' },
+  { to: '/ventas',              page: 'ventas',   label: 'Ventas',   icon: ShoppingCartIcon,    module: 'ventas' },
+  { to: '/despacho/domicilios', page: 'despacho', label: 'Despacho', icon: MapPinIcon,          module: 'despacho' },
+])
 
-  ]
-  return items
-})
-
-const secondaryItems = [
-  { to: '/analitica',                        page: 'analytics',     label: 'Analítica Ventas', icon: ChartBarIcon },
-  { to: '/finanzas/arqueo',                  page: 'finanzas',      label: 'Finanzas',       icon: BanknotesIcon },
-  { to: '/facturacion',                      page: 'facturacion',   label: 'Facturación',    icon: DocumentTextIcon },
-  { to: '/menu/productos',                   page: 'menu',          label: 'Menú',           icon: CubeIcon },
-  { to: '/operaciones/comandas',             page: 'operaciones',   label: 'Operaciones',    icon: AdjustmentsHorizontalIcon },
-  { to: '/abastecimiento/compras-directas',  page: 'abastecimiento',label: 'Abastecimiento', icon: TruckIcon },
-  { to: '/equipo/miembros',                  page: 'equipo',        label: 'Equipo',         icon: UserGroupIcon },
-  { to: '/integraciones',                    page: 'integraciones', label: 'Integraciones',  icon: KeyIcon },
+const secondaryItems: SidebarItem[] = [
+  { to: '/analitica',                        page: 'analytics',      label: 'Analítica Ventas', icon: ChartBarIcon,              module: 'analitica' },
+  { to: '/finanzas/arqueo',                  page: 'finanzas',       label: 'Finanzas',         icon: BanknotesIcon,             module: 'finanzas' },
+  { to: '/facturacion',                      page: 'facturacion',    label: 'Facturación',      icon: DocumentTextIcon,          module: 'facturacion' },
+  { to: '/menu/productos',                   page: 'menu',           label: 'Menú',             icon: CubeIcon,                  module: 'menu' },
+  { to: '/operaciones/comandas',             page: 'operaciones',    label: 'Operaciones',      icon: AdjustmentsHorizontalIcon, module: 'operaciones' },
+  { to: '/abastecimiento/compras-directas',  page: 'abastecimiento', label: 'Abastecimiento',   icon: TruckIcon,                 module: 'abastecimiento' },
+  { to: '/equipo/miembros',                  page: 'equipo',         label: 'Equipo',           icon: UserGroupIcon,             module: 'equipo' },
+  { to: '/integraciones',                    page: 'integraciones',  label: 'Integraciones',    icon: KeyIcon,                   module: 'integraciones' },
 ]
 
-const cuentaItems = [
-  { to: '/negocio',         page: 'negocio', label: 'Mi Negocio', icon: BuildingStorefrontIcon },
-  { to: '/gestion/billing', page: 'admin',   label: 'Mi Plan',    icon: CreditCardIcon },
+const cuentaItems: SidebarItem[] = [
+  { to: '/negocio',         page: 'negocio', label: 'Mi Negocio', icon: BuildingStorefrontIcon, module: 'mi_negocio' },
+  { to: '/gestion/billing', page: 'admin',   label: 'Mi Plan',    icon: CreditCardIcon,         module: 'mi_plan' },
 ]
+
+// ── Module-based filtering (#559) ──────────────────────────────
+const { can } = useModuleAccess()
+const accessStore = useAccessStore()
+
+const visiblePrimaryItems = computed(() =>
+  primaryItems.value.filter((item) => can(item.module).value)
+)
+const visibleSecondaryItems = computed(() =>
+  secondaryItems.filter((item) => can(item.module).value)
+)
+const visibleCuentaItems = computed(() =>
+  cuentaItems.filter((item) => can(item.module).value)
+)
+
+// Eventos is special: Module.EVENTOS was removed from the backend enum
+// in api-warolabs#212 (Eventos lives in warotickets.com — external product).
+// Gate by role directly. Owner-only.
+const showEventos = computed(() => accessStore.role === 'owner')
 
 const handleLogout = async () => {
   try {

--- a/composables/useModuleAccess.ts
+++ b/composables/useModuleAccess.ts
@@ -1,0 +1,50 @@
+import type { ComputedRef } from 'vue'
+import type { Module } from '~/stores/access'
+
+/**
+ * useModuleAccess — Epic 4 (warocol.com#489) sub-task #556.
+ *
+ * Thin composable wrapper over `useAccessStore` (#555). Components, the
+ * sidebar (#559), bottom nav (#560), route middleware (#557), and
+ * component-level guards (#563) call this instead of importing the store
+ * directly.
+ *
+ * Pattern mirrors `composables/useTenantReactive.ts`:
+ *   - Function-style (not `defineStore`, not `defineNuxtPlugin`)
+ *   - Returns `computed` refs for reactive state
+ *   - `can()` returns a `ComputedRef<boolean>` so templates auto-re-render
+ *     when the user's access changes (e.g. when polling #562 picks up an
+ *     owner-edited matrix)
+ *
+ * The composable is read-only by design. Mutation (`load`, `clear`) lives
+ * on the store and is triggered by the auth middleware (#555) and the
+ * polling task (#562). Components do not call mutations directly.
+ */
+export const useModuleAccess = () => {
+  const store = useAccessStore()
+
+  const role = computed(() => store.role)
+  const enforcementMode = computed(() => store.enforcementMode)
+  const isLoaded = computed(() => store.isLoaded)
+
+  /**
+   * Returns a `ComputedRef<boolean>` that's `true` when the current user
+   * can access `module`.
+   *
+   * Fail-open semantics — always `true` when `enforcementMode` is
+   * `'disabled'` or `'shadow'`. Only `'enforce'` mode actually checks
+   * membership. This mirrors the backend's gate behavior so the UI matches
+   * runtime authorization without surprises.
+   *
+   * Usage in templates:
+   *   <button v-if="can('finanzas').value">Ver finanzas</button>
+   *
+   * Usage in script setup:
+   *   const finanzasAccess = can('finanzas')
+   *   watch(finanzasAccess, (newVal) => { ... })
+   */
+  const can = (module: Module): ComputedRef<boolean> =>
+    computed(() => store.can(module))
+
+  return { role, enforcementMode, isLoaded, can }
+}

--- a/middleware/auth.global.js
+++ b/middleware/auth.global.js
@@ -11,6 +11,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   const isKds = to.meta?.layout === 'kds'
 
   const authStore = useAuthStore()
+  const accessStore = useAccessStore()
 
   // If user already has a valid session and tries to access login, redirect to ventas
   if (authStore.isSessionValid && to.path === '/auth/login') {
@@ -33,6 +34,12 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 
   // ✅ Check if we already have a valid session in the store
   if (authStore.isSessionValid) {
+    // Hydrate the access store on first navigation if it wasn't loaded yet
+    // (e.g. page refresh inside an authenticated session). Fire-and-forget —
+    // sidebar / gates fail-open while enforcementMode stays at 'disabled'.
+    if (!accessStore.isLoaded) {
+      accessStore.load()
+    }
     return
   }
 
@@ -53,6 +60,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
     if (error.value || !sessionResponse.value?.user) {
       // No valid session
       authStore.clearAuth()
+      accessStore.clear()
 
       // If not on a public route, redirect to login
 
@@ -69,10 +77,14 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
           // ... other user properties
         }
       })
+
+      // Hydrate access store (role + modules + enforcement_mode for Epic 4)
+      await accessStore.load()
     }
   } catch (err) {
     console.error('Auth middleware error:', err)
     authStore.clearAuth()
+    accessStore.clear()
     return navigateTo('/auth/login')
   } finally {
     authStore.setLoading(false)

--- a/middleware/module-access.global.ts
+++ b/middleware/module-access.global.ts
@@ -1,0 +1,63 @@
+import type { Module } from '~/stores/access'
+
+/**
+ * module-access.global.ts — Epic 4 (warocol.com#489) sub-task #557.
+ *
+ * Route-level enforcement of module access. Activates only when:
+ *   1. The destination page declares `definePageMeta({ module: 'X' })` (#558).
+ *   2. The tenant's `enforcement_mode` is `'enforce'` (flipped per-tenant in
+ *      Epic 6).
+ *
+ * Otherwise no-op (fail-open). Mirrors the backend's behavior — backend's
+ * `require_module()` also passes through on `'disabled'` / `'shadow'` modes,
+ * so the frontend gate matches what the API would actually return.
+ *
+ * Execution order: runs after `auth.global.js` (which hydrates
+ * `useAccessStore`) and after `billing-gate.global.ts` (no point gating
+ * modules for a user who's about to be redirected to billing).
+ *
+ * Redirect target `/403` ships in #561. Until that lands, a denial would
+ * hit a 404 — but denial only triggers when `enforcement_mode === 'enforce'`
+ * AND a page has `module` meta, neither of which exists in production
+ * today. The coordination requirement: #561 must merge BEFORE any tenant
+ * is flipped to `'enforce'`.
+ */
+export default defineNuxtRouteMiddleware((to) => {
+  if (process.server) return
+
+  // Skip-list: routes that never require module gating. Mirrors the lists
+  // in auth.global.js and billing-gate.global.ts. If this list drifts,
+  // extract to utils/route-helpers.ts as a follow-up.
+  const skipExact = ['/', '/bogota']
+  const skipPrefixes = [
+    '/auth/',
+    '/proveedor/',
+    '/blog',
+    '/docs',
+    '/403', // prevent infinite redirect loop if /403 itself gets gated
+  ]
+  const skipLayouts = ['public-restaurant', 'customer-portal', 'kds']
+
+  if (
+    skipExact.includes(to.path) ||
+    skipPrefixes.some((p) => to.path.startsWith(p)) ||
+    skipLayouts.includes(to.meta?.layout as string)
+  ) return
+
+  // Page didn't opt in to module gating → pass through.
+  // Type augmentation of PageMeta lives in #558 (where pages add the meta).
+  // Until then, cast to keep this middleware self-contained.
+  const moduleKey = (to.meta as { module?: string })?.module
+  if (!moduleKey) return
+
+  const { can, enforcementMode } = useModuleAccess()
+
+  // Fail-open: only 'enforce' mode actually denies. 'disabled' and 'shadow'
+  // let the request through (backend behavior matches).
+  if (enforcementMode.value !== 'enforce') return
+
+  // Denied → redirect to /403 (page ships in #561).
+  if (!can(moduleKey as Module).value) {
+    return navigateTo('/403')
+  }
+})

--- a/stores/access.ts
+++ b/stores/access.ts
@@ -1,0 +1,98 @@
+/**
+ * Access Store — Epic 4 (warocol.com#489) sub-task #555.
+ *
+ * Single source of truth for the current user's role, module access, and the
+ * tenant's enforcement mode. Hydrates from GET /api/me/access (backend lives
+ * in api-warolabs#200, merged via PR #219).
+ *
+ * Read by sidebar (#559), bottom nav (#560), route middleware (#557), and
+ * page-level guards (#563). Refreshed periodically by polling (#562).
+ *
+ * Module string union is hand-maintained against the backend enum at
+ * api_warocol.com/app/core/permissions.py:Module. If a new module is added
+ * there, mirror it here.
+ */
+import { defineStore } from 'pinia'
+
+export type Module =
+  | 'pos'
+  | 'ventas'
+  | 'despacho'
+  | 'menu'
+  | 'operaciones'
+  | 'abastecimiento'
+  | 'analitica'
+  | 'finanzas'
+  | 'facturacion'
+  | 'equipo'
+  | 'integraciones'
+  | 'mi_plan'
+  | 'mi_negocio'
+  // EVENTOS removed in api-warolabs#212 (PR #212 merged) — Eventos lives in warotickets.com
+
+export type EnforcementMode = 'disabled' | 'shadow' | 'enforce'
+
+interface AccessResponse {
+  role: string | null
+  modules: string[]
+  enforcement_mode: EnforcementMode
+}
+
+export const useAccessStore = defineStore('access', () => {
+  const role = ref<string | null>(null)
+  const modules = ref<string[]>([])
+  const enforcementMode = ref<EnforcementMode>('disabled')
+  const isLoaded = ref(false)
+
+  // O(1) membership lookup derived from the array.
+  // Stored as `string[]` (not `Set`) because Pinia SSR serializes state to
+  // the Nuxt payload as JSON, and Sets don't survive the round trip.
+  const modulesSet = computed(() => new Set(modules.value))
+
+  async function load() {
+    try {
+      const data = await $fetch<AccessResponse>('/api/me/access')
+      role.value = data.role
+      modules.value = data.modules ?? []
+      enforcementMode.value = data.enforcement_mode ?? 'disabled'
+      isLoaded.value = true
+    } catch (err) {
+      // Fail-open: keep current state. enforcementMode stays at its current
+      // value (initially 'disabled' which makes can() always return true).
+      // Matches the safety guarantee in Epic 4's body.
+      console.error('useAccessStore.load() failed:', err)
+    }
+  }
+
+  function clear() {
+    role.value = null
+    modules.value = []
+    enforcementMode.value = 'disabled'
+    isLoaded.value = false
+  }
+
+  /**
+   * Returns true if the current user can access `module`.
+   *
+   * Fail-open semantics: when enforcementMode is 'disabled' or 'shadow',
+   * always returns true so the frontend renders today's behavior (no menu
+   * items hidden, no redirects). Backend mirrors this — shadow mode logs
+   * but does not deny.
+   *
+   * Only 'enforce' mode actually checks membership against `modules`.
+   */
+  function can(module: Module): boolean {
+    if (enforcementMode.value !== 'enforce') return true
+    return modulesSet.value.has(module)
+  }
+
+  return {
+    role: readonly(role),
+    modules: readonly(modules),
+    enforcementMode: readonly(enforcementMode),
+    isLoaded: readonly(isLoaded),
+    load,
+    clear,
+    can,
+  }
+})


### PR DESCRIPTION
## Summary

Sub-task **E4.5** of Epic 4 (#489). First user-visible Epic 4 piece — sidebar items now filter themselves based on the user's modules. Section headers and dividers collapse together when a section is empty. Fail-open while `enforcementMode !== 'enforce'`, so today's behavior is preserved until Epic 6 flips a tenant.

## Stack
🟢 Nuxt 3 + 🎨 UX (no UX regressions; pre-existing UX issues out of scope)

## ⚠️ Stacked PR (4th in the chain)

```
#564 (#555 store)
  └─ #565 (#556 composable)
       └─ #566 (#557 middleware)
            └─ THIS PR (#559 sidebar)
```

GitHub auto-retargets as upstream merges. Same pattern as the prior 3.

## Changes

| File | Type | What |
|---|---|---|
| `components/DashboardSidebar.vue` | modify | +SidebarItem interface, +module field on 13 items, +3 visible-X computeds + showEventos, wrap each section in `<template v-if>` so headers + leading dividers + items collapse together |

Single file change. No new files. Net: +134 / -101 lines.

## Module mapping

| Item | Module |
|---|---|
| POS | `pos` |
| Ventas | `ventas` |
| Despacho | `despacho` |
| Analítica Ventas | `analitica` |
| Finanzas | `finanzas` |
| Facturación | `facturacion` |
| Menú | `menu` |
| Operaciones | `operaciones` |
| Abastecimiento | `abastecimiento` |
| Equipo | `equipo` (owner-only per matrix) |
| Integraciones | `integraciones` |
| Mi Negocio | `mi_negocio` (owner-only post #209) |
| Mi Plan | `mi_plan` |
| Eventos | owner role only (not via `can()` — `Module.EVENTOS` was removed in api-warolabs#212) |

## Visibility by role (post Epic 6 enforce flip)

| Role | Visible items |
|---|---|
| Owner | All 13 + Eventos |
| Admin | All except Equipo |
| Supervisor | POS, Ventas, Despacho + Analítica, Menú, Operaciones, Abastecimiento, Mi Negocio |
| Cashier | POS, Ventas only (Operación section + Logout) |
| Kitchen | Despacho only |

## Today

`enforcementMode === 'disabled'` for all 16 tenants → `can()` always returns true → sidebar renders identically to before. **Zero visible change in production until Epic 6 flips a tenant.**

## Decisions applied

1. **Eventos via `role === 'owner'`** (not `can('eventos')`) — Module.EVENTOS doesn't exist in backend enum
2. **`primaryItems` included** in filter — issue body forgot, but POS/Ventas/Despacho ARE gated in Epic 2
3. **Filter via computed**, not `v-if` inside `v-for` — Vue convention
4. **Section + leading divider** wrapped in same `<template v-if>` so they collapse together (no orphan headers/dividers)
5. **No automated tests** — repo has no vitest/Pinia testing infra (consistent with #555-#557)

## Pre-existing UX issues — flagged, NOT addressed

| Line | Issue | Track as |
|---|---|---|
| 228-244 | Touch target ~24px (below WCAG 44×44 recommendation) | Future sidebar a11y pass |
| 79, 99 | Icon-only collapsed state has no `aria-label` (uses `:title`) | Same future pass |
| 282 | Section labels 11px (below 12px caption minimum) | Same future pass |

Expanding #559 to fix these would balloon scope. Track separately for an accessibility-focused PR.

## Testing

- ✅ Nuxt typecheck: zero new errors in `components/DashboardSidebar.vue`
- ⏳ Manual QA pending (after upstream PRs merge):
  - Owner / admin / cashier / kitchen views (toggle role in DevTools to verify filtering)
  - No empty section headers, no floating dividers when sections collapse
  - No Vue compiler warnings about `v-if` inside `v-for`
  - `hasCriticalAlerts` red dot on Abastecimiento still works
  - Logout button always visible in `#bottom` slot

## Coordination with PR #553

PR #553 also touches Eventos (with `v-if="isOwner"`). Both PRs end up at the same functional state. Whichever merges first, the other rebases cleanly. No blocking dependency.

## Out of scope

- Mobile bottom nav (`DashboardBottomNav.vue`) — #560
- `/403` page — #561
- Polling — #562
- Component-level guard composable — #563
- Sidebar a11y pass (touch targets, aria-labels, font sizing) — track separately

Closes #559