### PR TITLE
feat(menu/categorias): CRUD page with slide-over panel and cascade-aware delete (#600)

### DIFF
--- a/components/menu/CategoryPanel.vue
+++ b/components/menu/CategoryPanel.vue
@@ -1,0 +1,270 @@
+<template>
+  <Teleport to="body">
+    <!-- Backdrop -->
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-200"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="modelValue"
+        class="fixed inset-0 z-40 bg-black/40"
+        @click="close"
+        aria-hidden="true"
+      />
+    </Transition>
+
+    <!-- Panel: bottom sheet on mobile, slide-over on desktop -->
+    <Transition name="panel">
+      <div
+        v-if="modelValue"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="isEdit ? `Editar categoría: ${category?.name}` : 'Crear categoría'"
+        class="fixed z-50 flex flex-col bg-surface shadow-2xl
+               inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh]
+               md:inset-y-0 md:right-0 md:bottom-auto md:left-auto md:inset-x-auto md:rounded-none md:w-full md:max-w-md md:max-h-none md:h-full"
+      >
+        <!-- Mobile drag handle -->
+        <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
+          <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+        </div>
+
+        <!-- Header -->
+        <div class="flex-shrink-0 bg-surface-secondary/40 border-b border-border px-6 py-4">
+          <div class="flex items-start justify-between gap-3">
+            <div class="flex items-center gap-3 min-w-0 flex-1">
+              <div class="flex-shrink-0 w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
+                <TagIcon class="w-5 h-5" />
+              </div>
+              <div class="min-w-0">
+                <h2 class="text-base font-bold text-text-primary leading-tight">
+                  {{ isEdit ? 'Editar categoría' : 'Nueva categoría' }}
+                </h2>
+                <p class="text-xs text-text-secondary leading-snug mt-0.5">
+                  {{ isEdit ? category?.name : 'Agrupa productos para tu menú y comandas' }}
+                </p>
+              </div>
+            </div>
+            <button
+              @click="close"
+              type="button"
+              aria-label="Cerrar panel"
+              :disabled="saving"
+              class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50 transition-colors"
+            >
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- Scrollable body -->
+        <div class="flex-1 overflow-y-auto px-6 py-5 space-y-4">
+          <!-- Nombre -->
+          <div class="flex flex-col gap-1.5">
+            <label :for="nameId" class="text-sm font-medium text-text-primary">
+              Nombre <span class="text-destructive">*</span>
+            </label>
+            <input
+              :id="nameId"
+              ref="nameInput"
+              v-model="form.name"
+              type="text"
+              maxlength="100"
+              placeholder="Ej: Entradas, Bebidas, Postres..."
+              :class="inputClass"
+              @input="clearError('name')"
+              @keydown.enter.prevent="submit"
+            />
+            <p v-if="errors.name" class="text-xs text-destructive">{{ errors.name }}</p>
+          </div>
+
+          <!-- Descripción -->
+          <div class="flex flex-col gap-1.5">
+            <label :for="descId" class="text-sm font-medium text-text-primary">
+              Descripción
+              <span class="text-xs text-text-secondary font-normal">(opcional)</span>
+            </label>
+            <textarea
+              :id="descId"
+              v-model="form.description"
+              rows="3"
+              maxlength="500"
+              placeholder="Texto interno para identificar la categoría"
+              class="input-base w-full px-4 py-2 resize-none"
+            />
+          </div>
+
+          <!-- General error -->
+          <p v-if="errors.general" class="text-sm text-destructive">{{ errors.general }}</p>
+        </div>
+
+        <!-- Sticky footer -->
+        <div class="flex-shrink-0 border-t border-border bg-surface px-6 py-4">
+          <div class="flex flex-col-reverse sm:flex-row gap-2">
+            <button
+              type="button"
+              :disabled="saving"
+              class="flex-1 min-h-[44px] py-3 px-4 border-2 border-border rounded-lg text-text-primary font-medium hover:bg-background focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed active:scale-95 transition-all"
+              @click="close"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              :disabled="saving || !form.name.trim()"
+              class="flex-1 min-h-[44px] py-3 px-4 bg-primary text-primary-foreground rounded-lg font-semibold hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-60 disabled:cursor-not-allowed active:scale-95 transition-all flex items-center justify-center gap-2"
+              @click="submit"
+            >
+              <UiLoadingDots v-if="saving" size="8px" color="currentColor" />
+              <span>{{ saving ? 'Guardando...' : (isEdit ? 'Guardar cambios' : 'Crear categoría') }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { TagIcon } from '@heroicons/vue/24/outline'
+
+interface Category {
+  id: string
+  name: string
+  description: string | null
+  tenant_id: string | null
+}
+
+interface Props {
+  modelValue: boolean
+  category?: Category | null
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  category: null,
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'saved', category: Category): void
+}>()
+
+const isEdit = computed(() => !!props.category)
+
+const uid = useId()
+const nameId = `cat-panel-name-${uid}`
+const descId = `cat-panel-desc-${uid}`
+
+const inputClass = 'input-base w-full px-4 py-2'
+
+const form = ref<{ name: string; description: string }>({
+  name: '',
+  description: '',
+})
+
+const saving = ref(false)
+const errors = ref<Record<string, string>>({})
+
+const nameInput = ref<HTMLInputElement | null>(null)
+
+const clearError = (field: string) => {
+  delete errors.value[field]
+  delete errors.value.general
+}
+
+const resetForm = () => {
+  form.value = {
+    name: props.category?.name ?? '',
+    description: props.category?.description ?? '',
+  }
+  errors.value = {}
+}
+
+watch(
+  () => props.modelValue,
+  async (open) => {
+    if (!open) return
+    resetForm()
+    await nextTick()
+    nameInput.value?.focus()
+  },
+)
+
+watch(
+  () => props.category,
+  () => {
+    if (props.modelValue) resetForm()
+  },
+)
+
+const close = () => {
+  if (saving.value) return
+  emit('update:modelValue', false)
+}
+
+const submit = async () => {
+  const name = form.value.name.trim()
+  if (!name) {
+    errors.value = { name: 'El nombre es obligatorio' }
+    return
+  }
+
+  saving.value = true
+  errors.value = {}
+  try {
+    const description = form.value.description.trim() || null
+    const payload: Record<string, unknown> = { name }
+    if (description !== null || isEdit.value) payload.description = description
+
+    const response = isEdit.value
+      ? await $fetch<{ success: boolean; data: Category }>(
+          `/api/menu/categories/${props.category!.id}`,
+          { method: 'PUT', body: payload },
+        )
+      : await $fetch<{ success: boolean; data: Category }>(
+          '/api/menu/categories',
+          { method: 'POST', body: payload },
+        )
+
+    emit('saved', response.data)
+    emit('update:modelValue', false)
+  } catch (err: any) {
+    if (err?.status === 409) {
+      const detail = err?.data?.detail
+      errors.value = {
+        name: typeof detail === 'string' ? detail : 'Ya existe una categoría con ese nombre',
+      }
+    } else {
+      errors.value = {
+        general: err?.data?.detail || 'No se pudo guardar la categoría. Inténtalo de nuevo.',
+      }
+    }
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style scoped>
+.panel-enter-active,
+.panel-leave-active {
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+.panel-enter-from,
+.panel-leave-to {
+  opacity: 0;
+  transform: translateY(100%);
+}
+@media (min-width: 768px) {
+  .panel-enter-from,
+  .panel-leave-to {
+    transform: translateX(100%);
+  }
+}
+</style>

--- a/pages/menu.vue
+++ b/pages/menu.vue
@@ -35,7 +35,8 @@ const navigationItems = [
   { to: '/menu/recetas', label: 'Recetas', matchPath: '/menu/recetas' },
   { to: '/menu/productos', label: 'Productos' },
   { to: '/menu/reventa', label: 'Reventa', matchPath: '/menu/reventa' },
-  { to: '/menu/modificadores', label: 'Modificadores', matchPath: '/menu/modificadores' }
+  { to: '/menu/modificadores', label: 'Modificadores', matchPath: '/menu/modificadores' },
+  { to: '/menu/categorias', label: 'Categorías', matchPath: '/menu/categorias' }
 ]
 
 // Meta tags

--- a/pages/menu/categorias/index.vue
+++ b/pages/menu/categorias/index.vue
@@ -1,0 +1,287 @@
+<template>
+  <div class="px-3 md:px-4 py-4 space-y-4">
+    <!-- Header -->
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h1 class="text-lg sm:text-xl font-bold text-text-primary">Categorías</h1>
+        <p class="text-sm text-text-secondary mt-0.5">
+          Agrupa productos del menú y enruta comandas por categoría.
+        </p>
+      </div>
+      <button
+        type="button"
+        class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap min-h-[44px]"
+        @click="openCreatePanel"
+      >
+        + Nueva categoría
+      </button>
+    </div>
+
+    <!-- List -->
+    <UiResponsiveDataView
+      :columns="columns"
+      :data="categories"
+      :loading="isLoading"
+      empty-message="No hay categorías"
+      empty-sub-message="Crea la primera para organizar tu menú."
+      variant="default"
+      row-size="sm"
+    >
+      <!-- Mobile Card -->
+      <template #card="{ item }">
+        <div class="flex items-center gap-3 py-3 px-3 border-b border-border bg-surface">
+          <div class="flex-shrink-0 w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
+            <TagIcon class="w-4 h-4" />
+          </div>
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 flex-wrap">
+              <span class="text-sm font-semibold text-text-primary">{{ item.name }}</span>
+              <span
+                v-if="item.tenant_id === null"
+                class="text-xs font-medium px-2 py-0.5 rounded-full bg-text-secondary/10 text-text-secondary"
+              >
+                Global
+              </span>
+            </div>
+            <p v-if="item.description" class="text-xs text-text-secondary mt-0.5 truncate">{{ item.description }}</p>
+          </div>
+          <div class="flex items-center gap-1 flex-shrink-0">
+            <button
+              v-if="item.tenant_id !== null"
+              type="button"
+              :aria-label="`Editar categoría ${item.name}`"
+              class="min-h-[44px] min-w-[44px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
+              @click.stop="openEditPanel(item)"
+            >
+              <PencilSquareIcon class="w-5 h-5" />
+            </button>
+            <button
+              v-if="item.tenant_id !== null"
+              type="button"
+              :aria-label="`Eliminar categoría ${item.name}`"
+              class="min-h-[44px] min-w-[44px] inline-flex items-center justify-center rounded-lg text-destructive hover:bg-destructive/10 focus:outline-none focus:ring-2 focus:ring-destructive/30 transition-colors"
+              @click.stop="requestDelete(item)"
+            >
+              <TrashIcon class="w-5 h-5" />
+            </button>
+          </div>
+        </div>
+      </template>
+
+      <!-- Desktop cells -->
+      <template #cell-name="{ value, item }">
+        <div class="flex items-center gap-2">
+          <span class="text-sm font-medium text-text-primary">{{ value }}</span>
+          <span
+            v-if="item.tenant_id === null"
+            class="text-xs font-medium px-2 py-0.5 rounded-full bg-text-secondary/10 text-text-secondary"
+          >
+            Global
+          </span>
+        </div>
+      </template>
+
+      <template #cell-description="{ value }">
+        <span class="text-sm text-text-secondary">{{ value || '—' }}</span>
+      </template>
+
+      <template #cell-actions="{ item }">
+        <div class="flex items-center justify-end gap-1">
+          <button
+            v-if="item.tenant_id !== null"
+            type="button"
+            :aria-label="`Editar categoría ${item.name}`"
+            class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
+            @click="openEditPanel(item)"
+          >
+            <PencilSquareIcon class="w-4 h-4" />
+          </button>
+          <button
+            v-if="item.tenant_id !== null"
+            type="button"
+            :aria-label="`Eliminar categoría ${item.name}`"
+            class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-destructive hover:bg-destructive/10 focus:outline-none focus:ring-2 focus:ring-destructive/30 transition-colors"
+            @click="requestDelete(item)"
+          >
+            <TrashIcon class="w-4 h-4" />
+          </button>
+          <span v-if="item.tenant_id === null" class="text-xs text-text-tertiary px-2">Solo lectura</span>
+        </div>
+      </template>
+    </UiResponsiveDataView>
+
+    <!-- Create/Edit slide-over -->
+    <MenuCategoryPanel
+      v-model="panelOpen"
+      :category="panelCategory"
+      @saved="onSaved"
+    />
+
+    <!-- Delete confirm -->
+    <UiConfirmActionModal
+      v-model="confirmOpen"
+      :title="confirmTitle"
+      :message="confirmMessage"
+      confirm-label="Eliminar"
+      loading-label="Eliminando..."
+      variant="destructive"
+      :loading="isDeleting"
+      @confirm="performDelete"
+    />
+
+    <!-- Error modal -->
+    <UiErrorAlertModal
+      v-model="errorModal.open"
+      :title="errorModal.title"
+      :message="errorModal.message"
+      :dependents="errorModal.dependents"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { TagIcon, PencilSquareIcon, TrashIcon } from '@heroicons/vue/24/outline'
+
+definePageMeta({
+  // layout: 'dashboard' — inherited from parent menu.vue
+  // module gating: inherited as 'menu' from parent menu.vue
+})
+
+useHead({ title: 'Categorías' })
+
+interface Category {
+  id: string
+  name: string
+  description: string | null
+  tenant_id: string | null
+  created_at?: string
+  updated_at?: string
+}
+
+interface ErrorModalDependent {
+  label: string
+  count: number
+}
+
+const { currentTenant } = useTenantReactive()
+const cache = useQueryCache()
+
+const columns = [
+  { key: 'name', title: 'Nombre' },
+  { key: 'description', title: 'Descripción' },
+  { key: 'actions', title: '', align: 'right' as const },
+]
+
+const { data: categoriesData, status: queryStatus } = useQuery({
+  key: () => ['tenant', 'menu-categories', currentTenant.value?.id ?? null],
+  query: () => $fetch<{ success: boolean; data: Category[] }>('/api/menu/categories'),
+  enabled: () => !!currentTenant.value,
+  staleTime: 30_000,
+})
+
+const categories = computed<Category[]>(() => categoriesData.value?.data ?? [])
+const isLoading = computed(() => queryStatus.value === 'pending')
+
+// ── Slide-over (create/edit) ────────────────────────────────────────────
+const panelOpen = ref(false)
+const panelCategory = ref<Category | null>(null)
+
+const openCreatePanel = () => {
+  panelCategory.value = null
+  panelOpen.value = true
+}
+
+const openEditPanel = (cat: Record<string, any>) => {
+  panelCategory.value = cat as Category
+  panelOpen.value = true
+}
+
+const invalidateConsumers = async () => {
+  await cache.invalidateQueries({ key: ['tenant', 'menu-categories'] })
+  await cache.invalidateQueries({ key: ['tenant', 'category-stations'] })
+}
+
+const onSaved = async () => {
+  await invalidateConsumers()
+}
+
+// ── Delete flow ─────────────────────────────────────────────────────────
+const confirmOpen = ref(false)
+const confirmTitle = ref('')
+const confirmMessage = ref('')
+const isDeleting = ref(false)
+const pendingDelete = ref<Category | null>(null)
+
+const errorModal = ref<{
+  open: boolean
+  title: string
+  message: string
+  dependents: ErrorModalDependent[]
+}>({
+  open: false,
+  title: '',
+  message: '',
+  dependents: [],
+})
+
+const requestDelete = async (rawCat: Record<string, any>) => {
+  const cat = rawCat as Category
+  if (cat.tenant_id === null) return // safety net — UI also hides
+
+  pendingDelete.value = cat
+  confirmTitle.value = '¿Eliminar categoría?'
+  confirmMessage.value = `Esta acción no se puede deshacer y removerá "${cat.name}" del menú.`
+
+  // Fetch cascade impact (products + station mappings) before opening the
+  // confirm modal so we can warn about the kitchen-routing side effect.
+  try {
+    const impact = await $fetch<{ success: boolean; data: { products: number; station_mappings: number } }>(
+      `/api/menu/categories/${cat.id}/delete-impact`,
+    )
+    if (impact.data.station_mappings > 0) {
+      confirmMessage.value += ` Esto también quitará la asignación a la estación de cocina; tendrás que reasignarla en /operaciones/comandas si quieres seguir usándola.`
+    }
+  } catch {
+    // Pre-fetch is best-effort — if it fails, fall through with the base
+    // message. The DELETE itself will still surface the structured 409.
+  }
+
+  confirmOpen.value = true
+}
+
+const performDelete = async () => {
+  if (!pendingDelete.value || isDeleting.value) return
+  const cat = pendingDelete.value
+  isDeleting.value = true
+  try {
+    await $fetch(`/api/menu/categories/${cat.id}`, { method: 'DELETE' })
+    confirmOpen.value = false
+    pendingDelete.value = null
+    await invalidateConsumers()
+  } catch (err: any) {
+    const detail = err?.data?.detail
+    const isStructured409 =
+      err?.status === 409 &&
+      detail &&
+      typeof detail === 'object' &&
+      (detail.code === 'category_has_dependents' || detail.code === 'category_has_dependents_unknown')
+
+    const dependents: ErrorModalDependent[] = isStructured409 && detail.counts
+      ? [{ label: 'Productos asociados', count: detail.counts.products ?? 0 }].filter((d) => d.count > 0)
+      : []
+
+    confirmOpen.value = false
+    pendingDelete.value = null
+    errorModal.value = {
+      open: true,
+      title: 'No se pudo eliminar la categoría',
+      message: isStructured409 && typeof detail.message === 'string'
+        ? detail.message
+        : 'Ocurrió un error al intentar eliminar la categoría. Inténtalo de nuevo.',
+      dependents,
+    }
+  } finally {
+    isDeleting.value = false
+  }
+}
+</script>

--- a/pages/menu/categorias/index.vue
+++ b/pages/menu/categorias/index.vue
@@ -35,46 +35,37 @@
           variant="default"
           row-size="sm"
         >
-      <!-- Mobile Card -->
-      <template #card="{ item }">
-        <div class="flex items-center gap-3 py-3 px-3 border-b border-border bg-surface">
-          <div class="flex-shrink-0 w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
-            <TagIcon class="w-4 h-4" />
-          </div>
+      <!-- Mobile row (matches /menu/modificadores pattern) -->
+      <template #card="{ item, index }">
+        <div
+          class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors"
+          :class="[
+            item.tenant_id !== null ? 'hover:bg-surface-secondary cursor-pointer' : 'cursor-default',
+            index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30',
+          ]"
+          @click="item.tenant_id !== null && openEditPanel(item)"
+        >
           <div class="flex-1 min-w-0">
-            <div class="flex items-center gap-2 flex-wrap">
-              <span class="text-sm font-semibold text-text-primary">{{ item.name }}</span>
-              <span
-                class="text-xs font-medium px-2 py-0.5 rounded-full"
-                :class="item.tenant_id === null
-                  ? 'bg-text-secondary/10 text-text-secondary'
-                  : 'bg-primary/10 text-primary'"
-              >
-                {{ item.tenant_id === null ? 'Global' : 'Propia' }}
-              </span>
-            </div>
+            <span class="text-sm font-bold text-text-primary">{{ item.name }}</span>
             <p v-if="item.description" class="text-xs text-text-secondary mt-0.5 truncate">{{ item.description }}</p>
           </div>
-          <div class="flex items-center gap-1 flex-shrink-0">
-            <button
-              v-if="item.tenant_id !== null"
-              type="button"
-              :aria-label="`Editar categoría ${item.name}`"
-              class="min-h-[44px] min-w-[44px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
-              @click.stop="openEditPanel(item)"
-            >
-              <PencilSquareIcon class="w-5 h-5" />
-            </button>
-            <button
-              v-if="item.tenant_id !== null"
-              type="button"
-              :aria-label="`Eliminar categoría ${item.name}`"
-              class="min-h-[44px] min-w-[44px] inline-flex items-center justify-center rounded-lg text-destructive hover:bg-destructive/10 focus:outline-none focus:ring-2 focus:ring-destructive/30 transition-colors"
-              @click.stop="requestDelete(item)"
-            >
-              <TrashIcon class="w-5 h-5" />
-            </button>
-          </div>
+          <span
+            class="text-xs font-medium px-2 py-0.5 rounded-full flex-shrink-0"
+            :class="item.tenant_id === null
+              ? 'bg-text-secondary/10 text-text-secondary'
+              : 'bg-primary/10 text-primary'"
+          >
+            {{ item.tenant_id === null ? 'Global' : 'Propia' }}
+          </span>
+          <button
+            v-if="item.tenant_id !== null"
+            type="button"
+            :aria-label="`Eliminar categoría ${item.name}`"
+            class="flex-shrink-0 min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-destructive hover:bg-destructive/10 focus:outline-none focus:ring-2 focus:ring-destructive/30 transition-colors"
+            @click.stop="requestDelete(item)"
+          >
+            <TrashIcon class="w-4 h-4" />
+          </button>
         </div>
       </template>
 
@@ -155,7 +146,7 @@
 </template>
 
 <script setup lang="ts">
-import { TagIcon, PencilSquareIcon, TrashIcon } from '@heroicons/vue/24/outline'
+import { PencilSquareIcon, TrashIcon } from '@heroicons/vue/24/outline'
 
 definePageMeta({
   // layout: 'dashboard' — inherited from parent menu.vue

--- a/pages/menu/categorias/index.vue
+++ b/pages/menu/categorias/index.vue
@@ -1,32 +1,40 @@
 <template>
-  <div class="px-3 md:px-4 py-4 space-y-4">
-    <!-- Header -->
-    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-      <div>
-        <h1 class="text-lg sm:text-xl font-bold text-text-primary">Categorías</h1>
-        <p class="text-sm text-text-secondary mt-0.5">
-          Agrupa productos del menú y enruta comandas por categoría.
-        </p>
-      </div>
-      <button
-        type="button"
-        class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap min-h-[44px]"
-        @click="openCreatePanel"
-      >
-        + Nueva categoría
-      </button>
+  <div>
+    <!-- Loading State -->
+    <div v-if="isLoading" class="flex items-center justify-center min-h-[400px]">
+      <CommonsTheCustomLoader size="large" />
     </div>
 
-    <!-- List -->
-    <UiResponsiveDataView
-      :columns="columns"
-      :data="categories"
-      :loading="isLoading"
-      empty-message="No hay categorías"
-      empty-sub-message="Crea la primera para organizar tu menú."
-      variant="default"
-      row-size="sm"
-    >
+    <!-- Error State -->
+    <CommonsTheErrorState v-else-if="fetchError" />
+
+    <!-- Main Content -->
+    <div v-else class="page-layout">
+      <div class="flex flex-col gap-3 md:gap-4">
+        <!-- Page subtitle + CTA -->
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <p class="text-sm text-text-secondary">
+            Agrupa productos del menú y enruta comandas por categoría.
+          </p>
+          <button
+            type="button"
+            class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap min-h-[44px]"
+            @click="openCreatePanel"
+          >
+            <span class="hidden sm:inline">+ Nueva categoría</span>
+            <span class="sm:hidden">+ Nueva</span>
+          </button>
+        </div>
+
+        <!-- List -->
+        <UiResponsiveDataView
+          :columns="columns"
+          :data="categories"
+          empty-message="No hay categorías"
+          empty-sub-message="Crea la primera para organizar tu menú."
+          variant="default"
+          row-size="sm"
+        >
       <!-- Mobile Card -->
       <template #card="{ item }">
         <div class="flex items-center gap-3 py-3 px-3 border-b border-border bg-surface">
@@ -37,10 +45,12 @@
             <div class="flex items-center gap-2 flex-wrap">
               <span class="text-sm font-semibold text-text-primary">{{ item.name }}</span>
               <span
-                v-if="item.tenant_id === null"
-                class="text-xs font-medium px-2 py-0.5 rounded-full bg-text-secondary/10 text-text-secondary"
+                class="text-xs font-medium px-2 py-0.5 rounded-full"
+                :class="item.tenant_id === null
+                  ? 'bg-text-secondary/10 text-text-secondary'
+                  : 'bg-primary/10 text-primary'"
               >
-                Global
+                {{ item.tenant_id === null ? 'Global' : 'Propia' }}
               </span>
             </div>
             <p v-if="item.description" class="text-xs text-text-secondary mt-0.5 truncate">{{ item.description }}</p>
@@ -68,17 +78,20 @@
         </div>
       </template>
 
-      <!-- Desktop cells -->
-      <template #cell-name="{ value, item }">
-        <div class="flex items-center gap-2">
-          <span class="text-sm font-medium text-text-primary">{{ value }}</span>
-          <span
-            v-if="item.tenant_id === null"
-            class="text-xs font-medium px-2 py-0.5 rounded-full bg-text-secondary/10 text-text-secondary"
-          >
-            Global
-          </span>
-        </div>
+      <!-- Desktop cells: one data per column -->
+      <template #cell-name="{ value }">
+        <span class="text-sm font-medium text-text-primary">{{ value }}</span>
+      </template>
+
+      <template #cell-tipo="{ item }">
+        <span
+          class="text-xs font-medium px-2 py-0.5 rounded-full inline-block"
+          :class="item.tenant_id === null
+            ? 'bg-text-secondary/10 text-text-secondary'
+            : 'bg-primary/10 text-primary'"
+        >
+          {{ item.tenant_id === null ? 'Global' : 'Propia' }}
+        </span>
       </template>
 
       <template #cell-description="{ value }">
@@ -108,7 +121,9 @@
           <span v-if="item.tenant_id === null" class="text-xs text-text-tertiary px-2">Solo lectura</span>
         </div>
       </template>
-    </UiResponsiveDataView>
+        </UiResponsiveDataView>
+      </div>
+    </div>
 
     <!-- Create/Edit slide-over -->
     <MenuCategoryPanel
@@ -168,11 +183,17 @@ const cache = useQueryCache()
 
 const columns = [
   { key: 'name', title: 'Nombre' },
+  { key: 'tipo', title: 'Tipo' },
   { key: 'description', title: 'Descripción' },
   { key: 'actions', title: '', align: 'right' as const },
 ]
 
-const { data: categoriesData, status: queryStatus } = useQuery({
+const {
+  data: categoriesData,
+  asyncStatus: queryAsyncStatus,
+  error: queryError,
+  refetch,
+} = useQuery({
   key: () => ['tenant', 'menu-categories', currentTenant.value?.id ?? null],
   query: () => $fetch<{ success: boolean; data: Category[] }>('/api/menu/categories'),
   enabled: () => !!currentTenant.value,
@@ -180,7 +201,26 @@ const { data: categoriesData, status: queryStatus } = useQuery({
 })
 
 const categories = computed<Category[]>(() => categoriesData.value?.data ?? [])
-const isLoading = computed(() => queryStatus.value === 'pending')
+// Matrix loader: only the very first load (no data yet). Subsequent refetches
+// surface as a progressive indicator in the header — see registerProgressiveLoading.
+const isLoading = computed(() => !categoriesData.value && !queryError.value)
+const fetchError = computed(() => !!queryError.value)
+const isRefreshing = computed(
+  () => queryAsyncStatus.value === 'loading' && categoriesData.value != null,
+)
+
+// Header refresh button + progressive loading indicator (mirrors siblings).
+const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
+const refreshHandler = async () => {
+  await refetch()
+}
+onMounted(() => {
+  setRefreshHandler(refreshHandler)
+  registerProgressiveLoading(isRefreshing)
+})
+onUnmounted(() => {
+  clearRefreshHandler(refreshHandler)
+})
 
 // ── Slide-over (create/edit) ────────────────────────────────────────────
 const panelOpen = ref(false)


### PR DESCRIPTION
## Summary
Adds a new `/menu/categorias` tab under the Menu module so users can list, create, edit, and delete categories — frontend half of #600.

- New `components/menu/CategoryPanel.vue`: reusable slide-over (bottom-sheet on mobile, slide-over on desktop), same skeleton/transitions as `IngredientePropioPanel`. Handles create + edit with one component (`isEdit = !!category`). Two inputs: name + description.
- New `pages/menu/categorias/index.vue`: list view with `UiResponsiveDataView`, `Global` badge on seeded read-only rows, edit/delete row actions gated on `tenant_id !== null`. Cascade impact pre-fetched before opening the destructive confirm modal — warns when `tenant_category_stations` would be cleared.
- Reuses `UiConfirmActionModal` + `UiErrorAlertModal` shipped in #599.
- Adds `Categorías` tab to `pages/menu.vue` navigation.

## Module gating
Inherits `module: 'menu'` from parent `pages/menu.vue:16` via Nuxt route meta merging — same as siblings (`productos`, `recetas`, `reventa`, `modificadores`), all of which have empty `definePageMeta()` blocks. Enforced by `middleware/module-access.global.ts`.

## Stack
Nuxt 3 + UX + Color + Typography (specialists applied)

## Design notes
- Color: `bg-primary/10` + `text-primary` for the slide-over icon (mirrors `IngredientePropioPanel:35-38`). Global badge `bg-text-secondary/10 text-text-secondary` — neutral, low-emphasis. Destructive button only on the confirm modal — not on close.
- Typography: `text-xl/text-base/text-sm` chain in the slide-over header/body. No `text-xs` on actionable controls.
- UX: cascade warning surfaced upfront in the confirm modal (Nielsen — destructive side-effects must be visible before commit). Autofocus on Cancel for destructive (safer default). Tab cycles within the panel; ESC + backdrop + Cancel all close.

## Pairs with
uno0uno/api-warolabs PR for the PUT/DELETE/delete-impact endpoints — backend should deploy first or together. Without it, edit attempts will return 404 from the BFF proxy.

## Test plan
- [ ] List page loads with all categories (global + tenant), Global badge visible on seeded rows.
- [ ] Edit/delete buttons disabled on Global rows ("Solo lectura" hint on desktop).
- [ ] Create: opens panel → name + description → saves → list refreshes.
- [ ] Edit: opens panel populated → modify → saves → name updates everywhere (product crear flow, comandas routing, ventas filter).
- [ ] Duplicate name on save → inline error on name field, panel stays open.
- [ ] Delete category with 0 products: confirm modal → confirms → row disappears.
- [ ] Delete category with 0 products + 1+ station mapping: confirm modal shows cascade warning copy.
- [ ] Delete category with 1+ products: error modal shows count, no DB change.
- [ ] Mobile: panel opens bottom-sheet with drag handle.
- [ ] Desktop: panel slides in from right.
- [ ] Keyboard: name autofocused on open; Cancel autofocused in confirm modal; ESC closes.

Closes #600