### PR TITLE
feat(bottom-nav): module-based dynamic filtering for Epic 4 (#560)

### DIFF
--- a/components/DashboardBottomNav.vue
+++ b/components/DashboardBottomNav.vue
@@ -75,226 +75,47 @@
     <!-- Menu Modal (grid of icons) -->
     <UiBottomSheetModal v-model="showMenuModal" title="Navegación" max-height="sm">
       <div class="p-4">
-        <div class="grid grid-cols-4 gap-4">
+        <!-- Module-gated grid (#560). Fail-open when enforcement is disabled. -->
+        <div v-if="visibleGridItems.length > 0" class="grid grid-cols-4 gap-4">
           <NuxtLink
-            to="/ventas"
-            @click="showMenuModal = false"
+            v-for="item in visibleGridItems"
+            :key="item.to"
+            :to="item.to"
             class="flex flex-col items-center gap-1"
-          >
-            <div
-              class="w-12 h-12 rounded-full flex items-center justify-center transition-colors"
-              :class="activePage === 'ventas' ? 'bg-crocus-100' : 'bg-titan-100 hover:bg-titan-200'"
-            >
-              <ShoppingCartIcon
-                class="w-6 h-6"
-                :class="activePage === 'ventas' ? 'text-crocus-600' : 'text-titan-600'"
-              />
-            </div>
-            <span class="text-[10px] text-titan-600">Ventas</span>
-          </NuxtLink>
-
-          <NuxtLink
-            to="/pos"
             @click="showMenuModal = false"
-            class="flex flex-col items-center gap-1"
-          >
-            <div
-              class="w-12 h-12 rounded-full flex items-center justify-center transition-colors"
-              :class="activePage === 'pos' ? 'bg-crocus-100' : 'bg-titan-100 hover:bg-titan-200'"
-            >
-              <ComputerDesktopIcon
-                class="w-6 h-6"
-                :class="activePage === 'pos' ? 'text-crocus-600' : 'text-titan-600'"
-              />
-            </div>
-            <span class="text-[10px] text-titan-600">POS</span>
-          </NuxtLink>
-
-
-          <NuxtLink
-            to="/abastecimiento/compras-directas"
-            @click="showMenuModal = false"
-            class="flex flex-col items-center gap-1"
           >
             <div class="relative">
               <div
                 class="w-12 h-12 rounded-full flex items-center justify-center transition-colors"
-                :class="activePage === 'abastecimiento' ? 'bg-crocus-100' : 'bg-titan-100 hover:bg-titan-200'"
+                :class="activePage === item.page ? 'bg-crocus-100' : 'bg-titan-100 hover:bg-titan-200'"
               >
-                <DocumentTextIcon
+                <component
+                  :is="item.icon"
                   class="w-6 h-6"
-                  :class="activePage === 'abastecimiento' ? 'text-crocus-600' : 'text-titan-600'"
+                  :class="activePage === item.page ? 'text-crocus-600' : 'text-titan-600'"
                 />
               </div>
               <span
-                v-if="hasCriticalAlerts"
+                v-if="item.showCriticalDot && hasCriticalAlerts"
                 class="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 bg-destructive border-2 border-white rounded-full"
-                aria-label="Alertas críticas en abastecimiento"
+                :aria-label="`Alertas críticas en ${item.label.toLowerCase()}`"
               />
             </div>
-            <span class="text-[10px] text-titan-600">Abastecimiento</span>
+            <span class="text-[10px] text-titan-600">{{ item.label }}</span>
           </NuxtLink>
+        </div>
 
+        <!-- Empty-state fallback — guarantees at least one navigation target. -->
+        <div v-else class="grid grid-cols-4 gap-4">
           <NuxtLink
-            to="/menu/productos"
-            @click="showMenuModal = false"
+            to="/"
             class="flex flex-col items-center gap-1"
-          >
-            <div
-              class="w-12 h-12 rounded-full flex items-center justify-center transition-colors"
-              :class="activePage === 'menu' ? 'bg-crocus-100' : 'bg-titan-100 hover:bg-titan-200'"
-            >
-              <CubeIcon
-                class="w-6 h-6"
-                :class="activePage === 'menu' ? 'text-crocus-600' : 'text-titan-600'"
-              />
-            </div>
-            <span class="text-[10px] text-titan-600">Menú</span>
-          </NuxtLink>
-
-          <NuxtLink
-            to="/operaciones/comandas"
             @click="showMenuModal = false"
-            class="flex flex-col items-center gap-1"
           >
-            <div
-              class="w-12 h-12 rounded-full flex items-center justify-center transition-colors"
-              :class="activePage === 'operaciones' ? 'bg-crocus-100' : 'bg-titan-100 hover:bg-titan-200'"
-            >
-              <AdjustmentsHorizontalIcon
-                class="w-6 h-6"
-                :class="activePage === 'operaciones' ? 'text-crocus-600' : 'text-titan-600'"
-              />
+            <div class="w-12 h-12 rounded-full flex items-center justify-center bg-crocus-100">
+              <HomeIcon class="w-6 h-6 text-crocus-600" />
             </div>
-            <span class="text-[10px] text-titan-600">Operaciones</span>
-          </NuxtLink>
-
-          <NuxtLink
-            to="/analitica"
-            @click="showMenuModal = false"
-            class="flex flex-col items-center gap-1"
-          >
-            <div
-              class="w-12 h-12 rounded-full flex items-center justify-center transition-colors"
-              :class="activePage === 'analytics' ? 'bg-crocus-100' : 'bg-titan-100 hover:bg-titan-200'"
-            >
-              <ChartBarIcon
-                class="w-6 h-6"
-                :class="activePage === 'analytics' ? 'text-crocus-600' : 'text-titan-600'"
-              />
-            </div>
-            <span class="text-[10px] text-titan-600">Analítica</span>
-          </NuxtLink>
-
-          <NuxtLink
-            to="/finanzas/cartera"
-            @click="showMenuModal = false"
-            class="flex flex-col items-center gap-1"
-          >
-            <div
-              class="w-12 h-12 rounded-full flex items-center justify-center transition-colors"
-              :class="activePage === 'finanzas' ? 'bg-crocus-100' : 'bg-titan-100 hover:bg-titan-200'"
-            >
-              <BanknotesIcon
-                class="w-6 h-6"
-                :class="activePage === 'finanzas' ? 'text-crocus-600' : 'text-titan-600'"
-              />
-            </div>
-            <span class="text-[10px] text-titan-600">Finanzas</span>
-          </NuxtLink>
-
-          <NuxtLink
-            to="/equipo/miembros"
-            @click="showMenuModal = false"
-            class="flex flex-col items-center gap-1"
-          >
-            <div
-              class="w-12 h-12 rounded-full flex items-center justify-center transition-colors"
-              :class="activePage === 'equipo' ? 'bg-crocus-100' : 'bg-titan-100 hover:bg-titan-200'"
-            >
-              <UserGroupIcon
-                class="w-6 h-6"
-                :class="activePage === 'equipo' ? 'text-crocus-600' : 'text-titan-600'"
-              />
-            </div>
-            <span class="text-[10px] text-titan-600">Equipo</span>
-          </NuxtLink>
-
-          <NuxtLink
-            to="/integraciones"
-            @click="showMenuModal = false"
-            class="flex flex-col items-center gap-1"
-          >
-            <div
-              class="w-12 h-12 rounded-full flex items-center justify-center transition-colors"
-              :class="activePage === 'integraciones' ? 'bg-crocus-100' : 'bg-titan-100 hover:bg-titan-200'"
-            >
-              <KeyIcon
-                class="w-6 h-6"
-                :class="activePage === 'integraciones' ? 'text-crocus-600' : 'text-titan-600'"
-              />
-            </div>
-            <span class="text-[10px] text-titan-600">Integraciones</span>
-          </NuxtLink>
-
-          <NuxtLink
-            to="/despacho/domicilios"
-            @click="showMenuModal = false"
-            class="flex flex-col items-center gap-1"
-          >
-            <div class="relative">
-              <div
-                class="w-12 h-12 rounded-full flex items-center justify-center transition-colors"
-                :class="activePage === 'despacho' ? 'bg-crocus-100' : 'bg-titan-100 hover:bg-titan-200'"
-              >
-                <MapPinIcon
-                  class="w-6 h-6"
-                  :class="activePage === 'despacho' ? 'text-crocus-600' : 'text-titan-600'"
-                />
-              </div>
-              <span
-                v-if="props.notificationsCount > 0"
-                aria-label="`${props.notificationsCount} notificaciones sin leer`"
-                class="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 flex items-center justify-center bg-crocus-500 text-white text-[10px] font-bold rounded-full leading-none"
-              >
-                {{ props.notificationsCount > 9 ? '9+' : props.notificationsCount }}
-              </span>
-            </div>
-            <span class="text-[10px] text-titan-600">Domicilios</span>
-          </NuxtLink>
-
-          <NuxtLink
-            to="/negocio"
-            @click="showMenuModal = false"
-            class="flex flex-col items-center gap-1"
-          >
-            <div
-              class="w-12 h-12 rounded-full flex items-center justify-center transition-colors"
-              :class="activePage === 'negocio' ? 'bg-crocus-100' : 'bg-titan-100 hover:bg-titan-200'"
-            >
-              <BuildingStorefrontIcon
-                class="w-6 h-6"
-                :class="activePage === 'negocio' ? 'text-crocus-600' : 'text-titan-600'"
-              />
-            </div>
-            <span class="text-[10px] text-titan-600">Mi Negocio</span>
-          </NuxtLink>
-
-          <NuxtLink
-            to="/gestion/billing"
-            @click="showMenuModal = false"
-            class="flex flex-col items-center gap-1"
-          >
-            <div
-              class="w-12 h-12 rounded-full flex items-center justify-center transition-colors"
-              :class="activePage === 'admin' ? 'bg-crocus-100' : 'bg-titan-100 hover:bg-titan-200'"
-            >
-              <CreditCardIcon
-                class="w-6 h-6"
-                :class="activePage === 'admin' ? 'text-crocus-600' : 'text-titan-600'"
-              />
-            </div>
-            <span class="text-[10px] text-titan-600">Mi Plan</span>
+            <span class="text-[10px] text-titan-600">Inicio</span>
           </NuxtLink>
         </div>
       </div>
@@ -391,30 +212,43 @@
 
 <script setup lang="ts">
 import {
+  AdjustmentsHorizontalIcon,
   BanknotesIcon,
+  Bars3Icon,
+  BellAlertIcon,
+  BellIcon,
   BuildingStorefrontIcon,
+  ChartBarIcon,
+  CheckCircleIcon,
+  Cog6ToothIcon,
   ComputerDesktopIcon,
   CreditCardIcon,
+  CubeIcon,
   DocumentTextIcon,
-  Cog6ToothIcon,
-  CheckCircleIcon,
-  Bars3Icon,
+  HomeIcon,
   KeyIcon,
   MapPinIcon,
-  ShoppingCartIcon,
-  CubeIcon,
-  ChartBarIcon,
-  AdjustmentsHorizontalIcon,
-  UserGroupIcon,
-  BellIcon,
-  BellAlertIcon,
+  ReceiptPercentIcon,
   ShoppingBagIcon,
+  ShoppingCartIcon,
+  UserGroupIcon,
 } from '@heroicons/vue/24/outline'
 import { computed, ref } from 'vue'
+import type { FunctionalComponent } from 'vue'
 import { useLayoutActions } from '../composables/useLayoutActions'
+import type { Module } from '~/stores/access'
+
+type ActivePage =
+  | 'dashboard'
+  | 'ventas' | 'pos' | 'despacho' | 'comandas'
+  | 'financiero' | 'finanzas' | 'facturacion'
+  | 'abastecimiento' | 'inventario' | 'menu' | 'operaciones'
+  | 'analytics' | 'analitica' | 'reportes' | 'pagos'
+  | 'equipo' | 'integraciones'
+  | 'negocio' | 'admin' | 'configuracion'
 
 interface Props {
-  activePage?: 'dashboard' | 'pos' | 'despacho' | 'financiero' | 'abastecimiento' | 'pagos' | 'analytics' | 'analitica' | 'reportes' | 'configuracion' | 'admin' | 'ventas' | 'inventario' | 'menu' | 'equipo' | 'integraciones' | 'operaciones' | 'finanzas'
+  activePage?: ActivePage
   notificationsCount?: number
 }
 
@@ -422,6 +256,37 @@ const props = withDefaults(defineProps<Props>(), {
   activePage: 'financiero',
   notificationsCount: 0,
 })
+
+// Epic 4 (#560): each grid item declares the backend module it requires.
+// useModuleAccess().can() fails open while enforcementMode !== 'enforce',
+// so today's full grid is preserved until Epic 6 flips a tenant.
+interface GridItem {
+  to: string
+  page: ActivePage
+  label: string
+  icon: FunctionalComponent
+  module: Module
+  showCriticalDot?: boolean
+}
+
+const gridItems: GridItem[] = [
+  { to: '/ventas',                          page: 'ventas',         label: 'Ventas',         icon: ShoppingCartIcon,          module: 'ventas' },
+  { to: '/pos',                             page: 'pos',            label: 'POS',            icon: ComputerDesktopIcon,       module: 'pos' },
+  { to: '/abastecimiento/compras-directas', page: 'abastecimiento', label: 'Abastecimiento', icon: DocumentTextIcon,          module: 'abastecimiento', showCriticalDot: true },
+  { to: '/menu/productos',                  page: 'menu',           label: 'Menú',           icon: CubeIcon,                  module: 'menu' },
+  { to: '/operaciones/comandas',            page: 'operaciones',    label: 'Operaciones',    icon: AdjustmentsHorizontalIcon, module: 'operaciones' },
+  { to: '/analitica',                       page: 'analytics',      label: 'Analítica',      icon: ChartBarIcon,              module: 'analitica' },
+  { to: '/finanzas/cartera',                page: 'finanzas',       label: 'Finanzas',       icon: BanknotesIcon,             module: 'finanzas' },
+  { to: '/facturacion',                     page: 'facturacion',    label: 'Facturación',    icon: ReceiptPercentIcon,        module: 'facturacion' },
+  { to: '/equipo/miembros',                 page: 'equipo',         label: 'Equipo',         icon: UserGroupIcon,             module: 'equipo' },
+  { to: '/integraciones',                   page: 'integraciones',  label: 'Integraciones',  icon: KeyIcon,                   module: 'integraciones' },
+  { to: '/despacho/domicilios',             page: 'despacho',       label: 'Domicilios',     icon: MapPinIcon,                module: 'despacho' },
+  { to: '/negocio',                         page: 'negocio',        label: 'Mi Negocio',     icon: BuildingStorefrontIcon,    module: 'mi_negocio' },
+  { to: '/gestion/billing',                 page: 'admin',          label: 'Mi Plan',        icon: CreditCardIcon,            module: 'mi_plan' },
+]
+
+const { can } = useModuleAccess()
+const visibleGridItems = computed(() => gridItems.filter((item) => can(item.module).value))
 
 // Data quality dot indicator
 const { hasCriticalAlerts } = useDataQualityStatus()

--- a/components/DashboardSidebar.vue
+++ b/components/DashboardSidebar.vue
@@ -18,90 +18,94 @@
     <template #navigation="{ collapsed }">
 
       <!-- ── OPERACIÓN (frecuente) ── -->
-      <div class="space-y-0.5">
-        <p v-if="!collapsed" class="nav-section-label">Operación</p>
-        <NuxtLink
-          v-for="item in primaryItems"
-          :key="item.to"
-          :to="item.to"
-          :title="item.label"
-          :class="[
-            'nav-item group',
-            collapsed ? 'justify-center' : '',
-            activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
-          ]"
-        >
-          <component :is="item.icon" class="nav-icon" />
-          <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">{{ item.label }}</span>
-        </NuxtLink>
-      </div>
+      <template v-if="visiblePrimaryItems.length">
+        <div class="space-y-0.5">
+          <p v-if="!collapsed" class="nav-section-label">Operación</p>
+          <NuxtLink
+            v-for="item in visiblePrimaryItems"
+            :key="item.to"
+            :to="item.to"
+            :title="item.label"
+            :class="[
+              'nav-item group',
+              collapsed ? 'justify-center' : '',
+              activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
+            ]"
+          >
+            <component :is="item.icon" class="nav-icon" />
+            <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">{{ item.label }}</span>
+          </NuxtLink>
+        </div>
+      </template>
 
-      <!-- ── DIVIDER ── -->
-      <div class="my-1.5 mx-1 border-t nav-divider" />
+      <!-- ── HERRAMIENTAS (with leading divider) ── -->
+      <template v-if="visibleSecondaryItems.length">
+        <div class="my-1.5 mx-1 border-t nav-divider" />
+        <div class="space-y-0.5">
+          <p v-if="!collapsed" class="nav-section-label">Herramientas</p>
+          <NuxtLink
+            v-for="item in visibleSecondaryItems"
+            :key="item.to"
+            :to="item.to"
+            :title="item.label"
+            :class="[
+              'nav-item',
+              collapsed ? 'justify-center' : '',
+              activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
+            ]"
+          >
+            <component :is="item.icon" class="nav-icon" />
+            <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">
+              {{ item.label }}
+              <span
+                v-if="item.page === 'abastecimiento' && hasCriticalAlerts"
+                class="inline-block w-1.5 h-1.5 rounded-full bg-destructive align-middle ml-1.5"
+              />
+            </span>
+          </NuxtLink>
+        </div>
+      </template>
 
-      <!-- ── HERRAMIENTAS ── -->
-      <div class="space-y-0.5">
-        <p v-if="!collapsed" class="nav-section-label">Herramientas</p>
-        <NuxtLink
-          v-for="item in secondaryItems"
-          :key="item.to"
-          :to="item.to"
-          :title="item.label"
-          :class="[
-            'nav-item',
-            collapsed ? 'justify-center' : '',
-            activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
-          ]"
-        >
-          <component :is="item.icon" class="nav-icon" />
-          <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">
-            {{ item.label }}
-            <span
-              v-if="item.page === 'abastecimiento' && hasCriticalAlerts"
-              class="inline-block w-1.5 h-1.5 rounded-full bg-destructive align-middle ml-1.5"
-            />
-          </span>
-        </NuxtLink>
-      </div>
-
-      <!-- ── DIVIDER ── -->
-      <div class="my-1.5 mx-1 border-t nav-divider" />
-
-      <!-- ── APPS ── -->
-      <div class="space-y-0.5">
-        <p v-if="!collapsed" class="nav-section-label">Apps</p>
-        <a
-          href="https://warotickets.com/gestion/eventos"
-          target="_blank"
-          title="Eventos"
-          :class="['nav-item nav-item--idle', collapsed ? 'justify-center' : '']"
-        >
-          <Squares2X2Icon class="nav-icon" />
-          <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">Eventos</span>
-        </a>
-      </div>
+      <!-- ── APPS (with leading divider) — Eventos is owner-only — -->
+      <template v-if="showEventos">
+        <div class="my-1.5 mx-1 border-t nav-divider" />
+        <div class="space-y-0.5">
+          <p v-if="!collapsed" class="nav-section-label">Apps</p>
+          <a
+            href="https://warotickets.com/gestion/eventos"
+            target="_blank"
+            title="Eventos"
+            :class="['nav-item nav-item--idle', collapsed ? 'justify-center' : '']"
+          >
+            <Squares2X2Icon class="nav-icon" />
+            <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">Eventos</span>
+          </a>
+        </div>
+      </template>
 
       <!-- ── SPACER ── -->
       <div class="flex-1" style="min-height: 1rem;" />
 
       <!-- ── CUENTA (fondo) ── -->
-      <div class="space-y-0.5">
-        <p v-if="!collapsed" class="nav-section-label">Cuenta</p>
-        <NuxtLink
-          v-for="item in cuentaItems"
-          :key="item.to"
-          :to="item.to"
-          :title="item.label"
-          :class="[
-            'nav-item',
-            collapsed ? 'justify-center' : '',
-            activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
-          ]"
-        >
-          <component :is="item.icon" class="nav-icon" />
-          <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">{{ item.label }}</span>
-        </NuxtLink>
-      </div>
+      <template v-if="visibleCuentaItems.length">
+        <div class="space-y-0.5">
+          <p v-if="!collapsed" class="nav-section-label">Cuenta</p>
+          <NuxtLink
+            v-for="item in visibleCuentaItems"
+            :key="item.to"
+            :to="item.to"
+            :title="item.label"
+            :class="[
+              'nav-item',
+              collapsed ? 'justify-center' : '',
+              activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
+            ]"
+          >
+            <component :is="item.icon" class="nav-icon" />
+            <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">{{ item.label }}</span>
+          </NuxtLink>
+        </div>
+      </template>
 
     </template>
 
@@ -129,7 +133,9 @@
 defineOptions({ inheritAttrs: false })
 
 import { computed, nextTick, ref } from 'vue'
+import type { FunctionalComponent } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
+import type { Module } from '~/stores/access'
 import {
   AdjustmentsHorizontalIcon,
   ArrowRightOnRectangleIcon,
@@ -157,6 +163,14 @@ interface Props {
 }
 const props = withDefaults(defineProps<Props>(), { activePage: 'financiero' })
 
+interface SidebarItem {
+  to: string
+  page: string
+  label: string
+  icon: FunctionalComponent
+  module: Module
+}
+
 const isLoggingOut = ref(false)
 const router = useRouter()
 
@@ -167,31 +181,50 @@ const authStore = useAuthStore()
 // ── Nav items ──────────────────────────────────────────────
 const { businessProfile } = useTenantReactive()
 
-const primaryItems = computed(() => {
-  const items = [
-    { to: '/pos',               page: 'pos',       label: 'POS',        icon: ComputerDesktopIcon },
-    { to: '/ventas',            page: 'ventas',    label: 'Ventas',     icon: ShoppingCartIcon },
-    { to: '/despacho/domicilios', page: 'despacho', label: 'Despacho', icon: MapPinIcon },
+// Epic 4 (#559): each item declares the backend module it requires.
+// useModuleAccess().can() fails open while enforcementMode !== 'enforce',
+// so today's sidebar (every module visible) is preserved until Epic 6
+// flips a tenant.
+const primaryItems = computed<SidebarItem[]>(() => [
+  { to: '/pos',                 page: 'pos',      label: 'POS',      icon: ComputerDesktopIcon, module: 'pos' },
+  { to: '/ventas',              page: 'ventas',   label: 'Ventas',   icon: ShoppingCartIcon,    module: 'ventas' },
+  { to: '/despacho/domicilios', page: 'despacho', label: 'Despacho', icon: MapPinIcon,          module: 'despacho' },
+])
 
-  ]
-  return items
-})
-
-const secondaryItems = [
-  { to: '/analitica',                        page: 'analytics',     label: 'Analítica Ventas', icon: ChartBarIcon },
-  { to: '/finanzas/arqueo',                  page: 'finanzas',      label: 'Finanzas',       icon: BanknotesIcon },
-  { to: '/facturacion',                      page: 'facturacion',   label: 'Facturación',    icon: DocumentTextIcon },
-  { to: '/menu/productos',                   page: 'menu',          label: 'Menú',           icon: CubeIcon },
-  { to: '/operaciones/comandas',             page: 'operaciones',   label: 'Operaciones',    icon: AdjustmentsHorizontalIcon },
-  { to: '/abastecimiento/compras-directas',  page: 'abastecimiento',label: 'Abastecimiento', icon: TruckIcon },
-  { to: '/equipo/miembros',                  page: 'equipo',        label: 'Equipo',         icon: UserGroupIcon },
-  { to: '/integraciones',                    page: 'integraciones', label: 'Integraciones',  icon: KeyIcon },
+const secondaryItems: SidebarItem[] = [
+  { to: '/analitica',                        page: 'analytics',      label: 'Analítica Ventas', icon: ChartBarIcon,              module: 'analitica' },
+  { to: '/finanzas/arqueo',                  page: 'finanzas',       label: 'Finanzas',         icon: BanknotesIcon,             module: 'finanzas' },
+  { to: '/facturacion',                      page: 'facturacion',    label: 'Facturación',      icon: DocumentTextIcon,          module: 'facturacion' },
+  { to: '/menu/productos',                   page: 'menu',           label: 'Menú',             icon: CubeIcon,                  module: 'menu' },
+  { to: '/operaciones/comandas',             page: 'operaciones',    label: 'Operaciones',      icon: AdjustmentsHorizontalIcon, module: 'operaciones' },
+  { to: '/abastecimiento/compras-directas',  page: 'abastecimiento', label: 'Abastecimiento',   icon: TruckIcon,                 module: 'abastecimiento' },
+  { to: '/equipo/miembros',                  page: 'equipo',         label: 'Equipo',           icon: UserGroupIcon,             module: 'equipo' },
+  { to: '/integraciones',                    page: 'integraciones',  label: 'Integraciones',    icon: KeyIcon,                   module: 'integraciones' },
 ]
 
-const cuentaItems = [
-  { to: '/negocio',         page: 'negocio', label: 'Mi Negocio', icon: BuildingStorefrontIcon },
-  { to: '/gestion/billing', page: 'admin',   label: 'Mi Plan',    icon: CreditCardIcon },
+const cuentaItems: SidebarItem[] = [
+  { to: '/negocio',         page: 'negocio', label: 'Mi Negocio', icon: BuildingStorefrontIcon, module: 'mi_negocio' },
+  { to: '/gestion/billing', page: 'admin',   label: 'Mi Plan',    icon: CreditCardIcon,         module: 'mi_plan' },
 ]
+
+// ── Module-based filtering (#559) ──────────────────────────────
+const { can } = useModuleAccess()
+const accessStore = useAccessStore()
+
+const visiblePrimaryItems = computed(() =>
+  primaryItems.value.filter((item) => can(item.module).value)
+)
+const visibleSecondaryItems = computed(() =>
+  secondaryItems.filter((item) => can(item.module).value)
+)
+const visibleCuentaItems = computed(() =>
+  cuentaItems.filter((item) => can(item.module).value)
+)
+
+// Eventos is special: Module.EVENTOS was removed from the backend enum
+// in api-warolabs#212 (Eventos lives in warotickets.com — external product).
+// Gate by role directly. Owner-only.
+const showEventos = computed(() => accessStore.role === 'owner')
 
 const handleLogout = async () => {
   try {

--- a/composables/useModuleAccess.ts
+++ b/composables/useModuleAccess.ts
@@ -1,0 +1,50 @@
+import type { ComputedRef } from 'vue'
+import type { Module } from '~/stores/access'
+
+/**
+ * useModuleAccess — Epic 4 (warocol.com#489) sub-task #556.
+ *
+ * Thin composable wrapper over `useAccessStore` (#555). Components, the
+ * sidebar (#559), bottom nav (#560), route middleware (#557), and
+ * component-level guards (#563) call this instead of importing the store
+ * directly.
+ *
+ * Pattern mirrors `composables/useTenantReactive.ts`:
+ *   - Function-style (not `defineStore`, not `defineNuxtPlugin`)
+ *   - Returns `computed` refs for reactive state
+ *   - `can()` returns a `ComputedRef<boolean>` so templates auto-re-render
+ *     when the user's access changes (e.g. when polling #562 picks up an
+ *     owner-edited matrix)
+ *
+ * The composable is read-only by design. Mutation (`load`, `clear`) lives
+ * on the store and is triggered by the auth middleware (#555) and the
+ * polling task (#562). Components do not call mutations directly.
+ */
+export const useModuleAccess = () => {
+  const store = useAccessStore()
+
+  const role = computed(() => store.role)
+  const enforcementMode = computed(() => store.enforcementMode)
+  const isLoaded = computed(() => store.isLoaded)
+
+  /**
+   * Returns a `ComputedRef<boolean>` that's `true` when the current user
+   * can access `module`.
+   *
+   * Fail-open semantics — always `true` when `enforcementMode` is
+   * `'disabled'` or `'shadow'`. Only `'enforce'` mode actually checks
+   * membership. This mirrors the backend's gate behavior so the UI matches
+   * runtime authorization without surprises.
+   *
+   * Usage in templates:
+   *   <button v-if="can('finanzas').value">Ver finanzas</button>
+   *
+   * Usage in script setup:
+   *   const finanzasAccess = can('finanzas')
+   *   watch(finanzasAccess, (newVal) => { ... })
+   */
+  const can = (module: Module): ComputedRef<boolean> =>
+    computed(() => store.can(module))
+
+  return { role, enforcementMode, isLoaded, can }
+}

--- a/middleware/auth.global.js
+++ b/middleware/auth.global.js
@@ -11,6 +11,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   const isKds = to.meta?.layout === 'kds'
 
   const authStore = useAuthStore()
+  const accessStore = useAccessStore()
 
   // If user already has a valid session and tries to access login, redirect to ventas
   if (authStore.isSessionValid && to.path === '/auth/login') {
@@ -33,6 +34,12 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 
   // ✅ Check if we already have a valid session in the store
   if (authStore.isSessionValid) {
+    // Hydrate the access store on first navigation if it wasn't loaded yet
+    // (e.g. page refresh inside an authenticated session). Fire-and-forget —
+    // sidebar / gates fail-open while enforcementMode stays at 'disabled'.
+    if (!accessStore.isLoaded) {
+      accessStore.load()
+    }
     return
   }
 
@@ -53,6 +60,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
     if (error.value || !sessionResponse.value?.user) {
       // No valid session
       authStore.clearAuth()
+      accessStore.clear()
 
       // If not on a public route, redirect to login
 
@@ -69,10 +77,14 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
           // ... other user properties
         }
       })
+
+      // Hydrate access store (role + modules + enforcement_mode for Epic 4)
+      await accessStore.load()
     }
   } catch (err) {
     console.error('Auth middleware error:', err)
     authStore.clearAuth()
+    accessStore.clear()
     return navigateTo('/auth/login')
   } finally {
     authStore.setLoading(false)

--- a/middleware/module-access.global.ts
+++ b/middleware/module-access.global.ts
@@ -1,0 +1,63 @@
+import type { Module } from '~/stores/access'
+
+/**
+ * module-access.global.ts — Epic 4 (warocol.com#489) sub-task #557.
+ *
+ * Route-level enforcement of module access. Activates only when:
+ *   1. The destination page declares `definePageMeta({ module: 'X' })` (#558).
+ *   2. The tenant's `enforcement_mode` is `'enforce'` (flipped per-tenant in
+ *      Epic 6).
+ *
+ * Otherwise no-op (fail-open). Mirrors the backend's behavior — backend's
+ * `require_module()` also passes through on `'disabled'` / `'shadow'` modes,
+ * so the frontend gate matches what the API would actually return.
+ *
+ * Execution order: runs after `auth.global.js` (which hydrates
+ * `useAccessStore`) and after `billing-gate.global.ts` (no point gating
+ * modules for a user who's about to be redirected to billing).
+ *
+ * Redirect target `/403` ships in #561. Until that lands, a denial would
+ * hit a 404 — but denial only triggers when `enforcement_mode === 'enforce'`
+ * AND a page has `module` meta, neither of which exists in production
+ * today. The coordination requirement: #561 must merge BEFORE any tenant
+ * is flipped to `'enforce'`.
+ */
+export default defineNuxtRouteMiddleware((to) => {
+  if (process.server) return
+
+  // Skip-list: routes that never require module gating. Mirrors the lists
+  // in auth.global.js and billing-gate.global.ts. If this list drifts,
+  // extract to utils/route-helpers.ts as a follow-up.
+  const skipExact = ['/', '/bogota']
+  const skipPrefixes = [
+    '/auth/',
+    '/proveedor/',
+    '/blog',
+    '/docs',
+    '/403', // prevent infinite redirect loop if /403 itself gets gated
+  ]
+  const skipLayouts = ['public-restaurant', 'customer-portal', 'kds']
+
+  if (
+    skipExact.includes(to.path) ||
+    skipPrefixes.some((p) => to.path.startsWith(p)) ||
+    skipLayouts.includes(to.meta?.layout as string)
+  ) return
+
+  // Page didn't opt in to module gating → pass through.
+  // Type augmentation of PageMeta lives in #558 (where pages add the meta).
+  // Until then, cast to keep this middleware self-contained.
+  const moduleKey = (to.meta as { module?: string })?.module
+  if (!moduleKey) return
+
+  const { can, enforcementMode } = useModuleAccess()
+
+  // Fail-open: only 'enforce' mode actually denies. 'disabled' and 'shadow'
+  // let the request through (backend behavior matches).
+  if (enforcementMode.value !== 'enforce') return
+
+  // Denied → redirect to /403 (page ships in #561).
+  if (!can(moduleKey as Module).value) {
+    return navigateTo('/403')
+  }
+})

--- a/stores/access.ts
+++ b/stores/access.ts
@@ -1,0 +1,98 @@
+/**
+ * Access Store — Epic 4 (warocol.com#489) sub-task #555.
+ *
+ * Single source of truth for the current user's role, module access, and the
+ * tenant's enforcement mode. Hydrates from GET /api/me/access (backend lives
+ * in api-warolabs#200, merged via PR #219).
+ *
+ * Read by sidebar (#559), bottom nav (#560), route middleware (#557), and
+ * page-level guards (#563). Refreshed periodically by polling (#562).
+ *
+ * Module string union is hand-maintained against the backend enum at
+ * api_warocol.com/app/core/permissions.py:Module. If a new module is added
+ * there, mirror it here.
+ */
+import { defineStore } from 'pinia'
+
+export type Module =
+  | 'pos'
+  | 'ventas'
+  | 'despacho'
+  | 'menu'
+  | 'operaciones'
+  | 'abastecimiento'
+  | 'analitica'
+  | 'finanzas'
+  | 'facturacion'
+  | 'equipo'
+  | 'integraciones'
+  | 'mi_plan'
+  | 'mi_negocio'
+  // EVENTOS removed in api-warolabs#212 (PR #212 merged) — Eventos lives in warotickets.com
+
+export type EnforcementMode = 'disabled' | 'shadow' | 'enforce'
+
+interface AccessResponse {
+  role: string | null
+  modules: string[]
+  enforcement_mode: EnforcementMode
+}
+
+export const useAccessStore = defineStore('access', () => {
+  const role = ref<string | null>(null)
+  const modules = ref<string[]>([])
+  const enforcementMode = ref<EnforcementMode>('disabled')
+  const isLoaded = ref(false)
+
+  // O(1) membership lookup derived from the array.
+  // Stored as `string[]` (not `Set`) because Pinia SSR serializes state to
+  // the Nuxt payload as JSON, and Sets don't survive the round trip.
+  const modulesSet = computed(() => new Set(modules.value))
+
+  async function load() {
+    try {
+      const data = await $fetch<AccessResponse>('/api/me/access')
+      role.value = data.role
+      modules.value = data.modules ?? []
+      enforcementMode.value = data.enforcement_mode ?? 'disabled'
+      isLoaded.value = true
+    } catch (err) {
+      // Fail-open: keep current state. enforcementMode stays at its current
+      // value (initially 'disabled' which makes can() always return true).
+      // Matches the safety guarantee in Epic 4's body.
+      console.error('useAccessStore.load() failed:', err)
+    }
+  }
+
+  function clear() {
+    role.value = null
+    modules.value = []
+    enforcementMode.value = 'disabled'
+    isLoaded.value = false
+  }
+
+  /**
+   * Returns true if the current user can access `module`.
+   *
+   * Fail-open semantics: when enforcementMode is 'disabled' or 'shadow',
+   * always returns true so the frontend renders today's behavior (no menu
+   * items hidden, no redirects). Backend mirrors this — shadow mode logs
+   * but does not deny.
+   *
+   * Only 'enforce' mode actually checks membership against `modules`.
+   */
+  function can(module: Module): boolean {
+    if (enforcementMode.value !== 'enforce') return true
+    return modulesSet.value.has(module)
+  }
+
+  return {
+    role: readonly(role),
+    modules: readonly(modules),
+    enforcementMode: readonly(enforcementMode),
+    isLoaded: readonly(isLoaded),
+    load,
+    clear,
+    can,
+  }
+})


### PR DESCRIPTION
## Summary

Mirrors the sidebar's module-based filtering (#559 / PR #567) on the mobile bottom-nav menu grid. The 12 hardcoded `<NuxtLink>` blocks become a single data-driven `v-for` over a `GridItem[]` array, filtered by `useModuleAccess().can(item.module).value`. While `enforcement_mode !== 'enforce'` (production default today) the composable fails open, so every item still renders — zero visible change for current tenants.

Closes #560 — part of Epic 4 (warocol.com#489).

## Stack

Nuxt 3 + UX

## Stack order

This PR sits on top of PR #567 (`gh-559-sidebar-module-filter`). GitHub will auto-retarget to `main` once #567 lands.

```
main
 └ #564 gh-555-access-store              (E4.1)
   └ #565 gh-556-module-access-composable  (E4.2)
     └ #566 gh-557-module-access-middleware (E4.3)
       └ #567 gh-559-sidebar-module-filter   (E4.5)
         └ this PR gh-560-bottom-nav-module-filter (E4.6)
         └ #568 gh-561-page-403                (E4.7)
```

## Changes

- `components/DashboardBottomNav.vue`:
  - Refactor 12 inlined `<NuxtLink>` grid items → single `v-for` over `gridItems: GridItem[]` (13 items — adds Facturación for sidebar parity)
  - Add `useModuleAccess()` + `visibleGridItems` computed filter
  - Add empty-state fallback: when filter result is empty, render a single "Inicio" link to `/`
  - Sync `activePage` prop union with `DashboardSidebar.vue:162` — adds `'comandas'`, `'negocio'`, `'facturacion'`
  - Drop the duplicated notification badge on the Domicilios grid item (it was reusing the global `notificationsCount` already shown in the top-bar bell icon)
  - Drop the broken `aria-label` template literal that lived inside that badge (was a literal string, never interpolated)
  - Preserve the `hasCriticalAlerts` red dot on Abastecimiento via an optional `showCriticalDot` flag on `GridItem`

Net diff: **+73 / -208 lines** (data-driven refactor is much shorter than 12 copy-pasted blocks).

## Safety / fail-open semantics

`useModuleAccess().can(module).value` returns `true` whenever `enforcementMode !== 'enforce'`. Today every tenant is on `enforcement_mode = 'disabled'`, so every grid item still renders. Filtering only kicks in once Epic 6 flips a tenant to `'enforce'`.

The empty-state fallback (single "Inicio" link) is a defense-in-depth: even if a tenant somehow ends up with `modules = []` under `'enforce'`, the menu modal never shows a blank grid.

## Testing

Static:
- `nuxi typecheck` — zero new errors in `DashboardBottomNav.vue` (40 pre-existing errors in `components/Auth/LoginForm.vue` are unrelated)

Manual (to run before merge):
- [ ] Load on mobile viewport in dev → menu modal shows 13 items in default `enforcement_mode = 'disabled'` mode (12 previous + Facturación)
- [ ] No regression on the Abastecimiento `hasCriticalAlerts` red dot
- [ ] No second/duplicated notification badge on the Domicilios grid item
- [ ] Inspect Abastecimiento dot via accessibility tree → `aria-label` now reads "Alertas críticas en abastecimiento" (interpolated correctly)
- [ ] DevTools mock: `useAccessStore.enforcementMode = 'enforce'` + `modules = ['pos']` → only POS appears in grid
- [ ] DevTools mock: same with `modules = []` → "Inicio" fallback link appears (single item, links to `/`)

## Out of scope

- Bumping `text-[10px]` grid labels to `text-xs` — deferred to a dedicated typography PR (would force layout rework on small phones; labels live inside a 48px tap target with a dominant icon, so the touch area is still well above WCAG AA).
- Reconciling icon mismatches between sidebar and bottom-nav (e.g., sidebar uses `TruckIcon` for Abastecimiento while bottom-nav uses `DocumentTextIcon`) — pre-existing, separate visual-consistency PR.

Closes #560