### PR TITLE
fix(api-paths): correct /api/api/* → /api/* for pos + operaciones aggregators

### DIFF
--- a/pages/operaciones/comandas.vue
+++ b/pages/operaciones/comandas.vue
@@ -456,7 +456,7 @@ const toast = useToast()
 const cache = useQueryCache()
 const { data: profileData, asyncStatus: profileAsyncStatus, refetch: refreshProfile } = useQuery({
   key: () => ['operaciones', 'restaurant-context', currentTenant.value?.id],
-  query: () => $fetch<{ success: boolean; data: any }>('/api/api/operaciones/restaurant-context'),
+  query: () => $fetch<{ success: boolean; data: any }>('/api/operaciones/restaurant-context'),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })
@@ -585,7 +585,7 @@ const handleToggleComandas = async (event: Event) => {
   if (isTogglingComandas.value) return
   isTogglingComandas.value = true
   try {
-    await $fetch('/api/api/operaciones/toggles/comandas', { method: 'PATCH', body: { enabled: true } })
+    await $fetch('/api/operaciones/toggles/comandas', { method: 'PATCH', body: { enabled: true } })
     await invalidateContextCaches()
     toast.success('Módulo de comandas activado', { title: 'Activado' })
   } catch (error: any) {
@@ -600,7 +600,7 @@ const confirmDisableComandas = async () => {
   if (isTogglingComandas.value) return
   isTogglingComandas.value = true
   try {
-    await $fetch('/api/api/operaciones/toggles/comandas', { method: 'PATCH', body: { enabled: false } })
+    await $fetch('/api/operaciones/toggles/comandas', { method: 'PATCH', body: { enabled: false } })
     await invalidateContextCaches()
     toast.success('Módulo de comandas desactivado', { title: 'Desactivado' })
   } catch (error: any) {
@@ -615,7 +615,7 @@ const handleToggleKds = async (event: Event) => {
   const newState = (event.target as HTMLInputElement).checked
   isTogglingKds.value = true
   try {
-    await $fetch('/api/api/operaciones/toggles/kds', { method: 'PATCH', body: { enabled: newState } })
+    await $fetch('/api/operaciones/toggles/kds', { method: 'PATCH', body: { enabled: newState } })
     await invalidateContextCaches()
     toast.success(
       newState ? 'Pantallas KDS activadas' : 'Pantallas KDS desactivadas',
@@ -635,7 +635,7 @@ const handleToggleExpediter = async (event: Event) => {
   const newState = (event.target as HTMLInputElement).checked
   isTogglingExpediter.value = true
   try {
-    await $fetch('/api/api/operaciones/toggles/expediter', { method: 'PATCH', body: { enabled: newState } })
+    await $fetch('/api/operaciones/toggles/expediter', { method: 'PATCH', body: { enabled: newState } })
     await invalidateContextCaches()
     toast.success(
       newState

--- a/pages/operaciones/mesas.vue
+++ b/pages/operaciones/mesas.vue
@@ -23,7 +23,7 @@ const { data: tablesData, status: tablesStatus, asyncStatus: tablesAsyncStatus, 
 const cache = useQueryCache()
 const { data: profileData, asyncStatus: profileAsyncStatus, refetch: refreshProfile } = useQuery({
   key: () => ['operaciones', 'restaurant-context', currentTenant.value?.id],
-  query: () => $fetch<{ success: boolean; data: any }>('/api/api/operaciones/restaurant-context'),
+  query: () => $fetch<{ success: boolean; data: any }>('/api/operaciones/restaurant-context'),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })
@@ -203,7 +203,7 @@ const toggleTablesEnabled = async () => {
   isTogglingTables.value = true
   const newState = !businessProfile.value.tables_enabled
   try {
-    await $fetch('/api/api/operaciones/toggles/tables', {
+    await $fetch('/api/operaciones/toggles/tables', {
       method: 'PATCH',
       body: { enabled: newState },
     })

--- a/pages/operaciones/personalizar.vue
+++ b/pages/operaciones/personalizar.vue
@@ -15,7 +15,7 @@ const cache = useQueryCache()
 // Shared cache key with /operaciones/mesas and /operaciones/comandas.
 const { data: profileData, asyncStatus: profileAsyncStatus, refetch: refreshProfile } = useQuery({
   key: () => ['operaciones', 'restaurant-context', currentTenant.value?.id],
-  query: () => $fetch<{ success: boolean; data: any }>('/api/api/operaciones/restaurant-context'),
+  query: () => $fetch<{ success: boolean; data: any }>('/api/operaciones/restaurant-context'),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })
@@ -40,7 +40,7 @@ const toggleAutoSelectGeneric = async () => {
   isToggling.value = true
   const newState = !businessProfile.value.auto_select_generic_enabled
   try {
-    await $fetch('/api/api/operaciones/toggles/auto-select-generic', {
+    await $fetch('/api/operaciones/toggles/auto-select-generic', {
       method: 'PATCH',
       body: { enabled: newState },
     })

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -186,7 +186,7 @@ const refreshTaxPreview = async () => {
 // Migrated from /api/api/tenant/public-profile (now owner-only MI_NEGOCIO).
 const { data: settingsData } = useQuery({
   key: () => ['pos', 'restaurant-context', currentTenant.value?.id ?? null],
-  query: () => $fetch<{ success: boolean; data: any }>('/api/api/pos/restaurant-context'),
+  query: () => $fetch<{ success: boolean; data: any }>('/api/pos/restaurant-context'),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -31,7 +31,7 @@ if (typeof window !== 'undefined' && sessionStorage.getItem('posNavigation') !==
 // aggregator payload. /api/api/tenant/public-profile is now owner-only (MI_NEGOCIO).
 const { data: settingsData, asyncStatus: settingsAsyncStatus } = useQuery({
   key: () => ['pos', 'restaurant-context', currentTenant.value?.id],
-  query: () => $fetch<{ success: boolean; data: any }>('/api/api/pos/restaurant-context'),
+  query: () => $fetch<{ success: boolean; data: any }>('/api/pos/restaurant-context'),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -83,7 +83,7 @@ const { data: invoiceData, refetch: refetchInvoice } = useQuery({
 // Shares the cache key with /pos/index + /pos/checkout — no extra request.
 const { data: posContextRes, asyncStatus: posContextAsyncStatus } = useQuery({
   key: () => ['pos', 'restaurant-context', currentTenant.value?.id ?? null],
-  query: () => $fetch<{ success: boolean; data: { invoicing_ready: boolean } }>('/api/api/pos/restaurant-context'),
+  query: () => $fetch<{ success: boolean; data: { invoicing_ready: boolean } }>('/api/pos/restaurant-context'),
   enabled: () => !!currentTenant.value,
   staleTime: 60_000,
 })


### PR DESCRIPTION
## Summary

Fixes 404 errors on the new POS + Operaciones aggregator endpoints introduced in #551 and #552. The call sites used a double `/api/api/` prefix that doesn't match how those backend routers register.

## Root cause

Backend `pos_context.py` and `operaciones_context.py` register their `APIRouter` with `prefix="/pos"` and `prefix="/operaciones"` (no `/api` inside the router itself). They're then included in `main.py` without an additional `/api` prefix, so the final routes are:

- `GET /pos/restaurant-context`
- `GET /operaciones/restaurant-context`
- `PATCH /operaciones/toggles/{comandas,kds,expediter,tables,auto-select-generic}`

Frontend calls were doing:
```
$fetch('/api/api/pos/restaurant-context')
```

Nuxt's proxy rule `'/api/**' → 'http://localhost:9999/**'` strips a single `/api` prefix, so the backend received `/api/pos/restaurant-context` — which doesn't exist — and returned **404 Not Found**.

The mistake came from copying the call style used for `comandas` and `stations` (which register with `prefix="/api/comandas"` and `prefix="/api/stations"` — those DO need the double prefix). The new aggregators follow a different convention.

Reference proof — `useAccessStore.load()` already uses the correct single-prefix call:
```ts
const data = await $fetch<AccessResponse>('/api/me/access')
```
That works because `me` router has `prefix="/me"`. Same shape as `pos` and `operaciones`.

## Changes

| File | Path replacements |
|---|---|
| `pages/pos/index.vue` | 1 |
| `pages/pos/checkout.vue` | 1 |
| `pages/operaciones/mesas.vue` | 2 (restaurant-context + tables toggle) |
| `pages/operaciones/comandas.vue` | 5 (restaurant-context + 4 toggles) |
| `pages/operaciones/personalizar.vue` | 2 (restaurant-context + auto-select toggle) |
| `pages/ventas/[id].vue` | 1 (restaurant-context for invoicing readiness) |

**Total: 12 path replacements across 6 files.**

## Audit

After the fix, I scanned the entire frontend for similar mismatches:

```
$ grep -rohE "/api/api/[a-zA-Z0-9_/-]+" --include="*.vue" --include="*.ts" pages/ components/ composables/ stores/ middleware/ plugins/ | sort -u
/api/api/comandas         → backend prefix=/api/comandas         ✓ CORRECT (double needed)
/api/api/stations         → backend prefix=/api/stations         ✓ CORRECT
/api/api/tenant/*         → backend prefix=/api/tenant           ✓ CORRECT
```

No remaining `/api/api/{pos,operaciones,me,etc}` calls — only the legitimate double-prefix ones survived.

Reverse audit (single `/api/` for routes that need double): also clean — no `/api/comandas`, `/api/stations`, `/api/tenant` calls anywhere in the frontend.

## Test plan

After merging + restarting dev:

- [ ] `/pos` loads without 404 in Network tab — `/api/pos/restaurant-context` returns 200
- [ ] `/pos/checkout` displays fiscal data correctly
- [ ] `/operaciones/comandas` loads, toggle KDS works
- [ ] `/operaciones/mesas` loads, toggle tables works
- [ ] `/operaciones/personalizar` loads, toggle auto-select-generic works
- [ ] `/ventas/{id}` shows invoicing-readiness section gated by the boolean from the aggregator

## Stack

🟢 Nuxt 3

Closes the dev-blocker introduced by #551 and #552.