### PR TITLE
feat(operaciones): admin panel for waiter-per-table assignment (#573)

### DIFF
--- a/components/gestion/operaciones/MesaAssignmentHistoryModal.vue
+++ b/components/gestion/operaciones/MesaAssignmentHistoryModal.vue
@@ -1,0 +1,165 @@
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-150"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="open"
+        class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+        @click.self="$emit('close')"
+      >
+        <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md max-h-[80vh] flex flex-col overflow-hidden">
+          <!-- Header -->
+          <div class="flex items-center justify-between px-5 py-4 border-b border-border">
+            <div class="min-w-0">
+              <h3 class="text-base font-bold text-text-primary truncate">Historial de mesero</h3>
+              <p class="text-xs text-text-secondary truncate">{{ table.name }}</p>
+            </div>
+            <button
+              type="button"
+              aria-label="Cerrar"
+              class="flex-shrink-0 min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+              @click="$emit('close')"
+            >
+              <XMarkIcon class="w-5 h-5" />
+            </button>
+          </div>
+
+          <!-- Body -->
+          <div class="flex-1 overflow-y-auto px-5 py-4">
+            <!-- Loading -->
+            <div v-if="status === 'pending' && (!data || data.length === 0)" class="py-12 flex items-center justify-center">
+              <CommonsTheCustomLoader size="medium" />
+            </div>
+
+            <!-- Empty -->
+            <div v-else-if="!data || data.length === 0" class="py-12 flex flex-col items-center justify-center text-center">
+              <div class="w-14 h-14 rounded-full bg-surface-secondary flex items-center justify-center mb-3">
+                <ClockIcon class="w-7 h-7 text-text-tertiary" />
+              </div>
+              <p class="text-sm font-semibold text-text-secondary">Sin historial</p>
+              <p class="text-xs text-text-tertiary mt-1 max-w-[14rem]">
+                Esta mesa nunca ha tenido un mesero asignado.
+              </p>
+            </div>
+
+            <!-- List -->
+            <ul v-else class="space-y-2">
+              <li
+                v-for="entry in data"
+                :key="entry.id"
+                class="rounded-lg border border-border bg-surface p-3"
+              >
+                <div class="flex items-start gap-3">
+                  <div class="flex-shrink-0 w-9 h-9 rounded-full bg-primary/10 text-primary flex items-center justify-center font-bold text-xs">
+                    {{ initials(entry.member_name) }}
+                  </div>
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm font-semibold text-text-primary truncate">
+                      {{ entry.member_name || 'Sin asignar' }}
+                      <span v-if="entry.member_role" class="text-xs text-text-tertiary font-normal">
+                        ({{ entry.member_role }})
+                      </span>
+                    </p>
+                    <p class="text-xs text-text-secondary mt-0.5 tabular-nums">
+                      <span>{{ formatDate(entry.assigned_at) }}</span>
+                      <span class="mx-1.5">→</span>
+                      <span v-if="entry.unassigned_at">{{ formatDate(entry.unassigned_at) }}</span>
+                      <span v-else class="font-semibold text-primary">Actual</span>
+                    </p>
+                    <p v-if="entry.assigned_by_name" class="text-[11px] text-text-tertiary mt-0.5">
+                      Asignado por {{ entry.assigned_by_name }}
+                    </p>
+                  </div>
+                </div>
+              </li>
+            </ul>
+
+            <!-- Error state -->
+            <div v-if="error" class="mt-3 text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2">
+              No se pudo cargar el historial.
+            </div>
+          </div>
+
+          <!-- Footer -->
+          <div class="flex-shrink-0 px-5 py-3 border-t border-border bg-surface-secondary/40">
+            <button
+              type="button"
+              class="w-full min-h-[44px] rounded-lg bg-surface border border-border text-sm font-semibold text-text-primary hover:bg-surface-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+              @click="$emit('close')"
+            >
+              Cerrar
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, watch } from 'vue'
+import { useQuery } from '@pinia/colada'
+import { XMarkIcon, ClockIcon } from '@heroicons/vue/24/outline'
+
+interface HistoryEntry {
+  id: string
+  member_id: string | null
+  member_name: string | null
+  member_role: string | null
+  assigned_at: string
+  unassigned_at: string | null
+  assigned_by: string | null
+  assigned_by_name: string | null
+}
+
+const props = defineProps<{
+  open: boolean
+  table: { id: string; name: string }
+}>()
+
+defineEmits<{ (e: 'close'): void }>()
+
+const { state, refetch } = useQuery({
+  key: () => ['operaciones', 'tables', props.table.id, 'assignment-history'],
+  query: () => $fetch<{ success: boolean; data: HistoryEntry[] }>(
+    `/api/operaciones/tables/${props.table.id}/assignment-history?limit=50`,
+  ),
+  enabled: () => props.open,
+})
+
+const data = computed(() => state.value?.data?.data ?? [])
+const status = computed(() => state.value?.status)
+const error = computed(() => state.value?.error)
+
+// Refetch each time the modal opens to ensure fresh data
+watch(() => props.open, (isOpen) => {
+  if (isOpen) refetch()
+})
+
+const initials = (name: string | null | undefined): string => {
+  if (!name) return '—'
+  const parts = name.trim().split(/\s+/)
+  return parts.slice(0, 2).map(p => p[0]?.toUpperCase() ?? '').join('') || '—'
+}
+
+const formatDate = (iso: string | null | undefined): string => {
+  if (!iso) return '—'
+  try {
+    const d = new Date(iso)
+    return d.toLocaleString('es-CO', {
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+</script>

--- a/components/gestion/operaciones/MesaMemberAssignRow.vue
+++ b/components/gestion/operaciones/MesaMemberAssignRow.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="flex items-center justify-between p-4 bg-surface border border-border rounded-xl hover:border-primary/30 transition-colors group">
+    <div class="flex items-center gap-3 min-w-0 flex-1">
+      <div class="w-10 h-10 rounded-xl bg-primary/10 text-primary flex items-center justify-center font-bold text-xs flex-shrink-0">
+        {{ table.name.substring(0, 2).toUpperCase() }}
+      </div>
+      <div class="min-w-0">
+        <p class="text-sm font-bold text-text-primary truncate">{{ table.name }}</p>
+        <p class="text-[10px] text-text-tertiary font-medium uppercase tracking-wider">
+          {{ table.capacity ? `${table.capacity} personas` : 'Mesa' }}
+        </p>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-2 flex-shrink-0">
+      <!-- Current assignment badge (only on sm+) -->
+      <span
+        v-if="table.assigned_member_name"
+        class="hidden sm:inline-flex items-center gap-1.5 px-2 py-1 rounded-lg text-[10px] font-bold uppercase tracking-tight bg-primary/10 text-primary border border-primary/20"
+      >
+        <UserIcon class="w-3 h-3" aria-hidden="true" />
+        {{ table.assigned_member_name }}
+      </span>
+
+      <!-- Member dropdown -->
+      <select
+        :value="table.assigned_member_id || ''"
+        :disabled="loading"
+        :aria-label="`Asignar mesero a ${table.name}`"
+        class="min-w-[140px] min-h-[36px] px-3 py-1.5 bg-background border border-border rounded-lg text-xs font-medium focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all outline-none text-text-primary disabled:opacity-50 disabled:cursor-not-allowed"
+        @change="handleSelect"
+      >
+        <option value="">(Sin asignar)</option>
+        <option
+          v-for="m in members"
+          :key="m.id"
+          :value="m.id"
+        >
+          {{ m.name }} ({{ m.role }})
+        </option>
+      </select>
+
+      <!-- History trigger -->
+      <button
+        type="button"
+        :aria-label="`Ver historial de ${table.name}`"
+        class="min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg border border-border text-text-secondary hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+        @click="emit('view-history')"
+      >
+        <ClockIcon class="w-4 h-4" aria-hidden="true" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { UserIcon, ClockIcon } from '@heroicons/vue/24/outline'
+
+interface Member {
+  id: string
+  name: string
+  role: string
+}
+
+interface Table {
+  id: string
+  name: string
+  capacity?: number | null
+  assigned_member_id?: string | null
+  assigned_member_name?: string | null
+  assigned_member_role?: string | null
+}
+
+const props = defineProps<{
+  table: Table
+  members: Member[]
+  loading?: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'assign', memberId: string | null): void
+  (e: 'view-history'): void
+}>()
+
+const handleSelect = (event: Event) => {
+  const val = (event.target as HTMLSelectElement).value
+  emit('assign', val || null)
+}
+</script>

--- a/pages/operaciones/comandas.vue
+++ b/pages/operaciones/comandas.vue
@@ -147,6 +147,31 @@
             </div>
           </div>
         </div>
+
+        <!-- Issue #573 — Waiter attribution feature flag (independent of comandas) -->
+        <div class="space-y-2 pt-3 border-t border-border">
+          <div class="flex items-center justify-between py-1">
+            <div>
+              <p class="text-sm font-medium text-text-primary">Asignar mesero por mesa</p>
+              <p class="text-xs text-text-secondary mt-0.5">
+                Permite asignar un mesero por defecto a cada mesa (con historial), y atribuir
+                meseros por sesión y por orden en POS. Habilita el panel de gestión debajo.
+              </p>
+            </div>
+            <div class="flex-shrink-0 ml-4 flex items-center justify-center w-10 h-6">
+              <UiLoadingDots v-if="isTogglingWaiterAttribution" color="var(--color-primary)" size="11px" />
+              <label v-else class="relative inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  class="sr-only peer"
+                  :checked="businessProfile?.waiter_attribution_enabled"
+                  @change="handleToggleWaiterAttribution"
+                />
+                <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+              </label>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -293,6 +318,49 @@
         </template>
       </UiResponsiveDataView>
     </div>
+
+    <!-- ══════ MESERO POR MESA (issue #573) — visible solo si toggles ON ══════ -->
+    <div
+      v-if="businessProfile?.waiter_attribution_enabled && businessProfile?.tables_enabled"
+      class="bg-surface border-2 border-border rounded-xl p-4 sm:p-6"
+    >
+      <div class="flex items-center gap-2 mb-1">
+        <UserGroupIcon class="w-5 h-5 text-primary flex-shrink-0" />
+        <h3 class="text-base sm:text-lg font-semibold text-text-primary">Mesero por mesa</h3>
+      </div>
+      <p class="text-xs text-text-secondary mb-4">
+        Asigna un mesero por defecto a cada mesa. Las barras no aplican.
+        El historial se preserva incluso si el miembro se elimina.
+      </p>
+
+      <div v-if="assignableTables.length === 0" class="py-8 text-center">
+        <p class="text-sm font-semibold text-text-secondary">Sin mesas asignables</p>
+        <p class="text-xs text-text-tertiary mt-1">
+          Crea mesas en <span class="font-mono">/operaciones/mesas</span> para asignar meseros.
+        </p>
+      </div>
+
+      <div v-else class="space-y-2">
+        <GestionOperacionesMesaMemberAssignRow
+          v-for="tbl in assignableTables"
+          :key="tbl.id"
+          :table="tbl"
+          :members="tenantMembers"
+          :loading="isAssigningMemberTableId === tbl.id"
+          @assign="(memberId) => handleAssignMember(tbl.id, memberId)"
+          @view-history="() => openHistoryModal(tbl)"
+        />
+      </div>
+    </div>
+
+    <!-- History modal -->
+    <GestionOperacionesMesaAssignmentHistoryModal
+      v-if="historyModalTable"
+      :open="!!historyModalTable"
+      :table="historyModalTable"
+      @close="historyModalTable = null"
+    />
+
     </template>
 
     <!-- Station Deactivate Confirmation Modal -->
@@ -444,6 +512,7 @@ import {
   XMarkIcon,
   ExclamationTriangleIcon,
   PencilSquareIcon,
+  UserGroupIcon,
 } from '@heroicons/vue/24/outline'
 
 definePageMeta({ layout: 'dashboard' })
@@ -648,6 +717,73 @@ const handleToggleExpediter = async (event: Event) => {
   } finally {
     isTogglingExpediter.value = false
   }
+}
+
+// Issue #573 — Waiter attribution toggle + per-table assignment
+const isTogglingWaiterAttribution = ref(false)
+const handleToggleWaiterAttribution = async (event: Event) => {
+  if (isTogglingWaiterAttribution.value) return
+  const newState = (event.target as HTMLInputElement).checked
+  isTogglingWaiterAttribution.value = true
+  try {
+    await $fetch('/api/operaciones/toggles/waiter-attribution', { method: 'PATCH', body: { enabled: newState } })
+    await invalidateContextCaches()
+    await cache.invalidateQueries({ key: ['tables'] })
+    toast.success(
+      newState
+        ? 'Habilitado. Configura meseros en el panel debajo.'
+        : 'Asignación de meseros deshabilitada',
+      { title: newState ? 'Activado' : 'Desactivado' }
+    )
+  } catch (error: any) {
+    toast.error(error.data?.detail || 'Error al cambiar el toggle', { title: 'Error' })
+  } finally {
+    isTogglingWaiterAttribution.value = false
+  }
+}
+
+// Members list comes embedded in the operaciones aggregator (so cashiers/
+// supervisors don't need Module.EQUIPO to populate the dropdown).
+const tenantMembers = computed(() =>
+  (businessProfile.value as any)?.members ?? [],
+)
+
+// Tables data (reusing /api/api/tables which is already gated under POS).
+// Only assignable tables: not bar, active, not deleted.
+const { data: tablesData, refetch: refetchTables } = useQuery({
+  key: () => ['tables', 'for-assignment'],
+  query: () => $fetch<{ success: boolean; data: any[] }>('/api/api/tables?include_inactive=false'),
+})
+const assignableTables = computed(() => {
+  const rows = tablesData.value?.data ?? []
+  return rows.filter((t: any) => !t.is_bar && t.is_active && !t.deleted_at)
+})
+
+const isAssigningMemberTableId = ref<string | null>(null)
+const handleAssignMember = async (tableId: string, memberId: string | null) => {
+  if (isAssigningMemberTableId.value) return
+  isAssigningMemberTableId.value = tableId
+  try {
+    await $fetch(`/api/operaciones/tables/${tableId}/assigned-member`, {
+      method: 'PATCH',
+      body: { member_id: memberId },
+    })
+    await refetchTables()
+    await cache.invalidateQueries({ key: ['operaciones', 'tables', tableId, 'assignment-history'] })
+    toast.success(
+      memberId ? 'Mesero asignado' : 'Asignación removida',
+      { title: 'Guardado' },
+    )
+  } catch (error: any) {
+    toast.error(error.data?.detail || 'Error al asignar mesero', { title: 'Error' })
+  } finally {
+    isAssigningMemberTableId.value = null
+  }
+}
+
+const historyModalTable = ref<{ id: string; name: string } | null>(null)
+const openHistoryModal = (tbl: any) => {
+  historyModalTable.value = { id: tbl.id, name: tbl.name }
 }
 
 const kdsBaseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://warocol.com'


### PR DESCRIPTION
## Summary

Frontend admin surface for the waiter attribution family (#573). Paired with backend `api-warolabs#227`.

Adds the toggle UI in `/operaciones/comandas` toggles section, a new "Mesero por mesa" panel below "Routing de categorías", and 2 new components (assignment row + history modal).

Closes #573 (frontend portion).

## Stack

🟢 Nuxt 3 + 🎨 UX

## Depends on

**api-warolabs#227** — must merge first. Without it, the `$fetch('/api/operaciones/tables/...')` calls return 404.

## Changes

| File | Type | Notes |
|---|---|---|
| `pages/operaciones/comandas.vue` | modify | Toggle UI + handler + panel + 4 new refs/computeds + 2 handlers |
| `components/gestion/operaciones/MesaMemberAssignRow.vue` | create | Row mirroring `GestionCocinaCategoryMappingRow.vue` pattern |
| `components/gestion/operaciones/MesaAssignmentHistoryModal.vue` | create | Center modal with paginated history + member snapshots |

## Visibility logic

| `waiter_attribution_enabled` | `tables_enabled` | Surfaces visible |
|:---:|:---:|---|
| ❌ | — | None (toggle visible, panel hidden) |
| ✅ | ❌ | Toggle ON, panel still hidden (panel needs mesas) |
| ✅ | ✅ | Toggle ON + full panel "Mesero por mesa" rendered |

The toggle itself always renders when `Module.OPERACIONES` is available. Panel needs both flags. Owner can prepare the data while `tables_enabled` is off, but visual feedback only kicks in when both are on.

## UX decisions

- **Touch targets**: dropdown 36px min-height, history button 36x36px. All above 32px floor for compact dense panels; below the strict 44px AAA only because they sit in a row layout with adjacent labels providing extra hit area (matches existing `CategoryMappingRow` precedent).
- **Empty state**: if no assignable mesas, panel renders an empty state pointing to `/operaciones/mesas`.
- **Loading state**: per-row `isAssigningMemberTableId` ref disables the dropdown during PATCH; toast confirms on success.
- **History modal**: separate component (not slide-over) — supervisor flow is configuration-time, less frequent than POS rush operations.

## Cache strategy

- Toggle change → invalidates `operaciones,restaurant-context` + `pos,restaurant-context` + `tables`.
- Per-row assignment → refetches the local `tables` query + invalidates the table's specific history query.
- The history modal calls `useQuery` keyed by `table.id` and refetches every time the modal opens, ensuring fresh data after any change made elsewhere.

## Testing

Static:
- `nuxi typecheck` — zero new errors in the 3 changed/new files. The 40 errors visible in output are pre-existing in `components/Auth/LoginForm.vue` (unrelated).

Manual smoke (to run after api-warolabs#227 merges and uvicorn is restarted):
- [ ] Owner enters `/operaciones/comandas` → sees the new toggle "Asignar mesero por mesa"
- [ ] Toggle ON → toast confirms + panel appears (if `tables_enabled` is also on)
- [ ] Each non-bar table in the panel shows its current assignment (or "Sin asignar")
- [ ] Change a dropdown → toast OK, value persists on refresh
- [ ] Click history button → modal opens with the new entry visible
- [ ] Change again → modal next time shows 2 entries (old period closed, new period open)
- [ ] Toggle OFF → panel disappears, but data in DB persists
- [ ] Toggle ON again → panel re-appears with the data intact

## Out of scope

- POS UX (modal at table-open, banner button, floor plan render) — that's #574
- Bar/counter order attribution chip — that's #575
- Reportería de performance por mesero — futuro, depende de cuál módulo lo gate

Closes #573