### PR TITLE
fix(invoicing): rejected-state banner on ventas + safer /facturacion form (#589)

### DIFF
--- a/pages/facturacion.vue
+++ b/pages/facturacion.vue
@@ -40,12 +40,26 @@ const resolutions = computed(() => resolutionsData.value?.data ?? [])
 const showResolutionForm = ref(false)
 const editingResolutionId = ref<string | null>(null)
 const isSavingResolution = ref(false)
-const resolutionForm = reactive({
+// warocol.com#589 — `current_number` initialised to null on create so the
+// backend seeds it to `from_number - 1` (the correct initial state for the
+// api-facturacion allocator). Sending 0 here was the root cause of the
+// "ya validado" bug: it forced the allocator to start at LZT1/LZT2 and
+// collide with Matias' cross-resolution history.
+const resolutionForm = reactive<{
+  resolution_number: string
+  prefix: string
+  from_number: number
+  to_number: number
+  current_number: number | null
+  date_from: string
+  date_to: string
+  document_type: string
+}>({
   resolution_number: '',
   prefix: '',
   from_number: 1,
   to_number: 1000,
-  current_number: 0,
+  current_number: null,
   date_from: '',
   date_to: '',
   document_type: 'invoice',
@@ -56,12 +70,24 @@ const resetResolutionForm = () => {
   resolutionForm.prefix = ''
   resolutionForm.from_number = 1
   resolutionForm.to_number = 1000
-  resolutionForm.current_number = 0
+  resolutionForm.current_number = null
   resolutionForm.date_from = ''
   resolutionForm.date_to = ''
   resolutionForm.document_type = 'invoice'
   editingResolutionId.value = null
 }
+
+// warocol.com#589 — surface the same validation the backend enforces.
+// current_number must satisfy from_number - 1 <= current_number <= to_number,
+// otherwise the next emission will reuse already-validated DIAN numbers.
+const isCurrentNumberInvalid = computed(() => {
+  if (resolutionForm.current_number === null) return false
+  if (!resolutionForm.from_number || !resolutionForm.to_number) return false
+  return (
+    resolutionForm.current_number < resolutionForm.from_number - 1 ||
+    resolutionForm.current_number > resolutionForm.to_number
+  )
+})
 
 const openNewResolution = () => {
   resetResolutionForm()
@@ -389,9 +415,29 @@ const taxLevels = [
             <label class="text-xs font-medium text-text-secondary">Rango hasta <span class="text-red-500">*</span></label>
             <input v-model.number="resolutionForm.to_number" type="number" min="1" class="min-h-[44px] px-3 py-2 border border-border rounded-lg text-sm bg-background focus:outline-none focus:ring-2 focus:ring-primary" />
           </div>
-          <div class="flex flex-col gap-1">
+          <!-- warocol.com#589 — `current_number` solo visible al editar.
+               Al crear se omite del payload → backend lo siembra como
+               `from_number - 1` automáticamente, evitando colisiones con
+               la historia cruzada de Matias. -->
+          <div v-if="editingResolutionId" class="flex flex-col gap-1">
             <label class="text-xs font-medium text-text-secondary">Número actual (consecutivo)</label>
-            <input v-model.number="resolutionForm.current_number" type="number" min="0" class="min-h-[44px] px-3 py-2 border border-border rounded-lg text-sm bg-background focus:outline-none focus:ring-2 focus:ring-primary" />
+            <input
+              v-model.number="resolutionForm.current_number"
+              type="number"
+              :min="resolutionForm.from_number - 1"
+              :max="resolutionForm.to_number"
+              :class="[
+                'min-h-[44px] px-3 py-2 border rounded-lg text-sm bg-background focus:outline-none focus:ring-2',
+                isCurrentNumberInvalid ? 'border-destructive focus:ring-destructive/30' : 'border-border focus:ring-primary',
+              ]"
+            />
+            <p v-if="isCurrentNumberInvalid" class="text-xs text-destructive leading-snug">
+              Debe estar entre {{ resolutionForm.from_number - 1 }} y {{ resolutionForm.to_number }}. Valores
+              menores reusarían números ya emitidos en DIAN.
+            </p>
+            <p v-else class="text-[11px] text-text-tertiary leading-snug">
+              Próxima emisión usará {{ (resolutionForm.current_number ?? resolutionForm.from_number - 1) + 1 }}.
+            </p>
           </div>
           <div class="flex flex-col gap-1">
             <label class="text-xs font-medium text-text-secondary">Tipo de documento</label>
@@ -414,7 +460,7 @@ const taxLevels = [
           </button>
           <button
             @click="saveResolution"
-            :disabled="isSavingResolution || !resolutionForm.prefix || !resolutionForm.resolution_number || !resolutionForm.date_from || !resolutionForm.date_to"
+            :disabled="isSavingResolution || !resolutionForm.prefix || !resolutionForm.resolution_number || !resolutionForm.date_from || !resolutionForm.date_to || isCurrentNumberInvalid"
             class="min-h-[44px] px-4 py-2 text-sm font-medium rounded-lg bg-primary text-white hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
           >
             <CheckIcon v-if="!isSavingResolution" class="w-4 h-4" aria-hidden="true" />

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -95,6 +95,15 @@ const isEmittingInvoice = ref(false)
 const emitInvoiceError = ref('')
 const copiedCufe = ref(false)
 
+// warocol.com#589 — detect the "ya validado" un-recoverable case so the UI
+// shows a clearer support-action banner instead of dumping the raw Matias
+// error and confusing the cashier into clicking emit again.
+const isUnrecoverableRejection = computed(() => {
+  if (!invoiceData.value || invoiceData.value.status !== 'rejected') return false
+  const msg = (invoiceData.value.error_message || '').toLowerCase()
+  return msg.includes('ya se encuentra validado')
+})
+
 const emitInvoice = async () => {
   if (isEmittingInvoice.value) return
   isEmittingInvoice.value = true
@@ -648,9 +657,30 @@ onUnmounted(() => {
             </div>
           </div>
 
-          <!-- Error message for rejected -->
-          <div v-if="invoiceData.status === 'rejected' && invoiceData.error_message"
-            class="flex items-start gap-2 text-xs text-red-600 bg-red-50 rounded-lg p-2.5">
+          <!-- warocol.com#589 — unrecoverable rejection: factura ya validada en DIAN
+               pero la fila local no se pudo persistir. La emisión ya consumió
+               un número de la resolución; no tiene sentido reintentar. -->
+          <div v-if="isUnrecoverableRejection"
+            class="mx-5 mb-5 flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4 dark:bg-amber-950/20 dark:border-amber-800/40">
+            <svg class="w-5 h-5 mt-0.5 shrink-0 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
+            </svg>
+            <div class="min-w-0">
+              <p class="text-sm font-semibold text-amber-800 dark:text-amber-300">
+                Factura {{ invoiceData.prefix }}{{ invoiceData.invoice_number }} ya validada en DIAN
+              </p>
+              <p class="text-xs text-amber-700/90 dark:text-amber-400 mt-1 leading-relaxed">
+                DIAN tiene esta factura validada pero la información local quedó desincronizada.
+                Contacta soporte para reconciliar el documento — no la vuelvas a emitir, eso consumiría
+                otro número de la resolución sin éxito.
+              </p>
+            </div>
+          </div>
+
+          <!-- Error message for rejected (other reasons — retry is allowed elsewhere) -->
+          <div v-else-if="invoiceData.status === 'rejected' && invoiceData.error_message"
+            class="mx-5 mb-5 flex items-start gap-2 text-xs text-red-600 bg-red-50 rounded-lg p-2.5">
             <svg class="w-3.5 h-3.5 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"
               aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"


### PR DESCRIPTION
## Summary

Frontend half of the warocol.com#589 fix. Pairs with the backend PR in `api-warolabs#232`.

1. **`/ventas/{id}` rejected-state UX**: when the last electronic invoice attempt failed with the Matias \"ya validado\" signature, show an amber banner explaining the desync and pointing to support — instead of dumping the raw API error and inviting the cashier to retry. Retry on other rejection reasons (e.g., missing NIT) is unchanged.

2. **`/facturacion` form root-cause fix**: the create form pre-filled `current_number: 0`, which the backend allocator interpreted as \"next number = 1\", colliding with Matias' cross-resolution history of already-validated documents. Now:
   - `current_number` is initialised to `null` and the field is hidden on create. Backend (in the paired PR) seeds it to `from_number - 1` when null.
   - On edit, the field is visible but bounded by `[from_number - 1, to_number]` with inline validation + a hint showing the next number that will be emitted.
   - Save button disabled while the value is out of range.

## Stack
🟢 Nuxt 3 + 🎨 UX

## Changes
- `pages/ventas/[id].vue`: new `isUnrecoverableRejection` computed; conditional amber banner in the invoice block.
- `pages/facturacion.vue`: form state typed; `current_number` defaults to null, hidden on create, validated on edit; save button gated by validity.

## Testing (manual)
- [ ] Order with no invoice → \"Sin factura\" + emit button (unchanged).
- [ ] Order with `status=accepted` → existing details + PDF link (unchanged).
- [ ] Order with `status=rejected` + Matias \"ya validado\" message → **NEW** amber banner with invoice number and \"contacta soporte\" message. No retry button.
- [ ] Order with `status=rejected` + other message (e.g., missing NIT) → existing red error block; retry available elsewhere.
- [ ] `/facturacion` → click \"Nueva resolución\" → form **hides** the `current_number` field.
- [ ] Save without `current_number` → 201 (backend seeds it to `from_number - 1`).
- [ ] Edit an existing resolution → field visible with bounds + hint.
- [ ] Type a value below `from_number - 1` → field turns destructive, hint appears, save button disabled.

Closes #589 (frontend portion).