### PR TITLE
feat(pos): per-order waiter chip in cart for bar + counter (#575)

### DIFF
--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -10,6 +10,34 @@
       </div>
     </div>
 
+    <!-- Issue #575 — Served by chip (bar + counter only, gated by waiter_attribution_enabled) -->
+    <div
+      v-if="showServedByChip"
+      class="px-4 py-2 border-b border-border bg-surface-secondary/40"
+    >
+      <div class="flex items-center gap-2">
+        <svg class="w-3.5 h-3.5 text-text-tertiary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+        </svg>
+        <span class="text-[10px] font-bold text-text-tertiary uppercase tracking-wider flex-shrink-0">Servido por</span>
+        <select
+          :value="servedByMemberId || ''"
+          class="flex-1 min-h-[36px] px-2.5 py-1 text-xs font-medium bg-surface border border-border rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary transition-colors outline-none text-text-primary cursor-pointer"
+          aria-label="Atribuir esta orden a un mesero"
+          @change="onServedByChange"
+        >
+          <option value="">Sin asignar</option>
+          <option
+            v-for="m in (members || [])"
+            :key="m.id"
+            :value="m.id"
+          >
+            {{ m.name }} ({{ m.role }})
+          </option>
+        </select>
+      </div>
+    </div>
+
     <!-- Items list: tab items (committed) + current cart items -->
     <div class="flex-1 overflow-y-auto p-4 space-y-2.5">
 
@@ -234,6 +262,10 @@ interface Props {
   unfiredCount?: number
   isFiringToKitchen?: boolean
   pendingRemoveItemId?: string | null
+  // Issue #575 — per-order waiter attribution (bar + counter)
+  showServedByChip?: boolean
+  servedByMemberId?: string | null
+  members?: Array<{ id: string; name: string; role: string }>
 }
 
 interface Emits {
@@ -250,10 +282,18 @@ interface Emits {
   (e: 'increment-tab-item', orderItemId: string): void
   (e: 'decrement-tab-item', orderItemId: string): void
   (e: 'fire-to-kitchen'): void
+  // Issue #575
+  (e: 'update:served-by', memberId: string | null): void
 }
 
-withDefaults(defineProps<Props>(), { mesaMode: false, isAddingToTab: false, isLoadingTabItems: false, isClearingTab: false, tabItems: () => [], tabTotal: 0, tabItemsLoading: () => new Set(), comandasEnabled: false, unfiredCount: 0, isFiringToKitchen: false, pendingRemoveItemId: null })
-defineEmits<Emits>()
+withDefaults(defineProps<Props>(), { mesaMode: false, isAddingToTab: false, isLoadingTabItems: false, isClearingTab: false, tabItems: () => [], tabTotal: 0, tabItemsLoading: () => new Set(), comandasEnabled: false, unfiredCount: 0, isFiringToKitchen: false, pendingRemoveItemId: null, showServedByChip: false, servedByMemberId: null, members: () => [] })
+const emit = defineEmits<Emits>()
+
+// Issue #575 — handler for the served_by select
+const onServedByChange = (event: Event) => {
+  const target = event.target as HTMLSelectElement
+  emit('update:served-by', target.value || null)
+}
 
 // Obtener isDeleting directamente del store
 const posStore = usePOSStore()

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -367,6 +367,10 @@ const addSplitPayment = async () => {
             ...(isCashMethod.value
               ? { split_first_cash_received: Number(cashReceivedInput.value) }
               : {}),
+            // Issue #575 — per-order waiter attribution (bar + counter; mesa uses #574 session override)
+            ...(posStore.cartServedByMemberId
+              ? { served_by_member_id: posStore.cartServedByMemberId }
+              : {}),
           }
         }) as any
         paidTotal = response.data.paid_total ?? amountToCharge
@@ -670,6 +674,10 @@ const processOrder = async () => {
                 ? { delivery_instructions: deliveryInstructions.value.trim() }
                 : {}),
             }
+          : {}),
+        // Issue #575 — per-order waiter attribution (bar + counter; mesa uses #574 session override)
+        ...(posStore.cartServedByMemberId
+          ? { served_by_member_id: posStore.cartServedByMemberId }
           : {}),
       }
     }) as {

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -109,6 +109,11 @@ const expediterEnabled = computed(() => settingsData.value?.data?.expediter_enab
 const waiterAttributionEnabled = computed(() => settingsData.value?.data?.waiter_attribution_enabled === true)
 const tenantMembers = computed(() => (settingsData.value?.data as any)?.members ?? [])
 
+// Issue #575 — per-order chip in cart (bar + counter only; mesa uses #574 session override)
+const showServedByChip = computed(() =>
+  waiterAttributionEnabled.value && !isMesaMode.value,
+)
+
 // Effective waiter id for the active session — used by the banner chip.
 const bannerEffectiveWaiterId = computed(() =>
   posStore.activeTableSession?.effectiveWaiterMemberId ?? null,
@@ -1087,6 +1092,9 @@ onUnmounted(() => {
         :unfired-count="unfiredCount"
         :is-firing-to-kitchen="isFiringToKitchen"
         :pending-remove-item-id="pendingRemoveItemId"
+        :show-served-by-chip="showServedByChip"
+        :served-by-member-id="posStore.cartServedByMemberId"
+        :members="tenantMembers"
         @edit-item="editCartItem"
         @remove-item="removeFromCart"
         @increment-item="incrementCartItem"
@@ -1100,6 +1108,7 @@ onUnmounted(() => {
         @increment-tab-item="incrementTabItem"
         @decrement-tab-item="decrementTabItem"
         @fire-to-kitchen="fireToKitchen"
+        @update:served-by="(id) => posStore.setCartServedBy(id)"
       />
       </div>
     </div>

--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -80,6 +80,11 @@ export const usePOSStore = defineStore('pos', () => {
     // Mesa context — set when entering POS from a table session
     const activeTableSession = ref<ActiveTableSession | null>(null)
 
+    // Issue #575 — per-order waiter attribution (bar + counter modes)
+    // Tracks the "served_by" choice for the cart in flight. Sent in the
+    // body of POST /pos-cart/{id}/complete. Resets between sales.
+    const cartServedByMemberId = ref<string | null>(null)
+
     // Tenant feature flags — persists across navigation
     const tablesEnabled = ref<boolean | null>(null)
 
@@ -304,11 +309,18 @@ export const usePOSStore = defineStore('pos', () => {
         currentCustomer.value = null
         cartId.value = null
         tabItems.value = []
+        // #575 — reset served_by between sales
+        cartServedByMemberId.value = null
         // Keep bar session alive — bar is a permanent fixture, not a per-order session
         if (!activeTableSession.value?.isBar) {
             activeTableSession.value = null
         }
         // NO limpiar cachedProducts - se mantienen entre ventas
+    }
+
+    // #575 — setter exposed for the chip in cart panel
+    const setCartServedBy = (memberId: string | null) => {
+        cartServedByMemberId.value = memberId
     }
 
     // Explicit exit — always clears session including bar
@@ -410,6 +422,7 @@ export const usePOSStore = defineStore('pos', () => {
         activeTableSession,
         tabItems,
         tablesEnabled,
+        cartServedByMemberId,  // #575
 
         // Getters
         cartItemsCount,
@@ -428,6 +441,7 @@ export const usePOSStore = defineStore('pos', () => {
         clearCart,
         getCartItem,
         setCustomer,
+        setCartServedBy,  // #575
         clearCustomer,
         clearAll,
         exitSession,


### PR DESCRIPTION
## Summary

Frontend for warocol.com#575 — closes the WARO waiter attribution family. Adds the "Servido por" chip in the POS CartPanel header for bar + counter modes. Paired with **api-warolabs#229**.

**Stacked on #577** (gh-574-pos-session-waiter). GitHub will auto-retarget to `main` when the chain ahead merges.

Closes #575 (frontend portion).

## Stack

🟢 Nuxt 3 + 🎨 UX

## Final state of the attribution family

| Level | Where it lives | What controls it | Surface |
|---|---|---|---|
| Default per mesa | `tables.assigned_member_id` (#573) | Owner/Admin/Supervisor in `/operaciones/comandas` | Admin panel |
| Override per session | `table_sessions.attended_by_member_id` (#574) | Cashier in POS (auto-handoff) | Modal on table open + banner chip + floor plan card |
| **Attribution per order** | **`orders.served_by_member_id`** (this PR, #575) | Cashier in POS (auto-handoff) | **CartPanel chip "Servido por"** |

Resolver: `COALESCE(order > session > table > NULL)`.

## Changes

| File | Type | Notes |
|---|---|---|
| `stores/usePOSStore.ts` | modify | `cartServedByMemberId` ref + `setCartServedBy()` + reset on `clearAll` |
| `components/pos/CartPanel.vue` | modify | "Servido por" chip in header (select), new props + emit `@update:served-by` |
| `pages/pos/index.vue` | modify | `showServedByChip` computed, wires chip with `tenantMembers` |
| `pages/pos/checkout.vue` | modify | Both `/complete` calls (single + split) include `served_by_member_id` |

Net: 4 files, +73 / -2 lines.

## Visibility logic

- **Mesa mode** (`isMesaMode === true`): chip **hidden**. Mesa orders inherit from `attended_by_member_id` (#574 session override) or `assigned_member_id` (#573 default) via the resolver. Adding a 3rd chip would compete visually with the banner chip from #574.
- **Bar mode** (`isBar === true`): chip **visible**. Each order in the perpetual bar session gets explicit attribution.
- **Counter mode**: chip **visible**. No session — order is the unit.
- **`waiter_attribution_enabled = false`**: chip **hidden** in all modes. Zero regression for tenants without the feature.

## UX decisions (per plan)

| Decision | Why |
|---|---|
| Default value = NULL | Explicit consent > assumed default (NN/g). Cashier picks consciously. Avoids attributing the wrong member when the cashier and the bartender are different people. |
| Chip in cart header | Visible always during the sale, easy to change before complete. Header location matches the visual hierarchy of "Orden Actual" title. |
| Native `<select>` styled | Mobile-friendly without custom dropdown component. Min tap area ~36px on the select, ≥44px effective with the row padding. |
| Reset on `clearAll` | Between sales, the chip resets to "Sin asignar". Prevents accidentally carrying over the previous server's attribution. |
| Mesa hidden | Two chips for the same concept = bad UX. Mesa already has #574 banner chip. |

## Backend dependency

Endpoints needed (all in **api-warolabs#229**):
- `POST /pos-cart/{id}/complete` — body now accepts `served_by_member_id` ✓
- `PATCH /pos/orders/{id}/served-by` — for post-creation reassign with auto-handoff ✓

Frontend currently uses only the first one (set at creation time). Post-creation reassign would be a future surface in `/ventas/[id]` — kept out of scope for this PR.

## Testing

Static:
- `nuxi typecheck` — zero new errors. The 2 WARN about duplicated `CartItem`/`CartModifier` imports are pre-existing, unrelated to this PR.

Manual smoke (post-merge of cadena #573 → #574 → #575 + restart of uvicorn + dev server):
- [ ] Toggle ON, bar mode → chip visible in CartPanel header
- [ ] Toggle ON, counter mode → chip visible
- [ ] Toggle ON, mesa mode → chip hidden (#574 banner chip is the surface for mesa)
- [ ] Pick a member → POST `/complete` includes `served_by_member_id` → backend persists
- [ ] Complete sale → chip resets to "Sin asignar" for next sale
- [ ] Toggle OFF → chip hidden in all modes — no regression

## Out of scope

- `/ventas/[id]` reassign UI (uses the new PATCH endpoint) — future iteration
- Per-line attribution (chip is per-order, not per-line)
- Auto-assign to logged-in cashier — kept explicit by design
- Bar bartender vs counter cashier distinction — both modes use the same chip pattern

Closes #575