### PR TITLE
feat(operaciones-mesas): unify waiter-by-table on the Mesas page

### DIFF
--- a/components/mesas/MesaPanel.vue
+++ b/components/mesas/MesaPanel.vue
@@ -95,6 +95,27 @@
             <p v-if="errors.capacity" class="text-xs text-destructive">{{ errors.capacity }}</p>
           </div>
 
+          <!-- Mesero asignado (issue #573, only when feature flag ON) -->
+          <div v-if="showMeseroField" class="flex flex-col gap-1.5">
+            <label for="mesa-mesero" class="text-sm font-medium text-text-primary">
+              Mesero por defecto <span class="text-xs font-normal text-text-tertiary ml-1">(opcional)</span>
+            </label>
+            <select
+              id="mesa-mesero"
+              :value="form.assignedMemberId || ''"
+              :class="inputClass"
+              @change="(e) => (form.assignedMemberId = (e.target as HTMLSelectElement).value || null)"
+            >
+              <option value="">(Sin asignar)</option>
+              <option v-for="m in members" :key="m.id" :value="m.id">
+                {{ m.name }} ({{ m.role }})
+              </option>
+            </select>
+            <p class="text-[11px] text-text-tertiary leading-snug">
+              Se podrá cambiar al abrir la sesión o por orden desde POS.
+            </p>
+          </div>
+
           <!-- Error general -->
           <p v-if="errors.general" class="text-sm text-destructive bg-destructive/10 rounded-lg px-3 py-2">
             {{ errors.general }}
@@ -128,9 +149,17 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 
+interface Member {
+  id: string
+  name: string
+  role: string
+}
+
 interface Props {
   modelValue: boolean
   table?: any // null/undefined = create mode, object = edit mode
+  members?: Member[]
+  waiterAttributionEnabled?: boolean
 }
 
 interface Emits {
@@ -138,23 +167,41 @@ interface Emits {
   (e: 'saved', table: any): void
 }
 
-const props = withDefaults(defineProps<Props>(), { table: null })
+const props = withDefaults(defineProps<Props>(), {
+  table: null,
+  members: () => [],
+  waiterAttributionEnabled: false,
+})
 const emit = defineEmits<Emits>()
 
 const isEdit = computed(() => !!props.table)
+const showMeseroField = computed(
+  () => props.waiterAttributionEnabled && props.members.length > 0,
+)
 
 const inputClass = 'h-10 w-full rounded-lg border-2 border-border bg-background px-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 transition-colors'
 
-const form = ref({ name: '', capacity: null as number | null })
+const form = ref({
+  name: '',
+  capacity: null as number | null,
+  assignedMemberId: null as string | null,
+})
+const initialAssignedMemberId = ref<string | null>(null)
 const errors = ref<Record<string, string>>({})
 const saving = ref(false)
 
 // Populate form when table changes
 watch(() => props.table, (t) => {
   if (t) {
-    form.value = { name: t.name ?? '', capacity: t.capacity ?? null }
+    form.value = {
+      name: t.name ?? '',
+      capacity: t.capacity ?? null,
+      assignedMemberId: t.assigned_member_id ?? null,
+    }
+    initialAssignedMemberId.value = t.assigned_member_id ?? null
   } else {
-    form.value = { name: '', capacity: null }
+    form.value = { name: '', capacity: null, assignedMemberId: null }
+    initialAssignedMemberId.value = null
   }
   errors.value = {}
 }, { immediate: true })
@@ -163,7 +210,8 @@ watch(() => props.table, (t) => {
 watch(() => props.modelValue, (open) => {
   if (!open) return
   if (!props.table) {
-    form.value = { name: '', capacity: null }
+    form.value = { name: '', capacity: null, assignedMemberId: null }
+    initialAssignedMemberId.value = null
     errors.value = {}
   }
 })
@@ -196,6 +244,16 @@ async function submit() {
       result = await $fetch(`/api/tables/${props.table.id}`, { method: 'PUT', body })
     } else {
       result = await $fetch('/api/tables', { method: 'POST', body })
+    }
+
+    // Persist mesero assignment via the dedicated operaciones endpoint. We
+    // skip the PATCH when the value didn't change to avoid no-op writes
+    // (which would still create an empty history entry).
+    if (showMeseroField.value && result?.data?.id && form.value.assignedMemberId !== initialAssignedMemberId.value) {
+      await $fetch(`/api/operaciones/tables/${result.data.id}/assigned-member`, {
+        method: 'PATCH',
+        body: { member_id: form.value.assignedMemberId },
+      })
     }
 
     emit('saved', result.data)

--- a/pages/operaciones/comandas.vue
+++ b/pages/operaciones/comandas.vue
@@ -148,30 +148,6 @@
           </div>
         </div>
 
-        <!-- Issue #573 — Waiter attribution feature flag (independent of comandas) -->
-        <div class="space-y-2 pt-3 border-t border-border">
-          <div class="flex items-center justify-between py-1">
-            <div>
-              <p class="text-sm font-medium text-text-primary">Asignar mesero por mesa</p>
-              <p class="text-xs text-text-secondary mt-0.5">
-                Permite asignar un mesero por defecto a cada mesa (con historial), y atribuir
-                meseros por sesión y por orden en POS. Habilita el panel de gestión debajo.
-              </p>
-            </div>
-            <div class="flex-shrink-0 ml-4 flex items-center justify-center w-10 h-6">
-              <UiLoadingDots v-if="isTogglingWaiterAttribution" color="var(--color-primary)" size="11px" />
-              <label v-else class="relative inline-flex items-center cursor-pointer">
-                <input
-                  type="checkbox"
-                  class="sr-only peer"
-                  :checked="businessProfile?.waiter_attribution_enabled"
-                  @change="handleToggleWaiterAttribution"
-                />
-                <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
-              </label>
-            </div>
-          </div>
-        </div>
       </div>
     </div>
 
@@ -318,48 +294,6 @@
         </template>
       </UiResponsiveDataView>
     </div>
-
-    <!-- ══════ MESERO POR MESA (issue #573) — visible solo si toggles ON ══════ -->
-    <div
-      v-if="businessProfile?.waiter_attribution_enabled && businessProfile?.tables_enabled"
-      class="bg-surface border-2 border-border rounded-xl p-4 sm:p-6"
-    >
-      <div class="flex items-center gap-2 mb-1">
-        <UserGroupIcon class="w-5 h-5 text-primary flex-shrink-0" />
-        <h3 class="text-base sm:text-lg font-semibold text-text-primary">Mesero por mesa</h3>
-      </div>
-      <p class="text-xs text-text-secondary mb-4">
-        Asigna un mesero por defecto a cada mesa. Las barras no aplican.
-        El historial se preserva incluso si el miembro se elimina.
-      </p>
-
-      <div v-if="assignableTables.length === 0" class="py-8 text-center">
-        <p class="text-sm font-semibold text-text-secondary">Sin mesas asignables</p>
-        <p class="text-xs text-text-tertiary mt-1">
-          Crea mesas en <span class="font-mono">/operaciones/mesas</span> para asignar meseros.
-        </p>
-      </div>
-
-      <div v-else class="space-y-2">
-        <GestionOperacionesMesaMemberAssignRow
-          v-for="tbl in assignableTables"
-          :key="tbl.id"
-          :table="tbl"
-          :members="tenantMembers"
-          :loading="isAssigningMemberTableId === tbl.id"
-          @assign="(memberId) => handleAssignMember(tbl.id, memberId)"
-          @view-history="() => openHistoryModal(tbl)"
-        />
-      </div>
-    </div>
-
-    <!-- History modal -->
-    <GestionOperacionesMesaAssignmentHistoryModal
-      v-if="historyModalTable"
-      :open="!!historyModalTable"
-      :table="historyModalTable"
-      @close="historyModalTable = null"
-    />
 
     </template>
 
@@ -512,7 +446,6 @@ import {
   XMarkIcon,
   ExclamationTriangleIcon,
   PencilSquareIcon,
-  UserGroupIcon,
 } from '@heroicons/vue/24/outline'
 
 definePageMeta({ layout: 'dashboard' })
@@ -717,73 +650,6 @@ const handleToggleExpediter = async (event: Event) => {
   } finally {
     isTogglingExpediter.value = false
   }
-}
-
-// Issue #573 — Waiter attribution toggle + per-table assignment
-const isTogglingWaiterAttribution = ref(false)
-const handleToggleWaiterAttribution = async (event: Event) => {
-  if (isTogglingWaiterAttribution.value) return
-  const newState = (event.target as HTMLInputElement).checked
-  isTogglingWaiterAttribution.value = true
-  try {
-    await $fetch('/api/operaciones/toggles/waiter-attribution', { method: 'PATCH', body: { enabled: newState } })
-    await invalidateContextCaches()
-    await cache.invalidateQueries({ key: ['tables'] })
-    toast.success(
-      newState
-        ? 'Habilitado. Configura meseros en el panel debajo.'
-        : 'Asignación de meseros deshabilitada',
-      { title: newState ? 'Activado' : 'Desactivado' }
-    )
-  } catch (error: any) {
-    toast.error(error.data?.detail || 'Error al cambiar el toggle', { title: 'Error' })
-  } finally {
-    isTogglingWaiterAttribution.value = false
-  }
-}
-
-// Members list comes embedded in the operaciones aggregator (so cashiers/
-// supervisors don't need Module.EQUIPO to populate the dropdown).
-const tenantMembers = computed(() =>
-  (businessProfile.value as any)?.members ?? [],
-)
-
-// Tables data (reusing /api/tables which is already gated under POS).
-// Only assignable tables: not bar, active, not deleted.
-const { data: tablesData, refetch: refetchTables } = useQuery({
-  key: () => ['tables', 'for-assignment'],
-  query: () => $fetch<{ success: boolean; data: any[] }>('/api/tables?include_inactive=false'),
-})
-const assignableTables = computed(() => {
-  const rows = tablesData.value?.data ?? []
-  return rows.filter((t: any) => !t.is_bar && t.is_active && !t.deleted_at)
-})
-
-const isAssigningMemberTableId = ref<string | null>(null)
-const handleAssignMember = async (tableId: string, memberId: string | null) => {
-  if (isAssigningMemberTableId.value) return
-  isAssigningMemberTableId.value = tableId
-  try {
-    await $fetch(`/api/operaciones/tables/${tableId}/assigned-member`, {
-      method: 'PATCH',
-      body: { member_id: memberId },
-    })
-    await refetchTables()
-    await cache.invalidateQueries({ key: ['operaciones', 'tables', tableId, 'assignment-history'] })
-    toast.success(
-      memberId ? 'Mesero asignado' : 'Asignación removida',
-      { title: 'Guardado' },
-    )
-  } catch (error: any) {
-    toast.error(error.data?.detail || 'Error al asignar mesero', { title: 'Error' })
-  } finally {
-    isAssigningMemberTableId.value = null
-  }
-}
-
-const historyModalTable = ref<{ id: string; name: string } | null>(null)
-const openHistoryModal = (tbl: any) => {
-  historyModalTable.value = { id: tbl.id, name: tbl.name }
 }
 
 const kdsBaseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://warocol.com'

--- a/pages/operaciones/mesas.vue
+++ b/pages/operaciones/mesas.vue
@@ -76,12 +76,20 @@ const inactiveTables = computed(() => {
 })
 
 // ── Table columns ──────────────────────────────────────────────────────────
-const tableColumns = [
-  { key: 'name', title: 'Mesa', sortable: false },
-  { key: 'capacity', title: 'Capacidad' },
-  { key: 'status', title: 'Estado' },
-  { key: 'actions', title: '' },
-]
+// "Mesero" column only shows when waiter-attribution is on; the cell is
+// read-only — clicking "Editar" is the only way to change the assignment.
+const tableColumns = computed(() => {
+  const cols: Array<{ key: string; title: string; sortable?: boolean }> = [
+    { key: 'name', title: 'Mesa', sortable: false },
+    { key: 'capacity', title: 'Capacidad' },
+  ]
+  if (businessProfile.value?.waiter_attribution_enabled) {
+    cols.push({ key: 'mesero', title: 'Mesero' })
+  }
+  cols.push({ key: 'status', title: 'Estado' })
+  cols.push({ key: 'actions', title: '' })
+  return cols
+})
 
 // ── Panel state ────────────────────────────────────────────────────────────
 const showPanel = ref(false)
@@ -219,6 +227,40 @@ const toggleTablesEnabled = async () => {
     isTogglingTables.value = false
   }
 }
+
+// ── Toggle waiter attribution (issue #573) ─────────────────────────────────
+// Lives here (not on /operaciones/comandas) because the panel that depends on
+// it — per-mesa default mesero — also lives on this page now.
+const isTogglingWaiterAttribution = ref(false)
+const toggleWaiterAttribution = async () => {
+  if (!businessProfile.value || isTogglingWaiterAttribution.value) return
+  isTogglingWaiterAttribution.value = true
+  const newState = !businessProfile.value.waiter_attribution_enabled
+  try {
+    await $fetch('/api/operaciones/toggles/waiter-attribution', {
+      method: 'PATCH',
+      body: { enabled: newState },
+    })
+    await invalidateContextCaches()
+    await cache.invalidateQueries({ key: ['tables'] })
+    toast.success(
+      newState
+        ? 'Habilitado. Asigna meseros desde la tabla o al editar cada mesa.'
+        : 'Asignación de meseros deshabilitada',
+      { title: newState ? 'Activado' : 'Desactivado' }
+    )
+  } catch (error: any) {
+    toast.error(error.data?.detail || 'Error al cambiar el toggle', { title: 'Error' })
+  } finally {
+    isTogglingWaiterAttribution.value = false
+  }
+}
+
+// Members embedded in the operaciones aggregator (no Module.EQUIPO required).
+// Used by MesaPanel to render the "Mesero por defecto" picker.
+const tenantMembers = computed<Array<{ id: string; name: string; role: string }>>(() =>
+  (businessProfile.value as any)?.members ?? [],
+)
 </script>
 
 <template>
@@ -237,39 +279,69 @@ const toggleTablesEnabled = async () => {
       <!-- ══════ MÓDULOS ══════ -->
       <div
         v-if="businessProfile"
-        class="flex items-center justify-between gap-4 rounded-xl border-2 px-4 py-3 transition-colors"
+        class="rounded-xl border-2 transition-colors divide-y divide-border"
         :class="businessProfile.tables_enabled
           ? 'border-border bg-surface'
           : 'border-amber-200 bg-amber-50 dark:border-amber-800/40 dark:bg-amber-950/20'"
       >
-        <div class="min-w-0">
-          <p
-            class="text-sm font-semibold leading-snug"
-            :class="businessProfile.tables_enabled ? 'text-text-primary' : 'text-amber-800 dark:text-amber-300'"
+        <!-- Tables module -->
+        <div class="flex items-center justify-between gap-4 px-4 py-3">
+          <div class="min-w-0">
+            <p
+              class="text-sm font-semibold leading-snug"
+              :class="businessProfile.tables_enabled ? 'text-text-primary' : 'text-amber-800 dark:text-amber-300'"
+            >
+              {{ businessProfile.tables_enabled ? 'Gestión de mesas activa' : 'Gestión de mesas desactivada' }}
+            </p>
+            <p
+              class="text-xs mt-0.5 leading-snug"
+              :class="businessProfile.tables_enabled ? 'text-text-secondary' : 'text-amber-700 dark:text-amber-400'"
+            >
+              {{ businessProfile.tables_enabled ? 'El flujo de mesas está disponible en el punto de venta' : 'Actívala para usar el flujo de mesas en el punto de venta' }}
+            </p>
+          </div>
+          <label
+            class="relative inline-flex items-center cursor-pointer flex-shrink-0"
+            :class="isTogglingTables ? 'opacity-50 pointer-events-none' : ''"
+            :aria-label="businessProfile.tables_enabled ? 'Desactivar gestión de mesas' : 'Activar gestión de mesas'"
           >
-            {{ businessProfile.tables_enabled ? 'Gestión de mesas activa' : 'Gestión de mesas desactivada' }}
-          </p>
-          <p
-            class="text-xs mt-0.5 leading-snug"
-            :class="businessProfile.tables_enabled ? 'text-text-secondary' : 'text-amber-700 dark:text-amber-400'"
-          >
-            {{ businessProfile.tables_enabled ? 'El flujo de mesas está disponible en el punto de venta' : 'Actívala para usar el flujo de mesas en el punto de venta' }}
-          </p>
+            <input
+              type="checkbox"
+              class="sr-only peer"
+              :checked="businessProfile.tables_enabled"
+              @change="toggleTablesEnabled"
+              :disabled="isTogglingTables"
+            />
+            <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+          </label>
         </div>
-        <label
-          class="relative inline-flex items-center cursor-pointer flex-shrink-0"
-          :class="isTogglingTables ? 'opacity-50 pointer-events-none' : ''"
-          :aria-label="businessProfile.tables_enabled ? 'Desactivar gestión de mesas' : 'Activar gestión de mesas'"
-        >
-          <input
-            type="checkbox"
-            class="sr-only peer"
-            :checked="businessProfile.tables_enabled"
-            @change="toggleTablesEnabled"
-            :disabled="isTogglingTables"
-          />
-          <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
-        </label>
+
+        <!-- Waiter attribution (issue #573) — only meaningful when tables are enabled -->
+        <div v-if="businessProfile.tables_enabled" class="flex items-center justify-between gap-4 px-4 py-3">
+          <div class="min-w-0">
+            <p class="text-sm font-semibold leading-snug text-text-primary">
+              Asignar mesero por mesa
+            </p>
+            <p class="text-xs mt-0.5 leading-snug text-text-secondary">
+              Cada mesa puede tener un mesero por defecto. Se puede cambiar al abrir la sesión o por orden.
+              El historial se preserva incluso si el miembro se elimina.
+            </p>
+          </div>
+          <label
+            class="relative inline-flex items-center cursor-pointer flex-shrink-0"
+            :class="isTogglingWaiterAttribution ? 'opacity-50 pointer-events-none' : ''"
+            :aria-label="businessProfile.waiter_attribution_enabled ? 'Desactivar asignación de meseros por mesa' : 'Activar asignación de meseros por mesa'"
+          >
+            <input
+              type="checkbox"
+              class="sr-only peer"
+              :checked="businessProfile.waiter_attribution_enabled"
+              @change="toggleWaiterAttribution"
+              :disabled="isTogglingWaiterAttribution"
+            />
+            <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+          </label>
+        </div>
       </div>
 
       <!-- Filters -->
@@ -312,6 +384,13 @@ const toggleTablesEnabled = async () => {
                 <p class="text-xs text-text-secondary mt-0.5">
                   {{ item.capacity ? `${item.capacity} persona${item.capacity !== 1 ? 's' : ''}` : 'Sin capacidad definida' }}
                 </p>
+                <p
+                  v-if="businessProfile?.waiter_attribution_enabled"
+                  class="text-[11px] mt-0.5 font-medium truncate"
+                  :class="item.assigned_member_name ? 'text-primary' : 'text-text-tertiary italic'"
+                >
+                  Mesero: {{ item.assigned_member_name || 'sin asignar' }}
+                </p>
               </div>
               <div class="flex items-center gap-2 flex-shrink-0">
                 <UiStatusBadge :variant="badgeVariant(item.status)" size="sm">
@@ -339,6 +418,22 @@ const toggleTablesEnabled = async () => {
           <template #cell-capacity="{ value }">
             <span class="text-sm text-text-secondary">
               {{ value ? `${value} persona${value !== 1 ? 's' : ''}` : '—' }}
+            </span>
+          </template>
+
+          <!-- Desktop: mesero (only present when waiter-attribution is enabled) -->
+          <template #cell-mesero="{ row }">
+            <span
+              v-if="row.assigned_member_name"
+              class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-[11px] font-semibold bg-primary/10 text-primary border border-primary/20"
+            >
+              {{ row.assigned_member_name }}
+            </span>
+            <span
+              v-else
+              class="inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-semibold bg-surface-secondary text-text-tertiary border border-border"
+            >
+              Sin asignar
             </span>
           </template>
 
@@ -446,6 +541,8 @@ const toggleTablesEnabled = async () => {
     <MesasMesaPanel
       v-model="showPanel"
       :table="panelTable"
+      :members="tenantMembers"
+      :waiter-attribution-enabled="!!businessProfile?.waiter_attribution_enabled"
       @saved="onSaved"
     />
 


### PR DESCRIPTION
## Summary

Consolidates the waiter-attribution UI on `/operaciones/mesas`. The toggle and the per-mesa default-mesero now live next to the mesa list itself — no more duplicate mesa list on `/operaciones/comandas`.

## Changes
- `pages/operaciones/mesas.vue`:
  - Adds the **"Asignar mesero por mesa"** toggle inside the existing Modules card (only when `tables_enabled`).
  - When the feature is on, the active-mesa table gains a read-only **"Mesero"** column — member name when assigned, "Sin asignar" badge otherwise.
  - Mobile card mirrors the same with an inline "Mesero: ..." sub-line.
- `components/mesas/MesaPanel.vue`: new `members` + `waiterAttributionEnabled` props. When the feature is on, the create/edit form renders a "Mesero por defecto" picker. On submit, after the PUT to `/api/tables/{id}`, a PATCH to `/api/operaciones/tables/{id}/assigned-member` persists the assignment if it changed.
- `pages/operaciones/comandas.vue`: removes the duplicated toggle, panel, history modal, and related state — that page is now purely about comandas/cocina configuration.

## Test plan
- [ ] Tables enabled OFF → no waiter-attribution toggle visible.
- [ ] Tables enabled ON → waiter-attribution toggle visible inside the Modules card.
- [ ] Toggle ON → Mesa list shows the new "Mesero" column with "Sin asignar" badges.
- [ ] Editing a mesa shows the "Mesero por defecto" picker; saving with a new value updates the row immediately.
- [ ] Editing only name/capacity (mesero unchanged) does **not** create a no-op history entry.
- [ ] `/operaciones/comandas` no longer shows the waiter-attribution toggle or the per-mesa panel.