### PR TITLE
fix(checkout): use tenant min_order_amount instead of hardcoded $20.000 (warocol.com#632)

### DIFF
--- a/components/online/CartBottomBar.vue
+++ b/components/online/CartBottomBar.vue
@@ -2,8 +2,12 @@
   <Teleport to="body">
     <Transition name="bar-slide">
       <div v-if="cartStore.itemCount > 0 && acceptsOnlineOrders" class="cart-bottom-bar bg-white border-t border-border shadow-2xl">
-        <!-- Inner container — matches layout padding -->
-        <div class="px-4 md:px-16 2xl:px-[30rem] py-3">
+        <!-- Inner container — aligned with body content
+             (max-w-7xl mx-auto px-4 — same shape PublicMenu and
+             RestaurantHeader use). Previous `md:px-16 2xl:px-[30rem]`
+             diverged from the body at md+ breakpoints (e.g. on 2xl the
+             bar had 480px sides while body had ~320px). -->
+        <div class="max-w-7xl mx-auto px-4 py-3">
           <div class="flex items-center justify-between gap-3">
 
             <!-- Left: icon + stacked text -->

--- a/components/online/CartDrawer.vue
+++ b/components/online/CartDrawer.vue
@@ -165,6 +165,10 @@ const props = defineProps<{
   modelValue: boolean
   restaurantOpen?: boolean
   acceptsOnlineOrders?: boolean
+  // Real minimum from tenant_public_profiles.min_order_amount, forwarded
+  // by the parent page (warocol.com#632). Decimal-string-safe — the
+  // CartSummary boundary normalizes via Number().
+  minOrderAmount?: number | string
 }>()
 
 const emit = defineEmits<{
@@ -188,8 +192,12 @@ const showError = (msg: string) => {
 
 const deliveryFee = computed(() => 0)
 
+// The pickup/dine-in branches never enforce a minimum (delivery-only
+// business rule). For delivery, defer to the tenant's configured
+// min_order_amount instead of a hardcoded value (warocol.com#632).
 const minimumOrder = computed(() => {
-  return cartStore.orderType === 'delivery' ? 20000 : 0
+  if (cartStore.orderType !== 'delivery') return 0
+  return props.minOrderAmount ?? 0
 })
 
 const close = () => {

--- a/components/online/CartSummary.vue
+++ b/components/online/CartSummary.vue
@@ -38,9 +38,14 @@
     </div>
 
     <!-- Minimum order warning -->
-    <div v-if="minimumOrder > subtotal" class="flex flex-col items-center text-center text-xs p-2.5 rounded-lg bg-amber-50 border border-amber-300 text-amber-900 mb-3">
-      ⚠️ Pedido mínimo: {{ formatPrice(minimumOrder) }}
-      <small class="font-semibold mt-0.5">Faltan {{ formatPrice(minimumOrder - subtotal) }}</small>
+    <div v-if="normalizedMinimumOrder > subtotal" class="flex flex-col items-center text-center text-sm p-2.5 rounded-lg bg-amber-50 border border-amber-300 text-amber-900 mb-3">
+      <span class="flex items-center gap-1.5">
+        <svg class="w-4 h-4 flex-shrink-0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.732 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
+        </svg>
+        Pedido mínimo: {{ formatPrice(normalizedMinimumOrder) }}
+      </span>
+      <small class="font-semibold mt-0.5">Faltan {{ formatPrice(normalizedMinimumOrder - subtotal) }}</small>
     </div>
 
     <!-- Online orders disabled notice — takes priority over closed notice -->
@@ -72,7 +77,7 @@
     >
       <span v-if="!acceptsOnlineOrders">Pedidos en línea no disponibles</span>
       <span v-else-if="!restaurantOpen">Restaurante cerrado</span>
-      <span v-else-if="minimumOrder > subtotal">Pedido mínimo no alcanzado</span>
+      <span v-else-if="normalizedMinimumOrder > subtotal">Pedido mínimo no alcanzado</span>
       <span v-else>Continuar a Checkout</span>
     </button>
   </div>
@@ -88,7 +93,11 @@ const props = withDefaults(
     orderType?: 'delivery' | 'pickup' | 'dine-in'
     deliveryFee?: number
     discount?: number
-    minimumOrder?: number
+    // Accepts string too because the public restaurant endpoint
+    // serializes Decimal as a JSON string (warocol.com#632). Normalized
+    // below via `normalizedMinimumOrder` so consumers can pass the raw
+    // API value without thinking about it.
+    minimumOrder?: number | string
     showCheckoutButton?: boolean
     restaurantOpen?: boolean
     acceptsOnlineOrders?: boolean
@@ -108,6 +117,12 @@ defineEmits<{
   (e: 'checkout'): void
 }>()
 
+// Single boundary normalization for the Decimal-string trap. Every
+// downstream check (warning v-if, math, checkout-disabled, button label)
+// reads through this — so future consumers of <CartSummary> stay safe
+// without repeating the Number(...) || 0 dance.
+const normalizedMinimumOrder = computed(() => Number(props.minimumOrder) || 0)
+
 const total = computed(() => {
   return props.subtotal + props.deliveryFee - props.discount
 })
@@ -115,7 +130,7 @@ const total = computed(() => {
 const isCheckoutDisabled = computed(() => {
   if (!props.acceptsOnlineOrders) return true
   if (!props.restaurantOpen) return true
-  return props.minimumOrder > 0 && props.subtotal < props.minimumOrder
+  return normalizedMinimumOrder.value > 0 && props.subtotal < normalizedMinimumOrder.value
 })
 
 const formatPrice = (price: number) => {

--- a/components/online/checkout/StepConfirm.vue
+++ b/components/online/checkout/StepConfirm.vue
@@ -103,6 +103,7 @@
       :item-count="cartStore.itemCount"
       :order-type="cartStore.orderType"
       :delivery-fee="deliveryFee"
+      :minimum-order="minOrderAmount"
       :show-checkout-button="false"
     />
 
@@ -256,6 +257,21 @@ const router = useRouter()
 const cartStore = useOnlineCartStore()
 const otpAuthStore = useOtpAuthStore()
 const addressStore = useAddressStore()
+
+// Tenant profile fetch — same Pinia Colada query key as the parent
+// `pages/[tenant]/index.vue` so this is a cache hit when the user
+// navigates from the menu page (warocol.com#632). Falls back to one
+// fresh fetch when the user arrives directly at /checkout (bookmark).
+const restaurantSlug = computed(() => String(route.params.tenant ?? ''))
+const { data: tenantProfile } = useQuery({
+  key: () => ['restaurant', 'public', restaurantSlug.value],
+  query: () => $fetch(`/api/public/restaurant/${restaurantSlug.value}`),
+  enabled: () => !!restaurantSlug.value,
+})
+const minOrderAmount = computed(
+  () => (tenantProfile.value as { data?: { min_order_amount?: number | string } } | null)
+    ?.data?.min_order_amount ?? 0,
+)
 
 // ── Display helpers ───────────────────────────────────────────────────────
 

--- a/pages/[tenant]/index.vue
+++ b/pages/[tenant]/index.vue
@@ -371,6 +371,7 @@ const cancelSwitch = () => {
         v-model="isCartOpen"
         :restaurant-open="restaurant.is_currently_open ?? true"
         :accepts-online-orders="restaurant.accepts_online_orders ?? false"
+        :min-order-amount="restaurant.min_order_amount ?? 0"
         @checkout="handleCheckout"
         @open-product="handleOpenProductFromCart"
       />


### PR DESCRIPTION
## Summary

The cart drawer and checkout confirm step were both lying to customers about the minimum order threshold. The backend gate at `online_cart_service.py:670` enforces the real `min_order_amount` from `tenant_public_profiles`, but the frontend was either hardcoded to `\$20.000` (cart drawer) or didn't pass the value at all (confirm step → no warning ever shown).

Three production tenants are affected today:

| Tenant | Real `min_order_amount` | What customers saw |
|---|---|---|
| `natural-food` | \$16.000 | "Pedido mínimo \$20.000" — blocked too high |
| `waro-colombia` | \$15.000 | "Pedido mínimo \$20.000" — blocked too high |
| `jc-hoteleria` | \$50.000 | "Pedido mínimo \$20.000" — false OK, backend then 400s |

## Changes

- `components/online/CartSummary.vue` — relax `minimumOrder` prop type to `number | string` (Pydantic v2 serializes `Decimal` as JSON string), normalize via `Number(value) \|\| 0` in a single boundary computed. UX nits in the warning template: replace ⚠️ emoji with `<svg aria-hidden>` matching sibling banners (lines 48, 56), bump warning text from `text-xs` to `text-sm`.
- `components/online/CartDrawer.vue` — accept `minOrderAmount` prop, replace the hardcoded `20000` computed. Pickup / dine-in still short-circuit to 0 (delivery-only business rule).
- `pages/[tenant]/index.vue` — forward `:min-order-amount="restaurant?.min_order_amount ?? 0"` to `<CartDrawer>`.
- `components/online/checkout/StepConfirm.vue` — fetch the tenant profile via `useQuery` with the same key the parent page uses (Pinia Colada cache-shares automatically). Pass `:minimum-order` to the inner `<CartSummary>`.

## Test plan

Against the 3 affected tenants + 1 zero-min tenant:

- [ ] `/natural-food` cart drawer shows "Pedido mínimo: \$16.000"
- [ ] `/waro-colombia` cart drawer shows "Pedido mínimo: \$15.000"
- [ ] `/jc-hoteleria` cart drawer shows "Pedido mínimo: \$50.000"
- [ ] `/armelo-perro` cart drawer shows no warning (min = 0)
- [ ] `/[tenant]/checkout` confirm step shows the same warning when subtotal < min
- [ ] Backend 400 ("monto mínimo del pedido es \$X COP") never fires for a cart the frontend accepts
- [ ] Pickup / dine-in carts hide the warning regardless of `min_order_amount`
- [ ] Direct land on `/[tenant]/checkout` (no prior `/[tenant]` visit) — `useQuery` fires one fresh fetch, then warning renders correctly
- [ ] No Vue hydration warnings on either route

## Stack

Nuxt 3 / Vue 3. No backend, no schema, no new endpoint, no store change.

Closes warocol.com#632