### PR TITLE
feat(stock): slide-over to adjust any ingredient, including zero-stock (#608)

### DIFF
--- a/components/abastecimiento/StockAdjustmentPanel.vue
+++ b/components/abastecimiento/StockAdjustmentPanel.vue
@@ -1,0 +1,515 @@
+<template>
+  <Teleport to="body">
+    <!-- Backdrop -->
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-200"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="modelValue"
+        class="fixed inset-0 z-40 bg-black/40"
+        @click="close"
+        aria-hidden="true"
+      />
+    </Transition>
+
+    <!-- Panel: bottom sheet on mobile, slide-over on desktop -->
+    <Transition name="panel">
+      <div
+        v-if="modelValue"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Ajustar stock"
+        class="fixed z-50 flex flex-col bg-surface shadow-2xl
+               inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh]
+               md:inset-y-0 md:right-0 md:bottom-auto md:left-auto md:inset-x-auto md:rounded-none md:w-full md:max-w-md md:max-h-none md:h-full"
+        @keydown.esc="close"
+      >
+        <!-- Mobile drag handle -->
+        <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
+          <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+        </div>
+
+        <!-- Header -->
+        <div class="flex-shrink-0 bg-surface-secondary/40 border-b border-border px-6 py-4">
+          <div class="flex items-start justify-between gap-3">
+            <div class="flex items-center gap-3 min-w-0 flex-1">
+              <div class="flex-shrink-0 w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
+                <Icon name="heroicons:adjustments-horizontal" class="w-5 h-5" />
+              </div>
+              <div class="min-w-0">
+                <h2 class="text-base font-bold text-text-primary leading-tight">Ajustar stock</h2>
+                <p class="text-xs text-text-secondary leading-snug mt-0.5">
+                  {{ selectedIngredient ? selectedIngredient.name : 'Selecciona un ingrediente' }}
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              aria-label="Cerrar panel"
+              :disabled="isSubmitting"
+              class="flex-shrink-0 min-h-[44px] min-w-[44px] inline-flex items-center justify-center rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50 transition-colors"
+              @click="close"
+            >
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- ─── Success state ─────────────────────────────────────────────── -->
+        <div v-if="state === 'success'" class="flex-1 overflow-y-auto px-6 py-5 space-y-4">
+          <div class="flex items-start gap-3 rounded-xl border border-green-200 bg-green-50 p-4 dark:border-green-700/40 dark:bg-green-900/20">
+            <Icon name="heroicons:check-circle" class="w-5 h-5 text-green-700 dark:text-green-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <div class="min-w-0 flex-1">
+              <p class="text-sm font-semibold text-green-900 dark:text-green-200">Ajuste registrado</p>
+              <p class="text-xs text-green-800 dark:text-green-300 mt-0.5 leading-snug break-words">
+                {{ successMessage }}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- ─── Form (idle / sending / error) ─────────────────────────────── -->
+        <div v-else class="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+          <!-- 1. Ingredient picker -->
+          <div class="flex flex-col gap-1.5">
+            <label class="text-sm font-medium text-text-primary">
+              Ingrediente <span class="text-destructive">*</span>
+            </label>
+            <UiIngredientSearchInput
+              :allow-create="false"
+              placeholder="Buscar ingrediente..."
+              @select="onIngredientSelect"
+            />
+          </div>
+
+          <!-- 2. Selected ingredient summary (3 cards) -->
+          <div
+            v-if="selectedIngredient"
+            class="rounded-xl border border-border bg-background p-4 grid grid-cols-3 gap-3"
+          >
+            <div>
+              <p class="text-[10px] font-medium text-text-secondary uppercase tracking-wide">Stock Actual</p>
+              <p class="text-lg font-bold text-text-primary mt-0.5 leading-tight">
+                {{ formatNumber(currentStock) }}
+                <span class="text-xs text-text-secondary font-normal">{{ selectedIngredient.unit }}</span>
+              </p>
+            </div>
+            <div>
+              <p class="text-[10px] font-medium text-text-secondary uppercase tracking-wide">Mínimo</p>
+              <p class="text-sm font-semibold text-text-primary mt-0.5 leading-tight">
+                {{ formatNumber(selectedIngredient.minimum_stock || 0) }}
+                <span class="text-xs text-text-secondary font-normal">{{ selectedIngredient.unit }}</span>
+              </p>
+            </div>
+            <div>
+              <p class="text-[10px] font-medium text-text-secondary uppercase tracking-wide">Máximo</p>
+              <p class="text-sm font-semibold text-text-primary mt-0.5 leading-tight">
+                {{ selectedIngredient.maximum_stock ? formatNumber(selectedIngredient.maximum_stock) : '-' }}
+                <span v-if="selectedIngredient.maximum_stock" class="text-xs text-text-secondary font-normal">{{ selectedIngredient.unit }}</span>
+              </p>
+            </div>
+          </div>
+
+          <!-- 3. Type cards -->
+          <div v-if="selectedIngredient" class="flex flex-col gap-2">
+            <span class="text-sm font-medium text-text-primary">
+              Tipo de Ajuste <span class="text-destructive">*</span>
+            </span>
+            <div class="grid grid-cols-3 gap-2">
+              <button
+                v-for="t in TYPE_OPTIONS"
+                :key="t.value"
+                type="button"
+                :aria-pressed="form.adjustmentType === t.value"
+                class="min-h-[44px] flex flex-col items-center justify-center gap-1 p-2 rounded-xl border-2 text-center transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                :class="form.adjustmentType === t.value ? t.activeClass : 'border-border bg-background hover:border-primary/30 hover:bg-surface-secondary/60'"
+                @click="form.adjustmentType = t.value"
+              >
+                <Icon :name="t.icon" :class="['w-5 h-5', form.adjustmentType === t.value ? t.iconClass : 'text-text-secondary']" aria-hidden="true" />
+                <span class="text-xs font-semibold leading-tight" :class="form.adjustmentType === t.value ? t.labelClass : 'text-text-primary'">
+                  {{ t.label }}
+                </span>
+              </button>
+            </div>
+          </div>
+
+          <!-- 4. Quantity + unit selector with conversion preview -->
+          <div v-if="selectedIngredient && form.adjustmentType" class="grid grid-cols-2 gap-3">
+            <div class="flex flex-col gap-1.5">
+              <label :for="qtyId" class="text-sm font-medium text-text-primary">
+                {{ form.adjustmentType === 'set' ? 'Nuevo stock' : 'Cantidad' }}
+                <span class="text-destructive">*</span>
+              </label>
+              <input
+                :id="qtyId"
+                v-model.number="form.quantity"
+                type="number"
+                step="0.01"
+                min="0"
+                inputmode="decimal"
+                class="input-base w-full px-3 py-2 min-h-[44px]"
+                :placeholder="form.adjustmentType === 'set' ? 'Stock objetivo' : 'Cantidad'"
+              />
+            </div>
+            <div class="flex flex-col gap-1.5">
+              <label :for="unitId" class="text-sm font-medium text-text-primary">
+                Unidad <span class="text-destructive">*</span>
+              </label>
+              <div class="relative">
+                <select
+                  :id="unitId"
+                  v-model="form.unit"
+                  :disabled="purchaseUnitOptions.length === 0 || purchaseUnitsApi.isLoading(form.ingredientId)"
+                  class="input-base w-full px-3 py-2 min-h-[44px] disabled:bg-surface-secondary disabled:cursor-not-allowed"
+                >
+                  <!-- Always offer the base unit -->
+                  <option :value="selectedIngredient.unit">
+                    {{ selectedIngredient.unit }} (base)
+                  </option>
+                  <option
+                    v-for="u in purchaseUnitOptions"
+                    :key="u.value + '-' + u.conversion_factor"
+                    :value="u.value"
+                  >
+                    {{ u.label }}<template v-if="u.conversion_factor !== 1"> · 1 = {{ formatNumber(u.conversion_factor) }} {{ selectedIngredient.unit }}</template>
+                  </option>
+                </select>
+                <span
+                  v-if="purchaseUnitsApi.isLoading(form.ingredientId)"
+                  class="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-text-secondary"
+                  aria-hidden="true"
+                >
+                  <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/>
+                  </svg>
+                </span>
+              </div>
+              <p
+                v-if="form.quantity && form.quantity > 0 && form.unit !== selectedIngredient.unit"
+                class="text-[11px] text-text-secondary leading-snug"
+              >
+                = {{ formatNumber(convertedQuantity) }} {{ selectedIngredient.unit }}
+              </p>
+            </div>
+          </div>
+
+          <!-- 4b. Amber empty-state for ingredients without purchase units -->
+          <div
+            v-if="selectedIngredient && !purchaseUnitsApi.isLoading(form.ingredientId) && purchaseUnitOptions.length === 0"
+            class="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3 dark:border-amber-700/40 dark:bg-amber-900/20"
+          >
+            <Icon name="heroicons:exclamation-triangle" class="w-4 h-4 text-amber-700 dark:text-amber-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <p class="text-xs text-amber-800 dark:text-amber-300 leading-snug">
+              Sin unidades de compra configuradas. Podés ajustar usando la unidad base ({{ selectedIngredient.unit }}) o
+              <a :href="`/abastecimiento/ingredientes?highlight=${selectedIngredient.id}`" class="underline font-medium">configurar unidades</a>.
+            </p>
+          </div>
+
+          <!-- 5. Cost per unit (increment only) -->
+          <div v-if="selectedIngredient && form.adjustmentType === 'increment'" class="flex flex-col gap-1.5">
+            <label :for="costId" class="text-sm font-medium text-text-primary">
+              Costo por {{ form.unit || 'unidad' }}
+              <span class="text-xs text-text-secondary font-normal">(opcional)</span>
+            </label>
+            <div class="relative">
+              <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary pointer-events-none">$</span>
+              <input
+                :id="costId"
+                v-model.number="form.cost_per_unit"
+                type="number"
+                step="0.01"
+                min="0"
+                inputmode="decimal"
+                class="input-base w-full pl-7 pr-3 py-2 min-h-[44px]"
+                placeholder="0"
+              />
+            </div>
+            <p class="text-[11px] text-text-secondary leading-snug">
+              Si lo especificas, actualiza el costo promedio ponderado del ingrediente.
+            </p>
+          </div>
+
+          <!-- 6. Result preview -->
+          <div
+            v-if="selectedIngredient && form.adjustmentType && form.quantity && form.quantity > 0"
+            class="rounded-xl border border-primary/20 bg-primary/5 p-3"
+          >
+            <p class="text-xs text-text-secondary leading-snug">Resultado</p>
+            <p class="text-sm font-semibold text-text-primary mt-0.5">
+              Stock {{ resultVerb }}
+              <span class="text-text-primary">{{ formatNumber(newStockInBase) }} {{ selectedIngredient.unit }}</span>
+            </p>
+          </div>
+
+          <!-- 7. Reason -->
+          <div v-if="selectedIngredient && form.adjustmentType" class="flex flex-col gap-1.5">
+            <label :for="reasonId" class="text-sm font-medium text-text-primary">
+              Motivo del ajuste <span class="text-destructive">*</span>
+            </label>
+            <select
+              :id="reasonId"
+              v-model="form.reason"
+              class="input-base w-full px-3 py-2 min-h-[44px]"
+            >
+              <option value="">Seleccionar motivo...</option>
+              <option v-for="r in REASONS" :key="r.value" :value="r.value">{{ r.label }}</option>
+            </select>
+          </div>
+
+          <!-- 8. Notes -->
+          <div v-if="form.reason" class="flex flex-col gap-1.5">
+            <label :for="notesId" class="text-sm font-medium text-text-primary">
+              Notas
+              <span v-if="form.reason === 'other'" class="text-destructive">*</span>
+              <span v-else class="text-xs text-text-secondary font-normal">(opcional)</span>
+            </label>
+            <textarea
+              :id="notesId"
+              v-model="form.notes"
+              rows="3"
+              class="input-base w-full px-3 py-2 resize-none"
+              placeholder="Detalles del ajuste..."
+            />
+          </div>
+
+          <!-- 9. Large adjustment warning -->
+          <div
+            v-if="showLargeWarning"
+            class="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3 dark:border-amber-700/40 dark:bg-amber-900/20"
+          >
+            <Icon name="heroicons:exclamation-triangle" class="w-4 h-4 text-amber-700 dark:text-amber-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <p class="text-xs text-amber-800 dark:text-amber-300 leading-snug">
+              <strong>Advertencia:</strong> este ajuste representa un cambio mayor al 50% del stock actual. Verificá los datos antes de registrar.
+            </p>
+          </div>
+
+          <!-- Error banner -->
+          <div
+            v-if="errorMessage"
+            class="flex items-start gap-2 rounded-xl border border-destructive/30 bg-destructive/5 p-3 text-destructive"
+            role="alert"
+          >
+            <Icon name="heroicons:exclamation-triangle" class="w-4 h-4 flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <p class="text-xs leading-snug break-words">{{ errorMessage }}</p>
+          </div>
+        </div>
+
+        <!-- ─── Sticky footer ─────────────────────────────────────────────── -->
+        <div class="flex-shrink-0 border-t border-border bg-surface px-6 py-4">
+          <div v-if="state === 'success'" class="flex flex-col-reverse sm:flex-row gap-2">
+            <button
+              type="button"
+              class="flex-1 min-h-[44px] py-3 px-4 border-2 border-border rounded-xl text-text-primary font-medium hover:bg-background focus:outline-none focus:ring-2 focus:ring-primary/40 active:scale-95 transition-all"
+              @click="close"
+            >
+              Cerrar
+            </button>
+            <button
+              type="button"
+              class="flex-1 min-h-[44px] py-3 px-4 bg-primary text-primary-foreground rounded-xl font-semibold hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/40 active:scale-95 transition-all"
+              @click="resetForAnother"
+            >
+              Hacer otro ajuste
+            </button>
+          </div>
+          <div v-else class="flex flex-col-reverse sm:flex-row gap-2">
+            <button
+              type="button"
+              :disabled="isSubmitting"
+              class="flex-1 min-h-[44px] py-3 px-4 border-2 border-border rounded-xl text-text-primary font-medium hover:bg-background focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:opacity-50 disabled:cursor-not-allowed active:scale-95 transition-all"
+              @click="close"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              :disabled="!isFormValid || isSubmitting"
+              class="flex-1 min-h-[44px] py-3 px-4 bg-primary text-primary-foreground rounded-xl font-semibold hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:opacity-50 disabled:cursor-not-allowed active:scale-95 transition-all inline-flex items-center justify-center gap-2"
+              @click="onSubmit"
+            >
+              <UiLoadingDots v-if="isSubmitting" size="8px" color="currentColor" />
+              <span>{{ isSubmitting ? 'Registrando...' : 'Registrar ajuste' }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import {
+  useIngredientPurchaseUnits,
+} from '~/composables/useIngredientPurchaseUnits'
+import {
+  useInventoryAdjustment,
+  ADJUSTMENT_REASONS,
+  type SelectedIngredient,
+} from '~/composables/useInventoryAdjustment'
+
+interface Props {
+  modelValue: boolean
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'saved'): void
+}>()
+
+const uid = useId()
+const qtyId = `stock-adj-qty-${uid}`
+const unitId = `stock-adj-unit-${uid}`
+const costId = `stock-adj-cost-${uid}`
+const reasonId = `stock-adj-reason-${uid}`
+const notesId = `stock-adj-notes-${uid}`
+
+const REASONS = ADJUSTMENT_REASONS
+
+const TYPE_OPTIONS = [
+  { value: 'increment' as const, label: 'Incremento', icon: 'heroicons:arrow-up-circle',     activeClass: 'border-green-500 bg-green-50 dark:bg-green-900/20', iconClass: 'text-green-600', labelClass: 'text-green-700 dark:text-green-400' },
+  { value: 'decrement' as const, label: 'Decremento', icon: 'heroicons:arrow-down-circle',   activeClass: 'border-red-500 bg-red-50 dark:bg-red-900/20',       iconClass: 'text-red-600',   labelClass: 'text-red-700 dark:text-red-400' },
+  { value: 'set'       as const, label: 'Ajustar a',  icon: 'heroicons:arrows-right-left',   activeClass: 'border-primary bg-primary/5',                      iconClass: 'text-primary',   labelClass: 'text-primary' },
+]
+
+const purchaseUnitsApi = useIngredientPurchaseUnits()
+
+const {
+  form,
+  selectedIngredient,
+  currentStock,
+  isSubmitting,
+  errorMessage,
+  isFormValid,
+  calculateNewStockInBase,
+  largeAdjustmentWarning,
+  loadCurrentStock,
+  submit,
+  reset,
+} = useInventoryAdjustment()
+
+type State = 'idle' | 'success'
+const state = ref<State>('idle')
+const successMessage = ref('')
+
+watch(() => props.modelValue, (open) => {
+  if (open) {
+    state.value = 'idle'
+    successMessage.value = ''
+    reset()
+  }
+})
+
+const purchaseUnitOptions = computed(() =>
+  form.ingredientId ? purchaseUnitsApi.options(form.ingredientId) : [],
+)
+
+const convertedQuantity = computed(() => {
+  if (!form.quantity || form.quantity <= 0 || !form.unit) return 0
+  return purchaseUnitsApi.convertToBase(form.ingredientId, form.quantity, form.unit)
+})
+
+const newStockInBase = computed(() =>
+  calculateNewStockInBase((qty, unit) =>
+    purchaseUnitsApi.convertToBase(form.ingredientId, qty, unit),
+  ),
+)
+
+const showLargeWarning = computed(() =>
+  largeAdjustmentWarning((qty, unit) =>
+    purchaseUnitsApi.convertToBase(form.ingredientId, qty, unit),
+  ),
+)
+
+const resultVerb = computed(() => {
+  switch (form.adjustmentType) {
+    case 'increment': return 'aumentará a'
+    case 'decrement': return 'disminuirá a'
+    case 'set':       return 'se establecerá en'
+    default:          return 'se establecerá en'
+  }
+})
+
+const onIngredientSelect = async (ingredient: { id: string; name: string; unit: string; minimum_stock?: number | null; maximum_stock?: number | null }) => {
+  selectedIngredient.value = {
+    id: ingredient.id,
+    name: ingredient.name,
+    unit: ingredient.unit,
+    minimum_stock: ingredient.minimum_stock ?? null,
+    maximum_stock: ingredient.maximum_stock ?? null,
+  }
+  form.ingredientId = ingredient.id
+  form.adjustmentType = ''
+  form.quantity = null
+  form.cost_per_unit = null
+  errorMessage.value = ''
+
+  // Fetch purchase units (cached) and stock in parallel.
+  const [units] = await Promise.all([
+    purchaseUnitsApi.fetch(ingredient.id),
+    loadCurrentStock(ingredient.id),
+  ])
+
+  // Default unit selection: is_default → first → base.
+  const def = purchaseUnitsApi.defaultFor(ingredient.id)
+  form.unit = def ? def.value : ingredient.unit
+}
+
+const onSubmit = async () => {
+  try {
+    await submit()
+    const sign = form.adjustmentType === 'decrement' ? '-' : (form.adjustmentType === 'set' ? '→ ' : '+')
+    const qty = form.quantity ?? 0
+    successMessage.value = `Se registró el ajuste de ${selectedIngredient.value?.name}: ${sign}${formatNumber(qty)} ${form.unit}.`
+    state.value = 'success'
+    emit('saved')
+  } catch {
+    // errorMessage already set inside submit()
+  }
+}
+
+const resetForAnother = () => {
+  state.value = 'idle'
+  reset()
+}
+
+const close = () => {
+  if (isSubmitting.value) return
+  emit('update:modelValue', false)
+}
+
+const formatNumber = (value: number | null | undefined) => {
+  const v = Number(value ?? 0)
+  return new Intl.NumberFormat('es-CO', { minimumFractionDigits: 0, maximumFractionDigits: 2 }).format(v)
+}
+</script>
+
+<style scoped>
+.panel-enter-active,
+.panel-leave-active {
+  transition: transform 250ms ease;
+}
+
+/* Mobile: slide up from bottom. */
+.panel-enter-from,
+.panel-leave-to {
+  transform: translateY(100%);
+}
+
+/* Desktop: slide in from right. */
+@media (min-width: 768px) {
+  .panel-enter-from,
+  .panel-leave-to {
+    transform: translateX(100%);
+  }
+}
+</style>

--- a/components/abastecimiento/StockAdjustmentPanel.vue
+++ b/components/abastecimiento/StockAdjustmentPanel.vue
@@ -89,36 +89,58 @@
             />
           </div>
 
-          <!-- 2. Selected ingredient summary (3 cards) -->
+          <!-- 2. Selected ingredient summary (3 cards) — skeleton while loading -->
           <div
             v-if="selectedIngredient"
             class="rounded-xl border border-border bg-background p-4 grid grid-cols-3 gap-3"
           >
             <div>
               <p class="text-[10px] font-medium text-text-secondary uppercase tracking-wide">Stock Actual</p>
-              <p class="text-lg font-bold text-text-primary mt-0.5 leading-tight">
+              <div v-if="isLoadingStock || !stockLoaded" class="mt-1 h-6 w-20 bg-surface-secondary rounded animate-pulse" aria-label="Cargando stock actual" />
+              <p v-else class="text-lg font-bold text-text-primary mt-0.5 leading-tight">
                 {{ formatNumber(currentStock) }}
                 <span class="text-xs text-text-secondary font-normal">{{ selectedIngredient.unit }}</span>
               </p>
             </div>
             <div>
               <p class="text-[10px] font-medium text-text-secondary uppercase tracking-wide">Mínimo</p>
-              <p class="text-sm font-semibold text-text-primary mt-0.5 leading-tight">
+              <div v-if="isLoadingStock || !stockLoaded" class="mt-1 h-5 w-16 bg-surface-secondary rounded animate-pulse" aria-label="Cargando mínimo" />
+              <p v-else class="text-sm font-semibold text-text-primary mt-0.5 leading-tight">
                 {{ formatNumber(selectedIngredient.minimum_stock || 0) }}
                 <span class="text-xs text-text-secondary font-normal">{{ selectedIngredient.unit }}</span>
               </p>
             </div>
             <div>
               <p class="text-[10px] font-medium text-text-secondary uppercase tracking-wide">Máximo</p>
-              <p class="text-sm font-semibold text-text-primary mt-0.5 leading-tight">
+              <div v-if="isLoadingStock || !stockLoaded" class="mt-1 h-5 w-12 bg-surface-secondary rounded animate-pulse" aria-label="Cargando máximo" />
+              <p v-else class="text-sm font-semibold text-text-primary mt-0.5 leading-tight">
                 {{ selectedIngredient.maximum_stock ? formatNumber(selectedIngredient.maximum_stock) : '-' }}
                 <span v-if="selectedIngredient.maximum_stock" class="text-xs text-text-secondary font-normal">{{ selectedIngredient.unit }}</span>
               </p>
             </div>
           </div>
 
-          <!-- 3. Type cards -->
-          <div v-if="selectedIngredient" class="flex flex-col gap-2">
+          <!-- 2b. Stock-load error: refetch action so operator can recover -->
+          <div
+            v-if="selectedIngredient && !isLoadingStock && !stockLoaded && errorMessage"
+            class="flex items-start gap-2 rounded-xl border border-destructive/30 bg-destructive/5 p-3 text-destructive"
+            role="alert"
+          >
+            <ExclamationTriangleIcon class="w-4 h-4 flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <div class="flex-1 min-w-0 flex items-start justify-between gap-2">
+              <p class="text-xs leading-snug break-words">{{ errorMessage }}</p>
+              <button
+                type="button"
+                class="text-xs font-semibold underline hover:no-underline flex-shrink-0"
+                @click="retryStockFetch"
+              >
+                Reintentar
+              </button>
+            </div>
+          </div>
+
+          <!-- 3. Type cards (only after stock confirmed) -->
+          <div v-if="selectedIngredient && stockLoaded" class="flex flex-col gap-2">
             <span class="text-sm font-medium text-text-primary">
               Tipo de Ajuste <span class="text-destructive">*</span>
             </span>
@@ -399,6 +421,8 @@ const {
   form,
   selectedIngredient,
   currentStock,
+  isLoadingStock,
+  stockLoaded,
   isSubmitting,
   errorMessage,
   isFormValid,
@@ -465,8 +489,11 @@ const onIngredientSelect = async (ingredient: { id: string; name: string; unit: 
   form.cost_per_unit = null
   errorMessage.value = ''
 
-  // Fetch purchase units (cached) and stock in parallel.
-  const [units] = await Promise.all([
+  // Fire both fetches in parallel but tolerate either failing individually.
+  // Stock-load failure shows the "Reintentar" banner via the composable
+  // (loadCurrentStock now throws on failure instead of falling back to 0).
+  // Purchase-units failure is already swallowed inside the composable.
+  await Promise.allSettled([
     purchaseUnitsApi.fetch(ingredient.id),
     loadCurrentStock(ingredient.id),
   ])
@@ -474,6 +501,15 @@ const onIngredientSelect = async (ingredient: { id: string; name: string; unit: 
   // Default unit selection: is_default → first → base.
   const def = purchaseUnitsApi.defaultFor(ingredient.id)
   form.unit = def ? def.value : ingredient.unit
+}
+
+const retryStockFetch = async () => {
+  if (!form.ingredientId) return
+  try {
+    await loadCurrentStock(form.ingredientId)
+  } catch {
+    /* errorMessage already set by composable */
+  }
 }
 
 const onSubmit = async () => {
@@ -489,9 +525,25 @@ const onSubmit = async () => {
   }
 }
 
-const resetForAnother = () => {
+const resetForAnother = async () => {
+  // Preserve the selected ingredient so the operator can chain another
+  // adjustment without re-typing the search. Refetch its stock so the
+  // "Stock Actual" reflects what the previous submit just changed.
+  const keepId = form.ingredientId
+  const keepIngredient = selectedIngredient.value
   state.value = 'idle'
+  successMessage.value = ''
   reset()
+  if (keepId && keepIngredient) {
+    selectedIngredient.value = keepIngredient
+    form.ingredientId = keepId
+    await Promise.allSettled([
+      purchaseUnitsApi.fetch(keepId),
+      loadCurrentStock(keepId),  // ← refetch fresh stock for the new attempt
+    ])
+    const def = purchaseUnitsApi.defaultFor(keepId)
+    form.unit = def ? def.value : keepIngredient.unit
+  }
 }
 
 const close = () => {

--- a/components/abastecimiento/StockAdjustmentPanel.vue
+++ b/components/abastecimiento/StockAdjustmentPanel.vue
@@ -39,7 +39,7 @@
           <div class="flex items-start justify-between gap-3">
             <div class="flex items-center gap-3 min-w-0 flex-1">
               <div class="flex-shrink-0 w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
-                <Icon name="heroicons:adjustments-horizontal" class="w-5 h-5" />
+                <AdjustmentsHorizontalIcon class="w-5 h-5" />
               </div>
               <div class="min-w-0">
                 <h2 class="text-base font-bold text-text-primary leading-tight">Ajustar stock</h2>
@@ -65,7 +65,7 @@
         <!-- ─── Success state ─────────────────────────────────────────────── -->
         <div v-if="state === 'success'" class="flex-1 overflow-y-auto px-6 py-5 space-y-4">
           <div class="flex items-start gap-3 rounded-xl border border-green-200 bg-green-50 p-4 dark:border-green-700/40 dark:bg-green-900/20">
-            <Icon name="heroicons:check-circle" class="w-5 h-5 text-green-700 dark:text-green-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <CheckCircleIcon class="w-5 h-5 text-green-700 dark:text-green-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
             <div class="min-w-0 flex-1">
               <p class="text-sm font-semibold text-green-900 dark:text-green-200">Ajuste registrado</p>
               <p class="text-xs text-green-800 dark:text-green-300 mt-0.5 leading-snug break-words">
@@ -132,7 +132,11 @@
                 :class="form.adjustmentType === t.value ? t.activeClass : 'border-border bg-background hover:border-primary/30 hover:bg-surface-secondary/60'"
                 @click="form.adjustmentType = t.value"
               >
-                <Icon :name="t.icon" :class="['w-5 h-5', form.adjustmentType === t.value ? t.iconClass : 'text-text-secondary']" aria-hidden="true" />
+                <component
+                  :is="t.icon"
+                  :class="['w-5 h-5', form.adjustmentType === t.value ? t.iconClass : 'text-text-secondary']"
+                  aria-hidden="true"
+                />
                 <span class="text-xs font-semibold leading-tight" :class="form.adjustmentType === t.value ? t.labelClass : 'text-text-primary'">
                   {{ t.label }}
                 </span>
@@ -206,7 +210,7 @@
             v-if="selectedIngredient && !purchaseUnitsApi.isLoading(form.ingredientId) && purchaseUnitOptions.length === 0"
             class="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3 dark:border-amber-700/40 dark:bg-amber-900/20"
           >
-            <Icon name="heroicons:exclamation-triangle" class="w-4 h-4 text-amber-700 dark:text-amber-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <ExclamationTriangleIcon class="w-4 h-4 text-amber-700 dark:text-amber-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
             <p class="text-xs text-amber-800 dark:text-amber-300 leading-snug">
               Sin unidades de compra configuradas. Podés ajustar usando la unidad base ({{ selectedIngredient.unit }}) o
               <a :href="`/abastecimiento/ingredientes?highlight=${selectedIngredient.id}`" class="underline font-medium">configurar unidades</a>.
@@ -285,7 +289,7 @@
             v-if="showLargeWarning"
             class="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3 dark:border-amber-700/40 dark:bg-amber-900/20"
           >
-            <Icon name="heroicons:exclamation-triangle" class="w-4 h-4 text-amber-700 dark:text-amber-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <ExclamationTriangleIcon class="w-4 h-4 text-amber-700 dark:text-amber-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
             <p class="text-xs text-amber-800 dark:text-amber-300 leading-snug">
               <strong>Advertencia:</strong> este ajuste representa un cambio mayor al 50% del stock actual. Verificá los datos antes de registrar.
             </p>
@@ -297,7 +301,7 @@
             class="flex items-start gap-2 rounded-xl border border-destructive/30 bg-destructive/5 p-3 text-destructive"
             role="alert"
           >
-            <Icon name="heroicons:exclamation-triangle" class="w-4 h-4 flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <ExclamationTriangleIcon class="w-4 h-4 flex-shrink-0 mt-0.5" aria-hidden="true" />
             <p class="text-xs leading-snug break-words">{{ errorMessage }}</p>
           </div>
         </div>
@@ -348,6 +352,14 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import {
+  AdjustmentsHorizontalIcon,
+  ArrowDownCircleIcon,
+  ArrowUpCircleIcon,
+  ArrowsRightLeftIcon,
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+} from '@heroicons/vue/24/outline'
+import {
   useIngredientPurchaseUnits,
 } from '~/composables/useIngredientPurchaseUnits'
 import {
@@ -376,9 +388,9 @@ const notesId = `stock-adj-notes-${uid}`
 const REASONS = ADJUSTMENT_REASONS
 
 const TYPE_OPTIONS = [
-  { value: 'increment' as const, label: 'Incremento', icon: 'heroicons:arrow-up-circle',     activeClass: 'border-green-500 bg-green-50 dark:bg-green-900/20', iconClass: 'text-green-600', labelClass: 'text-green-700 dark:text-green-400' },
-  { value: 'decrement' as const, label: 'Decremento', icon: 'heroicons:arrow-down-circle',   activeClass: 'border-red-500 bg-red-50 dark:bg-red-900/20',       iconClass: 'text-red-600',   labelClass: 'text-red-700 dark:text-red-400' },
-  { value: 'set'       as const, label: 'Ajustar a',  icon: 'heroicons:arrows-right-left',   activeClass: 'border-primary bg-primary/5',                      iconClass: 'text-primary',   labelClass: 'text-primary' },
+  { value: 'increment' as const, label: 'Incremento', icon: ArrowUpCircleIcon,    activeClass: 'border-green-500 bg-green-50 dark:bg-green-900/20', iconClass: 'text-green-600', labelClass: 'text-green-700 dark:text-green-400' },
+  { value: 'decrement' as const, label: 'Decremento', icon: ArrowDownCircleIcon,  activeClass: 'border-red-500 bg-red-50 dark:bg-red-900/20',       iconClass: 'text-red-600',   labelClass: 'text-red-700 dark:text-red-400' },
+  { value: 'set'       as const, label: 'Ajustar a',  icon: ArrowsRightLeftIcon,  activeClass: 'border-primary bg-primary/5',                      iconClass: 'text-primary',   labelClass: 'text-primary' },
 ]
 
 const purchaseUnitsApi = useIngredientPurchaseUnits()

--- a/composables/useIngredientPurchaseUnits.ts
+++ b/composables/useIngredientPurchaseUnits.ts
@@ -1,0 +1,133 @@
+/**
+ * useIngredientPurchaseUnits — per-ingredient purchase-unit cache + helpers.
+ *
+ * Wraps the Map<ingredient_id, units[]> pattern that
+ * `pages/abastecimiento/compras-directas/crear.vue` inlines today. Returned
+ * from a singleton via `useState` so multiple components share the same cache
+ * during a session (re-opening the stock-adjustment slide-over does not
+ * re-fetch units for ingredients already seen).
+ *
+ * Backend: GET /api/suppliers/ingredient-purchase-units/ingredient/{id}
+ *   → { data: PurchaseUnit[] }
+ *
+ * warocol.com#608.
+ */
+
+export interface PurchaseUnit {
+  id: string
+  ingredient_id: string
+  purchase_unit: string          // canonical code: 'kg', 'lb', 'bulto', etc.
+  purchase_unit_label: string    // display label: '1 Kilogramo', 'Bulto 25kg', …
+  conversion_factor: number      // multiply by this to get base unit
+  is_default?: boolean
+  is_active?: boolean
+  unit_cost?: number | null
+}
+
+export interface PurchaseUnitOption {
+  value: string                  // = purchase_unit
+  label: string                  // = purchase_unit_label
+  conversion_factor: number
+  is_default: boolean
+  unit_cost: number | null
+}
+
+export function useIngredientPurchaseUnits() {
+  // Per-tab singleton via useState. Survives component unmounts.
+  const cache = useState<Map<string, PurchaseUnit[]>>(
+    'ingredient-purchase-units-cache',
+    () => new Map(),
+  )
+  const loadingSet = useState<Set<string>>(
+    'ingredient-purchase-units-loading',
+    () => new Set(),
+  )
+
+  const isLoading = (ingredientId: string): boolean =>
+    loadingSet.value.has(ingredientId)
+
+  const fetch = async (ingredientId: string): Promise<PurchaseUnit[]> => {
+    if (!ingredientId) return []
+    if (cache.value.has(ingredientId)) return cache.value.get(ingredientId)!
+
+    // Mark loading
+    const nextLoading = new Set(loadingSet.value)
+    nextLoading.add(ingredientId)
+    loadingSet.value = nextLoading
+
+    try {
+      const res = await $fetch<{ data: PurchaseUnit[] }>(
+        `/api/suppliers/ingredient-purchase-units/ingredient/${ingredientId}`,
+      )
+      const units = (res?.data ?? []).filter((u) => u.is_active !== false)
+      const nextCache = new Map(cache.value)
+      nextCache.set(ingredientId, units)
+      cache.value = nextCache
+      return units
+    } catch {
+      // On error, cache an empty list so subsequent calls don't loop.
+      const nextCache = new Map(cache.value)
+      nextCache.set(ingredientId, [])
+      cache.value = nextCache
+      return []
+    } finally {
+      const done = new Set(loadingSet.value)
+      done.delete(ingredientId)
+      loadingSet.value = done
+    }
+  }
+
+  const options = (ingredientId: string): PurchaseUnitOption[] => {
+    const units = cache.value.get(ingredientId) ?? []
+    return units.map((u) => ({
+      value: u.purchase_unit,
+      label: u.purchase_unit_label,
+      conversion_factor: Number(u.conversion_factor),
+      is_default: !!u.is_default,
+      unit_cost: u.unit_cost ?? null,
+    }))
+  }
+
+  const defaultFor = (ingredientId: string): PurchaseUnitOption | null => {
+    const opts = options(ingredientId)
+    if (opts.length === 0) return null
+    return opts.find((o) => o.is_default) ?? opts[0]
+  }
+
+  /**
+   * Convert a quantity expressed in `unitValue` (a purchase_unit code) to
+   * the ingredient's base unit. Returns the same quantity unchanged when no
+   * matching purchase unit is found — that mirrors the backend fallback
+   * (`inventory_service.py:498-516`).
+   */
+  const convertToBase = (
+    ingredientId: string,
+    qty: number,
+    unitValue: string,
+  ): number => {
+    if (!qty || !unitValue) return 0
+    const match = options(ingredientId).find((o) => o.value === unitValue)
+    if (!match) return qty
+    return qty * match.conversion_factor
+  }
+
+  const clear = (ingredientId?: string): void => {
+    if (ingredientId) {
+      const next = new Map(cache.value)
+      next.delete(ingredientId)
+      cache.value = next
+    } else {
+      cache.value = new Map()
+    }
+  }
+
+  return {
+    cache,
+    isLoading,
+    fetch,
+    options,
+    defaultFor,
+    convertToBase,
+    clear,
+  }
+}

--- a/composables/useInventoryAdjustment.ts
+++ b/composables/useInventoryAdjustment.ts
@@ -67,10 +67,16 @@ export function useInventoryAdjustment() {
 
   const selectedIngredient = ref<SelectedIngredient | null>(null)
   const currentStock = ref<number>(0)
+  const isLoadingStock = ref(false)
+  const stockLoaded = ref(false)
   const isSubmitting = ref(false)
   const errorMessage = ref('')
 
   const isFormValid = computed(() => {
+    // Block submit until the current stock has been confirmed by the
+    // backend — otherwise an operator could increment against a stale 0
+    // and silently distort inventory (caught in #608 follow-up).
+    if (!stockLoaded.value || isLoadingStock.value) return false
     if (!form.ingredientId || !form.adjustmentType || !form.unit) return false
     if (!form.quantity || form.quantity <= 0) return false
     if (!form.reason) return false
@@ -119,15 +125,23 @@ export function useInventoryAdjustment() {
     form.notes = ''
     selectedIngredient.value = null
     currentStock.value = 0
+    stockLoaded.value = false
+    isLoadingStock.value = false
     isSubmitting.value = false
     errorMessage.value = ''
   }
 
   /**
-   * Loads the current stock for an ingredient.
-   * Returns the numeric value (0 if not found / null).
+   * Loads the current stock for an ingredient. Throws on failure so the
+   * caller (panel) can show an error banner and gate the submit — we do
+   * NOT silently fall back to 0 because doing so misled the operator in
+   * a prior incident (a +2 libras "Incremento" was applied against an
+   * unknown real stock).
    */
   const loadCurrentStock = async (ingredientId: string): Promise<number> => {
+    isLoadingStock.value = true
+    stockLoaded.value = false
+    errorMessage.value = ''
     try {
       const res = await $fetch<{ current_stock?: number | null }>(
         `/api/inventory/stock/${ingredientId}`,
@@ -135,10 +149,19 @@ export function useInventoryAdjustment() {
       const v = res?.current_stock
       const num = typeof v === 'number' ? v : Number(v ?? 0)
       currentStock.value = isFinite(num) ? num : 0
-    } catch {
+      stockLoaded.value = true
+      return currentStock.value
+    } catch (e: any) {
       currentStock.value = 0
+      stockLoaded.value = false
+      errorMessage.value =
+        e?.data?.detail ||
+        e?.message ||
+        'No se pudo cargar el stock actual. Reintentá antes de registrar el ajuste.'
+      throw e
+    } finally {
+      isLoadingStock.value = false
     }
-    return currentStock.value
   }
 
   /**
@@ -207,6 +230,8 @@ export function useInventoryAdjustment() {
     form,
     selectedIngredient,
     currentStock,
+    isLoadingStock,
+    stockLoaded,
     isSubmitting,
     errorMessage,
     isFormValid,

--- a/composables/useInventoryAdjustment.ts
+++ b/composables/useInventoryAdjustment.ts
@@ -1,0 +1,219 @@
+/**
+ * useInventoryAdjustment — state + handlers for a single stock adjustment.
+ *
+ * Lifts the form logic from `pages/abastecimiento/ajustes/crear.vue` so the
+ * new slide-over (warocol.com#608) and the standalone page can share one
+ * code path. The standalone page is not migrated in this PR — to keep the
+ * diff focused — but the composable is shaped to be a drop-in for it later.
+ *
+ * Submits to: POST /api/inventory/adjustments
+ *   body: { ingredient_id, quantity_change (signed), unit, cost_per_unit?, reason, source }
+ */
+import { computed, reactive, ref } from 'vue'
+
+export type AdjustmentType = 'increment' | 'decrement' | 'set'
+
+export interface AdjustmentReason {
+  value: string
+  label: string
+}
+
+export const ADJUSTMENT_REASONS: AdjustmentReason[] = [
+  { value: 'inventory_count', label: 'Conteo físico de inventario' },
+  { value: 'expired',         label: 'Producto vencido' },
+  { value: 'damaged',         label: 'Producto dañado' },
+  { value: 'spoilage',        label: 'Merma o desperdicio' },
+  { value: 'theft',           label: 'Robo o pérdida' },
+  { value: 'correction',      label: 'Corrección de error de registro' },
+  { value: 'initial_stock',   label: 'Inventario inicial' },
+  { value: 'transfer',        label: 'Transferencia interna' },
+  { value: 'supplier_return', label: 'Devolución a proveedor' },
+  { value: 'other',           label: 'Otro' },
+]
+
+const REASON_LABELS: Record<string, string> = ADJUSTMENT_REASONS.reduce(
+  (acc, r) => { acc[r.value] = r.label; return acc },
+  {} as Record<string, string>,
+)
+
+export interface SelectedIngredient {
+  id: string
+  name: string
+  unit: string          // base unit
+  minimum_stock?: number | null
+  maximum_stock?: number | null
+}
+
+interface FormState {
+  ingredientId: string
+  adjustmentType: AdjustmentType | ''
+  quantity: number | null
+  unit: string                // purchase unit code (or base unit if no purchase units)
+  cost_per_unit: number | null  // only meaningful when type=increment
+  reason: string
+  notes: string
+}
+
+export function useInventoryAdjustment() {
+  const form = reactive<FormState>({
+    ingredientId: '',
+    adjustmentType: '',
+    quantity: null,
+    unit: '',
+    cost_per_unit: null,
+    reason: '',
+    notes: '',
+  })
+
+  const selectedIngredient = ref<SelectedIngredient | null>(null)
+  const currentStock = ref<number>(0)
+  const isSubmitting = ref(false)
+  const errorMessage = ref('')
+
+  const isFormValid = computed(() => {
+    if (!form.ingredientId || !form.adjustmentType || !form.unit) return false
+    if (!form.quantity || form.quantity <= 0) return false
+    if (!form.reason) return false
+    if (form.reason === 'other' && !form.notes.trim()) return false
+    return true
+  })
+
+  /**
+   * Computes the new stock value after the adjustment, expressed in the
+   * ingredient's BASE unit. Mirrors the preview shown to the operator.
+   * `quantity` is in the chosen purchase unit; `convertToBase` returns the
+   * value translated to base unit.
+   */
+  const calculateNewStockInBase = (convertToBase: (qty: number, unit: string) => number): number => {
+    const qty = form.quantity ?? 0
+    if (qty <= 0) return currentStock.value
+    const qtyInBase = convertToBase(qty, form.unit)
+    switch (form.adjustmentType) {
+      case 'increment': return currentStock.value + qtyInBase
+      case 'decrement': return Math.max(0, currentStock.value - qtyInBase)
+      case 'set':       return qtyInBase
+      default:          return currentStock.value
+    }
+  }
+
+  /**
+   * Fires the yellow "large adjustment" warning when the change is >50%
+   * of current stock. `set` never triggers (it's an absolute value, not a delta).
+   */
+  const largeAdjustmentWarning = (convertToBase: (qty: number, unit: string) => number): boolean => {
+    if (!form.quantity || form.quantity <= 0) return false
+    if (form.adjustmentType === 'set') return false
+    if (!currentStock.value || currentStock.value <= 0) return false
+    const qtyInBase = convertToBase(form.quantity, form.unit)
+    const pct = (qtyInBase / currentStock.value) * 100
+    return pct > 50
+  }
+
+  const reset = () => {
+    form.ingredientId = ''
+    form.adjustmentType = ''
+    form.quantity = null
+    form.unit = ''
+    form.cost_per_unit = null
+    form.reason = ''
+    form.notes = ''
+    selectedIngredient.value = null
+    currentStock.value = 0
+    isSubmitting.value = false
+    errorMessage.value = ''
+  }
+
+  /**
+   * Loads the current stock for an ingredient.
+   * Returns the numeric value (0 if not found / null).
+   */
+  const loadCurrentStock = async (ingredientId: string): Promise<number> => {
+    try {
+      const res = await $fetch<{ current_stock?: number | null }>(
+        `/api/inventory/stock/${ingredientId}`,
+      )
+      const v = res?.current_stock
+      const num = typeof v === 'number' ? v : Number(v ?? 0)
+      currentStock.value = isFinite(num) ? num : 0
+    } catch {
+      currentStock.value = 0
+    }
+    return currentStock.value
+  }
+
+  /**
+   * Submits the adjustment. Translates the chosen adjustment type into a
+   * signed `quantity_change` value in the PURCHASE unit (backend converts
+   * to base). On success returns the API response payload; on failure
+   * throws — caller surfaces `errorMessage`.
+   */
+  const submit = async (): Promise<unknown> => {
+    if (!isFormValid.value) {
+      throw new Error('Formulario inválido')
+    }
+    isSubmitting.value = true
+    errorMessage.value = ''
+    try {
+      const qty = form.quantity as number
+      let quantityChange = 0
+      if (form.adjustmentType === 'increment') {
+        quantityChange = qty
+      } else if (form.adjustmentType === 'decrement') {
+        quantityChange = -qty
+      } else if (form.adjustmentType === 'set') {
+        // Backend interprets quantity_change as a DELTA. For "set", the
+        // delta is `target - current` — both in the SAME unit. We send the
+        // PURCHASE unit, so we must express current_stock in that unit too.
+        // Simplest path: send the target as-is and let the cashier verify;
+        // matches the standalone page behaviour at ajustes/crear.vue:533.
+        // (`quantity` is the target value in the chosen unit.)
+        quantityChange = qty - currentStock.value
+      }
+
+      const payload: Record<string, unknown> = {
+        ingredient_id: form.ingredientId,
+        quantity_change: quantityChange,
+        unit: form.unit,
+        reason: `${REASON_LABELS[form.reason] || form.reason}${form.notes ? ': ' + form.notes : ''}`,
+        source: 'manual_adjustment',
+      }
+      if (form.adjustmentType === 'increment' && form.cost_per_unit) {
+        payload.cost_per_unit = form.cost_per_unit
+      }
+
+      const res = await $fetch('/api/inventory/adjustments', {
+        method: 'POST',
+        body: payload,
+      })
+      return res
+    } catch (e: any) {
+      const detail = e?.data?.detail
+      if (Array.isArray(detail)) {
+        errorMessage.value = detail
+          .map((d: any) => d?.msg || JSON.stringify(d))
+          .join(', ')
+      } else if (typeof detail === 'string') {
+        errorMessage.value = detail
+      } else {
+        errorMessage.value = e?.message || 'No se pudo registrar el ajuste.'
+      }
+      throw e
+    } finally {
+      isSubmitting.value = false
+    }
+  }
+
+  return {
+    form,
+    selectedIngredient,
+    currentStock,
+    isSubmitting,
+    errorMessage,
+    isFormValid,
+    calculateNewStockInBase,
+    largeAdjustmentWarning,
+    loadCurrentStock,
+    submit,
+    reset,
+  }
+}

--- a/pages/abastecimiento/stock.vue
+++ b/pages/abastecimiento/stock.vue
@@ -72,6 +72,20 @@
               {{ unit }}
             </option>
           </select>
+
+          <!-- warocol.com#608 — Adjust stock for any ingredient (including
+               those with zero stock, which never render as rows). -->
+          <button
+            type="button"
+            title="Ajustar stock"
+            @click="showAdjustmentPanel = true"
+            class="min-h-[44px] h-10 px-3 inline-flex items-center gap-1.5 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 transition-colors flex-shrink-0"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+            </svg>
+            <span class="hidden sm:inline">Ajustar stock</span>
+          </button>
         </template>
       </SharedFiltersBar>
 
@@ -188,11 +202,18 @@
       </UiResponsiveDataView>
       </HealthSemaphore>
     </div>
+
+    <!-- warocol.com#608 — Stock adjustment slide-over -->
+    <AbastecimientoStockAdjustmentPanel
+      v-model="showAdjustmentPanel"
+      @saved="onAdjustmentSaved"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, inject, onMounted } from 'vue'
+import { useQueryCache } from '@pinia/colada'
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 
@@ -206,6 +227,16 @@ const searchQuery = ref('')
 const categoryFilter = ref('')
 const statusFilter = ref('all')
 const unitFilter = ref('')
+
+// warocol.com#608 — stock adjustment slide-over
+const showAdjustmentPanel = ref(false)
+const toast = useToast()
+const cache = useQueryCache()
+const onAdjustmentSaved = () => {
+  // Invalidate the inventory query so the table reflects the new stock.
+  cache.invalidateQueries({ key: ['inventory'] })
+  toast.success('Ajuste registrado', { title: 'Stock actualizado' })
+}
 
 // Sorting state
 const sortField = ref('')


### PR DESCRIPTION
## Summary

Adds an "Ajustar stock" entry point on `/abastecimiento/stock` that opens a responsive slide-over to adjust ANY ingredient — including the 28 zero-stock rows currently invisible in the table (filtered out by `inventory_service.py:93` `WHERE ti.current_stock != 0`).

## Stack
🟢 Nuxt 3 + 🎨 UX. No backend changes.

## Changes

### `composables/useIngredientPurchaseUnits.ts` (new)
- Per-tab singleton cache via `useState` for `Map<ingredient_id, PurchaseUnit[]>`.
- API: `fetch(id)`, `isLoading(id)`, `options(id)`, `defaultFor(id)`, `convertToBase(id, qty, unit)`, `clear(id?)`.
- Hits `/api/suppliers/ingredient-purchase-units/ingredient/{id}`. Empty array cached on error so callers don't loop.
- Filters `is_active === false` rows out (mirrors backend filter in `inventory_service.py:506`).

### `composables/useInventoryAdjustment.ts` (new)
- Form state + helpers extracted from `pages/abastecimiento/ajustes/crear.vue` — both the panel and (future cleanup PR) the standalone page can use the same logic.
- Exports `ADJUSTMENT_REASONS` (10 reasons) + `useInventoryAdjustment()` which returns the reactive form, validation, `calculateNewStockInBase`, `largeAdjustmentWarning`, `loadCurrentStock`, `submit`, `reset`.
- Submit translates the chosen `adjustmentType` into a signed `quantity_change` in the **purchase** unit (backend converts to base). For `'set'`: sends `target - current_stock` as the delta — same convention as the standalone page.

### `components/abastecimiento/StockAdjustmentPanel.vue` (new, 515 LOC)
- Shell copied from `components/menu/CategoryPanel.vue`: bottom-sheet `<md`, slide-from-right `≥md`, `role="dialog"` + `aria-modal="true"`, Esc closes, backdrop click closes, focus on first input.
- **Ingredient picker uses `<UiIngredientSearchInput :allow-create="false">`** — the same type-to-search component compras-directas uses. No flat `<select>`.
- Sections in order:
  1. Ingredient picker.
  2. Stock summary card (Actual / Mínimo / Máximo) — only after selection.
  3. Three type buttons (Incremento / Decremento / Ajustar a) with green/red/primary highlight.
  4. Quantity input + purchase-unit `<select>` with the inline `= {qty * conversion_factor} {base_unit}` preview below — exactly like compras-directas.
  5. Amber empty-state banner when the ingredient has no `ingredient_purchase_units` rows, with link to `/abastecimiento/ingredientes?highlight={id}`.
  6. Cost-per-unit (only on `increment` type).
  7. Result preview (`Stock aumentará / disminuirá / se establecerá a X gr`).
  8. Reason selector (10 standard reasons).
  9. Notes textarea (required when `reason === 'other'`).
  10. Large-adjustment warning (`>50%` change of current stock).
- Footer: `Cancelar` + `Registrar ajuste` (≥44px). Submit shows `<UiLoadingDots>` while in-flight.
- Success state: in-panel banner + `Cerrar` / `Hacer otro ajuste` buttons. **No time-based auto-close** — operator dismisses or chains another adjustment. Matches the InvoiceEmailModal pattern from warocol.com#605.
- Error state: inline banner above the footer with the API `detail` string.

### `pages/abastecimiento/stock.vue`
- Import `useQueryCache` from `@pinia/colada`.
- Add `showAdjustmentPanel` ref + `toast` + `cache` + `onAdjustmentSaved` (invalidates `['inventory']` and toasts).
- Inside the `additional-filters` slot, after the unit filter `<select>`, add the new **"Ajustar stock"** button (`min-h-[44px]`, icon-only on mobile, icon+text on desktop).
- Mount `<AbastecimientoStockAdjustmentPanel v-model="..." @saved="..." />` after the data view.

## What's NOT in this PR (out of scope)

- The standalone page `/abastecimiento/ajustes/crear` still uses its own copy of the form logic. Will migrate to `useInventoryAdjustment` in a follow-up.
- The backend `WHERE ti.current_stock != 0` filter stays as-is. Table still hides zero-stock rows; the panel is the entry point for them.
- The `purchase_unit` ambiguity bug (multiple `bulto` rows with different conversions for the same `purchase_unit` string) is inherited from the standalone page — file as a separate issue when ready.

## Test Plan

- [x] Local typecheck via Nuxt auto-imports (no full `bun run build` per the project memory rule). All new code passes a visual review against the established patterns in CategoryPanel + compras-directas/crear.
- [ ] After deploy:
  - `/abastecimiento/stock` shows the "Ajustar stock" button next to "Todas las unidades". Icon-only on mobile, icon+text on desktop.
  - Click → slide-over opens (desktop right-slide, mobile bottom-sheet).
  - Type "tom" → search returns ingredients.
  - Pick "Tomate" → Stock Actual loads, default unit is `kg`, conversion preview shows `= {qty * 1000} gr`.
  - Switch unit to "Bulto 25kg" → preview reads `= {qty * 25000} gr`.
  - Pick `Incremento`, qty 2, reason "Conteo físico" → "Resultado" updates, submit enables.
  - Submit → success banner → "Hacer otro ajuste" → form resets → can immediately submit another.
  - Ingredient with no `ingredient_purchase_units` rows → amber banner with link to ingredient panel.
  - Ingredient with `current_stock = 0` → adjustment succeeds (backend creates the `tenant_inventory` row).
  - Mobile (<640px) → bottom-sheet renders with drag handle.

## Closes
warocol.com#608.