### PR TITLE
feat(pos): per-session waiter override UI — modal + banner chip + card line (#574)

### DIFF
--- a/components/gestion/operaciones/MesaAssignmentHistoryModal.vue
+++ b/components/gestion/operaciones/MesaAssignmentHistoryModal.vue
@@ -1,0 +1,165 @@
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-150"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="open"
+        class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+        @click.self="$emit('close')"
+      >
+        <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md max-h-[80vh] flex flex-col overflow-hidden">
+          <!-- Header -->
+          <div class="flex items-center justify-between px-5 py-4 border-b border-border">
+            <div class="min-w-0">
+              <h3 class="text-base font-bold text-text-primary truncate">Historial de mesero</h3>
+              <p class="text-xs text-text-secondary truncate">{{ table.name }}</p>
+            </div>
+            <button
+              type="button"
+              aria-label="Cerrar"
+              class="flex-shrink-0 min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+              @click="$emit('close')"
+            >
+              <XMarkIcon class="w-5 h-5" />
+            </button>
+          </div>
+
+          <!-- Body -->
+          <div class="flex-1 overflow-y-auto px-5 py-4">
+            <!-- Loading -->
+            <div v-if="status === 'pending' && (!data || data.length === 0)" class="py-12 flex items-center justify-center">
+              <CommonsTheCustomLoader size="medium" />
+            </div>
+
+            <!-- Empty -->
+            <div v-else-if="!data || data.length === 0" class="py-12 flex flex-col items-center justify-center text-center">
+              <div class="w-14 h-14 rounded-full bg-surface-secondary flex items-center justify-center mb-3">
+                <ClockIcon class="w-7 h-7 text-text-tertiary" />
+              </div>
+              <p class="text-sm font-semibold text-text-secondary">Sin historial</p>
+              <p class="text-xs text-text-tertiary mt-1 max-w-[14rem]">
+                Esta mesa nunca ha tenido un mesero asignado.
+              </p>
+            </div>
+
+            <!-- List -->
+            <ul v-else class="space-y-2">
+              <li
+                v-for="entry in data"
+                :key="entry.id"
+                class="rounded-lg border border-border bg-surface p-3"
+              >
+                <div class="flex items-start gap-3">
+                  <div class="flex-shrink-0 w-9 h-9 rounded-full bg-primary/10 text-primary flex items-center justify-center font-bold text-xs">
+                    {{ initials(entry.member_name) }}
+                  </div>
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm font-semibold text-text-primary truncate">
+                      {{ entry.member_name || 'Sin asignar' }}
+                      <span v-if="entry.member_role" class="text-xs text-text-tertiary font-normal">
+                        ({{ entry.member_role }})
+                      </span>
+                    </p>
+                    <p class="text-xs text-text-secondary mt-0.5 tabular-nums">
+                      <span>{{ formatDate(entry.assigned_at) }}</span>
+                      <span class="mx-1.5">→</span>
+                      <span v-if="entry.unassigned_at">{{ formatDate(entry.unassigned_at) }}</span>
+                      <span v-else class="font-semibold text-primary">Actual</span>
+                    </p>
+                    <p v-if="entry.assigned_by_name" class="text-[11px] text-text-tertiary mt-0.5">
+                      Asignado por {{ entry.assigned_by_name }}
+                    </p>
+                  </div>
+                </div>
+              </li>
+            </ul>
+
+            <!-- Error state -->
+            <div v-if="error" class="mt-3 text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-2">
+              No se pudo cargar el historial.
+            </div>
+          </div>
+
+          <!-- Footer -->
+          <div class="flex-shrink-0 px-5 py-3 border-t border-border bg-surface-secondary/40">
+            <button
+              type="button"
+              class="w-full min-h-[44px] rounded-lg bg-surface border border-border text-sm font-semibold text-text-primary hover:bg-surface-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+              @click="$emit('close')"
+            >
+              Cerrar
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, watch } from 'vue'
+import { useQuery } from '@pinia/colada'
+import { XMarkIcon, ClockIcon } from '@heroicons/vue/24/outline'
+
+interface HistoryEntry {
+  id: string
+  member_id: string | null
+  member_name: string | null
+  member_role: string | null
+  assigned_at: string
+  unassigned_at: string | null
+  assigned_by: string | null
+  assigned_by_name: string | null
+}
+
+const props = defineProps<{
+  open: boolean
+  table: { id: string; name: string }
+}>()
+
+defineEmits<{ (e: 'close'): void }>()
+
+const { state, refetch } = useQuery({
+  key: () => ['operaciones', 'tables', props.table.id, 'assignment-history'],
+  query: () => $fetch<{ success: boolean; data: HistoryEntry[] }>(
+    `/api/operaciones/tables/${props.table.id}/assignment-history?limit=50`,
+  ),
+  enabled: () => props.open,
+})
+
+const data = computed(() => state.value?.data?.data ?? [])
+const status = computed(() => state.value?.status)
+const error = computed(() => state.value?.error)
+
+// Refetch each time the modal opens to ensure fresh data
+watch(() => props.open, (isOpen) => {
+  if (isOpen) refetch()
+})
+
+const initials = (name: string | null | undefined): string => {
+  if (!name) return '—'
+  const parts = name.trim().split(/\s+/)
+  return parts.slice(0, 2).map(p => p[0]?.toUpperCase() ?? '').join('') || '—'
+}
+
+const formatDate = (iso: string | null | undefined): string => {
+  if (!iso) return '—'
+  try {
+    const d = new Date(iso)
+    return d.toLocaleString('es-CO', {
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+</script>

--- a/components/gestion/operaciones/MesaMemberAssignRow.vue
+++ b/components/gestion/operaciones/MesaMemberAssignRow.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="flex items-center justify-between p-4 bg-surface border border-border rounded-xl hover:border-primary/30 transition-colors group">
+    <div class="flex items-center gap-3 min-w-0 flex-1">
+      <div class="w-10 h-10 rounded-xl bg-primary/10 text-primary flex items-center justify-center font-bold text-xs flex-shrink-0">
+        {{ table.name.substring(0, 2).toUpperCase() }}
+      </div>
+      <div class="min-w-0">
+        <p class="text-sm font-bold text-text-primary truncate">{{ table.name }}</p>
+        <p class="text-[10px] text-text-tertiary font-medium uppercase tracking-wider">
+          {{ table.capacity ? `${table.capacity} personas` : 'Mesa' }}
+        </p>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-2 flex-shrink-0">
+      <!-- Current assignment badge (only on sm+) -->
+      <span
+        v-if="table.assigned_member_name"
+        class="hidden sm:inline-flex items-center gap-1.5 px-2 py-1 rounded-lg text-[10px] font-bold uppercase tracking-tight bg-primary/10 text-primary border border-primary/20"
+      >
+        <UserIcon class="w-3 h-3" aria-hidden="true" />
+        {{ table.assigned_member_name }}
+      </span>
+
+      <!-- Member dropdown -->
+      <select
+        :value="table.assigned_member_id || ''"
+        :disabled="loading"
+        :aria-label="`Asignar mesero a ${table.name}`"
+        class="min-w-[140px] min-h-[36px] px-3 py-1.5 bg-background border border-border rounded-lg text-xs font-medium focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all outline-none text-text-primary disabled:opacity-50 disabled:cursor-not-allowed"
+        @change="handleSelect"
+      >
+        <option value="">(Sin asignar)</option>
+        <option
+          v-for="m in members"
+          :key="m.id"
+          :value="m.id"
+        >
+          {{ m.name }} ({{ m.role }})
+        </option>
+      </select>
+
+      <!-- History trigger -->
+      <button
+        type="button"
+        :aria-label="`Ver historial de ${table.name}`"
+        class="min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg border border-border text-text-secondary hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+        @click="emit('view-history')"
+      >
+        <ClockIcon class="w-4 h-4" aria-hidden="true" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { UserIcon, ClockIcon } from '@heroicons/vue/24/outline'
+
+interface Member {
+  id: string
+  name: string
+  role: string
+}
+
+interface Table {
+  id: string
+  name: string
+  capacity?: number | null
+  assigned_member_id?: string | null
+  assigned_member_name?: string | null
+  assigned_member_role?: string | null
+}
+
+const props = defineProps<{
+  table: Table
+  members: Member[]
+  loading?: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'assign', memberId: string | null): void
+  (e: 'view-history'): void
+}>()
+
+const handleSelect = (event: Event) => {
+  const val = (event.target as HTMLSelectElement).value
+  emit('assign', val || null)
+}
+</script>

--- a/components/pos/MesasFloorPlan.vue
+++ b/components/pos/MesasFloorPlan.vue
@@ -2,8 +2,18 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { $fetch } from 'ofetch'
 
+interface WaiterMember {
+  id: string
+  name: string
+  role: string
+}
+
 const props = defineProps<{
   comandasEnabled?: boolean
+  /** Issue #574 — when true, show modal on table open + waiter chip in cards */
+  waiterAttributionEnabled?: boolean
+  /** Issue #574 — list of active tenant members for the waiter dropdown */
+  members?: WaiterMember[]
 }>()
 
 const emit = defineEmits<{
@@ -48,30 +58,20 @@ let pollInterval: ReturnType<typeof setInterval> | null = null
 // ── Open session ───────────────────────────────────────────────────────────
 const openingTableId = ref<string | null>(null)
 
+// Issue #574 — modal at table-open for waiter pre-selection
+const showWaiterModal = ref(false)
+const pendingOpenTable = ref<any | null>(null)
+
 const handleTableClick = async (table: any) => {
   if (table.status === 'free') {
     if (openingTableId.value) return
-    openingTableId.value = table.id
-    try {
-      const result = await $fetch<{ success: boolean; data: { session_id: string } }>(
-        `/api/tables/${table.id}/open`, { method: 'POST' }
-      )
-      await refetch()
-      emit('enter-table', {
-        tableId: table.id,
-        sessionId: result?.data?.session_id,
-        tableName: table.name,
-      })
-    } catch {
-      await refetch()
-      emit('enter-table', {
-        tableId: table.id,
-        sessionId: table.session?.id,
-        tableName: table.name,
-      })
-    } finally {
-      openingTableId.value = null
+    // #574: if waiter attribution is enabled, show modal before opening
+    if (props.waiterAttributionEnabled) {
+      pendingOpenTable.value = table
+      showWaiterModal.value = true
+      return
     }
+    await doOpenTable(table, null)
   } else if (table.status === 'open') {
     emit('enter-table', {
       tableId: table.id,
@@ -86,6 +86,46 @@ const handleTableClick = async (table: any) => {
       gotoCheckout: true,
     })
   }
+}
+
+const doOpenTable = async (table: any, attendedByMemberId: string | null) => {
+  openingTableId.value = table.id
+  try {
+    const result = await $fetch<{ success: boolean; data: { session_id: string } }>(
+      `/api/tables/${table.id}/open`,
+      {
+        method: 'POST',
+        body: attendedByMemberId ? { attended_by_member_id: attendedByMemberId } : undefined,
+      },
+    )
+    await refetch()
+    emit('enter-table', {
+      tableId: table.id,
+      sessionId: result?.data?.session_id,
+      tableName: table.name,
+    })
+  } catch {
+    await refetch()
+    emit('enter-table', {
+      tableId: table.id,
+      sessionId: table.session?.id,
+      tableName: table.name,
+    })
+  } finally {
+    openingTableId.value = null
+  }
+}
+
+const handleWaiterModalConfirm = async (memberId: string | null) => {
+  const target = pendingOpenTable.value
+  showWaiterModal.value = false
+  pendingOpenTable.value = null
+  if (target) await doOpenTable(target, memberId)
+}
+
+const handleWaiterModalClose = () => {
+  showWaiterModal.value = false
+  pendingOpenTable.value = null
 }
 
 // ── Bar click — session is always open, fetch current and enter ─────────────
@@ -362,10 +402,35 @@ onUnmounted(() => {
                 <span class="text-xs font-semibold text-slate-400">Libre</span>
               </div>
             </template>
+
+            <!-- Issue #574 — Waiter line (below strip). Visible only if feature ON
+                 and there's an effective waiter (session override > table default). -->
+            <div
+              v-if="waiterAttributionEnabled && table.effective_waiter_member_name"
+              class="flex items-center gap-1 px-2 h-6 border-t border-slate-100 bg-slate-50/60"
+            >
+              <svg class="w-3 h-3 text-slate-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+              </svg>
+              <span class="text-[10px] font-medium text-slate-500 truncate">
+                {{ table.effective_waiter_member_name }}
+              </span>
+            </div>
           </button>
 
         </div>
       </div>
     </div>
+
+    <!-- Issue #574 — Waiter assignment modal at table-open -->
+    <PosWaiterAssignModal
+      v-if="waiterAttributionEnabled"
+      :show="showWaiterModal"
+      :table-name="pendingOpenTable?.name ?? ''"
+      :default-member-id="pendingOpenTable?.assigned_member_id ?? null"
+      :members="members ?? []"
+      @close="handleWaiterModalClose"
+      @confirm="handleWaiterModalConfirm"
+    />
   </div>
 </template>

--- a/components/pos/WaiterAssignModal.vue
+++ b/components/pos/WaiterAssignModal.vue
@@ -1,0 +1,150 @@
+<script setup lang="ts">
+/**
+ * WaiterAssignModal — single-step picker for "¿Quién atiende esta mesa?".
+ *
+ * Skippable by design. Pre-selects `defaultMemberId` (typically the
+ * table's `assigned_member_id` from #573) so the cashier can confirm
+ * with Enter. Choosing "Continuar sin asignar" leaves the session
+ * `attended_by_member_id` NULL — the resolver falls back to the
+ * table default.
+ *
+ * Issue: warocol.com#574
+ */
+import { ref, computed, watch, nextTick } from 'vue'
+
+interface Member {
+  id: string
+  name: string
+  role: string
+}
+
+const props = defineProps<{
+  show: boolean
+  tableName: string
+  defaultMemberId: string | null
+  members: Member[]
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'confirm', memberId: string | null): void
+}>()
+
+const selectedId = ref<string | null>(props.defaultMemberId)
+const selectRef = ref<HTMLSelectElement | null>(null)
+
+// Reset selection + autofocus each time modal opens
+watch(
+  () => props.show,
+  async (isOpen) => {
+    if (isOpen) {
+      selectedId.value = props.defaultMemberId
+      await nextTick()
+      selectRef.value?.focus()
+    }
+  },
+)
+
+const selectedMember = computed(() =>
+  props.members.find((m) => m.id === selectedId.value) ?? null,
+)
+
+const handleConfirm = () => {
+  emit('confirm', selectedId.value)
+}
+
+const handleSkip = () => {
+  emit('confirm', null)
+}
+
+const onSelectChange = (e: Event) => {
+  const val = (e.target as HTMLSelectElement).value
+  selectedId.value = val || null
+}
+
+const onKeydown = (e: KeyboardEvent) => {
+  if (e.key === 'Enter') {
+    e.preventDefault()
+    handleConfirm()
+  } else if (e.key === 'Escape') {
+    e.preventDefault()
+    emit('close')
+  }
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-150"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="show"
+        class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 bg-black/50"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="`¿Quién atiende la ${tableName}?`"
+        @click.self="$emit('close')"
+        @keydown="onKeydown"
+      >
+        <div class="bg-surface w-full sm:max-w-sm rounded-t-2xl sm:rounded-2xl shadow-2xl overflow-hidden">
+          <!-- Header -->
+          <div class="px-5 pt-5 pb-3 border-b border-border">
+            <h3 class="text-base font-bold text-text-primary">¿Quién atiende?</h3>
+            <p class="text-xs text-text-secondary mt-0.5">{{ tableName }}</p>
+          </div>
+
+          <!-- Body -->
+          <div class="px-5 py-4 space-y-3">
+            <label for="waiter-select" class="text-sm font-medium text-text-primary">
+              Mesero asignado
+            </label>
+            <select
+              id="waiter-select"
+              ref="selectRef"
+              :value="selectedId || ''"
+              class="w-full min-h-[44px] px-3 py-2 bg-background border border-border rounded-lg text-sm font-medium text-text-primary focus:ring-2 focus:ring-primary/20 focus:border-primary transition-colors outline-none"
+              @change="onSelectChange"
+            >
+              <option value="">(Sin asignar)</option>
+              <option
+                v-for="m in members"
+                :key="m.id"
+                :value="m.id"
+              >
+                {{ m.name }} ({{ m.role }})
+              </option>
+            </select>
+
+            <p v-if="selectedMember" class="text-xs text-text-secondary">
+              Atribución para esta sesión. Se puede cambiar después desde el banner.
+            </p>
+          </div>
+
+          <!-- Footer -->
+          <div class="px-5 pb-5 pt-2 flex flex-col-reverse sm:flex-row gap-2">
+            <button
+              type="button"
+              class="flex-1 min-h-[44px] rounded-xl border border-border bg-surface text-sm font-semibold text-text-secondary hover:bg-surface-secondary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+              @click="handleSkip"
+            >
+              Sin asignar
+            </button>
+            <button
+              type="button"
+              class="flex-1 min-h-[44px] rounded-xl bg-primary text-white text-sm font-bold hover:bg-primary/90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+              @click="handleConfirm"
+            >
+              Abrir mesa
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/pages/operaciones/comandas.vue
+++ b/pages/operaciones/comandas.vue
@@ -147,6 +147,31 @@
             </div>
           </div>
         </div>
+
+        <!-- Issue #573 — Waiter attribution feature flag (independent of comandas) -->
+        <div class="space-y-2 pt-3 border-t border-border">
+          <div class="flex items-center justify-between py-1">
+            <div>
+              <p class="text-sm font-medium text-text-primary">Asignar mesero por mesa</p>
+              <p class="text-xs text-text-secondary mt-0.5">
+                Permite asignar un mesero por defecto a cada mesa (con historial), y atribuir
+                meseros por sesión y por orden en POS. Habilita el panel de gestión debajo.
+              </p>
+            </div>
+            <div class="flex-shrink-0 ml-4 flex items-center justify-center w-10 h-6">
+              <UiLoadingDots v-if="isTogglingWaiterAttribution" color="var(--color-primary)" size="11px" />
+              <label v-else class="relative inline-flex items-center cursor-pointer">
+                <input
+                  type="checkbox"
+                  class="sr-only peer"
+                  :checked="businessProfile?.waiter_attribution_enabled"
+                  @change="handleToggleWaiterAttribution"
+                />
+                <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+              </label>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -293,6 +318,49 @@
         </template>
       </UiResponsiveDataView>
     </div>
+
+    <!-- ══════ MESERO POR MESA (issue #573) — visible solo si toggles ON ══════ -->
+    <div
+      v-if="businessProfile?.waiter_attribution_enabled && businessProfile?.tables_enabled"
+      class="bg-surface border-2 border-border rounded-xl p-4 sm:p-6"
+    >
+      <div class="flex items-center gap-2 mb-1">
+        <UserGroupIcon class="w-5 h-5 text-primary flex-shrink-0" />
+        <h3 class="text-base sm:text-lg font-semibold text-text-primary">Mesero por mesa</h3>
+      </div>
+      <p class="text-xs text-text-secondary mb-4">
+        Asigna un mesero por defecto a cada mesa. Las barras no aplican.
+        El historial se preserva incluso si el miembro se elimina.
+      </p>
+
+      <div v-if="assignableTables.length === 0" class="py-8 text-center">
+        <p class="text-sm font-semibold text-text-secondary">Sin mesas asignables</p>
+        <p class="text-xs text-text-tertiary mt-1">
+          Crea mesas en <span class="font-mono">/operaciones/mesas</span> para asignar meseros.
+        </p>
+      </div>
+
+      <div v-else class="space-y-2">
+        <GestionOperacionesMesaMemberAssignRow
+          v-for="tbl in assignableTables"
+          :key="tbl.id"
+          :table="tbl"
+          :members="tenantMembers"
+          :loading="isAssigningMemberTableId === tbl.id"
+          @assign="(memberId) => handleAssignMember(tbl.id, memberId)"
+          @view-history="() => openHistoryModal(tbl)"
+        />
+      </div>
+    </div>
+
+    <!-- History modal -->
+    <GestionOperacionesMesaAssignmentHistoryModal
+      v-if="historyModalTable"
+      :open="!!historyModalTable"
+      :table="historyModalTable"
+      @close="historyModalTable = null"
+    />
+
     </template>
 
     <!-- Station Deactivate Confirmation Modal -->
@@ -444,6 +512,7 @@ import {
   XMarkIcon,
   ExclamationTriangleIcon,
   PencilSquareIcon,
+  UserGroupIcon,
 } from '@heroicons/vue/24/outline'
 
 definePageMeta({ layout: 'dashboard' })
@@ -648,6 +717,73 @@ const handleToggleExpediter = async (event: Event) => {
   } finally {
     isTogglingExpediter.value = false
   }
+}
+
+// Issue #573 — Waiter attribution toggle + per-table assignment
+const isTogglingWaiterAttribution = ref(false)
+const handleToggleWaiterAttribution = async (event: Event) => {
+  if (isTogglingWaiterAttribution.value) return
+  const newState = (event.target as HTMLInputElement).checked
+  isTogglingWaiterAttribution.value = true
+  try {
+    await $fetch('/api/operaciones/toggles/waiter-attribution', { method: 'PATCH', body: { enabled: newState } })
+    await invalidateContextCaches()
+    await cache.invalidateQueries({ key: ['tables'] })
+    toast.success(
+      newState
+        ? 'Habilitado. Configura meseros en el panel debajo.'
+        : 'Asignación de meseros deshabilitada',
+      { title: newState ? 'Activado' : 'Desactivado' }
+    )
+  } catch (error: any) {
+    toast.error(error.data?.detail || 'Error al cambiar el toggle', { title: 'Error' })
+  } finally {
+    isTogglingWaiterAttribution.value = false
+  }
+}
+
+// Members list comes embedded in the operaciones aggregator (so cashiers/
+// supervisors don't need Module.EQUIPO to populate the dropdown).
+const tenantMembers = computed(() =>
+  (businessProfile.value as any)?.members ?? [],
+)
+
+// Tables data (reusing /api/api/tables which is already gated under POS).
+// Only assignable tables: not bar, active, not deleted.
+const { data: tablesData, refetch: refetchTables } = useQuery({
+  key: () => ['tables', 'for-assignment'],
+  query: () => $fetch<{ success: boolean; data: any[] }>('/api/api/tables?include_inactive=false'),
+})
+const assignableTables = computed(() => {
+  const rows = tablesData.value?.data ?? []
+  return rows.filter((t: any) => !t.is_bar && t.is_active && !t.deleted_at)
+})
+
+const isAssigningMemberTableId = ref<string | null>(null)
+const handleAssignMember = async (tableId: string, memberId: string | null) => {
+  if (isAssigningMemberTableId.value) return
+  isAssigningMemberTableId.value = tableId
+  try {
+    await $fetch(`/api/operaciones/tables/${tableId}/assigned-member`, {
+      method: 'PATCH',
+      body: { member_id: memberId },
+    })
+    await refetchTables()
+    await cache.invalidateQueries({ key: ['operaciones', 'tables', tableId, 'assignment-history'] })
+    toast.success(
+      memberId ? 'Mesero asignado' : 'Asignación removida',
+      { title: 'Guardado' },
+    )
+  } catch (error: any) {
+    toast.error(error.data?.detail || 'Error al asignar mesero', { title: 'Error' })
+  } finally {
+    isAssigningMemberTableId.value = null
+  }
+}
+
+const historyModalTable = ref<{ id: string; name: string } | null>(null)
+const openHistoryModal = (tbl: any) => {
+  historyModalTable.value = { id: tbl.id, name: tbl.name }
 }
 
 const kdsBaseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://warocol.com'

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -104,6 +104,60 @@ const comandasEnabled = computed(() => settingsData.value?.data?.comandas_enable
 
 // Issue #537 — expediter mode (waiter advances comanda state from POS)
 const expediterEnabled = computed(() => settingsData.value?.data?.expediter_enabled === true)
+
+// Issue #574 — waiter attribution (per-session override + auto-handoff)
+const waiterAttributionEnabled = computed(() => settingsData.value?.data?.waiter_attribution_enabled === true)
+const tenantMembers = computed(() => (settingsData.value?.data as any)?.members ?? [])
+
+// Effective waiter id for the active session — used by the banner chip.
+const bannerEffectiveWaiterId = computed(() =>
+  posStore.activeTableSession?.effectiveWaiterMemberId ?? null,
+)
+const isChangingSessionWaiter = ref(false)
+const handleChangeSessionWaiter = async (event: Event) => {
+  if (isChangingSessionWaiter.value) return
+  if (!posStore.activeTableSession) return
+  const target = event.target as HTMLSelectElement
+  const newMemberId = target.value || null
+  isChangingSessionWaiter.value = true
+  try {
+    const result = await $fetch<{ success: boolean; data: { attended_by_member_id: string | null; attended_by_member_name: string | null } }>(
+      `/api/pos/tables/${posStore.activeTableSession.tableId}/session-waiter`,
+      { method: 'PATCH', body: { member_id: newMemberId } },
+    )
+    // Refresh session info so banner reflects the new effective waiter
+    const sessionData = await $fetch<{ success: boolean; data: any }>(
+      `/api/tables/${posStore.activeTableSession.tableId}/current`,
+    )
+    const s = sessionData?.data?.session
+    if (s && posStore.activeTableSession) {
+      posStore.setTableSession({
+        ...posStore.activeTableSession,
+        attendedByMemberId: s.attended_by_member_id ?? null,
+        attendedByMemberName: s.attended_by_member_name ?? null,
+        effectiveWaiterMemberId: s.effective_waiter_member_id ?? null,
+        effectiveWaiterMemberName: s.effective_waiter_member_name ?? null,
+      })
+    }
+    toast.success(
+      newMemberId ? `Mesero: ${result.data.attended_by_member_name}` : 'Sin mesero asignado',
+      { title: 'Actualizado' },
+    )
+  } catch (error: any) {
+    if (error?.statusCode === 403 || error?.response?.status === 403) {
+      toast.error(
+        'Solo el mesero actual o un supervisor pueden cambiar la asignación',
+        { title: 'No permitido' },
+      )
+    } else {
+      toast.error(error?.data?.detail || 'Error al cambiar mesero', { title: 'Error' })
+    }
+    // Reset the select to current value to avoid showing stale selection
+    target.value = posStore.activeTableSession?.effectiveWaiterMemberId ?? ''
+  } finally {
+    isChangingSessionWaiter.value = false
+  }
+}
 const showExpediterPanel = ref(false)
 const readyComandasCount = ref(0)
 let readyCountInterval: ReturnType<typeof setInterval> | null = null
@@ -167,13 +221,18 @@ const handleEnterTable = async (ctx: { tableId: string; sessionId: string; table
       `/api/tables/${ctx.tableId}/current`
     )
     if (session?.data?.session) {
+      const s = session.data.session
       posStore.setTableSession({
         tableId: ctx.tableId,
-        sessionId: session.data.session.id,
+        sessionId: s.id,
         tableName: ctx.tableName,
-        runningTotal: session.data.session.running_total,
-        openedAt: session.data.session.opened_at,
+        runningTotal: s.running_total,
+        openedAt: s.opened_at,
         isBar: ctx.isBar ?? false,
+        attendedByMemberId: s.attended_by_member_id ?? null,
+        attendedByMemberName: s.attended_by_member_name ?? null,
+        effectiveWaiterMemberId: s.effective_waiter_member_id ?? null,
+        effectiveWaiterMemberName: s.effective_waiter_member_name ?? null,
       })
       if (session.data.tab_items) {
         posStore.setTabItems(
@@ -211,13 +270,18 @@ const refreshTableSession = async () => {
       `/api/tables/${posStore.activeTableSession.tableId}/current`
     )
     if (session?.data?.session) {
+      const s = session.data.session
       posStore.setTableSession({
         tableId: posStore.activeTableSession.tableId,
-        sessionId: session.data.session.id,
+        sessionId: s.id,
         tableName: posStore.activeTableSession.tableName,
-        runningTotal: session.data.session.running_total,
-        openedAt: session.data.session.opened_at,
+        runningTotal: s.running_total,
+        openedAt: s.opened_at,
         isBar: posStore.activeTableSession.isBar,
+        attendedByMemberId: s.attended_by_member_id ?? null,
+        attendedByMemberName: s.attended_by_member_name ?? null,
+        effectiveWaiterMemberId: s.effective_waiter_member_id ?? null,
+        effectiveWaiterMemberName: s.effective_waiter_member_name ?? null,
       })
     }
     if (session?.data?.tab_items) {
@@ -764,6 +828,8 @@ onUnmounted(() => {
   <div v-else-if="showFloorPlan">
     <PosMesasFloorPlan
       :comandas-enabled="comandasEnabled"
+      :waiter-attribution-enabled="waiterAttributionEnabled"
+      :members="tenantMembers"
       @enter-table="handleEnterTable"
       @no-tables="noTablesConfigured = true"
       @move-table="handleMoveTable"
@@ -852,8 +918,43 @@ onUnmounted(() => {
               </span>
             </template>
           </div>
-          <!-- Action buttons: Volver (back to floor plan, keeps session) · Liberar (destructive) -->
+          <!-- Action buttons: [Mesero ▾ (#574)] · Volver (back to floor plan, keeps session) · Liberar (destructive) -->
           <div class="flex items-center gap-1.5 flex-shrink-0">
+            <!-- Issue #574 — Waiter chip with auto-handoff dropdown -->
+            <div v-if="waiterAttributionEnabled" class="relative">
+              <select
+                :value="bannerEffectiveWaiterId || ''"
+                :disabled="isChangingSessionWaiter"
+                aria-label="Cambiar mesero de la sesión activa"
+                class="inline-flex items-center gap-1.5 min-h-[36px] pl-7 pr-7 py-1.5 rounded-lg border text-[11px] font-bold uppercase tracking-wider transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed appearance-none cursor-pointer"
+                :class="bannerEffectiveWaiterId
+                  ? 'border-primary/30 bg-primary/5 text-primary'
+                  : 'border-border bg-surface text-text-tertiary hover:text-text-secondary'"
+                @change="handleChangeSessionWaiter"
+              >
+                <option value="">Sin mesero</option>
+                <option
+                  v-for="m in tenantMembers"
+                  :key="m.id"
+                  :value="m.id"
+                >
+                  {{ m.name }}
+                </option>
+              </select>
+              <!-- Icon (overlapping left) -->
+              <svg class="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 flex-shrink-0"
+                xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2"
+                :class="bannerEffectiveWaiterId ? 'text-primary' : 'text-text-tertiary'"
+                stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+              </svg>
+              <!-- Caret (overlapping right) -->
+              <svg class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 w-3 h-3 text-text-tertiary"
+                xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2"
+                stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+              </svg>
+            </div>
             <!-- Volver — clears local activeTableSession; the showFloorPlan computed switches view. Session stays open in backend. -->
             <button
               type="button"

--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -36,6 +36,12 @@ export interface ActiveTableSession {
     runningTotal: number
     openedAt: string
     isBar: boolean
+    // Waiter attribution (warocol.com#574) — optional for backward compat.
+    // `effectiveWaiter*` is the resolver result (session override > table default).
+    attendedByMemberId?: string | null
+    attendedByMemberName?: string | null
+    effectiveWaiterMemberId?: string | null
+    effectiveWaiterMemberName?: string | null
 }
 
 export interface TabItem {


### PR DESCRIPTION
## Summary

Frontend for warocol.com#574. Paired with **api-warolabs#228**. Adds the three POS surfaces for the waiter attribution family: skippable modal at table-open, chip with dropdown in the Mesa Banner, and waiter name on floor plan cards. Auto-handoff guard enforced in backend.

**Stacked on #576** (which itself stacks on `gh-573` in api-warolabs). GitHub will auto-retarget to `main` when the dependencies merge.

Closes #574 (frontend portion).

## Stack

🟢 Nuxt 3 + 🎨 UX

## Visibility logic

All 3 surfaces are gated on `settingsData.value?.data?.waiter_attribution_enabled === true` (which comes embedded in the POS aggregator from #573). When OFF, behavior is identical to before — no modal, no chip, no card line.

## Three surfaces

### 1. `WaiterAssignModal.vue` (new component)
Skippable modal at table-open. Pre-selects the table's `assigned_member_id` (default from #573). One keystroke (Enter) confirms. Buttons: "Sin asignar" (left) and "Abrir mesa" (primary). Mobile-friendly: bottom-sheet on small screens, centered on sm+.

### 2. Mesa Banner chip (`pages/pos/index.vue`)
Custom-styled native `<select>` to the left of [Volver] [Liberar]. Shows effective waiter (session override > table default > "Sin mesero"). On change → PATCH `/api/pos/tables/{id}/session-waiter`. The backend's auto-handoff guard returns 403 if the caller isn't the current waiter and isn't supervisor+; frontend shows a Spanish-friendly toast: "Solo el mesero actual o un supervisor pueden cambiar la asignación".

### 3. Floor plan card waiter line (`components/pos/MesasFloorPlan.vue`)
Adds a `h-6` line below the existing bottom strip with the effective waiter name (truncated). Only renders when the feature is ON AND there's a resolved waiter. Non-occupying — keeps the existing strip cells intact.

## Changes

| File | Type | Notes |
|---|---|---|
| `stores/usePOSStore.ts` | modify | `ActiveTableSession` interface extended with 4 optional fields |
| `components/pos/WaiterAssignModal.vue` | create | Skippable modal, pre-selects default, mobile bottom-sheet |
| `components/pos/MesasFloorPlan.vue` | modify | New props (`waiterAttributionEnabled`, `members`), `handleTableClick` shows modal, card adds waiter line |
| `pages/pos/index.vue` | modify | Banner chip + handler, props passed to floor plan, store hydration enriched with waiter fields |

Net: 4 files, +349 / -27 lines.

## Cache + state strategy

- `setTableSession` calls at all 3 hydration paths (initial enter, refresh, post-change) now include the 4 waiter fields from the `/api/tables/{id}/current` response.
- After PATCH session-waiter: refetch the session details via `/current` and update the store so the chip + card reflect the new effective waiter immediately.
- Failed PATCH (e.g. 403) resets the `<select>` to the previous value via `target.value = posStore.activeTableSession?.effectiveWaiterMemberId ?? ''`.

## UX decisions

- **Modal pre-selects default** (NN/g — minimize friction for recurring choices): cashier presses Enter → mesa abre con el waiter por defecto.
- **Modal is skippable** ("Sin asignar"): rush UX doesn't force a choice. Resolver inherits from table default if NULL.
- **Banner chip uses `min-h-[36px]`** matching the existing chip pattern (consistent with #560 bottom-nav chips). The select wrapper expands the effective tap area.
- **Card waiter line is `text-[10px]` muted**: matches the existing "Libre" label style for consistency in dense floor plan grids.
- **403 toast translated to Spanish** with clear actionable message.
- **No new mobile breakpoints** introduced — modal already bottom-sheet on mobile via existing `items-end sm:items-center` pattern.

## Testing

Static:
- `nuxi typecheck` — zero new errors. 2 pre-existing WARN about duplicated `CartItem`/`CartModifier` imports unrelated to this PR.

Manual smoke (post-merge of api-warolabs#228 + restart of uvicorn + dev server):
- [ ] Toggle OFF: no modal, no chip, no card line — exact prior behavior
- [ ] Toggle ON: free table tap → modal with default pre-selected
- [ ] Modal "Sin asignar" → mesa abre con NULL → resolver hereda del table default → card line shows default
- [ ] Modal "Abrir mesa" → POST con `attended_by_member_id` → session created con valor → card line shows new waiter
- [ ] Mesa Banner chip muestra effective waiter
- [ ] Cambiar chip como mesero actual → 200 → toast OK → chip + card actualizan
- [ ] Cambiar como supervisor distinto → 200 → toast OK
- [ ] Cambiar como cashier que NO es el actual → 403 → toast "Solo el mesero actual o supervisor..."
- [ ] Apagar toggle desde /operaciones/comandas → todas las surfaces desaparecen, datos en DB persisten

## Out of scope

- Atribución por orden (chip "Servido por" en barra/mostrador) — #575
- Reportería de performance — futuro

Closes #574