### PR TITLE
feat(ventas): send-invoice-by-email modal on /ventas/{id} (#598)

### DIFF
--- a/components/ventas/InvoiceEmailModal.vue
+++ b/components/ventas/InvoiceEmailModal.vue
@@ -1,0 +1,323 @@
+<template>
+  <UiModal :model-value="open" :title="title" @update:model-value="$emit('update:open', $event)">
+    <component :is="contentTemplate" />
+  </UiModal>
+  <UiBottomSheetModal :model-value="open" :title="title" @update:model-value="$emit('update:open', $event)">
+    <component :is="contentTemplate" />
+  </UiBottomSheetModal>
+</template>
+
+<script setup lang="ts">
+import { computed, h, ref, watch } from 'vue'
+import {
+  EnvelopeIcon,
+  ExclamationTriangleIcon,
+  CheckCircleIcon,
+} from '@heroicons/vue/24/outline'
+
+interface Customer {
+  email?: string | null
+  phone?: string | null
+  name?: string | null
+}
+
+interface Props {
+  open: boolean
+  trackId: string
+  invoiceLabel: string  // e.g. "LZT-5462" for the modal copy
+  customer: Customer | null
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{
+  (e: 'update:open', v: boolean): void
+  (e: 'sent', email: string): void
+}>()
+
+const title = 'Enviar factura por correo'
+
+// warocol.com#598 — A profile is "generic" (no useful email to prefill) when
+// either the phone is '0000000000' (per-tenant default Genérico) OR the email
+// ends in '@customer.temp' (auto-created POS walk-in). Both signals are used
+// elsewhere in the codebase — see pages/pos/checkout.vue:440,614.
+const isGenericCustomer = computed(() => {
+  const c = props.customer
+  if (!c) return true
+  const phoneIsZero = (c.phone ?? '') === '0000000000'
+  const tempEmail = (c.email ?? '').toLowerCase().endsWith('@customer.temp')
+  return phoneIsZero || tempEmail
+})
+
+const customerEmail = computed(() => props.customer?.email ?? '')
+
+type Mode = 'customer' | 'custom'
+const mode = ref<Mode>('customer')
+const customEmail = ref('')
+
+type State = 'idle' | 'sending' | 'sent' | 'error'
+const state = ref<State>('idle')
+const errorMessage = ref('')
+const sentToEmail = ref('')
+
+const resetForm = () => {
+  state.value = 'idle'
+  errorMessage.value = ''
+  sentToEmail.value = ''
+  if (isGenericCustomer.value) {
+    mode.value = 'custom'
+    customEmail.value = ''
+  } else {
+    mode.value = 'customer'
+    customEmail.value = customerEmail.value
+  }
+}
+
+watch(() => props.open, (isOpen) => {
+  if (isOpen) resetForm()
+})
+
+const canSubmit = computed(() => {
+  if (state.value === 'sending') return false
+  if (mode.value === 'customer') return !!customerEmail.value
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(customEmail.value)
+})
+
+const submit = async () => {
+  if (!canSubmit.value) return
+  state.value = 'sending'
+  errorMessage.value = ''
+  try {
+    if (mode.value === 'customer') {
+      await $fetch(`/api/api/documents/${props.trackId}/resend-email`, { method: 'POST' })
+      sentToEmail.value = customerEmail.value
+    } else {
+      await $fetch(`/api/api/documents/${props.trackId}/send-email-to`, {
+        method: 'POST',
+        body: { email: customEmail.value },
+      })
+      sentToEmail.value = customEmail.value
+    }
+    state.value = 'sent'
+    emit('sent', sentToEmail.value)
+  } catch (e: any) {
+    state.value = 'error'
+    const detail = e?.data?.detail
+    if (Array.isArray(detail)) {
+      errorMessage.value = detail.map((d: any) => d?.msg || JSON.stringify(d)).join(', ')
+    } else if (typeof detail === 'string') {
+      errorMessage.value = detail
+    } else {
+      errorMessage.value = e?.message || 'No se pudo enviar la factura. Intentá nuevamente.'
+    }
+  }
+}
+
+const sendAnother = () => {
+  state.value = 'idle'
+  errorMessage.value = ''
+  // Pre-fill custom mode with the just-sent address as a convenience.
+  if (mode.value === 'custom') customEmail.value = ''
+}
+
+const cancel = () => emit('update:open', false)
+
+// Shared template body rendered once and slotted into both modal frames.
+// Avoids duplicating ~80 lines of JSX in the SFC template.
+const contentTemplate = () =>
+  h('div', { class: 'p-5 sm:p-6 space-y-5' }, [
+    // ─── Success ────────────────────────────────────────────────────────────
+    state.value === 'sent'
+      ? h('div', { class: 'space-y-4' }, [
+          h(
+            'div',
+            { class: 'flex items-start gap-3 rounded-xl border border-green-200 bg-green-50 p-4 dark:border-green-700/40 dark:bg-green-900/20' },
+            [
+              h(CheckCircleIcon, { class: 'w-5 h-5 text-green-700 dark:text-green-400 flex-shrink-0 mt-0.5', 'aria-hidden': 'true' }),
+              h('div', { class: 'min-w-0' }, [
+                h('p', { class: 'text-sm font-semibold text-green-900 dark:text-green-200' }, 'Factura enviada'),
+                h(
+                  'p',
+                  { class: 'text-xs text-green-800 dark:text-green-300 mt-0.5 leading-snug break-all' },
+                  `Se envió ${props.invoiceLabel} a ${sentToEmail.value}.`,
+                ),
+              ]),
+            ],
+          ),
+          h('div', { class: 'flex flex-col sm:flex-row gap-2 sm:justify-end' }, [
+            h(
+              'button',
+              {
+                onClick: cancel,
+                class: 'order-2 sm:order-1 min-h-[44px] px-4 py-2 rounded-xl text-sm font-semibold bg-surface border border-border text-text-primary hover:bg-surface-secondary transition-colors',
+              },
+              'Cerrar',
+            ),
+            h(
+              'button',
+              {
+                onClick: sendAnother,
+                class: 'order-1 sm:order-2 min-h-[44px] px-4 py-2 rounded-xl text-sm font-semibold bg-primary text-primary-foreground hover:bg-primary/90 transition-colors',
+              },
+              'Enviar otra copia',
+            ),
+          ]),
+        ])
+      : null,
+
+    // ─── Form (idle / sending / error) ──────────────────────────────────────
+    state.value !== 'sent'
+      ? h('div', { class: 'space-y-4' }, [
+          // Generic-customer hint banner
+          isGenericCustomer.value
+            ? h(
+                'div',
+                { class: 'flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3 dark:border-amber-700/40 dark:bg-amber-900/20' },
+                [
+                  h(ExclamationTriangleIcon, { class: 'w-4 h-4 text-amber-700 dark:text-amber-400 flex-shrink-0 mt-0.5', 'aria-hidden': 'true' }),
+                  h(
+                    'p',
+                    { class: 'text-xs text-amber-800 dark:text-amber-300 leading-snug' },
+                    'Cliente genérico — sin correo en archivo. Indicá un destinatario.',
+                  ),
+                ],
+              )
+            : null,
+
+          // Option 1 — customer email (only for real customers)
+          !isGenericCustomer.value
+            ? h(
+                'button',
+                {
+                  type: 'button',
+                  onClick: () => { mode.value = 'customer' },
+                  class: [
+                    'w-full flex items-start gap-3 p-4 rounded-xl border-2 text-left transition-all min-h-[44px]',
+                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+                    mode.value === 'customer'
+                      ? 'border-primary bg-primary/5'
+                      : 'border-border bg-background hover:border-primary/30 hover:bg-surface-secondary/60',
+                  ],
+                  'aria-pressed': mode.value === 'customer',
+                },
+                [
+                  h(
+                    'span',
+                    {
+                      class: [
+                        'mt-0.5 h-4 w-4 flex-shrink-0 rounded-full border-2 transition-colors',
+                        mode.value === 'customer' ? 'border-primary bg-primary' : 'border-border bg-background',
+                      ],
+                      'aria-hidden': 'true',
+                    },
+                  ),
+                  h('div', { class: 'min-w-0 flex-1' }, [
+                    h('p', { class: 'text-sm font-semibold text-text-primary' }, 'Correo del cliente'),
+                    h(
+                      'p',
+                      { class: 'text-xs text-text-secondary mt-0.5 break-all' },
+                      customerEmail.value,
+                    ),
+                  ]),
+                ],
+              )
+            : null,
+
+          // Option 2 — custom email
+          !isGenericCustomer.value
+            ? h(
+                'button',
+                {
+                  type: 'button',
+                  onClick: () => { mode.value = 'custom' },
+                  class: [
+                    'w-full flex items-start gap-3 p-4 rounded-xl border-2 text-left transition-all min-h-[44px]',
+                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+                    mode.value === 'custom'
+                      ? 'border-primary bg-primary/5'
+                      : 'border-border bg-background hover:border-primary/30 hover:bg-surface-secondary/60',
+                  ],
+                  'aria-pressed': mode.value === 'custom',
+                },
+                [
+                  h(
+                    'span',
+                    {
+                      class: [
+                        'mt-0.5 h-4 w-4 flex-shrink-0 rounded-full border-2 transition-colors',
+                        mode.value === 'custom' ? 'border-primary bg-primary' : 'border-border bg-background',
+                      ],
+                      'aria-hidden': 'true',
+                    },
+                  ),
+                  h('div', { class: 'min-w-0 flex-1' }, [
+                    h('p', { class: 'text-sm font-semibold text-text-primary' }, 'Otro correo'),
+                    h(
+                      'p',
+                      { class: 'text-xs text-text-secondary mt-0.5' },
+                      'Enviar a una dirección distinta',
+                    ),
+                  ]),
+                ],
+              )
+            : null,
+
+          // Custom input (visible when custom mode OR generic customer)
+          mode.value === 'custom' || isGenericCustomer.value
+            ? h('div', { class: 'flex flex-col gap-1.5' }, [
+                h(
+                  'label',
+                  { for: 'invoice-email-custom', class: 'text-sm font-medium text-text-primary' },
+                  'Correo del destinatario',
+                ),
+                h('input', {
+                  id: 'invoice-email-custom',
+                  type: 'email',
+                  inputmode: 'email',
+                  autocomplete: 'email',
+                  placeholder: 'contador@empresa.com',
+                  value: customEmail.value,
+                  onInput: (e: Event) => { customEmail.value = (e.target as HTMLInputElement).value },
+                  class: 'min-h-[44px] px-3 py-2 border border-border rounded-xl text-sm bg-background text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary',
+                }),
+              ])
+            : null,
+
+          // Error
+          state.value === 'error' && errorMessage.value
+            ? h(
+                'div',
+                { class: 'flex items-start gap-2 rounded-xl border border-destructive/30 bg-destructive/5 p-3 text-destructive', role: 'alert' },
+                [
+                  h(ExclamationTriangleIcon, { class: 'w-4 h-4 flex-shrink-0 mt-0.5', 'aria-hidden': 'true' }),
+                  h('p', { class: 'text-xs leading-snug break-words' }, errorMessage.value),
+                ],
+              )
+            : null,
+
+          // Actions
+          h('div', { class: 'flex flex-col sm:flex-row gap-2 sm:justify-end pt-2' }, [
+            h(
+              'button',
+              {
+                onClick: cancel,
+                disabled: state.value === 'sending',
+                class: 'order-2 sm:order-1 min-h-[44px] px-4 py-2 rounded-xl text-sm font-semibold bg-surface border border-border text-text-primary hover:bg-surface-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
+              },
+              'Cancelar',
+            ),
+            h(
+              'button',
+              {
+                onClick: submit,
+                disabled: !canSubmit.value,
+                class: 'order-1 sm:order-2 min-h-[44px] px-4 py-2 rounded-xl text-sm font-semibold bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center justify-center gap-2',
+              },
+              state.value === 'sending'
+                ? 'Enviando…'
+                : [h(EnvelopeIcon, { class: 'w-4 h-4', 'aria-hidden': 'true' }), 'Enviar'],
+            ),
+          ]),
+        ])
+      : null,
+  ])
+</script>

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -95,6 +95,13 @@ const isEmittingInvoice = ref(false)
 const emitInvoiceError = ref('')
 const copiedCufe = ref(false)
 
+// warocol.com#598 — invoice email modal trigger
+const showEmailModal = ref(false)
+const toast = useToast()
+const onInvoiceEmailSent = (email: string) => {
+  toast.success(`Factura enviada a ${email}`, { title: 'Enviado' })
+}
+
 // warocol.com#589 — detect the "ya validado" un-recoverable case so the UI
 // shows a clearer support-action banner instead of dumping the raw Matias
 // error and confusing the cashier into clicking emit again.
@@ -615,7 +622,7 @@ onUnmounted(() => {
               </div>
             </div>
 
-            <!-- Col 2: Descargar -->
+            <!-- Col 2: Descargar / Enviar -->
             <div class="p-5 flex flex-col justify-start">
               <h3 class="text-sm font-bold text-text-primary mb-4">Descargar</h3>
               <div class="flex-1 flex flex-col justify-start gap-3 w-full h-fit">
@@ -631,6 +638,16 @@ onUnmounted(() => {
                   </svg>
                   Descargar PDF
                 </a>
+                <button v-if="invoiceData.status === 'accepted'"
+                  type="button"
+                  @click="showEmailModal = true"
+                  class="w-full inline-flex items-center justify-center gap-2 min-h-[44px] px-4 py-3 rounded-xl text-sm font-semibold border border-primary/20 text-primary hover:bg-primary/5 transition-colors">
+                  <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8"
+                      d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
+                  </svg>
+                  Enviar por correo
+                </button>
                 <p v-else class="text-xs text-text-tertiary">
                   Disponible cuando la factura esté aceptada.
                 </p>
@@ -1138,6 +1155,15 @@ onUnmounted(() => {
       </Transition>
     </Teleport>
 
+    <!-- warocol.com#598 — send-invoice-by-email modal -->
+    <VentasInvoiceEmailModal
+      v-if="invoiceData"
+      v-model:open="showEmailModal"
+      :track-id="invoiceData.id"
+      :invoice-label="`${invoiceData.prefix}-${invoiceData.invoice_number}`"
+      :customer="orderData?.customer ?? null"
+      @sent="onInvoiceEmailSent"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary

Adds an "Enviar por correo" action on the invoice card in `/ventas/{id}`. Opens a responsive modal letting the operator email the DIAN invoice to either the customer-of-record (via api-warolabs `resend-email`) or a custom recipient like the accountant (via `send-email-to`). Generic customers (per-tenant default Genérico or POS walk-ins) skip the customer-email option entirely and go straight to a custom-input form with an amber hint.

Pairs with **api-warolabs#235** (the backend half) — that PR has to ship first or the modal will hit 503s.

## Stack
🟢 Nuxt 3 + 🎨 UX

## Changes

### `components/ventas/InvoiceEmailModal.vue` (new)
- Dual-frame mount: `UiModal` (desktop ≥md) + `UiBottomSheetModal` (mobile <md). Both bound to the same `v-model:open`. Internal `hidden md:flex` / `md:hidden` guards keep only one visible per breakpoint.
- Generic detection: `phone === '0000000000' || email.endsWith('@customer.temp')` (mirrors `pages/pos/checkout.vue:440,614`).
- Modes:
  - **customer** — read-only chip with the customer email, no input.
  - **custom** — labelled email input prefilled with the customer email (or empty for generics), client-side regex check on submit gate.
- States: `idle` → `sending` (button disabled, "Enviando…") → `sent` (in-modal success banner + "Enviar otra copia" + "Cerrar") OR `error` (inline destructive banner with icon, modal stays open). No time-based auto-close.
- Submit dispatches:
  - customer mode → `POST /api/api/documents/{trackId}/resend-email`
  - custom mode → `POST /api/api/documents/{trackId}/send-email-to` body `{email}`

### `pages/ventas/[id].vue`
- New `showEmailModal` ref + `onInvoiceEmailSent` toast handler.
- "Enviar por correo" button injected next to the existing `Descargar PDF` button in the invoice card. Only renders when `invoiceData.status === 'accepted'`.
- Modal mounted at the bottom of the template (`v-if="invoiceData"`) wired to `orderData.customer`.

## UX rules applied
- Touch targets ≥44px on every interactive element.
- Persistent `<label>` on the custom email input — no placeholder-only fields. Source: [nngroup.com/articles/form-design-placeholders](https://www.nngroup.com/articles/form-design-placeholders/).
- Inline error has icon + text (`ExclamationTriangleIcon` paired with the destructive text) — not color-only. Source: [webaim.org/techniques/forms](https://webaim.org/techniques/forms/).
- Focus visible via `focus-visible:ring-2 focus-visible:ring-primary/40` on option cards.
- Spacing in 4px multiples (`gap-2/3`, `p-3/4/5`).
- Disabled state with explanatory copy ("Disponible cuando la factura esté aceptada") mirroring the existing PDF button.

## Test Plan

- [x] `bun run build` clean.
- [ ] After deploy: `/ventas/36285f8f-5a00-4009-9351-13e1a48262d3` (Genérico) → modal opens in custom-only mode, no "Correo del cliente" option.
- [ ] Different order with a real customer email → both options shown, "Correo del cliente" preselected, switching to "Otro correo" prefills the input editable.
- [ ] Submit → backend 200 → success banner + toast → "Enviar otra copia" resets to form.
- [ ] Submit with invalid email → backend 422 → error banner in modal, no toast.
- [ ] Try while `status='rejected'` → button absent.
- [ ] Mobile (<640px) → bottom-sheet variant renders.

## Closes
warocol.com#598.