### PR TITLE
fix(negocio): normalize Decimal string from API + hide stats strip in edit mode (warocol.com#626)

### DIFF
--- a/pages/negocio.vue
+++ b/pages/negocio.vue
@@ -260,8 +260,12 @@
         </div>
       </div>
 
-      <!-- ══════ STATS STRIP ══════ -->
-      <div v-if="businessProfile" class="grid grid-cols-3 divide-x divide-border bg-surface border-2 border-border rounded-xl overflow-hidden">
+      <!-- ══════ STATS STRIP ══════
+           Hidden while editing (warocol.com#626): the "Pedidos en línea"
+           section below owns the editable inputs for these three fields,
+           so showing the read-only summary at the same time duplicates
+           labels and confuses the operator about where to edit. -->
+      <div v-if="businessProfile && !isEditMode" class="grid grid-cols-3 divide-x divide-border bg-surface border-2 border-border rounded-xl overflow-hidden">
         <div class="px-3 sm:px-5 py-3 sm:py-4 flex flex-col justify-between text-left sm:text-center">
           <p class="text-[10px] sm:text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
             Tiempo prep.
@@ -724,17 +728,24 @@ const hasSocialMedia = computed(() => {
   return sm && Object.values(sm).some(v => !!v)
 })
 
-const formatCurrency = (value: number) => {
-  if (!value) return '$0'
-  return new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', maximumFractionDigits: 0 }).format(value)
+// Both formatters normalize the input to a number first because the API
+// serializes Decimal fields (e.g. min_order_amount) as JSON strings like
+// "0.00" — JS coerces strings in arithmetic but a string like "0.00" is
+// truthy, so `if (!value)` falsely fell through and the literal "0.00"
+// ended up in the template (warocol.com#626).
+const formatCurrency = (value: number | string | null | undefined) => {
+  const n = Number(value) || 0
+  if (!n) return '$0'
+  return new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', maximumFractionDigits: 0 }).format(n)
 }
 
-const formatCurrencyCompact = (value: number) => {
-  if (!value) return '$0'
-  if (value >= 1000) {
-    return `$${(value / 1000).toFixed(0)}k`
+const formatCurrencyCompact = (value: number | string | null | undefined) => {
+  const n = Number(value) || 0
+  if (!n) return '$0'
+  if (n >= 1000) {
+    return `$${(n / 1000).toFixed(0)}k`
   }
-  return `$${value}`
+  return `$${n}`
 }
 
 // ─── Edit actions ───


### PR DESCRIPTION
## Summary

Frontend half of warocol.com#626. Two small fixes on `/negocio`:

### 1. \"$0.00\" artifact for `min_order_amount = 0`

The backend serializes `Decimal` fields as JSON strings (Pydantic v2 default to preserve precision), so the formatters received `"0.00"` instead of `0`. The `if (!value)` short-circuit fell through (non-empty strings are truthy) and the template literal returned the raw `$0.00`. Both formatters now normalize via `Number(value) || 0` before the falsy check.

Non-zero values were working by accident — JS coerces strings in arithmetic — but the explicit normalization is the right boundary and future-proofs against any other Decimal field that lands on these formatters.

### 2. Stats strip duplicated labels during edit mode

In view mode the strip is the at-a-glance summary; in edit mode the \"Pedidos en línea\" section right below holds the inputs. Same labels in both places → operator couldn't tell which one to edit. Added `&& !isEditMode` to the strip's `v-if` so it disappears while editing, leaving the form section as the single source of truth.

## Stack

Nuxt 3 + Vue 3.

## Changes

- `pages/negocio.vue:264` — add `&& !isEditMode` to stats-strip `v-if`
- `pages/negocio.vue:727-744` — normalize string→number in `formatCurrency` and `formatCurrencyCompact`, relax type signature to `number | string | null | undefined`

## Test plan

- [ ] `/negocio` for a tenant with `min_order_amount = 0` → strip shows `$0` (not `$0.00`); "Pedidos en línea" section also shows `$0`
- [ ] `/negocio` for `jc-hoteleria` (`min_order_amount = 50000.00`) → strip shows `$50k`, section shows `$50.000` (locale-formatted COP)
- [ ] Click "Editar información" → stats strip disappears; "Pedidos en línea" section becomes editable
- [ ] Edit `min_order_amount` to 5000, save → strip shows `$5k` on return to view mode
- [ ] Cancel returns to view mode with strip reappearing

## Regression check

- `formatCurrency` in `ventas/[id].vue` and `ventas/facturas.vue` are independent local functions, NOT affected by this change.
- Save / load flow for `min_order_amount`, `estimated_preparation_time`, `accepts_online_orders` remains identical (only the display path is fixed).

Closes warocol.com#626 (frontend half)