### PR TITLE
feat(directory): ciudades hub + remove hardcoded /bogota nav (warocol.com#619)

### DIFF
--- a/components/layout/BottomNav.vue
+++ b/components/layout/BottomNav.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="md:hidden fixed bottom-0 left-0 right-0 z-[50] bg-white/95 backdrop-blur-sm border-t border-titan-200 shadow-[0_-1px_4px_rgba(0,0,0,0.06)] pb-[env(safe-area-inset-bottom)]">
+  <nav aria-label="Navegación móvil" class="md:hidden fixed bottom-0 left-0 right-0 z-[50] bg-white/95 backdrop-blur-sm border-t border-titan-200 shadow-[0_-1px_4px_rgba(0,0,0,0.06)] pb-[env(safe-area-inset-bottom)]">
     <div class="flex items-stretch h-[58px]">
 
       <!-- Inicio -->
@@ -10,13 +10,14 @@
         <span>Inicio</span>
       </NuxtLink>
 
-      <!-- Bogotá -->
-      <NuxtLink to="/bogota" class="nav-item" :class="route.path.startsWith('/bogota') ? 'active' : 'inactive'">
+      <!-- Ciudades (warocol.com#619) — replaces the hardcoded /bogota entry.
+           Active on /ciudades AND on any /<city_slug> directory page. -->
+      <NuxtLink to="/ciudades" class="nav-item" :class="isCitiesActive ? 'active' : 'inactive'">
         <svg class="w-[22px] h-[22px]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.8">
           <path stroke-linecap="round" stroke-linejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
           <path stroke-linecap="round" stroke-linejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
         </svg>
-        <span>Bogotá</span>
+        <span>Ciudades</span>
       </NuxtLink>
 
       <!-- Blog -->
@@ -60,12 +61,18 @@
 <script setup lang="ts">
 import { useAuthStore } from '~/stores/auth'
 import { useDocsNav } from '~/composables/useDocsNav'
+import { useCityCatalog } from '~/composables/useCityCatalog'
 
 const route = useRoute()
 const authStore = useAuthStore()
 const { showDocsNav } = useDocsNav()
+const { isCityRoute } = useCityCatalog()
 
 const isOnDocs = computed(() => route.path.startsWith('/docs'))
+// "Ciudades" item highlights on the hub and on every city directory page.
+const isCitiesActive = computed(
+  () => route.path === '/ciudades' || isCityRoute(route.path),
+)
 </script>
 
 <style scoped>

--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -9,7 +9,7 @@
       </NuxtLink>
 
       <!-- Nav principal (centro) — solo desktop -->
-      <nav class="hidden md:flex items-center gap-1 ml-6">
+      <nav aria-label="Navegación principal" class="hidden md:flex items-center gap-1 ml-6">
         <NuxtLink
           v-for="link in navLinks"
           :key="link.to"
@@ -60,28 +60,39 @@
 
 <script setup lang="ts">
 import { useAuthStore } from '~/stores/auth'
+import { useCityCatalog } from '~/composables/useCityCatalog'
 import logo from '~/public/logo_waro_colombia.png'
 
 const route = useRoute()
 const authStore = useAuthStore()
 const leadModal = useLeadModal()
+const { cityFromRoute, isCityRoute } = useCityCatalog()
 
 const isDocs = computed(() => route.path.startsWith('/docs'))
 
+// Contextual badge next to the logo. Order matters — known literal
+// prefixes win before the catalog lookup so future cities can't shadow
+// `/docs` or `/blog` accidentally (warocol.com#619).
 const badgeText = computed(() => {
   if (route.path.startsWith('/docs')) return 'Docs'
   if (route.path.startsWith('/blog')) return 'Blog'
-  if (route.path.startsWith('/bogota')) return 'Bogotá'
-  return null
+  if (route.path === '/ciudades') return 'Ciudades'
+  const city = cityFromRoute(route.path)
+  return city?.city ?? null
 })
 
 const navLinks = [
-  { to: '/bogota', label: 'Bogotá' },
+  { to: '/ciudades', label: 'Ciudades' },
   { to: '/blog', label: 'Blog' },
   { to: '/docs', label: 'Docs' },
 ]
 
 function isActive(path: string) {
+  // The "Ciudades" link highlights on both /ciudades and any /<city_slug>
+  // route so the customer always sees where they are in the directory.
+  if (path === '/ciudades') {
+    return route.path === '/ciudades' || isCityRoute(route.path)
+  }
   return route.path.startsWith(path)
 }
 </script>

--- a/composables/useCityCatalog.ts
+++ b/composables/useCityCatalog.ts
@@ -61,11 +61,75 @@ export function useCityCatalog() {
   const findCity = (slug: string): PublicCity | null =>
     cities.value.find((c) => c.city_slug === slug) ?? null
 
+  // Prefixes that are NOT cities but live at the same path level. Listed
+  // here so the route-aware helpers below short-circuit before doing a
+  // catalog lookup. Keep alphabetised. Add new top-level literal routes
+  // here as they are added to pages/.
+  const NON_CITY_PREFIXES = new Set([
+    '',          // root
+    'admin',
+    'analitica',
+    'api',
+    'auth',
+    'blog',
+    'ciudades',
+    'cocina',
+    'comandas',
+    'docs',
+    'equipo',
+    'facturacion',
+    'finanzas',
+    'inventario',
+    'menu',
+    'mis-pedidos',
+    'negocio',
+    'operaciones',
+    'pagos',
+    'pos',
+    'ventas',
+  ])
+
+  /**
+   * First path segment, lowercased. `/bogota/foo` → `bogota`. Empty for `/`.
+   * Used internally by `isCityRoute` and `cityFromRoute` to peel off the
+   * candidate slug before catalog lookup.
+   */
+  const firstSegment = (path: string): string => {
+    const trimmed = path.startsWith('/') ? path.slice(1) : path
+    return trimmed.split('/')[0].toLowerCase()
+  }
+
+  /**
+   * True when the route is a city directory (warocol.com#619).
+   * Used by the Header desktop nav and the BottomNav mobile bar to
+   * highlight the "Ciudades" link on both `/ciudades` and `/<city_slug>`.
+   * Falls back to false for any known non-city top-level prefix.
+   */
+  const isCityRoute = (path: string): boolean => {
+    const seg = firstSegment(path)
+    if (NON_CITY_PREFIXES.has(seg)) return false
+    return isCitySlug(seg)
+  }
+
+  /**
+   * Resolve the catalog entry for the current route's city, or null when
+   * the route is not a city directory. Used by the Header badge so it
+   * shows "Bogotá" on `/bogota`, "Medellín" on `/medellin`, and nothing
+   * on tenant URLs like `/sandwichito-monroy`.
+   */
+  const cityFromRoute = (path: string): PublicCity | null => {
+    const seg = firstSegment(path)
+    if (NON_CITY_PREFIXES.has(seg)) return null
+    return findCity(seg)
+  }
+
   return {
     cities,
     citySlugSet,
     isCitySlug,
     findCity,
+    isCityRoute,
+    cityFromRoute,
     fetchCatalog,
   }
 }

--- a/pages/ciudades.vue
+++ b/pages/ciudades.vue
@@ -1,0 +1,251 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { MapPinIcon, ChevronRightIcon } from '@heroicons/vue/24/outline'
+import { useCityCatalog } from '~/composables/useCityCatalog'
+
+/**
+ * Directory hub (warocol.com#619). Lists every city in the curated
+ * `public_cities` catalog: cities with active tenants get a count badge;
+ * cities seeded for future expansion get a muted "Próximamente" tag.
+ *
+ * The hub complements the discovery section on `/` — that one is a
+ * marketing teaser, this one is the canonical entry point linked from
+ * the global header / bottom nav.
+ */
+
+definePageMeta({
+  layout: 'default',
+})
+
+const config = useRuntimeConfig()
+const siteUrl = (config.public as Record<string, unknown>).siteUrl as string || 'https://warocol.com'
+
+const { cities } = useCityCatalog()
+
+// The SSR plugin already prefetches with include_empty=true, so the
+// catalog is populated by the time this page renders. Sort: active first,
+// then by sort_order from the backend (already applied server-side).
+const activeCities = computed(() => cities.value.filter((c) => c.tenant_count > 0))
+const upcomingCities = computed(() => cities.value.filter((c) => c.tenant_count === 0))
+
+useSeoMeta({
+  title: 'Ciudades · WaRo Colombia',
+  description: 'Descubre los restaurantes en cada ciudad donde opera WaRo Colombia.',
+  ogTitle: 'Ciudades · WaRo Colombia',
+  ogDescription: 'Descubre los restaurantes en cada ciudad donde opera WaRo Colombia.',
+  ogType: 'website',
+  ogUrl: `${siteUrl}/ciudades`,
+  ogSiteName: 'Waro Colombia',
+  ogLocale: 'es_CO',
+  twitterCard: 'summary_large_image',
+  twitterSite: '@warocolombia',
+})
+
+useHead({
+  link: [{ rel: 'canonical', href: `${siteUrl}/ciudades` }],
+})
+</script>
+
+<template>
+  <div class="ciudades-page">
+    <!-- Hero -->
+    <section class="ciudades-hero">
+      <h1 class="ciudades-title font-quantico">RESTAURANTES POR CIUDAD</h1>
+      <p class="ciudades-subtitle">
+        Descubre los restaurantes en cada ciudad donde WaRo está presente.
+      </p>
+    </section>
+
+    <!-- Active cities -->
+    <section v-if="activeCities.length > 0" class="ciudades-section">
+      <h2 class="ciudades-section-title">
+        <MapPinIcon class="ciudades-section-icon" aria-hidden="true" />
+        Disponibles ahora
+      </h2>
+      <div class="ciudades-grid">
+        <NuxtLink
+          v-for="city in activeCities"
+          :key="city.city_slug"
+          :to="`/${city.city_slug}`"
+          class="city-tile city-tile--active"
+        >
+          <span class="city-name">{{ city.city }}</span>
+          <span class="city-count">
+            {{ city.tenant_count }} restaurante{{ city.tenant_count !== 1 ? 's' : '' }}
+          </span>
+          <ChevronRightIcon class="city-arrow" aria-hidden="true" />
+        </NuxtLink>
+      </div>
+    </section>
+
+    <!-- Upcoming cities -->
+    <section v-if="upcomingCities.length > 0" class="ciudades-section">
+      <h2 class="ciudades-section-title">
+        <MapPinIcon class="ciudades-section-icon" aria-hidden="true" />
+        Próximamente
+      </h2>
+      <div class="ciudades-grid">
+        <NuxtLink
+          v-for="city in upcomingCities"
+          :key="city.city_slug"
+          :to="`/${city.city_slug}`"
+          class="city-tile city-tile--upcoming"
+        >
+          <span class="city-name">{{ city.city }}</span>
+          <span class="city-badge">Próximamente</span>
+        </NuxtLink>
+      </div>
+    </section>
+
+    <!-- Defensive empty state (only fires if the catalog is unreachable) -->
+    <section v-if="cities.length === 0" class="ciudades-empty">
+      <div class="text-6xl mb-4" aria-hidden="true">🗺️</div>
+      <p class="text-base text-text-secondary">
+        Estamos cargando las ciudades disponibles…
+      </p>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.ciudades-page {
+  min-height: calc(100vh - 60px);
+  padding: 48px 24px 80px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+/* Hero */
+.ciudades-hero {
+  text-align: center;
+  margin-bottom: 56px;
+}
+.ciudades-title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 900;
+  color: hsl(250, 30%, 16%);
+  letter-spacing: -1px;
+  text-transform: uppercase;
+  line-height: 1.05;
+  margin-bottom: 16px;
+}
+.ciudades-subtitle {
+  font-size: clamp(1rem, 1.5vw, 1.125rem);
+  color: hsl(250, 10%, 45%);
+  max-width: 540px;
+  margin: 0 auto;
+  line-height: 1.5;
+}
+
+/* Sections */
+.ciudades-section {
+  margin-bottom: 48px;
+}
+.ciudades-section-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: hsl(250, 30%, 16%);
+  opacity: 0.7;
+  margin-bottom: 20px;
+}
+.ciudades-section-icon {
+  width: 16px;
+  height: 16px;
+  color: hsl(262, 83%, 58%);
+}
+
+/* Grid */
+.ciudades-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+}
+
+/* Tiles */
+.city-tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 6px;
+  min-height: 112px;
+  padding: 20px 20px;
+  background: #ffffff;
+  border: 1px solid hsl(220, 14%, 88%);
+  border-radius: 14px;
+  text-decoration: none;
+  color: hsl(250, 30%, 16%);
+  transition: all 0.2s ease;
+}
+.city-tile:hover {
+  border-color: hsl(262, 83%, 58%);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 16px -6px rgba(124, 58, 237, 0.15);
+}
+.city-tile:focus-visible {
+  outline: 2px solid hsl(262, 83%, 58%);
+  outline-offset: 2px;
+}
+.city-tile--upcoming {
+  opacity: 0.75;
+}
+.city-tile--upcoming:hover {
+  opacity: 1;
+}
+
+.city-name {
+  font-size: 1.125rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.city-count {
+  font-size: 0.875rem;
+  color: hsl(250, 10%, 45%);
+}
+.city-badge {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: hsl(38, 92%, 95%);
+  color: hsl(28, 80%, 32%);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.city-arrow {
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 18px;
+  color: hsl(250, 10%, 60%);
+  transition: transform 0.2s ease, color 0.2s ease;
+}
+.city-tile--active:hover .city-arrow {
+  transform: translateY(-50%) translateX(2px);
+  color: hsl(262, 83%, 58%);
+}
+
+/* Empty (defensive) */
+.ciudades-empty {
+  text-align: center;
+  padding: 80px 24px;
+}
+
+@media (max-width: 640px) {
+  .ciudades-page {
+    padding: 32px 16px 64px;
+  }
+  .ciudades-hero {
+    margin-bottom: 40px;
+  }
+}
+</style>

--- a/pages/ciudades.vue
+++ b/pages/ciudades.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { MapPinIcon, ChevronRightIcon } from '@heroicons/vue/24/outline'
+import { MapPinIcon } from '@heroicons/vue/24/outline'
 import { useCityCatalog } from '~/composables/useCityCatalog'
 
 /**
@@ -62,18 +62,31 @@ useHead({
         <MapPinIcon class="ciudades-section-icon" aria-hidden="true" />
         Disponibles ahora
       </h2>
-      <div class="ciudades-grid">
+      <div class="ciudades-row">
         <NuxtLink
           v-for="city in activeCities"
           :key="city.city_slug"
           :to="`/${city.city_slug}`"
-          class="city-tile city-tile--active"
+          class="city-card"
         >
-          <span class="city-name">{{ city.city }}</span>
-          <span class="city-count">
-            {{ city.tenant_count }} restaurante{{ city.tenant_count !== 1 ? 's' : '' }}
-          </span>
-          <ChevronRightIcon class="city-arrow" aria-hidden="true" />
+          <!-- Header image / illustration: gradient placeholder with the
+               city name typeset large. Will be swapped for per-city hero
+               photos as we acquire them. -->
+          <div class="city-card__image">
+            <div class="city-card__gradient">
+              <span class="city-card__overlay-name">{{ city.city }}</span>
+            </div>
+            <div class="city-card__count-pill" aria-label="restaurantes activos">
+              <span>{{ city.tenant_count }}</span>
+              <span class="city-card__count-label">
+                restaurante{{ city.tenant_count !== 1 ? 's' : '' }}
+              </span>
+            </div>
+          </div>
+          <div class="city-card__meta">
+            <MapPinIcon class="city-card__meta-icon" aria-hidden="true" />
+            <span class="city-card__meta-text">{{ city.city }}, {{ city.country }}</span>
+          </div>
         </NuxtLink>
       </div>
     </section>
@@ -84,15 +97,23 @@ useHead({
         <MapPinIcon class="ciudades-section-icon" aria-hidden="true" />
         Próximamente
       </h2>
-      <div class="ciudades-grid">
+      <div class="ciudades-row">
         <NuxtLink
           v-for="city in upcomingCities"
           :key="city.city_slug"
           :to="`/${city.city_slug}`"
-          class="city-tile city-tile--upcoming"
+          class="city-card city-card--upcoming"
         >
-          <span class="city-name">{{ city.city }}</span>
-          <span class="city-badge">Próximamente</span>
+          <div class="city-card__image">
+            <div class="city-card__gradient city-card__gradient--upcoming">
+              <span class="city-card__overlay-name">{{ city.city }}</span>
+            </div>
+            <span class="city-card__badge">Próximamente</span>
+          </div>
+          <div class="city-card__meta">
+            <MapPinIcon class="city-card__meta-icon" aria-hidden="true" />
+            <span class="city-card__meta-text">{{ city.city }}, {{ city.country }}</span>
+          </div>
         </NuxtLink>
       </div>
     </section>
@@ -113,6 +134,7 @@ useHead({
   padding: 48px 24px 80px;
   max-width: 1200px;
   margin: 0 auto;
+  background: hsl(220, 14%, 97%);
 }
 
 /* Hero */
@@ -159,79 +181,167 @@ useHead({
   color: hsl(262, 83%, 58%);
 }
 
-/* Grid */
-.ciudades-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+/* Row — horizontal scroll on mobile, grid on wider viewports.
+   Matches the "Próximos Viajes" card-strip pattern. */
+.ciudades-row {
+  display: flex;
   gap: 16px;
+  overflow-x: auto;
+  padding-bottom: 16px;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+}
+.ciudades-row > * {
+  scroll-snap-align: start;
+}
+@media (min-width: 768px) {
+  .ciudades-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    overflow: visible;
+    padding-bottom: 0;
+  }
 }
 
-/* Tiles */
-.city-tile {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 6px;
-  min-height: 112px;
-  padding: 20px 20px;
+/* Card — outer pill, inner image with rounded-[28px], meta row below. */
+.city-card {
+  display: block;
+  flex: 0 0 240px;
+  min-width: 240px;
   background: #ffffff;
-  border: 1px solid hsl(220, 14%, 88%);
-  border-radius: 14px;
+  border-radius: 32px;
+  padding: 8px;
   text-decoration: none;
   color: hsl(250, 30%, 16%);
-  transition: all 0.2s ease;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  border: 1px solid hsl(220, 14%, 92%);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
-.city-tile:hover {
-  border-color: hsl(262, 83%, 58%);
+@media (min-width: 768px) {
+  .city-card {
+    flex: initial;
+    min-width: 0;
+  }
+}
+.city-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 16px -6px rgba(124, 58, 237, 0.15);
+  box-shadow: 0 12px 24px -10px rgba(124, 58, 237, 0.18);
+  border-color: hsl(262, 83%, 88%);
 }
-.city-tile:focus-visible {
+.city-card:focus-visible {
   outline: 2px solid hsl(262, 83%, 58%);
   outline-offset: 2px;
 }
-.city-tile--upcoming {
-  opacity: 0.75;
+.city-card--upcoming {
+  opacity: 0.85;
 }
-.city-tile--upcoming:hover {
+.city-card--upcoming:hover {
   opacity: 1;
 }
 
-.city-name {
-  font-size: 1.125rem;
-  font-weight: 700;
-  letter-spacing: -0.01em;
+/* Image area inside the card. Currently a gradient placeholder; will be
+   swapped for per-city hero photos when available. */
+.city-card__image {
+  position: relative;
+  width: 100%;
+  height: 192px;
+  border-radius: 28px;
+  overflow: hidden;
+  margin-bottom: 12px;
 }
-.city-count {
-  font-size: 0.875rem;
-  color: hsl(250, 10%, 45%);
-}
-.city-badge {
-  display: inline-flex;
+.city-card__gradient {
+  position: absolute;
+  inset: 0;
+  display: flex;
   align-items: center;
-  width: fit-content;
-  padding: 2px 8px;
+  justify-content: center;
+  background:
+    linear-gradient(160deg, hsl(262, 83%, 62%) 0%, hsl(252, 83%, 48%) 100%);
+}
+.city-card__gradient::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 70% 110%, rgba(255,255,255,0.18), transparent 55%);
+  pointer-events: none;
+}
+.city-card__gradient--upcoming {
+  background:
+    linear-gradient(160deg, hsl(220, 18%, 70%) 0%, hsl(220, 14%, 45%) 100%);
+}
+.city-card__overlay-name {
+  position: relative;
+  z-index: 1;
+  color: #ffffff;
+  font-size: clamp(1.25rem, 3vw, 1.75rem);
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  text-align: center;
+  padding: 0 20px;
+  line-height: 1.15;
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
+}
+
+/* Count pill bottom-right (active cities). Substitutes the "avatar
+   stack" position from the reference design with a tenant-count chip. */
+.city-card__count-pill {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  padding: 4px 10px;
   border-radius: 999px;
-  background: hsl(38, 92%, 95%);
-  color: hsl(28, 80%, 32%);
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(4px);
+  color: hsl(250, 30%, 16%);
   font-size: 0.75rem;
+  font-weight: 700;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+.city-card__count-pill > span:first-child {
+  font-size: 0.95rem;
+  color: hsl(262, 83%, 50%);
+}
+.city-card__count-label {
   font-weight: 600;
+  color: hsl(250, 10%, 35%);
+}
+
+/* "Próximamente" badge bottom-right (upcoming cities) */
+.city-card__badge {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(4px);
+  color: hsl(28, 80%, 32%);
+  font-size: 0.72rem;
+  font-weight: 700;
   letter-spacing: 0.02em;
 }
-.city-arrow {
-  position: absolute;
-  top: 50%;
-  right: 16px;
-  transform: translateY(-50%);
-  width: 18px;
-  height: 18px;
-  color: hsl(250, 10%, 60%);
-  transition: transform 0.2s ease, color 0.2s ease;
+
+/* Meta row: pin + location text. */
+.city-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px 8px;
 }
-.city-tile--active:hover .city-arrow {
-  transform: translateY(-50%) translateX(2px);
-  color: hsl(262, 83%, 58%);
+.city-card__meta-icon {
+  width: 16px;
+  height: 16px;
+  color: hsl(250, 10%, 55%);
+  flex-shrink: 0;
+}
+.city-card__meta-text {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: hsl(250, 30%, 30%);
+  line-height: 1.25;
 }
 
 /* Empty (defensive) */

--- a/server/routes/sitemap.xml.ts
+++ b/server/routes/sitemap.xml.ts
@@ -95,6 +95,7 @@ export default defineEventHandler(async (event) => {
   // URLs base
   const baseUrls = [
     { loc: '/', lastmod: today, changefreq: 'daily', priority: '1.0' },
+    { loc: '/ciudades', lastmod: today, changefreq: 'weekly', priority: '0.95' },
     { loc: '/blog', lastmod: latestBlogDate, changefreq: 'daily', priority: '0.9' }
   ]
 


### PR DESCRIPTION
## Summary

Closes the last hardcoded "Bogotá" surface in the global navigation. Ships `/ciudades` as the canonical directory hub (consumes the catalog from #615 — no new endpoint), replaces the Bogotá entries in the desktop Header and mobile BottomNav with a generic "Ciudades" link, and makes the contextual badge resolve city names from the catalog so any future city works automatically.

## Stack

Nuxt 3 + Vue 3. No backend or DB changes.

## Changes

- **`composables/useCityCatalog.ts`** — adds `isCityRoute(path)` and `cityFromRoute(path)` with a curated `NON_CITY_PREFIXES` short-circuit (docs, blog, api, ciudades + all operator routes). Future cities can never shadow a literal route.
- **`pages/ciudades.vue`** (new) — directory hub with two sections: "Disponibles ahora" (Bogotá, Mosquera) and "Próximamente" (the 8 seeded cities awaiting their first tenant). Upcoming tiles are muted but still navigable since `/<city_slug>` renders the friendly empty-state from #615.
- **`components/layout/Header.vue`** — badge resolver uses `cityFromRoute` so `/bogota` → "Bogotá", `/medellin` → "Medellín", `/sandwichito-monroy` → no badge. `navLinks` first entry is now `{ to: '/ciudades', label: 'Ciudades' }`. `isActive('/ciudades')` matches both the hub and any `/<city_slug>` URL. Adds `aria-label="Navegación principal"` to `<nav>`.
- **`components/layout/BottomNav.vue`** — Bogotá item becomes "Ciudades" → `/ciudades`, keeps the location-pin icon. Active state mirrors the desktop logic via `isCityRoute`. Adds `aria-label="Navegación móvil"`.
- **`server/routes/sitemap.xml.ts`** — `/ciudades` added to `baseUrls` with priority 0.95.

## Test plan

- [ ] `/` discovery section unchanged (Bogotá + Mosquera tiles)
- [ ] `/ciudades` renders 2 active tiles + 8 "Próximamente" tiles
- [ ] Clicking a "Próximamente" tile lands on `/<city_slug>` with the empty-state from #615
- [ ] Desktop nav shows "Ciudades", Bogotá link gone
- [ ] Visiting `/medellin` highlights "Ciudades" in the desktop nav
- [ ] Header badge resolves correctly: `/medellin` → "Medellín", `/bogota` → "Bogotá", `/ciudades` → "Ciudades", `/sandwichito-monroy` → no badge, `/blog` → "Blog", `/docs` → "Docs"
- [ ] Mobile bottom nav shows "Ciudades", active on `/ciudades` and on any city directory
- [ ] `/sitemap.xml` contains `<loc>https://warocol.com/ciudades</loc>`
- [ ] No Vue hydration warnings after hard reload on `/bogota` or `/medellin`
- [ ] `grep -rn "/bogota" components/ pages/ layouts/` returns only historical comments, zero live routes/links

## Regression guard

`/bogota` and other `/<city_slug>` URLs continue to work — they resolve through the `/[tenant]/index.vue` dispatch from #615. Customers landing from email or SEO references see the same directory as before.

Closes warocol.com#619