### PR TITLE
fix(directory): correct cities endpoint path (warocol.com#615)

### DIFF
--- a/composables/useCityCatalog.ts
+++ b/composables/useCityCatalog.ts
@@ -32,8 +32,13 @@ export function useCityCatalog() {
     // and changes rarely, so a per-request fetch is enough.
     if (cities.value.length > 0) return
     try {
+      // Endpoint lives under the public_restaurant router (prefix
+      // /public/restaurant), so the canonical path is
+      // /public/restaurant/cities — NOT /public/cities. The /public/* path
+      // hits the tenant-detection middleware and returns 404. See
+      // api-warolabs/app/main.py:196 for the router registration.
       const res = await $fetch<{ success: boolean; data: PublicCity[] }>(
-        '/api/public/cities',
+        '/api/public/restaurant/cities',
         { params: { include_empty: opts?.includeEmpty ? 'true' : 'false' } },
       )
       cities.value = res?.data ?? []

--- a/server/routes/sitemap.xml.ts
+++ b/server/routes/sitemap.xml.ts
@@ -74,8 +74,10 @@ export default defineEventHandler(async (event) => {
   let cityUrls: Array<{ loc: string; lastmod: string; changefreq: string; priority: string }> = []
   try {
     const fetchHeaders = { 'Origin': siteUrl, 'Referer': `${siteUrl}/` }
+    // Endpoint is under the public_restaurant router (prefix
+    // /public/restaurant) — see api-warolabs/app/main.py:196.
     const response = await $fetch<{ success: boolean; data: Array<{ city_slug: string }> }>(
-      `${apiUrl}/public/cities`,
+      `${apiUrl}/public/restaurant/cities`,
       { query: { include_empty: 'false' }, headers: fetchHeaders }
     )
     if (response?.data?.length > 0) {


### PR DESCRIPTION
## Summary

Hotfix on top of #617. The cities endpoint shipped under the `public_restaurant` router whose prefix is `/public/restaurant`, so the canonical URL is `/public/restaurant/cities` — not `/public/cities`. The composable and the sitemap were calling the wrong path, which made the `/negocio` city `<select>` render with no options ("Selecciona tu ciudad…" + empty list) and the discovery section on `/` stay invisible.

Verified locally:
\`\`\`
$ curl http://localhost:9999/public/restaurant/cities
{"success":true,"data":[{"country":"Colombia","city":"Bogotá","city_slug":"bogota","tenant_count":1},
                        {"country":"Colombia","city":"Mosquera","city_slug":"mosquera","tenant_count":1}]}
\`\`\`

## Changes

- `composables/useCityCatalog.ts` — fix the fetch URL
- `server/routes/sitemap.xml.ts` — same fix for the sitemap generator

## Test plan

- [ ] `/negocio` → click Editar → city `<select>` lists Bogotá, Medellín, Cali, ...
- [ ] `/` shows the discovery tiles for Bogotá and Mosquera
- [ ] `/sitemap.xml` contains `<loc>https://warocol.com/bogota</loc>` and `<loc>https://warocol.com/mosquera</loc>`