### PR TITLE
feat(403): access-denied page for Epic 4 frontend gating (#561)

### DIFF
--- a/components/DashboardSidebar.vue
+++ b/components/DashboardSidebar.vue
@@ -18,90 +18,94 @@
     <template #navigation="{ collapsed }">
 
       <!-- ── OPERACIÓN (frecuente) ── -->
-      <div class="space-y-0.5">
-        <p v-if="!collapsed" class="nav-section-label">Operación</p>
-        <NuxtLink
-          v-for="item in primaryItems"
-          :key="item.to"
-          :to="item.to"
-          :title="item.label"
-          :class="[
-            'nav-item group',
-            collapsed ? 'justify-center' : '',
-            activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
-          ]"
-        >
-          <component :is="item.icon" class="nav-icon" />
-          <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">{{ item.label }}</span>
-        </NuxtLink>
-      </div>
+      <template v-if="visiblePrimaryItems.length">
+        <div class="space-y-0.5">
+          <p v-if="!collapsed" class="nav-section-label">Operación</p>
+          <NuxtLink
+            v-for="item in visiblePrimaryItems"
+            :key="item.to"
+            :to="item.to"
+            :title="item.label"
+            :class="[
+              'nav-item group',
+              collapsed ? 'justify-center' : '',
+              activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
+            ]"
+          >
+            <component :is="item.icon" class="nav-icon" />
+            <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">{{ item.label }}</span>
+          </NuxtLink>
+        </div>
+      </template>
 
-      <!-- ── DIVIDER ── -->
-      <div class="my-1.5 mx-1 border-t nav-divider" />
+      <!-- ── HERRAMIENTAS (with leading divider) ── -->
+      <template v-if="visibleSecondaryItems.length">
+        <div class="my-1.5 mx-1 border-t nav-divider" />
+        <div class="space-y-0.5">
+          <p v-if="!collapsed" class="nav-section-label">Herramientas</p>
+          <NuxtLink
+            v-for="item in visibleSecondaryItems"
+            :key="item.to"
+            :to="item.to"
+            :title="item.label"
+            :class="[
+              'nav-item',
+              collapsed ? 'justify-center' : '',
+              activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
+            ]"
+          >
+            <component :is="item.icon" class="nav-icon" />
+            <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">
+              {{ item.label }}
+              <span
+                v-if="item.page === 'abastecimiento' && hasCriticalAlerts"
+                class="inline-block w-1.5 h-1.5 rounded-full bg-destructive align-middle ml-1.5"
+              />
+            </span>
+          </NuxtLink>
+        </div>
+      </template>
 
-      <!-- ── HERRAMIENTAS ── -->
-      <div class="space-y-0.5">
-        <p v-if="!collapsed" class="nav-section-label">Herramientas</p>
-        <NuxtLink
-          v-for="item in secondaryItems"
-          :key="item.to"
-          :to="item.to"
-          :title="item.label"
-          :class="[
-            'nav-item',
-            collapsed ? 'justify-center' : '',
-            activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
-          ]"
-        >
-          <component :is="item.icon" class="nav-icon" />
-          <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">
-            {{ item.label }}
-            <span
-              v-if="item.page === 'abastecimiento' && hasCriticalAlerts"
-              class="inline-block w-1.5 h-1.5 rounded-full bg-destructive align-middle ml-1.5"
-            />
-          </span>
-        </NuxtLink>
-      </div>
-
-      <!-- ── DIVIDER ── -->
-      <div class="my-1.5 mx-1 border-t nav-divider" />
-
-      <!-- ── APPS ── -->
-      <div class="space-y-0.5">
-        <p v-if="!collapsed" class="nav-section-label">Apps</p>
-        <a
-          href="https://warotickets.com/gestion/eventos"
-          target="_blank"
-          title="Eventos"
-          :class="['nav-item nav-item--idle', collapsed ? 'justify-center' : '']"
-        >
-          <Squares2X2Icon class="nav-icon" />
-          <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">Eventos</span>
-        </a>
-      </div>
+      <!-- ── APPS (with leading divider) — Eventos is owner-only — -->
+      <template v-if="showEventos">
+        <div class="my-1.5 mx-1 border-t nav-divider" />
+        <div class="space-y-0.5">
+          <p v-if="!collapsed" class="nav-section-label">Apps</p>
+          <a
+            href="https://warotickets.com/gestion/eventos"
+            target="_blank"
+            title="Eventos"
+            :class="['nav-item nav-item--idle', collapsed ? 'justify-center' : '']"
+          >
+            <Squares2X2Icon class="nav-icon" />
+            <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">Eventos</span>
+          </a>
+        </div>
+      </template>
 
       <!-- ── SPACER ── -->
       <div class="flex-1" style="min-height: 1rem;" />
 
       <!-- ── CUENTA (fondo) ── -->
-      <div class="space-y-0.5">
-        <p v-if="!collapsed" class="nav-section-label">Cuenta</p>
-        <NuxtLink
-          v-for="item in cuentaItems"
-          :key="item.to"
-          :to="item.to"
-          :title="item.label"
-          :class="[
-            'nav-item',
-            collapsed ? 'justify-center' : '',
-            activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
-          ]"
-        >
-          <component :is="item.icon" class="nav-icon" />
-          <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">{{ item.label }}</span>
-        </NuxtLink>
-      </div>
+      <template v-if="visibleCuentaItems.length">
+        <div class="space-y-0.5">
+          <p v-if="!collapsed" class="nav-section-label">Cuenta</p>
+          <NuxtLink
+            v-for="item in visibleCuentaItems"
+            :key="item.to"
+            :to="item.to"
+            :title="item.label"
+            :class="[
+              'nav-item',
+              collapsed ? 'justify-center' : '',
+              activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
+            ]"
+          >
+            <component :is="item.icon" class="nav-icon" />
+            <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">{{ item.label }}</span>
+          </NuxtLink>
+        </div>
+      </template>
 
     </template>
 
@@ -129,7 +133,9 @@
 defineOptions({ inheritAttrs: false })
 
 import { computed, nextTick, ref } from 'vue'
+import type { FunctionalComponent } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
+import type { Module } from '~/stores/access'
 import {
   AdjustmentsHorizontalIcon,
   ArrowRightOnRectangleIcon,
@@ -157,6 +163,14 @@ interface Props {
 }
 const props = withDefaults(defineProps<Props>(), { activePage: 'financiero' })
 
+interface SidebarItem {
+  to: string
+  page: string
+  label: string
+  icon: FunctionalComponent
+  module: Module
+}
+
 const isLoggingOut = ref(false)
 const router = useRouter()
 
@@ -167,31 +181,50 @@ const authStore = useAuthStore()
 // ── Nav items ──────────────────────────────────────────────
 const { businessProfile } = useTenantReactive()
 
-const primaryItems = computed(() => {
-  const items = [
-    { to: '/pos',               page: 'pos',       label: 'POS',        icon: ComputerDesktopIcon },
-    { to: '/ventas',            page: 'ventas',    label: 'Ventas',     icon: ShoppingCartIcon },
-    { to: '/despacho/domicilios', page: 'despacho', label: 'Despacho', icon: MapPinIcon },
+// Epic 4 (#559): each item declares the backend module it requires.
+// useModuleAccess().can() fails open while enforcementMode !== 'enforce',
+// so today's sidebar (every module visible) is preserved until Epic 6
+// flips a tenant.
+const primaryItems = computed<SidebarItem[]>(() => [
+  { to: '/pos',                 page: 'pos',      label: 'POS',      icon: ComputerDesktopIcon, module: 'pos' },
+  { to: '/ventas',              page: 'ventas',   label: 'Ventas',   icon: ShoppingCartIcon,    module: 'ventas' },
+  { to: '/despacho/domicilios', page: 'despacho', label: 'Despacho', icon: MapPinIcon,          module: 'despacho' },
+])
 
-  ]
-  return items
-})
-
-const secondaryItems = [
-  { to: '/analitica',                        page: 'analytics',     label: 'Analítica Ventas', icon: ChartBarIcon },
-  { to: '/finanzas/arqueo',                  page: 'finanzas',      label: 'Finanzas',       icon: BanknotesIcon },
-  { to: '/facturacion',                      page: 'facturacion',   label: 'Facturación',    icon: DocumentTextIcon },
-  { to: '/menu/productos',                   page: 'menu',          label: 'Menú',           icon: CubeIcon },
-  { to: '/operaciones/comandas',             page: 'operaciones',   label: 'Operaciones',    icon: AdjustmentsHorizontalIcon },
-  { to: '/abastecimiento/compras-directas',  page: 'abastecimiento',label: 'Abastecimiento', icon: TruckIcon },
-  { to: '/equipo/miembros',                  page: 'equipo',        label: 'Equipo',         icon: UserGroupIcon },
-  { to: '/integraciones',                    page: 'integraciones', label: 'Integraciones',  icon: KeyIcon },
+const secondaryItems: SidebarItem[] = [
+  { to: '/analitica',                        page: 'analytics',      label: 'Analítica Ventas', icon: ChartBarIcon,              module: 'analitica' },
+  { to: '/finanzas/arqueo',                  page: 'finanzas',       label: 'Finanzas',         icon: BanknotesIcon,             module: 'finanzas' },
+  { to: '/facturacion',                      page: 'facturacion',    label: 'Facturación',      icon: DocumentTextIcon,          module: 'facturacion' },
+  { to: '/menu/productos',                   page: 'menu',           label: 'Menú',             icon: CubeIcon,                  module: 'menu' },
+  { to: '/operaciones/comandas',             page: 'operaciones',    label: 'Operaciones',      icon: AdjustmentsHorizontalIcon, module: 'operaciones' },
+  { to: '/abastecimiento/compras-directas',  page: 'abastecimiento', label: 'Abastecimiento',   icon: TruckIcon,                 module: 'abastecimiento' },
+  { to: '/equipo/miembros',                  page: 'equipo',         label: 'Equipo',           icon: UserGroupIcon,             module: 'equipo' },
+  { to: '/integraciones',                    page: 'integraciones',  label: 'Integraciones',    icon: KeyIcon,                   module: 'integraciones' },
 ]
 
-const cuentaItems = [
-  { to: '/negocio',         page: 'negocio', label: 'Mi Negocio', icon: BuildingStorefrontIcon },
-  { to: '/gestion/billing', page: 'admin',   label: 'Mi Plan',    icon: CreditCardIcon },
+const cuentaItems: SidebarItem[] = [
+  { to: '/negocio',         page: 'negocio', label: 'Mi Negocio', icon: BuildingStorefrontIcon, module: 'mi_negocio' },
+  { to: '/gestion/billing', page: 'admin',   label: 'Mi Plan',    icon: CreditCardIcon,         module: 'mi_plan' },
 ]
+
+// ── Module-based filtering (#559) ──────────────────────────────
+const { can } = useModuleAccess()
+const accessStore = useAccessStore()
+
+const visiblePrimaryItems = computed(() =>
+  primaryItems.value.filter((item) => can(item.module).value)
+)
+const visibleSecondaryItems = computed(() =>
+  secondaryItems.filter((item) => can(item.module).value)
+)
+const visibleCuentaItems = computed(() =>
+  cuentaItems.filter((item) => can(item.module).value)
+)
+
+// Eventos is special: Module.EVENTOS was removed from the backend enum
+// in api-warolabs#212 (Eventos lives in warotickets.com — external product).
+// Gate by role directly. Owner-only.
+const showEventos = computed(() => accessStore.role === 'owner')
 
 const handleLogout = async () => {
   try {

--- a/composables/useModuleAccess.ts
+++ b/composables/useModuleAccess.ts
@@ -1,0 +1,50 @@
+import type { ComputedRef } from 'vue'
+import type { Module } from '~/stores/access'
+
+/**
+ * useModuleAccess — Epic 4 (warocol.com#489) sub-task #556.
+ *
+ * Thin composable wrapper over `useAccessStore` (#555). Components, the
+ * sidebar (#559), bottom nav (#560), route middleware (#557), and
+ * component-level guards (#563) call this instead of importing the store
+ * directly.
+ *
+ * Pattern mirrors `composables/useTenantReactive.ts`:
+ *   - Function-style (not `defineStore`, not `defineNuxtPlugin`)
+ *   - Returns `computed` refs for reactive state
+ *   - `can()` returns a `ComputedRef<boolean>` so templates auto-re-render
+ *     when the user's access changes (e.g. when polling #562 picks up an
+ *     owner-edited matrix)
+ *
+ * The composable is read-only by design. Mutation (`load`, `clear`) lives
+ * on the store and is triggered by the auth middleware (#555) and the
+ * polling task (#562). Components do not call mutations directly.
+ */
+export const useModuleAccess = () => {
+  const store = useAccessStore()
+
+  const role = computed(() => store.role)
+  const enforcementMode = computed(() => store.enforcementMode)
+  const isLoaded = computed(() => store.isLoaded)
+
+  /**
+   * Returns a `ComputedRef<boolean>` that's `true` when the current user
+   * can access `module`.
+   *
+   * Fail-open semantics — always `true` when `enforcementMode` is
+   * `'disabled'` or `'shadow'`. Only `'enforce'` mode actually checks
+   * membership. This mirrors the backend's gate behavior so the UI matches
+   * runtime authorization without surprises.
+   *
+   * Usage in templates:
+   *   <button v-if="can('finanzas').value">Ver finanzas</button>
+   *
+   * Usage in script setup:
+   *   const finanzasAccess = can('finanzas')
+   *   watch(finanzasAccess, (newVal) => { ... })
+   */
+  const can = (module: Module): ComputedRef<boolean> =>
+    computed(() => store.can(module))
+
+  return { role, enforcementMode, isLoaded, can }
+}

--- a/middleware/auth.global.js
+++ b/middleware/auth.global.js
@@ -11,6 +11,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   const isKds = to.meta?.layout === 'kds'
 
   const authStore = useAuthStore()
+  const accessStore = useAccessStore()
 
   // If user already has a valid session and tries to access login, redirect to ventas
   if (authStore.isSessionValid && to.path === '/auth/login') {
@@ -33,6 +34,12 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 
   // ✅ Check if we already have a valid session in the store
   if (authStore.isSessionValid) {
+    // Hydrate the access store on first navigation if it wasn't loaded yet
+    // (e.g. page refresh inside an authenticated session). Fire-and-forget —
+    // sidebar / gates fail-open while enforcementMode stays at 'disabled'.
+    if (!accessStore.isLoaded) {
+      accessStore.load()
+    }
     return
   }
 
@@ -53,6 +60,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
     if (error.value || !sessionResponse.value?.user) {
       // No valid session
       authStore.clearAuth()
+      accessStore.clear()
 
       // If not on a public route, redirect to login
 
@@ -69,10 +77,14 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
           // ... other user properties
         }
       })
+
+      // Hydrate access store (role + modules + enforcement_mode for Epic 4)
+      await accessStore.load()
     }
   } catch (err) {
     console.error('Auth middleware error:', err)
     authStore.clearAuth()
+    accessStore.clear()
     return navigateTo('/auth/login')
   } finally {
     authStore.setLoading(false)

--- a/middleware/module-access.global.ts
+++ b/middleware/module-access.global.ts
@@ -1,0 +1,63 @@
+import type { Module } from '~/stores/access'
+
+/**
+ * module-access.global.ts — Epic 4 (warocol.com#489) sub-task #557.
+ *
+ * Route-level enforcement of module access. Activates only when:
+ *   1. The destination page declares `definePageMeta({ module: 'X' })` (#558).
+ *   2. The tenant's `enforcement_mode` is `'enforce'` (flipped per-tenant in
+ *      Epic 6).
+ *
+ * Otherwise no-op (fail-open). Mirrors the backend's behavior — backend's
+ * `require_module()` also passes through on `'disabled'` / `'shadow'` modes,
+ * so the frontend gate matches what the API would actually return.
+ *
+ * Execution order: runs after `auth.global.js` (which hydrates
+ * `useAccessStore`) and after `billing-gate.global.ts` (no point gating
+ * modules for a user who's about to be redirected to billing).
+ *
+ * Redirect target `/403` ships in #561. Until that lands, a denial would
+ * hit a 404 — but denial only triggers when `enforcement_mode === 'enforce'`
+ * AND a page has `module` meta, neither of which exists in production
+ * today. The coordination requirement: #561 must merge BEFORE any tenant
+ * is flipped to `'enforce'`.
+ */
+export default defineNuxtRouteMiddleware((to) => {
+  if (process.server) return
+
+  // Skip-list: routes that never require module gating. Mirrors the lists
+  // in auth.global.js and billing-gate.global.ts. If this list drifts,
+  // extract to utils/route-helpers.ts as a follow-up.
+  const skipExact = ['/', '/bogota']
+  const skipPrefixes = [
+    '/auth/',
+    '/proveedor/',
+    '/blog',
+    '/docs',
+    '/403', // prevent infinite redirect loop if /403 itself gets gated
+  ]
+  const skipLayouts = ['public-restaurant', 'customer-portal', 'kds']
+
+  if (
+    skipExact.includes(to.path) ||
+    skipPrefixes.some((p) => to.path.startsWith(p)) ||
+    skipLayouts.includes(to.meta?.layout as string)
+  ) return
+
+  // Page didn't opt in to module gating → pass through.
+  // Type augmentation of PageMeta lives in #558 (where pages add the meta).
+  // Until then, cast to keep this middleware self-contained.
+  const moduleKey = (to.meta as { module?: string })?.module
+  if (!moduleKey) return
+
+  const { can, enforcementMode } = useModuleAccess()
+
+  // Fail-open: only 'enforce' mode actually denies. 'disabled' and 'shadow'
+  // let the request through (backend behavior matches).
+  if (enforcementMode.value !== 'enforce') return
+
+  // Denied → redirect to /403 (page ships in #561).
+  if (!can(moduleKey as Module).value) {
+    return navigateTo('/403')
+  }
+})

--- a/pages/403.vue
+++ b/pages/403.vue
@@ -1,0 +1,147 @@
+<template>
+  <div class="flex items-center justify-center min-h-[calc(100vh-8rem)] px-4 py-12">
+    <!-- Loading state while access store hydrates -->
+    <div v-if="!accessStore.isLoaded" class="text-center">
+      <div
+        class="mx-auto h-10 w-10 animate-spin rounded-full border-2 border-primary border-t-transparent"
+        aria-label="Cargando"
+      ></div>
+      <p class="mt-4 text-base text-text-secondary">Verificando permisos...</p>
+    </div>
+
+    <!-- Access denied content -->
+    <div
+      v-else
+      class="max-w-lg w-full bg-surface rounded-2xl border border-border p-8 md:p-12 text-center"
+    >
+      <!-- Icon: shield-exclamation, intentionally muted (not destructive — this is
+           a permissions boundary, not a system error). -->
+      <div
+        class="mx-auto mb-6 w-14 h-14 rounded-full bg-surface-secondary flex items-center justify-center"
+      >
+        <ShieldExclamationIcon class="w-8 h-8 text-muted-foreground" aria-hidden="true" />
+      </div>
+
+      <!-- Heading -->
+      <h1 class="text-2xl md:text-3xl font-bold text-text-primary mb-3">
+        No tienes acceso a este módulo
+      </h1>
+
+      <!-- Description -->
+      <p class="text-base leading-relaxed text-text-secondary mb-6 max-w-prose mx-auto">
+        Tu rol actual no incluye permisos para esta sección. Si crees que deberías
+        tener acceso, contacta al dueño del negocio.
+      </p>
+
+      <!-- Role badge -->
+      <div
+        class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-surface-secondary mb-8"
+      >
+        <span class="text-sm text-text-secondary">Tu rol:</span>
+        <span class="text-sm font-medium text-text-primary">{{ roleLabel }}</span>
+      </div>
+
+      <!-- Primary CTA — touch target 44px tall via h-11 -->
+      <div>
+        <NuxtLink
+          :to="firstAccessibleHome"
+          class="inline-flex items-center justify-center h-11 px-6 rounded-xl bg-primary text-primary-foreground font-medium hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/40 focus:ring-offset-2 transition-colors"
+        >
+          Ir al inicio
+        </NuxtLink>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ShieldExclamationIcon } from '@heroicons/vue/24/outline'
+
+/**
+ * /403 — Epic 4 (warocol.com#489) sub-task #561.
+ *
+ * Friendly access-denied page. Reached when `module-access.global.ts` (#557)
+ * detects the user lacks access to a page tagged with
+ * `definePageMeta({ module })`.
+ *
+ * Renders inside the dashboard layout so the (filtered) sidebar is visible —
+ * the user sees exactly what they CAN access right next to the denial.
+ *
+ * `/403` is in the skip-list of both auth.global.js (unauthenticated callers
+ * get redirected away first) and module-access.global.ts (prevents infinite
+ * redirect loop). So this page is only rendered for authenticated users.
+ */
+definePageMeta({ layout: 'dashboard' })
+
+useHead({ title: 'Acceso denegado · Waro' })
+
+const accessStore = useAccessStore()
+
+// Friendly Spanish role labels. Includes legacy values (superuser, employee,
+// member) that haven't been migrated to canonical names — Epic 6 will rename
+// them in the database; until then this map handles both.
+const ROLE_LABELS: Record<string, string> = {
+  owner: 'Dueño/a',
+  superuser: 'Dueño/a',
+  admin: 'Administrador/a',
+  supervisor: 'Supervisor/a',
+  cashier: 'Cajero/a',
+  employee: 'Cajero/a',
+  member: 'Cajero/a',
+  kitchen: 'Cocina',
+  customer: 'Cliente',
+}
+
+const roleLabel = computed(() =>
+  accessStore.role
+    ? ROLE_LABELS[accessStore.role] ?? accessStore.role
+    : 'Sin rol asignado'
+)
+
+// Module → landing-page URL. Mirrors DashboardSidebar.vue's item paths so
+// "Ir al inicio" lands on the same page the user would hit from the sidebar.
+const MODULE_HOMES: Record<string, string> = {
+  pos: '/pos',
+  ventas: '/ventas',
+  despacho: '/despacho/domicilios',
+  analitica: '/analitica',
+  finanzas: '/finanzas/arqueo',
+  facturacion: '/facturacion',
+  menu: '/menu/productos',
+  operaciones: '/operaciones/comandas',
+  abastecimiento: '/abastecimiento/compras-directas',
+  equipo: '/equipo/miembros',
+  integraciones: '/integraciones',
+  mi_negocio: '/negocio',
+  mi_plan: '/gestion/billing',
+}
+
+// Priority order: operational pages first, admin last. Cashier lands on POS,
+// kitchen on Despacho, owner on POS — everyone at their highest-frequency
+// page rather than the alphabetically-first module.
+const HOME_PRIORITY = [
+  'pos',
+  'ventas',
+  'despacho',
+  'analitica',
+  'finanzas',
+  'menu',
+  'operaciones',
+  'abastecimiento',
+  'facturacion',
+  'equipo',
+  'integraciones',
+  'mi_negocio',
+  'mi_plan',
+] as const
+
+const firstAccessibleHome = computed(() => {
+  const mods = new Set(accessStore.modules)
+  for (const m of HOME_PRIORITY) {
+    if (mods.has(m)) return MODULE_HOMES[m]
+  }
+  // Fallback for sessions with no modules (KDS-token, fresh-tenant owner
+  // pre-membership). /  is the public homepage.
+  return '/'
+})
+</script>

--- a/stores/access.ts
+++ b/stores/access.ts
@@ -1,0 +1,98 @@
+/**
+ * Access Store — Epic 4 (warocol.com#489) sub-task #555.
+ *
+ * Single source of truth for the current user's role, module access, and the
+ * tenant's enforcement mode. Hydrates from GET /api/me/access (backend lives
+ * in api-warolabs#200, merged via PR #219).
+ *
+ * Read by sidebar (#559), bottom nav (#560), route middleware (#557), and
+ * page-level guards (#563). Refreshed periodically by polling (#562).
+ *
+ * Module string union is hand-maintained against the backend enum at
+ * api_warocol.com/app/core/permissions.py:Module. If a new module is added
+ * there, mirror it here.
+ */
+import { defineStore } from 'pinia'
+
+export type Module =
+  | 'pos'
+  | 'ventas'
+  | 'despacho'
+  | 'menu'
+  | 'operaciones'
+  | 'abastecimiento'
+  | 'analitica'
+  | 'finanzas'
+  | 'facturacion'
+  | 'equipo'
+  | 'integraciones'
+  | 'mi_plan'
+  | 'mi_negocio'
+  // EVENTOS removed in api-warolabs#212 (PR #212 merged) — Eventos lives in warotickets.com
+
+export type EnforcementMode = 'disabled' | 'shadow' | 'enforce'
+
+interface AccessResponse {
+  role: string | null
+  modules: string[]
+  enforcement_mode: EnforcementMode
+}
+
+export const useAccessStore = defineStore('access', () => {
+  const role = ref<string | null>(null)
+  const modules = ref<string[]>([])
+  const enforcementMode = ref<EnforcementMode>('disabled')
+  const isLoaded = ref(false)
+
+  // O(1) membership lookup derived from the array.
+  // Stored as `string[]` (not `Set`) because Pinia SSR serializes state to
+  // the Nuxt payload as JSON, and Sets don't survive the round trip.
+  const modulesSet = computed(() => new Set(modules.value))
+
+  async function load() {
+    try {
+      const data = await $fetch<AccessResponse>('/api/me/access')
+      role.value = data.role
+      modules.value = data.modules ?? []
+      enforcementMode.value = data.enforcement_mode ?? 'disabled'
+      isLoaded.value = true
+    } catch (err) {
+      // Fail-open: keep current state. enforcementMode stays at its current
+      // value (initially 'disabled' which makes can() always return true).
+      // Matches the safety guarantee in Epic 4's body.
+      console.error('useAccessStore.load() failed:', err)
+    }
+  }
+
+  function clear() {
+    role.value = null
+    modules.value = []
+    enforcementMode.value = 'disabled'
+    isLoaded.value = false
+  }
+
+  /**
+   * Returns true if the current user can access `module`.
+   *
+   * Fail-open semantics: when enforcementMode is 'disabled' or 'shadow',
+   * always returns true so the frontend renders today's behavior (no menu
+   * items hidden, no redirects). Backend mirrors this — shadow mode logs
+   * but does not deny.
+   *
+   * Only 'enforce' mode actually checks membership against `modules`.
+   */
+  function can(module: Module): boolean {
+    if (enforcementMode.value !== 'enforce') return true
+    return modulesSet.value.has(module)
+  }
+
+  return {
+    role: readonly(role),
+    modules: readonly(modules),
+    enforcementMode: readonly(enforcementMode),
+    isLoaded: readonly(isLoaded),
+    load,
+    clear,
+    can,
+  }
+})


### PR DESCRIPTION
## Summary

Sub-task **E4.7** of Epic 4 (#489). Friendly access-denied page that the module-access middleware (#557) redirects to. Resolves the 404-on-redirect gap that would otherwise hit when a denial fires.

## Stack
🟢 Nuxt 3 + 🎨 UX + 🎨 Color + 📝 Typography

## ⚠️ Stacked PR (5th in chain)

```
#564 (#555 store)
  └─ #565 (#556 composable)
       └─ #566 (#557 middleware)
            └─ #567 (#559 sidebar)
                 └─ THIS PR (#561 /403 page)
```

GitHub auto-retargets as upstream merges.

## Changes

| File | Type | What |
|---|---|---|
| `pages/403.vue` | new | Access-denied page with dashboard layout, role label + first-accessible-page CTA (~140 lines) |

## API surface (what the page reads)

```ts
accessStore.role       // string | null → friendly Spanish label
accessStore.modules    // string[] → priority-ordered to find landing page
accessStore.isLoaded   // boolean → gates loading spinner
```

No `can()` calls; no `useModuleAccess`. Direct store read.

## Behavior by role

| Role | "Tu rol:" badge | "Ir al inicio" lands on |
|---|---|---|
| Owner | Dueño/a | /pos |
| Admin | Administrador/a | /pos |
| Supervisor | Supervisor/a | /pos |
| Cashier | Cajero/a | /pos |
| Kitchen | Cocina | /despacho/domicilios |
| Legacy `superuser` | Dueño/a | per modules |
| Legacy `employee` / `member` | Cajero/a | per modules |
| `role=null` | Sin rol asignado | / (fallback) |

## Decisions applied

1. **Layout: `dashboard`** — sidebar visible (filtered by #559), user sees what they CAN access alongside the denial
2. **`useAccessStore` direct** (not `useModuleAccess`) — page only reads `role` + `modules`, no `can()` calls
3. **Operational priority order** for "Ir al inicio" (`pos → ventas → despacho → ...`) — everyone lands at highest-frequency page
4. **Legacy role labels included** (`superuser`, `employee`, `member`) — Epic 6 will migrate in DB; until then handle both
5. **`ShieldExclamationIcon`** (not `text-destructive`) — permissions boundary, calmer than warning
6. **Design tokens only** (`bg-surface`, `text-text-primary`, `bg-primary`) — no inline hex/HSL
7. **Loading spinner** while `!isLoaded` — avoids flash of "Sin rol asignado" during cold load
8. **No automated tests** — consistent with #555-#559 (no test infra)

## UX/Color/Typography applied

| Concern | Applied | Source |
|---|---|---|
| Touch target ≥ 44px | CTA `h-11 px-6` | WCAG 2.5.5 |
| Body text ≥ 16px | All paragraphs `text-base` | WCAG SC 1.4.4 |
| Visual hierarchy | Icon → H1 → body → badge → CTA | Material empty states |
| Focus state | `focus:ring-2 ring-primary/40 ring-offset-2` | WCAG SC 2.4.7 |
| Not color-only | Icon + heading + text together | webaim.org colorblind |
| Single H1 | One `<h1>`, no skipped levels | WCAG ARIA practices |
| Optimal line length | `max-w-prose mx-auto` (~65ch) | NN/g typography |
| `aria-label` on spinner, `aria-hidden` on decorative icon | both present | WCAG SC 4.1.2 |

## Skip-list verification

| Middleware | Skips `/403`? | Effect |
|---|---|---|
| `auth.global.js` | NO | Unauthenticated users redirect to `/auth/login` first — page only renders for authenticated |
| `module-access.global.ts` (#557) | YES | No infinite redirect loop |

## Testing

- ✅ Nuxt typecheck: zero new errors in `pages/403.vue`
- ⏳ Manual QA after upstream PRs merge:
  - Type `/403` as each role → verify badge + button target
  - Direct URL hit while access store loading → verify spinner appears
  - role=null DevTools test → verify "Sin rol asignado" + `/` fallback
  - Mobile viewport (375px) → button tappable, no overflow

## Out of scope

- `definePageMeta({ module })` rollout — #558
- Polling — #562
- Component-level guard composable — #563
- Bottom nav dynamic filter — #560
- Sidebar a11y pass — separate future issue

Closes #561