### PR TITLE
feat(operaciones): persist mesa label in DB (#614)

### DIFF
--- a/composables/useTableLabel.ts
+++ b/composables/useTableLabel.ts
@@ -1,61 +1,109 @@
-import { ref, watch, readonly } from 'vue'
+import { computed } from 'vue'
+import { useQuery, useQueryCache } from '@pinia/colada'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 
-interface StoredLabel {
+interface TableLabelPayload {
   singular: string
   plural: string
 }
 
-const DEFAULTS: StoredLabel = { singular: 'Mesa', plural: 'Mesas' }
+const DEFAULTS: TableLabelPayload = { singular: 'Mesa', plural: 'Mesas' }
 
-const storageKey = (tenantId: string) => `waro_table_label_${tenantId}`
+/**
+ * Pre-#614 per-device localStorage key. Read once on first mount per device
+ * after the upgrade and migrated to the DB via `migrateLocalStorageIfPresent`.
+ * Kept as a const so the cleanup path doesn't drift if it ever moves.
+ */
+const oldLocalStorageKey = (tenantId: string) => `waro_table_label_${tenantId}`
 
+/**
+ * Tenant-global custom labels for the "Mesa" noun (warocol.com#614).
+ *
+ * Reads from the POS restaurant-context aggregator (cached on most pages
+ * the user lands on — POS, ventas, comandas, finanzas/arqueo). Pinia
+ * Colada shares the same cache key across all 21+ consumers, so the
+ * composable adds zero extra round-trips beyond what already happens.
+ *
+ * Writes via PATCH to `/api/operaciones/labels/tables` (gated under
+ * Module.OPERACIONES) and invalidates both audience caches so every
+ * page reflects the change without a manual refresh.
+ *
+ * Returns `computed` refs, not `ref`. Vue auto-unwraps both in templates
+ * so existing consumers from #612 keep working unchanged.
+ */
 export function useTableLabel() {
   const { currentTenant } = useTenantReactive()
+  const cache = useQueryCache()
 
-  const singular = ref<string>(DEFAULTS.singular)
-  const plural = ref<string>(DEFAULTS.plural)
+  const { data: contextData } = useQuery({
+    key: () => ['pos', 'restaurant-context', currentTenant.value?.id ?? null],
+    query: () => $fetch<{ success: boolean; data: any }>('/api/pos/restaurant-context'),
+    enabled: () => !!currentTenant.value,
+    staleTime: 30_000,
+  })
 
-  const load = (tenantId: string | null | undefined) => {
-    if (!tenantId || !import.meta.client) {
-      singular.value = DEFAULTS.singular
-      plural.value = DEFAULTS.plural
-      return
-    }
-    const stored = localStorage.getItem(storageKey(tenantId))
-    if (!stored) {
-      singular.value = DEFAULTS.singular
-      plural.value = DEFAULTS.plural
-      return
-    }
-    try {
-      const parsed = JSON.parse(stored) as Partial<StoredLabel>
-      singular.value = parsed.singular?.trim() || DEFAULTS.singular
-      plural.value = parsed.plural?.trim() || DEFAULTS.plural
-    } catch {
-      singular.value = DEFAULTS.singular
-      plural.value = DEFAULTS.plural
-    }
+  const singular = computed(() => {
+    const value = contextData.value?.data?.tables_label_singular
+    return (typeof value === 'string' && value.trim()) ? value.trim() : DEFAULTS.singular
+  })
+  const plural = computed(() => {
+    const value = contextData.value?.data?.tables_label_plural
+    return (typeof value === 'string' && value.trim()) ? value.trim() : DEFAULTS.plural
+  })
+
+  const setLabel = async (newSingular: string, newPlural: string) => {
+    await $fetch('/api/operaciones/labels/tables', {
+      method: 'PATCH',
+      body: { singular: newSingular, plural: newPlural },
+    })
+    // Cross-audience invalidation: POS pages and operaciones pages both
+    // read the aggregator under different cache keys.
+    await cache.invalidateQueries({ key: ['pos', 'restaurant-context'] })
+    await cache.invalidateQueries({ key: ['operaciones', 'restaurant-context'] })
   }
 
-  watch(() => currentTenant.value?.id, (id) => load(id), { immediate: true })
-
-  const setLabel = (newSingular: string, newPlural: string) => {
+  /**
+   * One-shot migration from the pre-#614 per-device localStorage to the
+   * tenant-global DB columns. Runs idempotently: if the localStorage key
+   * is gone (already migrated or never set), this is a no-op.
+   *
+   * Only writes to the API when the DB row still has NULL for both
+   * fields — never overwrites a tenant-global value that another device
+   * already configured.
+   *
+   * Guarded behind `import.meta.client` so it never runs during SSR.
+   */
+  const migrateLocalStorageIfPresent = async () => {
+    if (!import.meta.client) return
     const tenantId = currentTenant.value?.id
-    if (!tenantId || !import.meta.client) return
-    const sin = newSingular.trim() || DEFAULTS.singular
-    const plu = newPlural.trim() || DEFAULTS.plural
-    singular.value = sin
-    plural.value = plu
-    localStorage.setItem(
-      storageKey(tenantId),
-      JSON.stringify({ singular: sin, plural: plu }),
-    )
+    if (!tenantId) return
+
+    const raw = localStorage.getItem(oldLocalStorageKey(tenantId))
+    if (!raw) return
+
+    try {
+      const parsed = JSON.parse(raw) as Partial<TableLabelPayload>
+      const dbSingular = contextData.value?.data?.tables_label_singular
+      const dbPlural = contextData.value?.data?.tables_label_plural
+
+      const hasDbValue = !!(dbSingular || dbPlural)
+      const hasLocalValue = !!((parsed.singular ?? '').trim() || (parsed.plural ?? '').trim())
+
+      if (!hasDbValue && hasLocalValue) {
+        await setLabel(parsed.singular ?? '', parsed.plural ?? '')
+      }
+    } catch {
+      // Bad JSON or network failure — clear the key anyway so it doesn't
+      // retry on every mount.
+    } finally {
+      localStorage.removeItem(oldLocalStorageKey(tenantId))
+    }
   }
 
   return {
-    singular: readonly(singular),
-    plural: readonly(plural),
+    singular,
+    plural,
     setLabel,
+    migrateLocalStorageIfPresent,
   }
 }

--- a/pages/operaciones/personalizar.vue
+++ b/pages/operaciones/personalizar.vue
@@ -33,8 +33,8 @@ onUnmounted(() => clearRefreshHandler(refreshProfile))
 
 const toast = useToast()
 
-// ── Table label customization (issue #612) ──────────────────────────────────
-const { singular: storedSingular, plural: storedPlural, setLabel } = useTableLabel()
+// ── Table label customization (issue #612 → DB-backed in #614) ─────────────
+const { singular: storedSingular, plural: storedPlural, setLabel, migrateLocalStorageIfPresent } = useTableLabel()
 
 interface LabelPreset {
   key: string
@@ -110,18 +110,25 @@ const hasChanges = computed(
 
 const isSavingLabel = ref(false)
 
-const saveLabel = () => {
+const saveLabel = async () => {
   if (!hasChanges.value || isSavingLabel.value) return
   isSavingLabel.value = true
   try {
-    setLabel(previewSingular.value, previewPlural.value)
-    toast.success('Nombre actualizado en este dispositivo', { title: 'Guardado' })
+    await setLabel(previewSingular.value, previewPlural.value)
+    toast.success('Nombre actualizado para todo el restaurante', { title: 'Guardado' })
   } catch (error: any) {
-    toast.error('No se pudo guardar el nombre', { title: 'Error' })
+    toast.error(error?.data?.detail || 'No se pudo guardar el nombre', { title: 'Error' })
   } finally {
     isSavingLabel.value = false
   }
 }
+
+// One-shot migration: read any pre-#614 per-device value and push it to
+// the DB on first mount per device. No-op if the localStorage key is
+// already gone (already migrated, or never set).
+onMounted(() => {
+  void migrateLocalStorageIfPresent()
+})
 
 // ── Toggle: auto-select Genérico at /pos/checkout open ──────────────────────
 const isToggling = ref(false)
@@ -265,7 +272,7 @@ const toggleAutoSelectGeneric = async () => {
         <!-- Disclosure + Save -->
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
           <p class="text-xs text-text-secondary">
-            Configuración guardada en este dispositivo. Otros dispositivos verán el nombre por defecto.
+            Configuración guardada para todo el restaurante. Todos los dispositivos verán el mismo nombre.
           </p>
           <button
             type="button"


### PR DESCRIPTION
Replaces #612's per-device localStorage with tenant-global DB persistence. useTableLabel composable reads from POS aggregator + writes via new PATCH endpoint + invalidates both audience caches. One-shot localStorage→DB migration on first mount per device — idempotent, no-data-loss. The 21 consumers from #612 keep working unchanged (computed refs auto-unwrap in templates same as ref). Pairs with uno0uno/api-warolabs backend PR. Closes #614