### PR TITLE
fix(negocio): prevent spinner/scroll-driven drift on Pedido mínimo + Tiempo prep inputs

### DIFF
--- a/pages/negocio.vue
+++ b/pages/negocio.vue
@@ -524,11 +524,17 @@
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <label class="block text-xs font-medium text-text-secondary mb-1">Tiempo de preparación (min)</label>
+                <!-- text + inputmode='numeric' instead of type='number' to
+                     prevent the spinner buttons and mouse-wheel scroll
+                     from accidentally incrementing the value by the
+                     `step` amount — that caused values to drift up
+                     (warocol.com#626 follow-up). v-model.number still
+                     parses the string to a JS number. -->
                 <input
                   v-model.number="editForm.estimated_preparation_time"
-                  type="number"
-                  min="1"
-                  step="5"
+                  type="text"
+                  inputmode="numeric"
+                  pattern="[0-9]*"
                   class="input-base w-full px-3 py-2 text-sm"
                 />
               </div>
@@ -536,9 +542,9 @@
                 <label class="block text-xs font-medium text-text-secondary mb-1">Pedido mínimo (COP)</label>
                 <input
                   v-model.number="editForm.min_order_amount"
-                  type="number"
-                  min="0"
-                  step="1000"
+                  type="text"
+                  inputmode="numeric"
+                  pattern="[0-9]*"
                   class="input-base w-full px-3 py-2 text-sm"
                 />
               </div>


### PR DESCRIPTION
## Summary

Operator reported on warocol.com#626: typing **15000** into Pedido mínimo saved as **17000**, then typing **15** saved as **18000**. The displayed values are correct for what's in the DB — the drift happens **between input and save**.

## Root cause

The inputs were `type=\"number\"` with `step=\"1000\"`. That combination couples three browser-side behaviors that all mutate the value behind the user's back:

1. **Spinner up/down arrows** — clicking them increments by `step` (+1000)
2. **Mouse-wheel scroll** over a focused number input — also increments by `step`
3. **Form-validation auto-snap** — some browsers snap invalid step values to the nearest valid one on blur

Any of these firing once or twice during an edit session explains the +1000 / +2000 drift the operator observed.

Verified in DB just before this fix:
\`\`\`
slug          | min_order_amount | updated_at
waro-colombia |         18000.00 | 2026-05-16 14:50:36
\`\`\`

## Fix

Replace `type=\"number\"` + `step=\"1000\"` with `type=\"text\"` + `inputmode=\"numeric\"` + `pattern=\"[0-9]*\"`:

- No spinner buttons → no accidental clicks
- No scroll-to-increment
- No step auto-snap
- Mobile numeric keyboard preserved via `inputmode`
- `v-model.number` still parses the entered string to a JS number

Applied to both `estimated_preparation_time` and `min_order_amount` inputs since they had the same shape.

## Changes

- `pages/negocio.vue:526-544` — both inputs

## Test plan

- [ ] Edit Pedido mínimo, type 15000, save → DB has 15000.00, strip shows `$15k`
- [ ] Edit again, type 0, save → DB has 0.00, strip shows `$0`
- [ ] Same for Tiempo prep — typing 30 saves 30, not 31 or 35
- [ ] Mobile (real device) — numeric keyboard appears when focusing either input