### PR TITLE
fix(pos-banner): loading-dots + same-size waiter chip

### DIFF
--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -931,7 +931,8 @@ onUnmounted(() => {
                 :value="bannerEffectiveWaiterId || ''"
                 :disabled="isChangingSessionWaiter"
                 aria-label="Cambiar mesero de la sesión activa"
-                class="inline-flex items-center gap-1.5 min-h-[36px] pl-7 pr-7 py-1.5 rounded-lg border text-[11px] font-bold uppercase tracking-wider transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed appearance-none cursor-pointer"
+                class="inline-flex items-center gap-1.5 pl-7 pr-7 py-1.5 rounded-lg border text-[10px] font-bold uppercase tracking-wider transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed appearance-none bg-none cursor-pointer [&::-ms-expand]:hidden"
+                style="background-image: none; -webkit-appearance: none; -moz-appearance: none;"
                 :class="bannerEffectiveWaiterId
                   ? 'border-primary/30 bg-primary/5 text-primary'
                   : 'border-border bg-surface text-text-tertiary hover:text-text-secondary'"
@@ -947,7 +948,7 @@ onUnmounted(() => {
                 </option>
               </select>
               <!-- Icon (overlapping left) -->
-              <svg class="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 flex-shrink-0"
+              <svg class="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 flex-shrink-0"
                 xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2"
                 :class="bannerEffectiveWaiterId ? 'text-primary' : 'text-text-tertiary'"
                 stroke="currentColor" aria-hidden="true">
@@ -960,7 +961,7 @@ onUnmounted(() => {
                 size="6px"
                 color="currentColor"
               />
-              <svg v-else class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 w-3 h-3 text-text-tertiary"
+              <svg v-else class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 h-3 w-3 text-text-tertiary"
                 xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2"
                 stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -953,8 +953,14 @@ onUnmounted(() => {
                 stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
               </svg>
-              <!-- Caret (overlapping right) -->
-              <svg class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 w-3 h-3 text-text-tertiary"
+              <!-- Caret (overlapping right) — swapped for loading dots while the PATCH is in flight -->
+              <UiLoadingDots
+                v-if="isChangingSessionWaiter"
+                class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2"
+                size="6px"
+                color="currentColor"
+              />
+              <svg v-else class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 w-3 h-3 text-text-tertiary"
                 xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2"
                 stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />


### PR DESCRIPTION
## Summary

Two small fixes for the active-mesa banner on `/pos`:

1. **Visible loading state when changing the waiter.** The `<select>` was already disabled and a toast fired on success, but during the round-trip there was no visual feedback. We now swap the right-side caret for `UiLoadingDots` while `isChangingSessionWaiter` is true.

2. **Chip matches the sibling buttons.** The waiter chip was `min-h-[36px]` with `text-[11px]`, while Volver/Liberar are `text-[10px]` with no min-h (~28px). The chip towered over the rest. Drop the min-h and step text down to `text-[10px]` so all three controls share the same height.

3. **Kill the duplicated caret.** Safari was leaking the native `<select>` arrow through `appearance-none`, stacking it on top of our custom SVG caret. Force-disable with `bg-none` + inline `background-image: none` + vendor-prefixed `-webkit-appearance` / `-moz-appearance` resets + `[&::-ms-expand]:hidden` for legacy Edge.

## Changes
- `pages/pos/index.vue`: chip styling + loading-dots swap inside the banner.

## Test plan
- [ ] Open a mesa in `/pos`. Verify the banner row aligns: mesero chip / Volver / Liberar are the same height.
- [ ] Verify only **one** caret on the right of the chip — no duplicated arrow (Safari + Chrome).
- [ ] Change the mesero in the chip. While the PATCH is in flight, the caret is replaced by `UiLoadingDots`; on settle the caret comes back and the toast fires.