### PR TITLE
feat(operaciones): custom label for 'Mesas' — Habitaciones / Cabañas / custom (#612)

### DIFF
--- a/components/despacho/ComandaDetailPanel.vue
+++ b/components/despacho/ComandaDetailPanel.vue
@@ -64,12 +64,14 @@ const updateStatus = async (status: string) => {
   }
 }
 
-const SOURCE_LABELS: Record<string, string> = {
-  table:    'Mesa',
+const { singular: tableSingular } = useTableLabel()
+
+const SOURCE_LABELS = computed<Record<string, string>>(() => ({
+  table:    tableSingular.value,
   pos:      'Mostrador',
   delivery: 'Domicilio',
   pickup:   'Recogida',
-}
+}))
 
 const COMANDA_STATUS_LABELS: Record<string, string> = {
   pending:   'Pendiente',

--- a/components/gestion/operaciones/MesaAssignmentHistoryModal.vue
+++ b/components/gestion/operaciones/MesaAssignmentHistoryModal.vue
@@ -44,7 +44,7 @@
               </div>
               <p class="text-sm font-semibold text-text-secondary">Sin historial</p>
               <p class="text-xs text-text-tertiary mt-1 max-w-[14rem]">
-                Esta mesa nunca ha tenido un mesero asignado.
+                {{ `Esta ${tableSingularLower} nunca ha tenido un mesero asignado.` }}
               </p>
             </div>
 
@@ -106,6 +106,9 @@
 import { computed, watch } from 'vue'
 import { useQuery } from '@pinia/colada'
 import { XMarkIcon, ClockIcon } from '@heroicons/vue/24/outline'
+
+const { singular: tableSingular } = useTableLabel()
+const tableSingularLower = computed(() => tableSingular.value.toLowerCase())
 
 interface HistoryEntry {
   id: string

--- a/components/gestion/operaciones/MesaMemberAssignRow.vue
+++ b/components/gestion/operaciones/MesaMemberAssignRow.vue
@@ -7,7 +7,7 @@
       <div class="min-w-0">
         <p class="text-sm font-bold text-text-primary truncate">{{ table.name }}</p>
         <p class="text-[10px] text-text-tertiary font-medium uppercase tracking-wider">
-          {{ table.capacity ? `${table.capacity} personas` : 'Mesa' }}
+          {{ table.capacity ? `${table.capacity} personas` : tableSingular }}
         </p>
       </div>
     </div>
@@ -55,6 +55,8 @@
 
 <script setup lang="ts">
 import { UserIcon, ClockIcon } from '@heroicons/vue/24/outline'
+
+const { singular: tableSingular } = useTableLabel()
 
 interface Member {
   id: string

--- a/components/mesas/MesaPanel.vue
+++ b/components/mesas/MesaPanel.vue
@@ -18,7 +18,7 @@
         v-if="modelValue"
         role="dialog"
         aria-modal="true"
-        :aria-label="isEdit ? `Editar mesa: ${table?.name}` : 'Crear nueva mesa'"
+        :aria-label="isEdit ? `Editar ${tableSingularLower}: ${table?.name}` : `Crear nueva ${tableSingularLower}`"
         class="fixed z-50 flex flex-col bg-surface shadow-2xl
                inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh]
                md:inset-y-0 md:right-0 md:bottom-auto md:left-auto md:inset-x-auto md:rounded-none md:w-full md:max-w-md md:max-h-none md:h-full"
@@ -39,7 +39,7 @@
               </div>
               <div class="min-w-0">
                 <h2 class="text-base font-bold text-text-primary leading-tight">
-                  {{ isEdit ? 'Editar mesa' : 'Nueva mesa' }}
+                  {{ isEdit ? `Editar ${tableSingularLower}` : `Nueva ${tableSingularLower}` }}
                 </h2>
                 <p class="text-xs text-text-secondary leading-snug mt-0.5">
                   {{ isEdit ? table?.name : 'Configura el nombre y capacidad' }}
@@ -70,7 +70,7 @@
               id="mesa-name"
               v-model="form.name"
               type="text"
-              placeholder="Ej: Mesa 1, Barra 2, Terraza 3"
+              :placeholder="`Ej: ${tableSingular} 1, Barra 2, Terraza 3`"
               maxlength="50"
               :class="inputClass"
               @input="clearError('name')"
@@ -138,7 +138,7 @@
             @click="submit"
           >
             <span v-if="saving">Guardando...</span>
-            <span v-else>{{ isEdit ? 'Guardar cambios' : 'Crear mesa' }}</span>
+            <span v-else>{{ isEdit ? 'Guardar cambios' : `Crear ${tableSingularLower}` }}</span>
           </button>
         </div>
       </div>
@@ -148,6 +148,9 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+
+const { singular: tableSingular } = useTableLabel()
+const tableSingularLower = computed(() => tableSingular.value.toLowerCase())
 
 interface Member {
   id: string

--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -139,7 +139,7 @@
         <svg class="h-16 w-16 mx-auto text-text-secondary mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" />
         </svg>
-        <p class="text-text-secondary">{{ mesaMode ? 'Mesa sin pedidos' : 'Carrito vacío' }}</p>
+        <p class="text-text-secondary">{{ mesaMode ? `${tableSingular} sin pedidos` : 'Carrito vacío' }}</p>
         <p class="text-sm text-text-tertiary mt-1">Selecciona productos para agregar</p>
       </div>
       </template>
@@ -223,14 +223,14 @@
           type="button"
           :disabled="items.length === 0 || isDeleting || isAddingToTab"
           class="w-full h-12 rounded-xl bg-primary text-primary-foreground text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
-          aria-label="Agregar items a la mesa"
+          :aria-label="`Agregar items a la ${tableSingularLower}`"
           @click="$emit('add-to-tab')"
         >
           <UiLoadingDots v-if="isAddingToTab" size="9px" />
           <svg v-else class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>
-          {{ isAddingToTab ? 'Enviando...' : (comandasEnabled ? 'Agregar y enviar a cocina' : 'Agregar a la mesa') }}
+          {{ isAddingToTab ? 'Enviando...' : (comandasEnabled ? 'Agregar y enviar a cocina' : `Agregar a la ${tableSingularLower}`) }}
         </button>
       </div>
     </div>
@@ -240,6 +240,9 @@
 <script setup lang="ts">
 import { usePOSStore } from '~/stores/usePOSStore'
 import { storeToRefs } from 'pinia'
+
+const { singular: tableSingular } = useTableLabel()
+const tableSingularLower = computed(() => tableSingular.value.toLowerCase())
 
 interface CartItem {
   product: {

--- a/components/pos/ComandasEstadoPanel.vue
+++ b/components/pos/ComandasEstadoPanel.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onUnmounted } from 'vue'
+
+const { singular: tableSingular } = useTableLabel()
 import {
   XMarkIcon,
   ClipboardDocumentListIcon,
@@ -250,7 +252,7 @@ const submit = async () => {
               <div class="min-w-0">
                 <h2 class="text-base font-bold text-text-primary leading-tight">Estado de comandas</h2>
                 <p class="text-xs text-text-secondary leading-snug mt-0.5 truncate">
-                  {{ tableDisplayName ? `Mesa ${tableDisplayName}` : 'Comandas activas' }}
+                  {{ tableDisplayName ? `${tableSingular} ${tableDisplayName}` : 'Comandas activas' }}
                   · {{ comandas.length }} {{ comandas.length === 1 ? 'comanda' : 'comandas' }}
                 </p>
               </div>

--- a/components/pos/MesasFloorPlan.vue
+++ b/components/pos/MesasFloorPlan.vue
@@ -2,6 +2,9 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { $fetch } from 'ofetch'
 
+const { singular: tableSingular } = useTableLabel()
+const tableSingularLower = computed(() => tableSingular.value.toLowerCase())
+
 const props = defineProps<{
   comandasEnabled?: boolean
   /** Issue #574 — when true, render the effective-waiter line under each mesa card */
@@ -361,7 +364,7 @@ onUnmounted(() => {
                   type="button"
                   class="w-7 h-7 flex items-center justify-center rounded hover:bg-black/10 transition-colors focus:outline-none"
                   :class="stripTextClass(table.status)"
-                  :aria-label="`Mover ${table.name} a otra mesa`"
+                  :aria-label="`Mover ${table.name} a otra ${tableSingularLower}`"
                   @click.stop="handleMoveTable(table, $event)"
                 >
                   <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/components/pos/MoveTableModal.vue
+++ b/components/pos/MoveTableModal.vue
@@ -7,6 +7,10 @@
 import { ref, computed } from 'vue'
 import { useMoveTable } from '~/composables/useMoveTable'
 
+const { singular: tableSingular, plural: tablePlural } = useTableLabel()
+const tableSingularLower = computed(() => tableSingular.value.toLowerCase())
+const tablePluralLower = computed(() => tablePlural.value.toLowerCase())
+
 const props = defineProps<{
   show: boolean
   sourceTable: { tableId: string; sessionId: string; tableName: string } | null
@@ -65,7 +69,7 @@ const tableShortId = (name: string) => {
       class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
       aria-modal="true"
       role="dialog"
-      :aria-label="`Mover ${sourceTable?.tableName ?? 'mesa'} a otra mesa`"
+      :aria-label="`Mover ${sourceTable?.tableName ?? tableSingularLower} a otra ${tableSingularLower}`"
     >
       <!-- Backdrop -->
       <div
@@ -80,9 +84,9 @@ const tableShortId = (name: string) => {
         <div class="flex items-center justify-between px-5 pt-5 pb-4 border-b border-border flex-shrink-0">
           <div>
             <h2 class="text-base font-bold text-text-primary">
-              Mover {{ sourceTable?.tableName ?? 'mesa' }} a...
+              Mover {{ sourceTable?.tableName ?? tableSingularLower }} a...
             </h2>
-            <p class="text-xs text-text-secondary mt-0.5">Selecciona una mesa libre como destino</p>
+            <p class="text-xs text-text-secondary mt-0.5">{{ `Selecciona una ${tableSingularLower} libre como destino` }}</p>
           </div>
           <button
             type="button"
@@ -108,7 +112,7 @@ const tableShortId = (name: string) => {
           </div>
 
           <div v-if="destinationTables.length === 0" class="py-8 text-center text-sm text-text-secondary">
-            No hay otras mesas disponibles
+            {{ `No hay otras ${tablePluralLower} disponibles` }}
           </div>
 
           <div v-else class="grid grid-cols-3 gap-3">

--- a/composables/useTableLabel.ts
+++ b/composables/useTableLabel.ts
@@ -1,0 +1,61 @@
+import { ref, watch, readonly } from 'vue'
+import { useTenantReactive } from '@/composables/useTenantReactive'
+
+interface StoredLabel {
+  singular: string
+  plural: string
+}
+
+const DEFAULTS: StoredLabel = { singular: 'Mesa', plural: 'Mesas' }
+
+const storageKey = (tenantId: string) => `waro_table_label_${tenantId}`
+
+export function useTableLabel() {
+  const { currentTenant } = useTenantReactive()
+
+  const singular = ref<string>(DEFAULTS.singular)
+  const plural = ref<string>(DEFAULTS.plural)
+
+  const load = (tenantId: string | null | undefined) => {
+    if (!tenantId || !import.meta.client) {
+      singular.value = DEFAULTS.singular
+      plural.value = DEFAULTS.plural
+      return
+    }
+    const stored = localStorage.getItem(storageKey(tenantId))
+    if (!stored) {
+      singular.value = DEFAULTS.singular
+      plural.value = DEFAULTS.plural
+      return
+    }
+    try {
+      const parsed = JSON.parse(stored) as Partial<StoredLabel>
+      singular.value = parsed.singular?.trim() || DEFAULTS.singular
+      plural.value = parsed.plural?.trim() || DEFAULTS.plural
+    } catch {
+      singular.value = DEFAULTS.singular
+      plural.value = DEFAULTS.plural
+    }
+  }
+
+  watch(() => currentTenant.value?.id, (id) => load(id), { immediate: true })
+
+  const setLabel = (newSingular: string, newPlural: string) => {
+    const tenantId = currentTenant.value?.id
+    if (!tenantId || !import.meta.client) return
+    const sin = newSingular.trim() || DEFAULTS.singular
+    const plu = newPlural.trim() || DEFAULTS.plural
+    singular.value = sin
+    plural.value = plu
+    localStorage.setItem(
+      storageKey(tenantId),
+      JSON.stringify({ singular: sin, plural: plu }),
+    )
+  }
+
+  return {
+    singular: readonly(singular),
+    plural: readonly(plural),
+    setLabel,
+  }
+}

--- a/pages/comandas/index.vue
+++ b/pages/comandas/index.vue
@@ -9,19 +9,20 @@ definePageMeta({
 useHead({ title: 'Monitor de Comandas — WARO' })
 
 const { currentTenant, businessProfile } = useTenantReactive()
+const { plural: tablePlural } = useTableLabel()
 const toast = useToast()
 
 // ── Feature flag guard ──────────────────────────────────────────────────────
 const comandasEnabled = computed(() => businessProfile.value?.comandas_enabled === true)
 
 // ── Filters ────────────────────────────────────────────────────────────────
-const SOURCE_TYPES = [
+const SOURCE_TYPES = computed(() => [
   { value: '',         label: 'Todas' },
-  { value: 'table',    label: 'Mesas' },
+  { value: 'table',    label: tablePlural.value },
   { value: 'pos',      label: 'Mostrador' },
   { value: 'delivery', label: 'Domicilios' },
   { value: 'pickup',   label: 'Recogidas' },
-]
+])
 
 const STATUS_OPTIONS = [
   { value: 'pending,preparing', label: 'Activas' },

--- a/pages/despacho/comandas.vue
+++ b/pages/despacho/comandas.vue
@@ -10,13 +10,14 @@ definePageMeta({ layout: 'dashboard' })
 useHead({ title: 'Comandas — WARO' })
 
 const { currentTenant } = useTenantReactive()
+const { singular: tableSingular } = useTableLabel()
 
-const SOURCE_LABELS: Record<string, string> = {
-  table:    'Mesa',
+const SOURCE_LABELS = computed<Record<string, string>>(() => ({
+  table:    tableSingular.value,
   pos:      'Mostrador',
   delivery: 'Domicilio',
   pickup:   'Recogida',
-}
+}))
 
 const COMANDA_STATUS_LABELS: Record<string, string> = {
   pending:   'Pendiente',

--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -61,7 +61,7 @@
             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
-            {{ openTablesCount }} mesa{{ openTablesCount !== 1 ? 's' : '' }} abierta{{ openTablesCount !== 1 ? 's' : '' }}
+            {{ openTablesCount }} {{ openTablesCount === 1 ? tableSingular.toLowerCase() : tablePlural.toLowerCase() }} {{ openTablesCount === 1 ? 'abierta' : 'abiertas' }}
           </NuxtLink>
 
           <button
@@ -227,6 +227,7 @@ useHead({ title: 'Arqueo de caja - Warocol' })
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 const { currentTenant } = useTenantReactive()
+const { singular: tableSingular, plural: tablePlural } = useTableLabel()
 
 const today = new Date().toISOString().split('T')[0]
 

--- a/pages/finanzas/arqueo/nuevo.vue
+++ b/pages/finanzas/arqueo/nuevo.vue
@@ -226,8 +226,8 @@
               </svg>
             </div>
             <div class="flex-1 min-w-0">
-              <p class="text-sm font-semibold text-amber-800">{{ xPreviewData.openTablesCount }} mesa{{ xPreviewData.openTablesCount !== 1 ? 's' : '' }} con cuenta abierta</p>
-              <p class="text-xs text-amber-700 mt-0.5">Cierra todas las mesas en el POS antes de registrar el arqueo.</p>
+              <p class="text-sm font-semibold text-amber-800">{{ xPreviewData.openTablesCount }} {{ xPreviewData.openTablesCount === 1 ? tableSingular.toLowerCase() : tablePlural.toLowerCase() }} con cuenta abierta</p>
+              <p class="text-xs text-amber-700 mt-0.5">Cierra todas las {{ tablePlural.toLowerCase() }} en el POS antes de registrar el arqueo.</p>
               <div class="flex flex-wrap gap-2 mt-3">
                 <NuxtLink to="/pos" target="_blank" class="inline-flex items-center gap-1.5 min-h-[36px] px-4 py-1.5 rounded-lg bg-amber-600 text-white text-xs font-semibold hover:bg-amber-700 transition-colors">
                   <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
@@ -715,6 +715,7 @@ useHead({ title: 'Nuevo arqueo de caja - Warocol' })
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 const { currentTenant } = useTenantReactive()
+const { singular: tableSingular, plural: tablePlural } = useTableLabel()
 const cache = useQueryCache()
 
 const today = new Date().toISOString().split('T')[0]

--- a/pages/finanzas/arqueo/x.vue
+++ b/pages/finanzas/arqueo/x.vue
@@ -87,7 +87,7 @@
             <span class="text-text-primary">{{ formatCurrency(previewData.cashExpected) }}</span>
           </div>
           <div class="flex justify-between px-4 py-2.5 text-sm">
-            <span class="text-text-secondary">Mesas abiertas</span>
+            <span class="text-text-secondary">{{ tablePlural }} abiertas</span>
             <span
               class="font-medium"
               :class="previewData.openTablesCount > 0 ? 'text-amber-600 font-semibold' : 'text-text-primary'"
@@ -174,6 +174,7 @@ useHead({ title: 'Previsualización arqueo - Warocol' })
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 const { currentTenant } = useTenantReactive()
+const { plural: tablePlural } = useTableLabel()
 const route = useRoute()
 
 const today = new Date().toISOString().split('T')[0]

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -142,7 +142,7 @@
               <div class="flex justify-between px-4 py-2.5 text-sm"><span class="text-text-secondary">Gastos en efectivo</span><span class="font-medium text-destructive">− {{ formatCurrency(xPreviewData.gastosEfectivo) }}</span></div>
               <div class="flex justify-between px-4 py-2.5 text-sm font-semibold"><span class="text-text-primary">Esperado en caja</span><span>{{ formatCurrency(xPreviewData.cashExpected) }}</span></div>
               <div class="flex justify-between px-4 py-2.5 text-sm">
-                <span class="text-text-secondary">Mesas abiertas</span>
+                <span class="text-text-secondary">{{ tablePlural }} abiertas</span>
                 <span class="font-medium" :class="xPreviewData.openTablesCount > 0 ? 'text-amber-600 font-semibold' : 'text-text-primary'">{{ xPreviewData.openTablesCount }}</span>
               </div>
             </div>
@@ -293,9 +293,9 @@
           </div>
           <div class="flex-1 min-w-0">
             <p class="text-sm font-semibold text-amber-800">
-              {{ previewData.openTablesCount }} mesa{{ previewData.openTablesCount !== 1 ? 's' : '' }} con cuenta abierta
+              {{ previewData.openTablesCount }} {{ previewData.openTablesCount === 1 ? tableSingular.toLowerCase() : tablePlural.toLowerCase() }} con cuenta abierta
             </p>
-            <p class="text-xs text-amber-700 mt-0.5">Cierra todas las mesas en el POS antes de registrar el arqueo.</p>
+            <p class="text-xs text-amber-700 mt-0.5">Cierra todas las {{ tablePlural.toLowerCase() }} en el POS antes de registrar el arqueo.</p>
             <div class="flex flex-wrap gap-2 mt-3">
               <NuxtLink
                 to="/pos"
@@ -319,7 +319,7 @@
             </div>
           </div>
         </div>
-        <div v-else class="text-sm text-text-secondary py-2">No se pudo cargar el estado de las mesas.</div>
+        <div v-else class="text-sm text-text-secondary py-2">No se pudo cargar el estado de las {{ tablePlural.toLowerCase() }}.</div>
       </div>
 
       <!-- Step 2: Conteo de caja -->
@@ -785,6 +785,7 @@ useHead({ title: 'Arqueo de caja - Warocol' })
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 const { currentTenant } = useTenantReactive()
+const { singular: tableSingular, plural: tablePlural } = useTableLabel()
 const route = useRoute()
 
 const today = new Date().toISOString().split('T')[0]

--- a/pages/operaciones.vue
+++ b/pages/operaciones.vue
@@ -7,17 +7,18 @@
 
 <script setup lang="ts">
 const route = useRoute()
+const { plural } = useTableLabel()
 
 definePageMeta({
   layout: 'dashboard',
   module: 'operaciones',
 })
 
-const navigationItems = [
+const navigationItems = computed(() => [
   { to: '/operaciones/comandas', label: 'Comandas & Cocina' },
-  { to: '/operaciones/mesas', label: 'Mesas' },
+  { to: '/operaciones/mesas', label: plural.value },
   { to: '/operaciones/personalizar', label: 'Personalizar' },
-]
+])
 
 useHead({ title: 'Operaciones | WARO' })
 </script>

--- a/pages/operaciones/mesas.vue
+++ b/pages/operaciones/mesas.vue
@@ -6,7 +6,11 @@ definePageMeta({
   layout: 'dashboard'
 })
 
-useHead({ title: 'Mesas | Operaciones' })
+const { singular, plural } = useTableLabel()
+const singularLower = computed(() => singular.value.toLowerCase())
+const pluralLower = computed(() => plural.value.toLowerCase())
+
+useHead({ title: computed(() => `${plural.value} | Operaciones`) })
 
 const { currentTenant } = useTenantReactive()
 
@@ -80,7 +84,7 @@ const inactiveTables = computed(() => {
 // read-only — clicking "Editar" is the only way to change the assignment.
 const tableColumns = computed(() => {
   const cols: Array<{ key: string; title: string; sortable?: boolean }> = [
-    { key: 'name', title: 'Mesa', sortable: false },
+    { key: 'name', title: singular.value, sortable: false },
     { key: 'capacity', title: 'Capacidad' },
   ]
   if (businessProfile.value?.waiter_attribution_enabled) {
@@ -125,7 +129,7 @@ const confirmDeactivate = async () => {
   } catch (err: any) {
     const status = err?.response?.status ?? err?.status
     deactivateError.value = status === 409
-      ? (err?.data?.detail ?? 'Mesa con sesión abierta, ciérrala primero')
+      ? (err?.data?.detail ?? `${singular.value} con sesión abierta, ciérrala primero`)
       : (err?.data?.detail ?? 'Error al desactivar')
   } finally {
     isDeactivating.value = false
@@ -174,7 +178,7 @@ const confirmDelete = async () => {
   } catch (err: any) {
     const status = err?.response?.status ?? err?.status
     deleteError.value = status === 409
-      ? (err?.data?.detail ?? 'No se puede eliminar esta mesa ahora')
+      ? (err?.data?.detail ?? `No se puede eliminar esta ${singularLower.value} ahora`)
       : (err?.data?.detail ?? 'Error al eliminar')
   } finally {
     isDeleting.value = false
@@ -218,7 +222,7 @@ const toggleTablesEnabled = async () => {
     await invalidateContextCaches()
     posStore.tablesEnabled = newState
     toast.success(
-      newState ? 'Gestión de mesas activada para el POS' : 'Gestión de mesas desactivada',
+      newState ? `Gestión de ${pluralLower.value} activada para el POS` : `Gestión de ${pluralLower.value} desactivada`,
       { title: newState ? '¡Módulo activado!' : 'Módulo desactivado' }
     )
   } catch (error: any) {
@@ -291,19 +295,19 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
               class="text-sm font-semibold leading-snug"
               :class="businessProfile.tables_enabled ? 'text-text-primary' : 'text-amber-800 dark:text-amber-300'"
             >
-              {{ businessProfile.tables_enabled ? 'Gestión de mesas activa' : 'Gestión de mesas desactivada' }}
+              {{ businessProfile.tables_enabled ? `Gestión de ${pluralLower} activa` : `Gestión de ${pluralLower} desactivada` }}
             </p>
             <p
               class="text-xs mt-0.5 leading-snug"
               :class="businessProfile.tables_enabled ? 'text-text-secondary' : 'text-amber-700 dark:text-amber-400'"
             >
-              {{ businessProfile.tables_enabled ? 'El flujo de mesas está disponible en el punto de venta' : 'Actívala para usar el flujo de mesas en el punto de venta' }}
+              {{ businessProfile.tables_enabled ? `El flujo de ${pluralLower} está disponible en el punto de venta` : `Actívala para usar el flujo de ${pluralLower} en el punto de venta` }}
             </p>
           </div>
           <label
             class="relative inline-flex items-center cursor-pointer flex-shrink-0"
             :class="isTogglingTables ? 'opacity-50 pointer-events-none' : ''"
-            :aria-label="businessProfile.tables_enabled ? 'Desactivar gestión de mesas' : 'Activar gestión de mesas'"
+            :aria-label="businessProfile.tables_enabled ? `Desactivar gestión de ${pluralLower}` : `Activar gestión de ${pluralLower}`"
           >
             <input
               type="checkbox"
@@ -320,17 +324,17 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
         <div v-if="businessProfile.tables_enabled" class="flex items-center justify-between gap-4 px-4 py-3">
           <div class="min-w-0">
             <p class="text-sm font-semibold leading-snug text-text-primary">
-              Asignar mesero por mesa
+              {{ `Asignar mesero por ${singularLower}` }}
             </p>
             <p class="text-xs mt-0.5 leading-snug text-text-secondary">
-              Cada mesa puede tener un mesero por defecto. Se puede cambiar al abrir la sesión o por orden.
+              {{ `Cada ${singularLower} puede tener un mesero por defecto. Se puede cambiar al abrir la sesión o por orden.` }}
               El historial se preserva incluso si el miembro se elimina.
             </p>
           </div>
           <label
             class="relative inline-flex items-center cursor-pointer flex-shrink-0"
             :class="isTogglingWaiterAttribution ? 'opacity-50 pointer-events-none' : ''"
-            :aria-label="businessProfile.waiter_attribution_enabled ? 'Desactivar asignación de meseros por mesa' : 'Activar asignación de meseros por mesa'"
+            :aria-label="businessProfile.waiter_attribution_enabled ? `Desactivar asignación de meseros por ${singularLower}` : `Activar asignación de meseros por ${singularLower}`"
           >
             <input
               type="checkbox"
@@ -349,21 +353,21 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
         v-model:search="searchTerm"
         v-model:status-filter="statusFilter"
         :status-options="statusOptions"
-        search-placeholder="Buscar mesa..."
+        :search-placeholder="`Buscar ${singularLower}...`"
         status-label="Estado"
         status-placeholder="Todos los estados"
         show-status-filter
       />
 
       <!-- ══════ ACTIVE TABLES ══════ -->
-      <HealthSemaphore :is-unlocked="true" title="Mesas configuradas">
+      <HealthSemaphore :is-unlocked="true" :title="`${plural} configuradas`">
         <template #header-actions>
           <button
             type="button"
             class="h-9 px-4 rounded-lg bg-primary text-sm font-semibold text-white hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 active:scale-[0.98] transition-all shadow-sm shadow-primary/30 whitespace-nowrap"
             @click="openPanel(null)"
           >
-            <span class="hidden sm:inline">+ Nueva mesa</span>
+            <span class="hidden sm:inline">{{ `+ Nueva ${singularLower}` }}</span>
             <span class="sm:hidden">+ Nueva</span>
           </button>
         </template>
@@ -371,8 +375,8 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
         <UiResponsiveDataView
           :columns="tableColumns"
           :data="activeTables"
-          empty-message="No hay mesas configuradas"
-          empty-sub-message="Crea tu primera mesa para empezar a gestionar el salón"
+          :empty-message="`No hay ${pluralLower} configuradas`"
+          :empty-sub-message="`Crea tu primera ${singularLower} para empezar a gestionar el salón`"
           variant="default"
           row-size="sm"
         >
@@ -462,7 +466,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
       </HealthSemaphore>
 
       <!-- ══════ INACTIVE TABLES ══════ -->
-      <HealthSemaphore v-if="inactiveTables.length > 0" :is-unlocked="true" title="Mesas desactivadas">
+      <HealthSemaphore v-if="inactiveTables.length > 0" :is-unlocked="true" :title="`${plural} desactivadas`">
         <UiResponsiveDataView
           :columns="tableColumns"
           :data="inactiveTables"
@@ -577,7 +581,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
                     <svg class="w-5 h-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 115.636 5.636m12.728 12.728L5.636 5.636" /></svg>
                   </div>
                   <div class="min-w-0 flex-1 pt-0.5">
-                    <h3 class="text-base font-bold text-text-primary leading-tight">Desactivar mesa</h3>
+                    <h3 class="text-base font-bold text-text-primary leading-tight">{{ `Desactivar ${singularLower}` }}</h3>
                     <p class="text-sm text-text-secondary mt-0.5 truncate font-medium">{{ deactivateModalTable?.name }}</p>
                   </div>
                 </div>
@@ -593,7 +597,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
 
               <div class="px-5 py-4 flex flex-col gap-3">
                 <p class="text-sm text-text-secondary leading-relaxed">
-                  La mesa quedará inactiva y no aparecerá en el punto de venta. Podrás reactivarla en cualquier momento desde esta pantalla.
+                  {{ `La ${singularLower} quedará inactiva y no aparecerá en el punto de venta. Podrás reactivarla en cualquier momento desde esta pantalla.` }}
                 </p>
                 <div v-if="deactivateError" class="rounded-xl bg-destructive/8 border border-destructive/20 px-4 py-3">
                   <p class="text-sm text-destructive font-medium">{{ deactivateError }}</p>
@@ -655,7 +659,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
                     <svg class="w-5 h-5 text-destructive" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
                   </div>
                   <div class="min-w-0 flex-1 pt-0.5">
-                    <h3 class="text-base font-bold text-text-primary leading-tight">Eliminar mesa</h3>
+                    <h3 class="text-base font-bold text-text-primary leading-tight">{{ `Eliminar ${singularLower}` }}</h3>
                     <p class="text-sm text-text-secondary mt-0.5 truncate font-medium">{{ deleteModalTable?.name }}</p>
                   </div>
                 </div>
@@ -678,7 +682,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
                     </div>
                     <div>
                       <p class="text-sm font-semibold text-destructive leading-snug">No se puede eliminar ahora</p>
-                      <p class="text-xs text-destructive/80 mt-1 leading-relaxed">Esta mesa tiene una sesión activa. Ciérrala antes de eliminarla.</p>
+                      <p class="text-xs text-destructive/80 mt-1 leading-relaxed">{{ `Esta ${singularLower} tiene una sesión activa. Ciérrala antes de eliminarla.` }}</p>
                     </div>
                   </div>
                 </div>
@@ -690,7 +694,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
                       <svg class="w-4 h-4 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" /></svg>
                     </div>
                     <div>
-                      <p class="text-sm font-semibold text-amber-800 dark:text-amber-300 leading-snug">Esta mesa se archivará</p>
+                      <p class="text-sm font-semibold text-amber-800 dark:text-amber-300 leading-snug">{{ `Esta ${singularLower} se archivará` }}</p>
                       <p class="text-xs text-amber-700/80 dark:text-amber-400 mt-1 leading-relaxed">Tiene historial de sesiones. Se archivará para preservar los reportes y dejará de aparecer en el sistema.</p>
                     </div>
                   </div>
@@ -704,7 +708,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
                     </div>
                     <div>
                       <p class="text-sm font-semibold text-emerald-800 dark:text-emerald-300 leading-snug">Sin historial — eliminación permanente</p>
-                      <p class="text-xs text-emerald-700/80 dark:text-emerald-400 mt-1 leading-relaxed">Esta mesa no tiene sesiones registradas. Se eliminará de forma definitiva.</p>
+                      <p class="text-xs text-emerald-700/80 dark:text-emerald-400 mt-1 leading-relaxed">{{ `Esta ${singularLower} no tiene sesiones registradas. Se eliminará de forma definitiva.` }}</p>
                     </div>
                   </div>
                 </div>

--- a/pages/operaciones/personalizar.vue
+++ b/pages/operaciones/personalizar.vue
@@ -31,8 +31,99 @@ registerProgressiveLoading(isRefreshing)
 onMounted(() => setRefreshHandler(refreshProfile))
 onUnmounted(() => clearRefreshHandler(refreshProfile))
 
-// ── Toggle: auto-select Genérico at /pos/checkout open ──────────────────────
 const toast = useToast()
+
+// ── Table label customization (issue #612) ──────────────────────────────────
+const { singular: storedSingular, plural: storedPlural, setLabel } = useTableLabel()
+
+interface LabelPreset {
+  key: string
+  label: string
+  singular: string
+  plural: string
+}
+
+const labelPresets: LabelPreset[] = [
+  { key: 'mesas', label: 'Mesas (predeterminado)', singular: 'Mesa', plural: 'Mesas' },
+  { key: 'habitaciones', label: 'Habitaciones', singular: 'Habitación', plural: 'Habitaciones' },
+  { key: 'cabanas', label: 'Cabañas', singular: 'Cabaña', plural: 'Cabañas' },
+  { key: 'areas', label: 'Áreas', singular: 'Área', plural: 'Áreas' },
+  { key: 'custom', label: 'Personalizado', singular: '', plural: '' },
+]
+
+const matchPresetKey = (sin: string, plu: string): string => {
+  const match = labelPresets.find(
+    (p) => p.key !== 'custom' && p.singular === sin && p.plural === plu,
+  )
+  return match ? match.key : 'custom'
+}
+
+const selectedPresetKey = ref<string>('mesas')
+const customSingular = ref<string>('')
+const customPlural = ref<string>('')
+
+// Initialize from stored values
+watch(
+  [storedSingular, storedPlural],
+  ([sin, plu]) => {
+    const key = matchPresetKey(sin, plu)
+    selectedPresetKey.value = key
+    if (key === 'custom') {
+      customSingular.value = sin
+      customPlural.value = plu
+    } else {
+      customSingular.value = ''
+      customPlural.value = ''
+    }
+  },
+  { immediate: true },
+)
+
+const selectPreset = (key: string) => {
+  selectedPresetKey.value = key
+  if (key !== 'custom') {
+    const preset = labelPresets.find((p) => p.key === key)
+    if (preset) {
+      customSingular.value = preset.singular
+      customPlural.value = preset.plural
+    }
+  }
+}
+
+const previewSingular = computed(() => {
+  if (selectedPresetKey.value === 'custom') return customSingular.value.trim() || 'Mesa'
+  const preset = labelPresets.find((p) => p.key === selectedPresetKey.value)
+  return preset?.singular || 'Mesa'
+})
+
+const previewPlural = computed(() => {
+  if (selectedPresetKey.value === 'custom') return customPlural.value.trim() || 'Mesas'
+  const preset = labelPresets.find((p) => p.key === selectedPresetKey.value)
+  return preset?.plural || 'Mesas'
+})
+
+const hasChanges = computed(
+  () =>
+    previewSingular.value !== storedSingular.value
+    || previewPlural.value !== storedPlural.value,
+)
+
+const isSavingLabel = ref(false)
+
+const saveLabel = () => {
+  if (!hasChanges.value || isSavingLabel.value) return
+  isSavingLabel.value = true
+  try {
+    setLabel(previewSingular.value, previewPlural.value)
+    toast.success('Nombre actualizado en este dispositivo', { title: 'Guardado' })
+  } catch (error: any) {
+    toast.error('No se pudo guardar el nombre', { title: 'Error' })
+  } finally {
+    isSavingLabel.value = false
+  }
+}
+
+// ── Toggle: auto-select Genérico at /pos/checkout open ──────────────────────
 const isToggling = ref(false)
 
 const toggleAutoSelectGeneric = async () => {
@@ -103,6 +194,88 @@ const toggleAutoSelectGeneric = async () => {
           />
           <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
         </label>
+      </div>
+
+      <!-- ══════ TABLE LABEL CUSTOMIZATION (Issue #612) ══════ -->
+      <div class="rounded-xl border-2 border-border bg-surface px-4 py-4 flex flex-col gap-4">
+        <div class="flex flex-col gap-1">
+          <p class="text-sm font-semibold text-text-primary">Nombre de las mesas</p>
+          <p class="text-xs leading-snug text-text-secondary">
+            Cambia el sustantivo que aparece en toda la plataforma. Usa palabras femeninas para que la concordancia del texto siga siendo correcta.
+          </p>
+        </div>
+
+        <!-- Preset chips -->
+        <div role="group" aria-label="Sustantivo predeterminado" class="flex flex-wrap gap-2">
+          <button
+            v-for="preset in labelPresets"
+            :key="preset.key"
+            type="button"
+            :aria-pressed="selectedPresetKey === preset.key"
+            class="min-h-[44px] px-3 py-2 rounded-lg border-2 text-sm font-medium transition-all active:scale-95"
+            :class="selectedPresetKey === preset.key
+              ? 'border-primary bg-primary/10 text-primary shadow-sm'
+              : 'border-border bg-background text-text-secondary hover:border-primary/40 hover:text-text-primary'"
+            @click="selectPreset(preset.key)"
+          >
+            {{ preset.label }}
+          </button>
+        </div>
+
+        <!-- Custom inputs (only when Personalizado is selected) -->
+        <div v-if="selectedPresetKey === 'custom'" class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div class="flex flex-col gap-1">
+            <label for="label-singular" class="text-sm font-medium text-text-primary">
+              Singular
+            </label>
+            <input
+              id="label-singular"
+              v-model="customSingular"
+              type="text"
+              maxlength="40"
+              placeholder="Ej: Habitación"
+              class="input-base w-full px-4 py-2 min-h-[44px]"
+            />
+          </div>
+          <div class="flex flex-col gap-1">
+            <label for="label-plural" class="text-sm font-medium text-text-primary">
+              Plural
+            </label>
+            <input
+              id="label-plural"
+              v-model="customPlural"
+              type="text"
+              maxlength="40"
+              placeholder="Ej: Habitaciones"
+              class="input-base w-full px-4 py-2 min-h-[44px]"
+            />
+          </div>
+        </div>
+
+        <!-- Live preview -->
+        <div class="rounded-lg bg-background border border-border px-4 py-3 flex flex-col gap-1">
+          <p class="text-xs font-semibold uppercase tracking-wider text-text-secondary">Vista previa</p>
+          <p class="text-sm text-text-primary leading-relaxed">
+            Tu menú dirá: <span class="font-semibold">{{ previewSingular }} 5</span>,
+            <span class="font-semibold">{{ previewPlural }} abiertas</span>,
+            <span class="font-semibold">{{ previewPlural }} configuradas</span>.
+          </p>
+        </div>
+
+        <!-- Disclosure + Save -->
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <p class="text-xs text-text-secondary">
+            Configuración guardada en este dispositivo. Otros dispositivos verán el nombre por defecto.
+          </p>
+          <button
+            type="button"
+            :disabled="!hasChanges || isSavingLabel"
+            class="min-h-[44px] px-4 py-2 rounded-lg bg-primary text-primary-foreground font-medium text-sm transition-all hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed active:scale-95"
+            @click="saveLabel"
+          >
+            {{ isSavingLabel ? 'Guardando...' : 'Guardar' }}
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -35,6 +35,8 @@ const posStore = usePOSStore()
 const cache = useQueryCache()
 const toast = useToast()
 const { currentTenant, businessProfile } = useTenantReactive()
+const { singular: tableSingular } = useTableLabel()
+const tableSingularLower = computed(() => tableSingular.value.toLowerCase())
 
 // Inject subtitle setter from layout
 const setPageSubtitle = inject<(subtitle: string | undefined) => void>('setPageSubtitle', () => {})
@@ -616,7 +618,7 @@ const processOrder = async () => {
       posStore.clearAll()
       showSuccessModal.value = true
     } catch (error: any) {
-      processingError.value = error.data?.message || error.message || 'Error al cerrar la mesa'
+      processingError.value = error.data?.message || error.message || `Error al cerrar la ${tableSingularLower.value}`
     } finally {
       isProcessing.value = false
     }
@@ -2681,7 +2683,7 @@ onUnmounted(() => {
     <div class="receipt-row" style="font-weight:bold;">*** PRE-CUENTA ***</div>
     <div class="receipt-row receipt-small">{{ prefacturaDateTime }}</div>
     <div v-if="isMesaMode && posStore.activeTableSession?.tableName" class="receipt-row receipt-small">
-      Mesa: {{ posStore.activeTableSession.tableName }}
+      {{ tableSingular }}: {{ posStore.activeTableSession.tableName }}
     </div>
     <div v-else-if="posStore.activeTableSession?.isBar" class="receipt-row receipt-small">Barra</div>
     <div v-else class="receipt-row receipt-small">Mostrador</div>

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -14,6 +14,9 @@ useHead({ title: 'Punto de Venta' })
 
 // Tenant reactivity
 const { currentTenant } = useTenantReactive()
+const { singular: tableSingular, plural: tablePlural } = useTableLabel()
+const tableSingularLower = computed(() => tableSingular.value.toLowerCase())
+const tablePluralLower = computed(() => tablePlural.value.toLowerCase())
 
 const router = useRouter()
 const posStore = usePOSStore()
@@ -435,7 +438,7 @@ const addToTab = async () => {
     // Refresh session + tab items
     await refreshTableSession()
   } catch (e: any) {
-    tabError.value = e?.data?.detail ?? 'Error al agregar a la mesa'
+    tabError.value = e?.data?.detail ?? `Error al agregar a la ${tableSingularLower.value}`
   } finally {
     isAddingToTab.value = false
   }
@@ -922,7 +925,7 @@ onUnmounted(() => {
             </svg>
           </div>
           <div class="flex-1 min-w-0 flex items-center gap-2 flex-wrap">
-            <span class="text-[10px] font-bold text-status-success-text uppercase tracking-widest flex-shrink-0">Mesa Activa</span>
+            <span class="text-[10px] font-bold text-status-success-text uppercase tracking-widest flex-shrink-0">{{ tableSingular }} Activa</span>
             <span class="w-px h-3 bg-border flex-shrink-0" aria-hidden="true" />
             <span class="text-sm font-bold text-text-primary flex-shrink-0">{{ posStore.activeTableSession.tableName }}</span>
             <span class="w-px h-3 bg-border flex-shrink-0" aria-hidden="true" />
@@ -995,7 +998,7 @@ onUnmounted(() => {
               type="button"
               :disabled="isBannerClosing || posStore.isCancellingMesa"
               class="h-9 inline-flex items-center gap-1.5 text-[10px] font-bold text-text-secondary uppercase tracking-wider px-2.5 rounded-lg border border-border hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed"
-              aria-label="Volver al plano de mesas (la mesa sigue abierta)"
+              :aria-label="`Volver al plano de ${tablePluralLower} (la ${tableSingularLower} sigue abierta)`"
               @click="posStore.clearAll()"
             >
               <svg class="h-3.5 w-3.5 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
@@ -1008,7 +1011,7 @@ onUnmounted(() => {
               type="button"
               :disabled="isBannerClosing || posStore.isCancellingMesa"
               class="h-9 inline-flex items-center gap-1.5 text-[10px] font-bold text-status-error-text uppercase tracking-wider px-2.5 rounded-lg border border-status-error-text/30 hover:bg-status-error-bg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-status-error-text focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed"
-              aria-label="Liberar la mesa"
+              :aria-label="`Liberar la ${tableSingularLower}`"
               @click="handleReleaseMesa"
             >
               <UiLoadingDots v-if="isBannerClosing || posStore.isCancellingMesa" size="6px" />
@@ -1168,9 +1171,9 @@ onUnmounted(() => {
                 </svg>
               </div>
               <div class="flex-1 min-w-0">
-                <h3 class="text-base font-bold text-text-primary leading-tight">¿Liberar la mesa?</h3>
+                <h3 class="text-base font-bold text-text-primary leading-tight">{{ `¿Liberar la ${tableSingularLower}?` }}</h3>
                 <p class="text-sm text-text-secondary mt-1 leading-snug">
-                  Esta mesa tiene <strong class="text-text-primary">{{ formatCurrencyPOS(posStore.activeTableSession.runningTotal) }}</strong> en consumo. Si la liberas ahora, se cerrará sin cobrar.
+                  {{ `Esta ${tableSingularLower} tiene` }} <strong class="text-text-primary">{{ formatCurrencyPOS(posStore.activeTableSession.runningTotal) }}</strong> en consumo. Si la liberas ahora, se cerrará sin cobrar.
                 </p>
               </div>
             </div>
@@ -1191,7 +1194,7 @@ onUnmounted(() => {
               @click="executeBannerClose"
             >
               <UiLoadingDots v-if="isBannerClosing" size="9px" color="white" aria-hidden="true" />
-              <span v-else>Sí, liberar mesa</span>
+              <span v-else>{{ `Sí, liberar ${tableSingularLower}` }}</span>
             </button>
           </div>
         </div>

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -10,6 +10,7 @@ useHead({ title: 'Detalle de Venta' })
 
 // Tenant reactivity
 const { currentTenant } = useTenantReactive()
+const { singular: tableSingular } = useTableLabel()
 
 // Payment groups for label resolution and method buttons
 const { data: paymentGroupsData } = useQuery({
@@ -464,7 +465,7 @@ onUnmounted(() => {
                   d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
               </svg>
             </template>
-            {{ order.is_delivery ? 'Domicilio' : order.source === 'barra' ? 'Barra' : order.source === 'mesa' ? 'Mesa' : 'POS' }}
+            {{ order.is_delivery ? 'Domicilio' : order.source === 'barra' ? 'Barra' : order.source === 'mesa' ? tableSingular : 'POS' }}
           </span>
         </div>
 

--- a/pages/ventas/ordenes.vue
+++ b/pages/ventas/ordenes.vue
@@ -11,6 +11,7 @@ useHead({ title: 'Órdenes - Ventas' })
 
 // Tenant reactivity
 const { currentTenant } = useTenantReactive()
+const { singular: tableSingular } = useTableLabel()
 
 // Payment groups for filter and bulk-update dropdowns
 const { data: paymentGroupsData } = useQuery({
@@ -644,7 +645,7 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
                 </span>
               </div>
               <p class="text-xs text-text-secondary mt-0.5 truncate">
-                {{ item.customer_name }} · {{ item.items_count }} items · {{ resolveLabel(item.payment_method, item.payment_method_id) }} · {{ item.is_delivery ? 'Domicilio' : (item.source === 'barra' ? 'Barra' : item.source === 'mesa' ? 'Mesa' : 'POS') }}
+                {{ item.customer_name }} · {{ item.items_count }} items · {{ resolveLabel(item.payment_method, item.payment_method_id) }} · {{ item.is_delivery ? 'Domicilio' : (item.source === 'barra' ? 'Barra' : item.source === 'mesa' ? tableSingular : 'POS') }}
               </p>
               <p v-if="item.discount_amount > 0" class="text-xs text-destructive mt-0.5">Descuento: -{{ formatCurrency(item.discount_amount) }}</p>
             </div>
@@ -742,7 +743,7 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
               : value === 'mesa' ? 'bg-crocus-100 text-crocus-700 dark:bg-crocus-900/30 dark:text-crocus-400'
               : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'"
           >
-            {{ row?.is_delivery ? 'Domicilio' : (value === 'barra' ? 'Barra' : value === 'mesa' ? 'Mesa' : 'POS') }}
+            {{ row?.is_delivery ? 'Domicilio' : (value === 'barra' ? 'Barra' : value === 'mesa' ? tableSingular : 'POS') }}
           </span>
         </template>
 


### PR DESCRIPTION
Frontend-only relabel of 'Mesa'/'Mesas' to a customizable noun. New composables/useTableLabel.ts (per-tenant localStorage) + section in /operaciones/personalizar (preset chips + custom inputs + live preview). 22 files touched, ~67 string swaps + 3 inline-plural rewrites. Internal identifiers, routes, API payloads, DB, and backend untouched. Feminine-only v1; 'En mesa' dine-in cluster left as-is. Closes #612