### PR TITLE
fix(pos-checkout): cash presets add cumulatively to tender

### DIFF
--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -786,18 +786,16 @@ const cashIsValid = computed(() =>
 
 // Issue #524 — quick-tap presets. "Sin vuelto" is the friendly equivalent of
 // the industry term "exact tender" — it tells the cashier what happens
-// (no change to give) instead of generic POS jargon. The three +amount
+// (no change to give) instead of generic POS jargon. The four +amount
 // shortcuts cover the most common Colombian bill denominations the customer
-// hands over above the total.
-const cashPresetsExtra = computed(() => {
-  const a = cashAmountToCharge.value
-  return [
-    { label: '+ $1.000',  value: a + 1000 },
-    { label: '+ $5.000',  value: a + 5000 },
-    { label: '+ $10.000', value: a + 10000 },
-    { label: '+ $20.000', value: a + 20000 },
-  ]
-})
+// hands over above the total. Issue #646: presets add cumulatively to the
+// tender — tapping "+ $1.000" then "+ $5.000" lands at $6.000.
+const cashPresetsExtra = [
+  { label: '+ $1.000',  offset: 1000 },
+  { label: '+ $5.000',  offset: 5000 },
+  { label: '+ $10.000', offset: 10000 },
+  { label: '+ $20.000', offset: 20000 },
+] as const
 
 // Issue #524 — input starts at 0 and stays at 0 until the cashier either
 // taps a preset or types. Auto-prefilling with the amount made it look like
@@ -1991,7 +1989,7 @@ onUnmounted(() => {
                   v-for="preset in cashPresetsExtra"
                   :key="preset.label"
                   type="button"
-                  @click="cashReceivedInput = preset.value"
+                  @click="cashReceivedInput = (cashReceivedInput || 0) + preset.offset"
                   class="min-h-[56px] px-4 py-3 rounded-lg bg-surface-secondary dark:bg-surface text-text-primary text-base font-semibold hover:bg-border/50 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
                 >
                   {{ preset.label }}
@@ -2072,7 +2070,7 @@ onUnmounted(() => {
               v-for="preset in cashPresetsExtra"
               :key="preset.label"
               type="button"
-              @click="cashReceivedInput = preset.value"
+              @click="cashReceivedInput = (cashReceivedInput || 0) + preset.offset"
               class="min-h-[56px] px-4 py-3 rounded-lg bg-surface-secondary dark:bg-surface text-text-primary text-base font-semibold hover:bg-border/50 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
             >
               {{ preset.label }}


### PR DESCRIPTION
## Summary

Closes #646.

The cash tender preset buttons used to overwrite `cashReceivedInput` with `cashAmountToCharge + offset`. On a \$1.200 order, tapping `+ \$1.000` produced \$2.200 instead of \$1.000, and tapping the same preset twice was a no-op (no doubling). The labels suggested addition but the behaviour was absolute.

User-confirmed desired behaviour: each preset tap **cumulatively adds** to whatever is in the tender field — `+ \$1.000` then `+ \$5.000` lands at \$6.000.

## Stack

Nuxt 3 / Vue 3 Composition API.

## Changes

`front_nuxt/pages/pos/checkout.vue` (1 file, +11 / -13):

- `cashPresetsExtra`: converted from `computed(() => ...)` returning `value: cashAmountToCharge + offset` to a plain `const` array exposing `offset` directly. Bill denominations are static; reactivity was unnecessary.
- Both preset click handlers (split mode + single mode) updated:
  ```vue
  @click="cashReceivedInput = (cashReceivedInput || 0) + preset.offset"
  ```

## What stays unchanged

- **"Sin vuelto"** continues to overwrite to `cashAmountToCharge` (de-facto reset gesture).
- **Three #636 resets** (partial edit, split toggle, post-partial) keep zeroing the field.
- **`isCashMethod` watcher** still resets on method change.
- **`cashShortfall` / `cashChange` / `cashIsValid` computeds** unchanged.

## Test plan

Run locally with `pnpm dev`. On a \$1.200 order in counter mode with **Efectivo** selected:

- [ ] Empty Efectivo recibido → tap `+ \$1.000` → field shows `\$1.000` (not \$2.200).
- [ ] Tap `+ \$5.000` next → field shows `\$6.000`.
- [ ] Tap `+ \$1.000` again → field shows `\$7.000`.
- [ ] Tap `Sin vuelto` → field jumps to `\$1.200` (overwrite preserved).
- [ ] Switch method to card and back to cash → field resets to empty.
- [ ] In split mode with partial `\$500`: same accumulation works, `Sin vuelto` lands at `\$500`, changing the partial resets to 0.
- [ ] Repeat on **mostrador**, **barra**, **mesa**.

## Out of scope

- Reset button next to presets (research flagged as UX follow-up — track separately if cashiers report friction).
- Backend changes — none required.