### PR TITLE
fix(operaciones-comandas): correct tables API path

### DIFF
--- a/pages/operaciones/comandas.vue
+++ b/pages/operaciones/comandas.vue
@@ -748,11 +748,11 @@ const tenantMembers = computed(() =>
   (businessProfile.value as any)?.members ?? [],
 )
 
-// Tables data (reusing /api/api/tables which is already gated under POS).
+// Tables data (reusing /api/tables which is already gated under POS).
 // Only assignable tables: not bar, active, not deleted.
 const { data: tablesData, refetch: refetchTables } = useQuery({
   key: () => ['tables', 'for-assignment'],
-  query: () => $fetch<{ success: boolean; data: any[] }>('/api/api/tables?include_inactive=false'),
+  query: () => $fetch<{ success: boolean; data: any[] }>('/api/tables?include_inactive=false'),
 })
 const assignableTables = computed(() => {
   const rows = tablesData.value?.data ?? []


### PR DESCRIPTION
## Summary

The "Mesero por mesa" panel on `/operaciones/comandas` was rendering "Sin mesas asignables" even on tenants with mesas configured. Root cause: the fetch used `/api/api/tables`, but the `tables` router is mounted at `prefix="/tables"` on the backend — so the Nuxt proxy needs a single `/api/` prefix (`/api/tables`), not double.

This is the same bug class as #572, scoped to a single call site that landed in the waiter-attribution stack.

## Changes
- `pages/operaciones/comandas.vue`: `/api/api/tables?include_inactive=false` → `/api/tables?include_inactive=false` (matches the existing usage in `components/pos/MesasFloorPlan.vue`).

## Test plan
- [ ] Toggle "Asignar mesero por mesa" ON on a tenant with mesas configured.
- [ ] Panel renders one row per assignable mesa with the member dropdown.
- [ ] Selecting a mesero persists and shows in the badge.