### PR TITLE
feat(facturacion): DIAN sequence-gaps audit page + range-burn alert + forward-only form clamp (#592)

### DIFF
--- a/pages/facturacion/audit.vue
+++ b/pages/facturacion/audit.vue
@@ -1,0 +1,278 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { useQueryCache } from '@pinia/colada'
+import { useFormatters } from '~/composables/useFormatters'
+import {
+  ExclamationTriangleIcon,
+  ArrowLeftIcon,
+  DocumentTextIcon,
+} from '@heroicons/vue/24/outline'
+import type { Column } from '~/components/ui/ResponsiveDataView.vue'
+
+definePageMeta({ layout: 'dashboard', module: 'mi_negocio' })
+useHead({ title: 'Bitácora de números quemados — DIAN' })
+
+const { currentTenant } = useTenantReactive()
+const router = useRouter()
+const route = useRoute()
+const { formatDate } = useFormatters()
+const cache = useQueryCache()
+
+const PAGE_SIZE = 50
+const currentPage = ref(1)
+const resolutionFilter = ref<string | null>(
+  typeof route.query.resolution_id === 'string' ? route.query.resolution_id : null,
+)
+
+watch(resolutionFilter, () => { currentPage.value = 1 })
+
+// Available resolutions for the filter dropdown
+const { data: resolutionsData } = useQuery({
+  key: () => ['tenant', 'dian-resolutions', currentTenant.value?.id],
+  query: () => $fetch<{ success: boolean; data: any[] }>('/api/api/tenant/dian-resolutions'),
+  enabled: () => !!currentTenant.value,
+  staleTime: 60_000,
+})
+const resolutions = computed(() => resolutionsData.value?.data ?? [])
+
+// Summary header
+const { data: summaryData, refetch: refetchSummary } = useQuery({
+  key: () => ['tenant', 'dian-gaps-summary', currentTenant.value?.id],
+  query: () => $fetch<{ success: boolean; data: { last_24h: number; last_7d: number; last_30d: number; total: number } }>(
+    '/api/api/tenant/dian-resolutions/gaps-summary',
+  ),
+  enabled: () => !!currentTenant.value,
+  staleTime: 60_000,
+})
+const summary = computed(() => summaryData.value?.data ?? null)
+
+// Paginated gaps
+const { data: gapsData, status: gapsStatus, asyncStatus: gapsAsync, refetch: refetchGaps } = useQuery({
+  key: () => ['tenant', 'dian-gaps', currentTenant.value?.id, {
+    limit: PAGE_SIZE,
+    offset: (currentPage.value - 1) * PAGE_SIZE,
+    resolution_id: resolutionFilter.value,
+  }],
+  query: () => {
+    const params: Record<string, any> = {
+      limit: PAGE_SIZE,
+      offset: (currentPage.value - 1) * PAGE_SIZE,
+    }
+    if (resolutionFilter.value) params.resolution_id = resolutionFilter.value
+    return $fetch<{ success: boolean; total: number; data: any[] }>('/api/api/tenant/dian-resolutions/gaps', { params })
+  },
+  enabled: () => !!currentTenant.value,
+  staleTime: 60_000,
+})
+
+const gaps = computed(() => gapsData.value?.data ?? [])
+const gapsTotal = computed(() => gapsData.value?.total ?? 0)
+const totalPages = computed(() => Math.ceil(gapsTotal.value / PAGE_SIZE) || 1)
+const isLoading = computed(() => gapsStatus.value === 'pending' && !gapsData.value)
+const isRefreshing = computed(() => gapsAsync.value === 'loading' && gapsData.value != null)
+
+const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
+const handleRefresh = async () => {
+  await Promise.all([refetchGaps(), refetchSummary()])
+}
+onMounted(() => { setRefreshHandler(handleRefresh) })
+onUnmounted(() => { clearRefreshHandler() })
+registerProgressiveLoading(isRefreshing)
+
+const goToPage = (page: number) => {
+  if (page >= 1 && page <= totalPages.value) currentPage.value = page
+}
+
+const columns = computed<Column[]>(() => [
+  { key: 'created_at', title: 'Cuándo', sortable: false },
+  { key: 'number', title: 'Número quemado', sortable: false },
+  { key: 'resolution_number', title: 'Resolución', sortable: false },
+  { key: 'reason', title: 'Motivo', sortable: false },
+  { key: 'original_order_number', title: 'Orden', sortable: false },
+])
+
+const reasonLabel = (reason: string) => {
+  const map: Record<string, string> = {
+    matias_ya_validado: 'Ya validado en DIAN',
+    matias_500: 'Error 5xx de Matias',
+    network_timeout: 'Timeout de red',
+  }
+  return map[reason] || reason
+}
+
+const reasonClass = (reason: string) => {
+  if (reason === 'matias_ya_validado') return 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
+  if (reason?.startsWith('matias_')) return 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+  return 'bg-surface-secondary text-text-secondary'
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <!-- Header / back -->
+    <div class="flex items-center gap-2">
+      <button
+        @click="router.push('/facturacion')"
+        class="min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg hover:bg-surface-secondary transition-colors"
+        aria-label="Volver a Facturación"
+      >
+        <ArrowLeftIcon class="w-5 h-5 text-text-secondary" aria-hidden="true" />
+      </button>
+      <div class="flex-1 min-w-0">
+        <h1 class="text-lg sm:text-xl font-semibold text-text-primary flex items-center gap-2">
+          <DocumentTextIcon class="w-5 h-5 text-primary flex-shrink-0" />
+          Bitácora de números quemados
+        </h1>
+        <p class="text-xs text-text-secondary mt-0.5 leading-snug">
+          Números retirados de la secuencia DIAN. Cada fila es un número que ya no puede reutilizarse —
+          la justificación auditable está en el motivo y la respuesta de Matias.
+        </p>
+      </div>
+    </div>
+
+    <!-- Summary tiles -->
+    <div v-if="summary" class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <div class="bg-surface border-2 border-border rounded-xl p-3">
+        <p class="text-[11px] uppercase tracking-wide text-text-tertiary font-semibold">Últimas 24h</p>
+        <p class="text-2xl font-bold text-text-primary tabular-nums mt-1">{{ summary.last_24h }}</p>
+      </div>
+      <div class="bg-surface border-2 border-border rounded-xl p-3">
+        <p class="text-[11px] uppercase tracking-wide text-text-tertiary font-semibold">Últimos 7 días</p>
+        <p class="text-2xl font-bold text-text-primary tabular-nums mt-1">{{ summary.last_7d }}</p>
+      </div>
+      <div class="bg-surface border-2 border-border rounded-xl p-3">
+        <p class="text-[11px] uppercase tracking-wide text-text-tertiary font-semibold">Últimos 30 días</p>
+        <p class="text-2xl font-bold text-text-primary tabular-nums mt-1">{{ summary.last_30d }}</p>
+      </div>
+      <div class="bg-surface border-2 border-border rounded-xl p-3">
+        <p class="text-[11px] uppercase tracking-wide text-text-tertiary font-semibold">Total histórico</p>
+        <p class="text-2xl font-bold text-text-primary tabular-nums mt-1">{{ summary.total }}</p>
+      </div>
+    </div>
+
+    <!-- Filter -->
+    <div class="flex flex-wrap items-center gap-3">
+      <select
+        v-model="resolutionFilter"
+        class="py-2 pl-3 pr-8 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer"
+        aria-label="Filtrar por resolución"
+      >
+        <option :value="null">Todas las resoluciones</option>
+        <option v-for="r in resolutions" :key="r.id" :value="r.id">
+          {{ r.prefix }} · {{ r.resolution_number }}
+        </option>
+      </select>
+      <span class="text-sm text-text-secondary ml-auto">
+        {{ gapsTotal }} {{ gapsTotal === 1 ? 'registro' : 'registros' }}
+      </span>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="isLoading" class="flex justify-center py-16">
+      <CommonsTheCustomLoader size="medium" />
+    </div>
+
+    <!-- Empty -->
+    <div v-else-if="gaps.length === 0" class="text-center py-16 space-y-3">
+      <DocumentTextIcon class="w-12 h-12 mx-auto text-text-tertiary" />
+      <p class="text-text-secondary">No hay números quemados</p>
+      <p class="text-sm text-text-tertiary">
+        Tu numeración DIAN no ha tenido descartes
+        <template v-if="resolutionFilter">en esta resolución</template>.
+      </p>
+    </div>
+
+    <!-- Table -->
+    <UiResponsiveDataView
+      v-else
+      :columns="columns"
+      :data="gaps"
+      row-key="id"
+    >
+      <template #cell-created_at="{ value }">
+        <span class="text-sm text-text-secondary">{{ value ? formatDate(value) : '—' }}</span>
+      </template>
+
+      <template #cell-number="{ row }">
+        <span class="font-bold text-text-primary tabular-nums">{{ row.prefix }}-{{ row.skipped_number }}</span>
+      </template>
+
+      <template #cell-resolution_number="{ row }">
+        <span class="text-sm text-text-secondary font-mono">
+          {{ row.resolution_number }}
+          <span class="text-text-tertiary">
+            ({{ row.from_number }}→{{ row.to_number }})
+          </span>
+        </span>
+      </template>
+
+      <template #cell-reason="{ value }">
+        <span
+          class="inline-flex items-center gap-1 text-xs font-bold px-2.5 py-1 rounded-full"
+          :class="reasonClass(value)"
+        >
+          <ExclamationTriangleIcon class="w-3 h-3" aria-hidden="true" />
+          {{ reasonLabel(value) }}
+        </span>
+      </template>
+
+      <template #cell-original_order_number="{ row }">
+        <NuxtLink
+          v-if="row.original_attempt_order_id"
+          :to="`/ventas/${row.original_attempt_order_id}`"
+          class="text-sm text-primary hover:underline"
+          @click.stop
+        >
+          {{ row.original_order_number || '—' }}
+        </NuxtLink>
+        <span v-else class="text-sm text-text-tertiary">—</span>
+      </template>
+
+      <template #mobile-card="{ row }">
+        <div class="bg-surface border border-border rounded-xl p-4 space-y-2">
+          <div class="flex items-center justify-between">
+            <span class="font-bold text-text-primary tabular-nums">{{ row.prefix }}-{{ row.skipped_number }}</span>
+            <span
+              class="inline-flex items-center gap-1 text-[11px] font-bold px-2 py-0.5 rounded-full"
+              :class="reasonClass(row.reason)"
+            >
+              {{ reasonLabel(row.reason) }}
+            </span>
+          </div>
+          <div class="flex items-center justify-between text-xs text-text-secondary">
+            <span class="font-mono">{{ row.resolution_number }}</span>
+            <span>{{ row.created_at ? formatDate(row.created_at) : '' }}</span>
+          </div>
+          <NuxtLink
+            v-if="row.original_attempt_order_id"
+            :to="`/ventas/${row.original_attempt_order_id}`"
+            class="block text-xs text-primary hover:underline"
+          >
+            Orden {{ row.original_order_number || row.original_attempt_order_id.substring(0, 8) }}
+          </NuxtLink>
+        </div>
+      </template>
+    </UiResponsiveDataView>
+
+    <!-- Pagination -->
+    <div v-if="!isLoading && totalPages > 1" class="flex items-center justify-between pt-2">
+      <button
+        @click="goToPage(currentPage - 1)"
+        :disabled="currentPage === 1"
+        class="min-h-[36px] px-3 py-1.5 text-sm font-medium rounded-lg border border-border bg-surface text-text-primary hover:bg-surface-secondary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        Anterior
+      </button>
+      <span class="text-sm text-text-secondary tabular-nums">
+        Página {{ currentPage }} de {{ totalPages }}
+      </span>
+      <button
+        @click="goToPage(currentPage + 1)"
+        :disabled="currentPage === totalPages"
+        class="min-h-[36px] px-3 py-1.5 text-sm font-medium rounded-lg border border-border bg-surface text-text-primary hover:bg-surface-secondary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        Siguiente
+      </button>
+    </div>
+  </div>
+</template>

--- a/pages/facturacion/index.vue
+++ b/pages/facturacion/index.vue
@@ -36,15 +36,25 @@ const { data: resolutionsData, asyncStatus: resAsyncStatus, refetch: refetchReso
 })
 const resolutions = computed(() => resolutionsData.value?.data ?? [])
 
+// DIAN sequence-gap summary — drives the range-burn alert (#592)
+const { data: gapsSummaryData, refetch: refetchGapsSummary } = useQuery({
+  key: () => ['tenant', 'dian-gaps-summary', currentTenant.value?.id],
+  query: () => $fetch<{ success: boolean; data: { last_24h: number; last_7d: number; last_30d: number; total: number } }>(
+    '/api/api/tenant/dian-resolutions/gaps-summary'
+  ),
+  enabled: () => !!currentTenant.value,
+  staleTime: 60_000,
+})
+const gapsSummary = computed(() => gapsSummaryData.value?.data ?? null)
+const hasRecentGaps = computed(() => (gapsSummary.value?.last_7d ?? 0) > 0)
+
 // Resolution form state
 const showResolutionForm = ref(false)
 const editingResolutionId = ref<string | null>(null)
 const isSavingResolution = ref(false)
-// warocol.com#589 — `current_number` initialised to null on create so the
-// backend seeds it to `from_number - 1` (the correct initial state for the
-// api-facturacion allocator). Sending 0 here was the root cause of the
-// "ya validado" bug: it forced the allocator to start at LZT1/LZT2 and
-// collide with Matias' cross-resolution history.
+// warocol.com#592 — stored value when opening edit. DIAN forbids rewinds,
+// so the form clamps `current_number` at or above this value.
+const editingStoredCurrentNumber = ref<number | null>(null)
 const resolutionForm = reactive<{
   resolution_number: string
   prefix: string
@@ -75,16 +85,24 @@ const resetResolutionForm = () => {
   resolutionForm.date_to = ''
   resolutionForm.document_type = 'invoice'
   editingResolutionId.value = null
+  editingStoredCurrentNumber.value = null
 }
 
-// warocol.com#589 — surface the same validation the backend enforces.
-// current_number must satisfy from_number - 1 <= current_number <= to_number,
-// otherwise the next emission will reuse already-validated DIAN numbers.
+// Forward-only floor: when editing, clamp at the stored value (#592).
+// Otherwise clamp at from_number - 1 (the allocator's initial state).
+const currentNumberFloor = computed(() => {
+  const fromFloor = (resolutionForm.from_number || 1) - 1
+  if (editingStoredCurrentNumber.value !== null) {
+    return Math.max(fromFloor, editingStoredCurrentNumber.value)
+  }
+  return fromFloor
+})
+
 const isCurrentNumberInvalid = computed(() => {
   if (resolutionForm.current_number === null) return false
   if (!resolutionForm.from_number || !resolutionForm.to_number) return false
   return (
-    resolutionForm.current_number < resolutionForm.from_number - 1 ||
+    resolutionForm.current_number < currentNumberFloor.value ||
     resolutionForm.current_number > resolutionForm.to_number
   )
 })
@@ -96,6 +114,7 @@ const openNewResolution = () => {
 
 const openEditResolution = (res: any) => {
   editingResolutionId.value = res.id
+  editingStoredCurrentNumber.value = res.current_number
   resolutionForm.resolution_number = res.resolution_number
   resolutionForm.prefix = res.prefix
   resolutionForm.from_number = res.from_number
@@ -166,7 +185,7 @@ const isRefreshing = computed(() =>
 )
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 const handleRefresh = async () => {
-  await Promise.all([refetchResolutions(), refetchStatus()])
+  await Promise.all([refetchResolutions(), refetchStatus(), refetchGapsSummary()])
 }
 onMounted(() => { setRefreshHandler(handleRefresh) })
 onUnmounted(() => { clearRefreshHandler() })
@@ -385,6 +404,31 @@ const taxLevels = [
         </button>
       </div>
 
+      <!-- Range-burn alert (#592) -->
+      <NuxtLink
+        v-if="hasRecentGaps"
+        to="/facturacion/audit"
+        class="block mb-4 rounded-lg border border-amber-200 bg-amber-50 p-3 hover:bg-amber-100/70 transition-colors dark:border-amber-700/40 dark:bg-amber-900/20 dark:hover:bg-amber-900/30"
+      >
+        <div class="flex items-start gap-3">
+          <ExclamationTriangleIcon class="w-5 h-5 text-amber-700 dark:text-amber-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
+          <div class="flex-1 min-w-0">
+            <p class="text-sm font-semibold text-amber-900 dark:text-amber-200">
+              Números quemados detectados en tu numeración
+            </p>
+            <p class="text-xs text-amber-800 dark:text-amber-300 mt-0.5 leading-snug">
+              <span class="font-semibold tabular-nums">{{ gapsSummary?.last_24h ?? 0 }}</span> en 24h ·
+              <span class="font-semibold tabular-nums">{{ gapsSummary?.last_7d ?? 0 }}</span> en 7d ·
+              <span class="font-semibold tabular-nums">{{ gapsSummary?.last_30d ?? 0 }}</span> en 30d.
+              DIAN no permite reutilizarlos — revisa la bitácora.
+            </p>
+          </div>
+          <svg class="w-4 h-4 text-amber-700 dark:text-amber-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+          </svg>
+        </div>
+      </NuxtLink>
+
       <!-- Empty state -->
       <div v-if="resolutions.length === 0 && !showResolutionForm" class="text-center py-8">
         <DocumentTextIcon class="w-10 h-10 mx-auto text-text-tertiary mb-2" />
@@ -424,7 +468,7 @@ const taxLevels = [
             <input
               v-model.number="resolutionForm.current_number"
               type="number"
-              :min="resolutionForm.from_number - 1"
+              :min="currentNumberFloor"
               :max="resolutionForm.to_number"
               :class="[
                 'min-h-[44px] px-3 py-2 border rounded-lg text-sm bg-background focus:outline-none focus:ring-2',
@@ -432,11 +476,11 @@ const taxLevels = [
               ]"
             />
             <p v-if="isCurrentNumberInvalid" class="text-xs text-destructive leading-snug">
-              Debe estar entre {{ resolutionForm.from_number - 1 }} y {{ resolutionForm.to_number }}. Valores
-              menores reusarían números ya emitidos en DIAN.
+              Debe estar entre {{ currentNumberFloor }} y {{ resolutionForm.to_number }}. DIAN
+              prohíbe reutilizar números — el contador solo avanza.
             </p>
             <p v-else class="text-[11px] text-text-tertiary leading-snug">
-              Próxima emisión usará {{ (resolutionForm.current_number ?? resolutionForm.from_number - 1) + 1 }}.
+              Próxima emisión usará {{ (resolutionForm.current_number ?? currentNumberFloor) + 1 }}.
             </p>
           </div>
           <div class="flex flex-col gap-1">


### PR DESCRIPTION
## Summary

Admin-facing surface for the DIAN sequence-gaps audit trail introduced in api-warolabs#233. When api-facturacion auto-skips a DIAN number (Matias "ya validado", network timeout, 5xx), the skip is logged in `dian_sequence_gaps` and **never reused** — DIAN forbids it. This PR exposes that audit trail to admins + tightens the resolution edit form.

## Changes

### `pages/facturacion/index.vue` (moved from `pages/facturacion.vue`)
- Range-burn alert banner above the resolutions list. Surfaces 24h / 7d / 30d counters from `GET /api/api/tenant/dian-resolutions/gaps-summary`. Links to `/facturacion/audit`. Only renders when `last_7d > 0`.
- Resolution edit form now clamps `current_number` at `MAX(from_number - 1, stored)`. The UI matches the DB-level forward-only invariant — users cannot lower the counter, only advance it.

### `pages/facturacion/audit.vue` (new, `module: mi_negocio`)
- Four summary tiles (24h / 7d / 30d / total).
- Filter dropdown by resolution.
- Paginated `UiResponsiveDataView` (50/page). Columns: cuándo · número quemado · resolución · motivo (badge) · orden original (deep-links to `/ventas/{id}`).
- Mobile-friendly card layout via `#mobile-card` slot.

### Routing
- Renamed `pages/facturacion.vue` → `pages/facturacion/index.vue` so `/facturacion/audit` resolves cleanly as a sibling route (no `<NuxtPage>` wrapper needed on the parent).
- `/facturacion` still serves the index — verified the navigation/sidebar/`/403` references all point to `/facturacion` (no hard-coded file paths).

## Out of scope

- The retry loop that *produces* gap rows lives in api-facturacion (separate repo).
- Backend schema + endpoints land in api-warolabs#233.

## Test plan

- [x] `bun run build` clean.
- [ ] `/facturacion` renders index identically to before the move; no banner when `last_7d === 0`.
- [ ] When gaps exist, banner links to `/facturacion/audit` and counters match the summary endpoint.
- [ ] `/facturacion/audit` paginates correctly with >50 rows.
- [ ] Filter by `resolution_id` narrows the table.
- [ ] Mobile (<640px) renders cards, not the table.
- [ ] Resolution edit form rejects `current_number < stored`; "Próxima emisión usará …" preview is accurate.
- [ ] Non-admin (no `mi_negocio`) → 403 redirect.

Closes warocol.com#592 (frontend surface).