### PR TITLE
fix(pos-checkout): partial calculator validates against partial, not total

### DIFF
--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -268,18 +268,25 @@ const onSplitAmountInput = (e: Event) => {
   const input = e.target as HTMLInputElement
   const raw = Number(input.value.replace(/\./g, '').replace(/\D/g, ''))
   splitPartialAmount.value = raw || null
+  cashReceivedInput.value = 0
   input.value = raw ? raw.toLocaleString('es-CO') : ''
 }
 const isAddingPayment = ref(false)
 const splitPartialAmount = ref<number | null>(null)
 
-// When splitMode activates or remaining changes, reset the partial input to the full remaining
-watch(splitRemaining, (val) => {
-  if (!splitIsComplete.value) splitPartialAmount.value = val
+// After a payment lands, suggest the new remaining as the next partial — but
+// never seed it on initial toggle. The cashier must explicitly set the first
+// partial, otherwise the calculator was silently charging the full total and
+// the backend was closing the order instead of registering a partial.
+watch(splitRemaining, (val, oldVal) => {
+  if (splitIsComplete.value) return
+  if (splitPayments.value.length === 0) return
+  if (val !== oldVal) splitPartialAmount.value = val
 }, { immediate: false })
 watch(splitMode, (val) => {
+  cashReceivedInput.value = 0
   if (val) {
-    splitPartialAmount.value = splitRemaining.value
+    splitPartialAmount.value = null
     activeAccordion.value = null
   }
 })
@@ -287,7 +294,7 @@ watch(splitMode, (val) => {
 const splitAmountToCharge = computed(() =>
   splitPartialAmount.value !== null && splitPartialAmount.value > 0
     ? Math.min(splitPartialAmount.value, splitRemaining.value)
-    : splitRemaining.value
+    : 0
 )
 
 const addSplitPayment = async () => {
@@ -409,6 +416,7 @@ const addSplitPayment = async () => {
       payment_method_name: subMethodName ?? getPaymentMethodLabel(selectedPaymentMethod.value),
     })
     splitPaidTotal.value = paidTotal
+    cashReceivedInput.value = 0
 
     if (isComplete) {
       orderResult.value = {


### PR DESCRIPTION
## Summary

Closes #636.

In Cobro Parcial, the cashier could type a partial amount and click Cobrar but the backend would close the order as fully paid instead of registering a partial payment. Root cause: the partial input auto-filled with the full remaining and `splitAmountToCharge` fell back to it when the input was empty — so any cash-calculator helper (Sin vuelto / presets / a missed lower-the-partial step) silently submitted `split_first_amount = total` to the backend, which then computed `_split_remaining = 0` and closed the order.

## Changes

`front_nuxt/pages/pos/checkout.vue`:

- `splitMode` watcher: on toggle-on, `splitPartialAmount = null` (was `splitRemaining`). Always reset `cashReceivedInput = 0`.
- `splitRemaining` watcher: only auto-suggests the new remaining as next partial **after** the first payment has landed (guard on `splitPayments.length > 0`).
- `splitAmountToCharge`: fallback returns `0` when partial is null/0 (was `splitRemaining`).
- `onSplitAmountInput`: resets `cashReceivedInput = 0` when partial changes.
- `addSplitPayment`: resets `cashReceivedInput = 0` after a successful partial.

Net effect: the Cobrar button stays disabled showing "Cobrar $0" until the cashier explicitly types a partial. No flow can silently emit `split_first_amount = total`.

## Test plan

Run locally with `pnpm dev`. For each mode — **mostrador**, **barra**, **mesa** — verify:

- [ ] Toggling Cobro Parcial leaves "Monto a cobrar ahora" empty and the Cobrar button disabled.
- [ ] Typing partial = $10.000 on a $50.000 order + any non-cash method enables the button; clicking registers `payment_status='partial'` and keeps checkout open with saldo $40.000.
- [ ] Same with cash method: partial $10.000 + cash received $20.000 shows vuelto $10.000 and persists `cash_received = 20000` on the `order_payments` row.
- [ ] After a first cash partial, the cash field resets to 0 and the next partial defaults to the new remaining.

## Out of scope

- Backend defense-in-depth guard (proposed Package 3 in the plan) — shipping as a follow-up PR once this fix is verified.