### PR TITLE
feat(pages): tag every gated page with definePageMeta module for Epic 4 (#558)

### DIFF
--- a/app.d.ts
+++ b/app.d.ts
@@ -1,0 +1,27 @@
+import type { Module } from '~/stores/access'
+
+/**
+ * TypeScript module augmentation for Nuxt 3 PageMeta.
+ *
+ * Adds the optional `module` field used by Epic 4 (warocol.com#489):
+ * pages tagged with `definePageMeta({ module: 'X' })` get gated by the
+ * global middleware `module-access.global.ts` (#557). Untagged pages
+ * render unconditionally.
+ *
+ * The Module union is imported from `stores/access.ts` so misspellings
+ * are caught at compile time.
+ */
+declare module '#app' {
+  interface PageMeta {
+    /**
+     * Backend module required to access this page. When set and the
+     * tenant's enforcement_mode is 'enforce', users without this module
+     * are redirected to /403. When unset, the page renders for any
+     * authenticated user.
+     */
+    module?: Module
+  }
+}
+
+// Required for the file to be treated as a module, not a script.
+export {}

--- a/middleware/module-access.global.ts
+++ b/middleware/module-access.global.ts
@@ -1,5 +1,3 @@
-import type { Module } from '~/stores/access'
-
 /**
  * module-access.global.ts — Epic 4 (warocol.com#489) sub-task #557.
  *
@@ -45,9 +43,8 @@ export default defineNuxtRouteMiddleware((to) => {
   ) return
 
   // Page didn't opt in to module gating → pass through.
-  // Type augmentation of PageMeta lives in #558 (where pages add the meta).
-  // Until then, cast to keep this middleware self-contained.
-  const moduleKey = (to.meta as { module?: string })?.module
+  // PageMeta.module type augmentation lives in app.d.ts (added in #558).
+  const moduleKey = to.meta.module
   if (!moduleKey) return
 
   const { can, enforcementMode } = useModuleAccess()
@@ -57,7 +54,7 @@ export default defineNuxtRouteMiddleware((to) => {
   if (enforcementMode.value !== 'enforce') return
 
   // Denied → redirect to /403 (page ships in #561).
-  if (!can(moduleKey as Module).value) {
+  if (!can(moduleKey).value) {
     return navigateTo('/403')
   }
 })

--- a/pages/abastecimiento.vue
+++ b/pages/abastecimiento.vue
@@ -17,7 +17,8 @@ const route = useRoute()
 const lastAbastecimientoPath = useState<string | null>('abastecimiento-last-path', () => null)
 
 definePageMeta({
-  layout: 'dashboard'
+  layout: 'dashboard',
+  module: 'abastecimiento',
 })
 
 watch(

--- a/pages/analitica.vue
+++ b/pages/analitica.vue
@@ -9,7 +9,8 @@
 const route = useRoute()
 
 definePageMeta({
-  layout: 'dashboard'
+  layout: 'dashboard',
+  module: 'analitica',
 })
 
 const navigationItems = [

--- a/pages/despacho.vue
+++ b/pages/despacho.vue
@@ -10,7 +10,7 @@
 <script setup lang="ts">
 import { useTenantReactive } from '@/composables/useTenantReactive'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'despacho' })
 
 const route = useRoute()
 const { businessProfile } = useTenantReactive()

--- a/pages/equipo.vue
+++ b/pages/equipo.vue
@@ -7,7 +7,8 @@
 
 <script setup lang="ts">
 definePageMeta({
-  layout: 'dashboard'
+  layout: 'dashboard',
+  module: 'equipo',
 })
 
 useHead({ title: 'Equipo' })

--- a/pages/facturacion.vue
+++ b/pages/facturacion.vue
@@ -13,7 +13,7 @@ import {
   CheckCircleIcon,
 } from '@heroicons/vue/24/outline'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'facturacion' })
 useHead({ title: 'Facturación' })
 
 const { currentTenant } = useTenantReactive()

--- a/pages/finanzas.vue
+++ b/pages/finanzas.vue
@@ -9,7 +9,8 @@
 const route = useRoute()
 
 definePageMeta({
-  layout: 'dashboard'
+  layout: 'dashboard',
+  module: 'finanzas',
 })
 
 const navigationItems = [

--- a/pages/gestion/billing.vue
+++ b/pages/gestion/billing.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script setup lang="ts">
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'mi_plan' })
 
 const route = useRoute()
 

--- a/pages/gestion/ingredientes.vue
+++ b/pages/gestion/ingredientes.vue
@@ -10,6 +10,7 @@
 <script setup lang="ts">
 definePageMeta({
   layout: 'dashboard',
+  module: 'abastecimiento',
 })
 
 const route = useRoute()

--- a/pages/integraciones.vue
+++ b/pages/integraciones.vue
@@ -291,7 +291,7 @@
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { useFormatters } from '~/composables/useFormatters'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'integraciones' })
 useHead({ title: 'Integraciones - API Keys' })
 
 const toast = useToast()

--- a/pages/inventario.vue
+++ b/pages/inventario.vue
@@ -14,7 +14,8 @@
 const route = useRoute()
 
 definePageMeta({
-  layout: 'dashboard'
+  layout: 'dashboard',
+  module: 'abastecimiento',
 })
 
 // Navigation configuration

--- a/pages/menu.vue
+++ b/pages/menu.vue
@@ -12,7 +12,8 @@
 
 <script setup lang="ts">
 definePageMeta({
-  layout: 'dashboard'
+  layout: 'dashboard',
+  module: 'menu',
 })
 
 const route = useRoute()

--- a/pages/negocio.vue
+++ b/pages/negocio.vue
@@ -570,7 +570,7 @@ import {
   ExclamationTriangleIcon,
 } from '@heroicons/vue/24/outline'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'mi_negocio' })
 useHead({ title: 'Mi Negocio' })
 
 const { isOpenNow, currentTenant } = useTenantReactive()

--- a/pages/operaciones.vue
+++ b/pages/operaciones.vue
@@ -9,7 +9,8 @@
 const route = useRoute()
 
 definePageMeta({
-  layout: 'dashboard'
+  layout: 'dashboard',
+  module: 'operaciones',
 })
 
 const navigationItems = [

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -25,7 +25,8 @@ interface CustomerInsights {
 }
 
 definePageMeta({
-  layout: 'dashboard'
+  layout: 'dashboard',
+  module: 'pos',
 })
 
 useHead({ title: 'Checkout' })

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -6,7 +6,8 @@ import type { CachedProduct, TabItem } from '~/stores/usePOSStore'
 import { usePOSStore } from '~/stores/usePOSStore'
 
 definePageMeta({
-  layout: 'dashboard'
+  layout: 'dashboard',
+  module: 'pos',
 })
 
 useHead({ title: 'Punto de Venta' })

--- a/pages/pos/producto/[id].vue
+++ b/pages/pos/producto/[id].vue
@@ -7,7 +7,8 @@ import {
 } from '@heroicons/vue/24/outline'
 
 definePageMeta({
-  layout: 'dashboard'
+  layout: 'dashboard',
+  module: 'pos',
 })
 
 useHead({ title: 'Producto POS' })

--- a/pages/ventas.vue
+++ b/pages/ventas.vue
@@ -9,7 +9,8 @@
 const route = useRoute()
 
 definePageMeta({
-  layout: 'dashboard'
+  layout: 'dashboard',
+  module: 'ventas',
 })
 
 const navigationItems = [


### PR DESCRIPTION
## Summary

Tags every hub/leaf page with `definePageMeta({ module: 'X' })`, which is what activates the route-level gate landed in #557 (`module-access.global.ts`). Without this PR the middleware is a no-op for every route because `to.meta.module` is undefined.

Adds `app.d.ts` with a TypeScript module augmentation for `#app`'s `PageMeta`, so `definePageMeta({ module: 'X' })` is compile-time validated against the `Module` union from `stores/access.ts`. This lets the middleware drop its `(to.meta as any)` escape hatch.

Closes #558 — part of Epic 4 (warocol.com#489).

## Stack

Nuxt 3 (frontend-only, no backend / DB / API impact)

## Stack order

```
main
 └ #564 #555 access-store              (ready-for-review)
   └ #565 #556 useModuleAccess          (ready-for-review)
     └ #566 #557 middleware             (ready-for-review)
       └ #567 #559 sidebar filter       (ready-for-review)
         ├ #569 #560 bottom-nav filter  (ready-for-review)
         └ #568 #561 página /403        (ready-for-review)
           └ this PR #558 definePageMeta module
```

## Changes

### New file
- `app.d.ts` — TypeScript module augmentation for `#app.PageMeta`, adds optional `module?: Module` field

### Hub pages (Vue Router parents — `definePageMeta` cascades to nested children)
- `pages/ventas.vue` → `module: 'ventas'`
- `pages/menu.vue` → `module: 'menu'`
- `pages/despacho.vue` → `module: 'despacho'`
- `pages/abastecimiento.vue` → `module: 'abastecimiento'`
- `pages/analitica.vue` → `module: 'analitica'`
- `pages/finanzas.vue` → `module: 'finanzas'`
- `pages/operaciones.vue` → `module: 'operaciones'`
- `pages/equipo.vue` → `module: 'equipo'`
- `pages/integraciones.vue` → `module: 'integraciones'`
- `pages/facturacion.vue` → `module: 'facturacion'`
- `pages/negocio.vue` → `module: 'mi_negocio'`

### Orphan hubs (no nested children in the route tree)
- `pages/inventario.vue` → `module: 'abastecimiento'` (inventario is conceptually part of abastecimiento)
- `pages/gestion/ingredientes.vue` → `module: 'abastecimiento'`

### POS leaves (no shared `pages/pos.vue` hub — each is a sibling)
- `pages/pos/index.vue` → `module: 'pos'`
- `pages/pos/checkout.vue` → `module: 'pos'`
- `pages/pos/producto/[id].vue` → `module: 'pos'`

### Other leaves
- `pages/gestion/billing.vue` → `module: 'mi_plan'`

### Middleware cleanup
- `middleware/module-access.global.ts` — drops `(to.meta as { module?: string })?.module` cast and the `as Module` cast on the `can()` call. Both are unnecessary now that `app.d.ts` augments `PageMeta`.

Net diff: **19 files, +58 / -22 lines**.

## Safety / fail-open

`middleware/module-access.global.ts` returns early when `enforcementMode !== 'enforce'`. Today every tenant is on `'disabled'` (default), so tagging pages has **zero behavioral effect** — pages still render for every authenticated user. The tags only become load-bearing once Epic 6 flips a tenant to `'enforce'`.

The plan in the Epic 4 body explicitly notes: "Even in 'enforce' mode, the middleware is opt-in per route via `definePageMeta({ module })` — pages without that meta render as today." This PR is what fulfills that opt-in.

## Coordination requirement

This PR adds tags. The redirect target `/403` ships in PR #568 (#561). **#568 must merge before any tenant is flipped to `'enforce'`** — otherwise tagged pages would 404 instead of 403. Both are in the same stack so the chain is enforced by the merge order.

## Testing

Static:
- `nuxi typecheck` — zero new errors in any of the 19 changed files. All TS errors reported are pre-existing in unrelated files (`components/Auth/LoginForm.vue` etc.).

Manual (to run before merge):
- [ ] Load each tagged hub page in default `enforcement_mode = 'disabled'` → renders normally, no redirect to `/403`
- [ ] Load nested children of tagged hubs (e.g., `/ventas/ordenes`, `/abastecimiento/compras-directas`) → inherit meta from parent, render normally
- [ ] DevTools mock: `useAccessStore.enforcementMode = 'enforce'` + `modules = ['pos']` → loading `/ventas` redirects to `/403`, loading `/pos` renders
- [ ] TypeScript autocomplete: typing `definePageMeta({ module: '' })` should suggest only the 13 modules from the union

## Out of scope

- Tagging the public/auth/supplier-portal/customer-portal/KDS routes — these are already in the middleware's skip list (`module-access.global.ts:30-37`)
- Tagging `pages/cuenta` / account routes — they have no module enforcement requirement per Epic 4 design (every authenticated user needs to manage their account)
- Pages under `/admin/*` and `/superadmin/*` (if any) — out of Epic 4 scope, handled by separate role gates

Closes #558