### PR TITLE
feat(ventas): re-wire invoice email modal to WARO-branded SES endpoint (#603)

### DIFF
--- a/components/ventas/InvoiceEmailModal.vue
+++ b/components/ventas/InvoiceEmailModal.vue
@@ -92,7 +92,7 @@ const submit = async () => {
   state.value = 'sending'
   errorMessage.value = ''
   try {
-    await $fetch(`/api/api/orders/${props.orderId}/invoice/send-email`, {
+    await $fetch(`/api/orders/${props.orderId}/invoice/send-email`, {
       method: 'POST',
       body: { email: recipientForMode.value },
     })

--- a/components/ventas/InvoiceEmailModal.vue
+++ b/components/ventas/InvoiceEmailModal.vue
@@ -23,8 +23,8 @@ interface Customer {
 
 interface Props {
   open: boolean
-  trackId: string
-  invoiceLabel: string  // e.g. "LZT-5462" for the modal copy
+  orderId: string
+  invoiceLabel: string  // e.g. "LZT-5462" for the in-modal copy
   customer: Customer | null
 }
 
@@ -36,10 +36,11 @@ const emit = defineEmits<{
 
 const title = 'Enviar factura por correo'
 
-// warocol.com#598 — A profile is "generic" (no useful email to prefill) when
-// either the phone is '0000000000' (per-tenant default Genérico) OR the email
-// ends in '@customer.temp' (auto-created POS walk-in). Both signals are used
-// elsewhere in the codebase — see pages/pos/checkout.vue:440,614.
+// warocol.com#603 — A profile is "generic" (no useful email to prefill)
+// when either the phone is '0000000000' (per-tenant default Genérico) OR
+// the email ends in '@customer.temp' (auto-created POS walk-in). Both
+// signals are used elsewhere in the codebase — see
+// pages/pos/checkout.vue:440,614.
 const isGenericCustomer = computed(() => {
   const c = props.customer
   if (!c) return true
@@ -76,6 +77,10 @@ watch(() => props.open, (isOpen) => {
   if (isOpen) resetForm()
 })
 
+const recipientForMode = computed(() =>
+  mode.value === 'customer' ? customerEmail.value : customEmail.value,
+)
+
 const canSubmit = computed(() => {
   if (state.value === 'sending') return false
   if (mode.value === 'customer') return !!customerEmail.value
@@ -87,16 +92,11 @@ const submit = async () => {
   state.value = 'sending'
   errorMessage.value = ''
   try {
-    if (mode.value === 'customer') {
-      await $fetch(`/api/api/documents/${props.trackId}/resend-email`, { method: 'POST' })
-      sentToEmail.value = customerEmail.value
-    } else {
-      await $fetch(`/api/api/documents/${props.trackId}/send-email-to`, {
-        method: 'POST',
-        body: { email: customEmail.value },
-      })
-      sentToEmail.value = customEmail.value
-    }
+    await $fetch(`/api/api/orders/${props.orderId}/invoice/send-email`, {
+      method: 'POST',
+      body: { email: recipientForMode.value },
+    })
+    sentToEmail.value = recipientForMode.value
     state.value = 'sent'
     emit('sent', sentToEmail.value)
   } catch (e: any) {
@@ -112,17 +112,17 @@ const submit = async () => {
   }
 }
 
+// warocol.com#603 — preserve the last-typed email when going back to the
+// form (the v0 in #598 cleared it, forcing the operator to retype).
 const sendAnother = () => {
   state.value = 'idle'
   errorMessage.value = ''
-  // Pre-fill custom mode with the just-sent address as a convenience.
-  if (mode.value === 'custom') customEmail.value = ''
 }
 
 const cancel = () => emit('update:open', false)
 
-// Shared template body rendered once and slotted into both modal frames.
-// Avoids duplicating ~80 lines of JSX in the SFC template.
+// Shared form/success body rendered once per breakpoint (Modal + BottomSheet
+// both mount but each is hidden at the wrong viewport via internal classes).
 const contentTemplate = () =>
   h('div', { class: 'p-5 sm:p-6 space-y-5' }, [
     // ─── Success ────────────────────────────────────────────────────────────
@@ -183,7 +183,7 @@ const contentTemplate = () =>
               )
             : null,
 
-          // Option 1 — customer email (only for real customers)
+          // Option 1 — customer email (real customers only)
           !isGenericCustomer.value
             ? h(
                 'button',

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -1155,11 +1155,11 @@ onUnmounted(() => {
       </Transition>
     </Teleport>
 
-    <!-- warocol.com#598 — send-invoice-by-email modal -->
+    <!-- warocol.com#603 — send-invoice-by-email modal (WARO-branded via SES) -->
     <VentasInvoiceEmailModal
       v-if="invoiceData"
       v-model:open="showEmailModal"
-      :track-id="invoiceData.id"
+      :order-id="orderId"
       :invoice-label="`${invoiceData.prefix}-${invoiceData.invoice_number}`"
       :customer="orderData?.customer ?? null"
       @sent="onInvoiceEmailSent"


### PR DESCRIPTION
## Summary

Frontend half of warocol.com#603. Re-wires the `/ventas/{id}` invoice-email modal to call the new orders endpoint that uses the same SES + branded template the POS checkout receipt uses, instead of the Matias generic email.

## Stack
🟢 Nuxt 3 + 🎨 UX

## Changes

### `components/ventas/InvoiceEmailModal.vue`
- Prop renamed `track-id` → `order-id` (the new endpoint is order-scoped, not invoice-track-id-scoped).
- Single submit path: both customer-mode and custom-mode POST to `/api/api/orders/${orderId}/invoice/send-email` body `{ email }`. The two-endpoint branch from the deleted v0 is gone.
- `sendAnother()` no longer clears `customEmail` — preserves the last-typed address so the operator can re-send to the same recipient or only edit a character. Fixes the UX nit we caught while testing #598.
- Generic detection unchanged: `phone === '0000000000' OR email LIKE '%@customer.temp'` → custom-only mode with amber hint.

### `pages/ventas/[id].vue`
- Mount uses `:order-id="orderId"` (the route param) instead of `:track-id="invoiceData.id"`.
- Comment ref bumped from #598 to #603.

## What stays
- The "Enviar por correo" button on the invoice card (still visible only when `invoiceData.status === 'accepted'`).
- All UX rules: ≥44px tap targets, persistent labels, icon+text error, focus visible, "Enviar otra copia" loop.

## Test Plan

- [ ] After deploy + backend deploy (api-warolabs#238):
  - `/ventas/36285f8f-…` (Genérico) → click "Enviar por correo" → modal opens in custom-only mode → enter `anderson.electronico@gmail.com` → submit → email arrives from `hola@warolabs.com` with WARO-branded template + LZT-XXXX.pdf attached + items + tax breakdown + CUFE block.
  - Other order with real customer → both options visible → preselected customer chip → switching to "Otro correo" prefills editable.
  - Try with rejected invoice → button absent (unchanged guard).
  - Mobile → bottom-sheet variant.

## PR ordering
1. **warocol.com#604** (revert of Matias-broken button) — must merge first.
2. **api-warolabs#238** (new SES endpoint) — must merge + deploy before this.
3. **This PR** — re-wires modal to new endpoint.

## Closes
warocol.com#603 (frontend half).