### PR TITLE
feat(access): poll every 60s + silent /403 redirect on revocation for Epic 4 (#562)

### DIFF
--- a/components/DashboardSidebar.vue
+++ b/components/DashboardSidebar.vue
@@ -231,10 +231,14 @@ const handleLogout = async () => {
     isLoggingOut.value = true
     await $fetch('/api/auth/signout', { method: 'POST', credentials: 'include' })
     authStore.clearAuth()
+    // #562: clear access store too — otherwise the polling setInterval keeps
+    // firing after logout. Symmetric with the auth.global.js cleanup path.
+    accessStore.clear()
     if (typeof window !== 'undefined') { localStorage.clear(); sessionStorage.clear() }
     await router.push('/')
   } catch {
     authStore.clearAuth()
+    accessStore.clear()
     await router.push('/')
   } finally {
     isLoggingOut.value = false

--- a/plugins/access-watcher.client.ts
+++ b/plugins/access-watcher.client.ts
@@ -1,0 +1,40 @@
+/**
+ * access-watcher.client.ts — Epic 4 (warocol.com#489) sub-task #562.
+ *
+ * Detects mid-session permission changes and silently redirects the user
+ * off any page they can no longer access. Complements:
+ *   - `module-access.global.ts` (#557) — gates on navigation
+ *   - `useAccessStore.armPolling()` (#562) — refreshes state every 60s
+ *
+ * This plugin closes the gap: when the polling tick updates `modules` while
+ * the user is parked on a static page, the route middleware never re-fires,
+ * so we need a reactive watcher to yank them off the now-forbidden route.
+ *
+ * Client-only by file extension — Nuxt skips it during SSR, so the watcher
+ * + navigateTo() never run on the server.
+ */
+export default defineNuxtPlugin(() => {
+  const accessStore = useAccessStore()
+  const route = useRoute()
+
+  // Single derived gate. Reads `route.path`, `route.meta.module`, and
+  // (through store.can) `enforcementMode` + `modulesSet` — all reactive,
+  // so this recomputes whenever any input changes.
+  const canStayOnRoute = computed<boolean>(() => {
+    // Defensive: prevent redirect loop if /403 itself is somehow gated.
+    if (route.path === '/403') return true
+    // Page didn't opt in to module gating → always allowed.
+    const moduleKey = route.meta.module
+    if (!moduleKey) return true
+    // store.can() returns true when enforcementMode !== 'enforce' (fail-open),
+    // so today's `disabled`/`shadow` tenants never trigger the redirect.
+    return accessStore.can(moduleKey)
+  })
+
+  // `flush: 'post'` ensures the watcher runs after Vue Router has finished
+  // committing the navigation, so `route.meta.module` is the destination's
+  // value, not the source's.
+  watch(canStayOnRoute, (allowed) => {
+    if (!allowed) navigateTo('/403')
+  }, { flush: 'post' })
+})

--- a/stores/access.ts
+++ b/stores/access.ts
@@ -38,6 +38,14 @@ interface AccessResponse {
   enforcement_mode: EnforcementMode
 }
 
+// Polling handle — module scope so it survives store re-evaluation but stays
+// per-tab on the client. Never written on SSR (the `import.meta.client` guard
+// in armPolling() ensures every server request leaves this as null).
+// Epic 4 (#562): refreshes access state every 60s so mid-session permission
+// changes (owner edits matrix in Epic 5) propagate without a page reload.
+const POLL_INTERVAL_MS = 60_000
+let pollingHandle: ReturnType<typeof setInterval> | null = null
+
 export const useAccessStore = defineStore('access', () => {
   const role = ref<string | null>(null)
   const modules = ref<string[]>([])
@@ -56,19 +64,38 @@ export const useAccessStore = defineStore('access', () => {
       modules.value = data.modules ?? []
       enforcementMode.value = data.enforcement_mode ?? 'disabled'
       isLoaded.value = true
+      armPolling()
     } catch (err) {
       // Fail-open: keep current state. enforcementMode stays at its current
       // value (initially 'disabled' which makes can() always return true).
-      // Matches the safety guarantee in Epic 4's body.
+      // Matches the safety guarantee in Epic 4's body. Polling stays unarmed
+      // until a successful load — next auth navigation will retry.
       console.error('useAccessStore.load() failed:', err)
     }
   }
 
   function clear() {
+    stopPolling()
     role.value = null
     modules.value = []
     enforcementMode.value = 'disabled'
     isLoaded.value = false
+  }
+
+  // Self-arms after first successful load. Idempotent — subsequent load()
+  // calls (whether from auth middleware re-entry or from the polling tick
+  // itself) won't double-arm.
+  function armPolling() {
+    if (!import.meta.client) return
+    if (pollingHandle !== null) return
+    pollingHandle = setInterval(() => { load() }, POLL_INTERVAL_MS)
+  }
+
+  function stopPolling() {
+    if (pollingHandle !== null) {
+      clearInterval(pollingHandle)
+      pollingHandle = null
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Detects mid-session permission changes within 60s and silently redirects the user off any page they can no longer access. Closes the gap between #557 (navigation-time gate) and Epic 5's permission matrix (an owner who revokes a module shouldn't have to wait for the cashier to F5 the page).

Closes #562 — part of Epic 4 (warocol.com#489).

## Stack

Nuxt 3 (frontend-only)

## Stack order

```
main
 └ #564 #555 access-store         (ready-for-review)
   └ #565 #556 useModuleAccess    (ready-for-review)
     └ #566 #557 middleware       (ready-for-review)
       └ #567 #559 sidebar filter (ready-for-review)
         ├ #569 #560 bottom-nav filter (ready-for-review)
         └ #568 #561 página /403       (ready-for-review)
           └ #570 #558 definePageMeta module (ready-for-review)
             └ this PR #562 access polling
```

## Changes

### `stores/access.ts` (modified — +29 lines)
- Module-scoped `pollingHandle` (per-tab on client, never written on SSR thanks to the `import.meta.client` guard).
- `load()` arms the 60s interval after first successful response.
- `clear()` stops it before resetting state.
- `armPolling()` is idempotent — repeated `load()` calls don't double-arm.

### `plugins/access-watcher.client.ts` (new file)
- `.client.ts` extension → Nuxt skips loading it on SSR.
- Computes a `canStayOnRoute` gate from `route.path`, `route.meta.module`, and (through `store.can`) `enforcementMode` + `modulesSet`.
- Watches the gate with `flush: 'post'`. When it flips false → `navigateTo('/403')` silently.
- Defensive: returns true on `/403` itself (no redirect loop); pages without `module` meta always pass.

### `components/DashboardSidebar.vue` (modified — +4 lines)
- The manual `handleLogout` called `authStore.clearAuth()` but skipped `accessStore.clear()`, leaving the polling timer orphaned post-logout.
- Symmetric fix matching the `auth.global.js` cleanup path. Applied in both try and catch branches.

Net diff: **3 files, +72 / -1 lines**.

## Safety / fail-open

`store.can()` returns `true` whenever `enforcementMode !== 'enforce'`. Every tenant is on `'disabled'` today, so:
- Polling runs but never causes a redirect.
- The watcher's gate stays `true` regardless of `route.meta.module` or `modules` state.
- Zero behavioral change in production until Epic 6 flips a tenant.

Backend cost is near-zero — `get_role_modules` is TTL-cached 300s and `get_enforcement_mode` is TTL-cached 60s, so the polling tick almost always hits server-side cache. Only 1 DB lookup per minute per tenant regardless of tab count.

## SSR safety

`setInterval` only ever fires client-side:
- The store guards `armPolling()` with `if (!import.meta.client) return`.
- The plugin filename ends in `.client.ts` so Nuxt never imports it during SSR.

No server-side `setInterval` is created, no timer leaks per SSR request.

## Testing

Static:
- `nuxi typecheck` — zero new errors in the 3 changed files (pre-existing errors in other files are unrelated)

Manual smoke (to run before merge):
- [ ] Login → ~60s later, Network panel shows `GET /api/me/access` firing on cadence
- [ ] DevTools mock: `useAccessStore.enforcementMode = 'enforce'` + remove a module the current route requires → silent redirect to `/403` on next polling tick (≤60s) or next route change
- [ ] Click "Cerrar sesión" in sidebar → Network panel stops the polling immediately, no orphan request 60s later
- [ ] Reload page directly on `/403` → no redirect loop
- [ ] Default-mode (`enforcement_mode === 'disabled'`) → polling runs, every page renders, zero `/403` redirects

## Out of scope

- Pausing polling when tab is hidden (`document.visibilitychange`) — browser already throttles `setInterval` in background tabs at ~1min. Not worth the complexity.
- Toast/notification on forced redirect — issue body explicitly asks for silent behavior.
- Cross-tab synchronization — each tab polls independently. Backend cache absorbs the cost.
- Cross-store cleanup refactor (calling `accessStore.clear()` from inside `authStore.clearAuth()`) — applied locally at the one bad call site instead.

Closes #562