### PR TITLE
feat(propinas): configuration page at /ventas/propinas

### DIFF
--- a/components/DashboardSidebar.vue
+++ b/components/DashboardSidebar.vue
@@ -159,7 +159,7 @@ import {
 } from '@heroicons/vue/24/outline'
 
 interface Props {
-  activePage?: 'dashboard' | 'ventas' | 'pos' | 'despacho' | 'comandas' | 'financiero' | 'abastecimiento' | 'inventario' | 'menu' | 'pagos' | 'equipo' | 'integraciones' | 'analytics' | 'reportes' | 'configuracion' | 'admin' | 'negocio' | 'operaciones' | 'finanzas' | 'facturacion'
+  activePage?: 'dashboard' | 'ventas' | 'propinas' | 'pos' | 'despacho' | 'comandas' | 'financiero' | 'abastecimiento' | 'inventario' | 'menu' | 'pagos' | 'equipo' | 'integraciones' | 'analytics' | 'reportes' | 'configuracion' | 'admin' | 'negocio' | 'operaciones' | 'finanzas' | 'facturacion'
 }
 const props = withDefaults(defineProps<Props>(), { activePage: 'financiero' })
 
@@ -188,6 +188,7 @@ const { businessProfile } = useTenantReactive()
 const primaryItems = computed<SidebarItem[]>(() => [
   { to: '/pos',                 page: 'pos',      label: 'POS',      icon: ComputerDesktopIcon, module: 'pos' },
   { to: '/ventas',              page: 'ventas',   label: 'Ventas',   icon: ShoppingCartIcon,    module: 'ventas' },
+  { to: '/ventas/propinas',     page: 'propinas', label: 'Propinas', icon: BanknotesIcon,       module: 'ventas' },
   { to: '/despacho/domicilios', page: 'despacho', label: 'Despacho', icon: MapPinIcon,          module: 'despacho' },
 ])
 

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -908,6 +908,16 @@ const getPageConfig = () => {
       breadcrumbPage: undefined,
       backButton: undefined
     }
+  } else if (path === '/ventas/propinas' || path === '/ventas/propinas/') {
+    return {
+      pageTitle: 'Propinas',
+      pageSubtitle: undefined,
+      searchPlaceholder: 'Buscar propinas...',
+      activePage: 'propinas' as const,
+      showBreadcrumb: false,
+      breadcrumbPage: undefined,
+      backButton: undefined
+    }
   } else if (path.startsWith('/ventas')) {
     return {
       pageTitle: 'Ventas',

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -786,18 +786,16 @@ const cashIsValid = computed(() =>
 
 // Issue #524 — quick-tap presets. "Sin vuelto" is the friendly equivalent of
 // the industry term "exact tender" — it tells the cashier what happens
-// (no change to give) instead of generic POS jargon. The three +amount
+// (no change to give) instead of generic POS jargon. The four +amount
 // shortcuts cover the most common Colombian bill denominations the customer
-// hands over above the total.
-const cashPresetsExtra = computed(() => {
-  const a = cashAmountToCharge.value
-  return [
-    { label: '+ $1.000',  value: a + 1000 },
-    { label: '+ $5.000',  value: a + 5000 },
-    { label: '+ $10.000', value: a + 10000 },
-    { label: '+ $20.000', value: a + 20000 },
-  ]
-})
+// hands over above the total. Issue #646: presets add cumulatively to the
+// tender — tapping "+ $1.000" then "+ $5.000" lands at $6.000.
+const cashPresetsExtra = [
+  { label: '+ $1.000',  offset: 1000 },
+  { label: '+ $5.000',  offset: 5000 },
+  { label: '+ $10.000', offset: 10000 },
+  { label: '+ $20.000', offset: 20000 },
+] as const
 
 // Issue #524 — input starts at 0 and stays at 0 until the cashier either
 // taps a preset or types. Auto-prefilling with the amount made it look like
@@ -1991,7 +1989,7 @@ onUnmounted(() => {
                   v-for="preset in cashPresetsExtra"
                   :key="preset.label"
                   type="button"
-                  @click="cashReceivedInput = preset.value"
+                  @click="cashReceivedInput = (cashReceivedInput || 0) + preset.offset"
                   class="min-h-[56px] px-4 py-3 rounded-lg bg-surface-secondary dark:bg-surface text-text-primary text-base font-semibold hover:bg-border/50 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
                 >
                   {{ preset.label }}
@@ -2072,7 +2070,7 @@ onUnmounted(() => {
               v-for="preset in cashPresetsExtra"
               :key="preset.label"
               type="button"
-              @click="cashReceivedInput = preset.value"
+              @click="cashReceivedInput = (cashReceivedInput || 0) + preset.offset"
               class="min-h-[56px] px-4 py-3 rounded-lg bg-surface-secondary dark:bg-surface text-text-primary text-base font-semibold hover:bg-border/50 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
             >
               {{ preset.label }}

--- a/pages/ventas/propinas.vue
+++ b/pages/ventas/propinas.vue
@@ -1,0 +1,320 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+
+definePageMeta({
+  layout: 'dashboard',
+})
+
+useHead({ title: 'Propinas | Ventas' })
+
+const { currentTenant } = useTenantReactive()
+const cache = useQueryCache()
+const toast = useToast()
+
+// Aggregator query — shared with /operaciones/* siblings.
+// Returns tip_enabled, tip_default_percentages, tip_preselect_index in
+// addition to the existing operaciones/POS toggles (warocol.com#638
+// backend extension).
+const { data: profileData, asyncStatus: profileAsyncStatus, refetch: refreshProfile } = useQuery({
+  key: () => ['operaciones', 'restaurant-context', currentTenant.value?.id],
+  query: () => $fetch<{ success: boolean; data: any }>('/api/operaciones/restaurant-context'),
+  enabled: () => !!currentTenant.value,
+  staleTime: 30_000,
+})
+const businessProfile = computed(() => profileData.value?.data ?? null)
+const loading = computed(() => !profileData.value)
+const isRefreshing = computed(() =>
+  profileAsyncStatus.value === 'loading' && profileData.value != null
+)
+
+const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
+registerProgressiveLoading(isRefreshing)
+onMounted(() => setRefreshHandler(refreshProfile))
+onUnmounted(() => clearRefreshHandler(refreshProfile))
+
+const invalidateContextCaches = async () => {
+  // POS reads tip_enabled at checkout (warocol.com#637 wiring), so both
+  // audiences must be invalidated after any save.
+  await cache.invalidateQueries({ key: ['operaciones', 'restaurant-context'] })
+  await cache.invalidateQueries({ key: ['pos', 'restaurant-context'] })
+}
+
+// ── Master toggle ──────────────────────────────────────────────────────────
+const isToggling = ref(false)
+
+const toggleTipEnabled = async () => {
+  if (!businessProfile.value || isToggling.value) return
+  const newState = !businessProfile.value.tip_enabled
+  isToggling.value = true
+  try {
+    await $fetch('/api/operaciones/toggles/tip', {
+      method: 'PATCH',
+      body: { enabled: newState },
+    })
+    await invalidateContextCaches()
+    toast.success(
+      newState
+        ? 'Los clientes verán la opción de propina en el checkout'
+        : 'La propina queda oculta en el checkout',
+      { title: newState ? 'Propinas activadas' : 'Propinas desactivadas' },
+    )
+  } catch (error: any) {
+    toast.error(error?.data?.detail || 'Error al cambiar la configuración', { title: 'Error' })
+  } finally {
+    isToggling.value = false
+  }
+}
+
+// ── Presets + preselect (editable local state, save explicit) ──────────────
+const draftPresets = ref<number[]>([])
+const draftPreselect = ref<boolean>(false)
+const newPresetInput = ref<string>('')
+const presetError = ref<string>('')
+
+// Hydrate the draft from the server every time the profile loads/refreshes.
+watch(
+  businessProfile,
+  (profile) => {
+    if (!profile) return
+    const serverPresets: number[] = (profile.tip_default_percentages ?? [10]).map((p: any) => Number(p))
+    draftPresets.value = [...serverPresets]
+    draftPreselect.value = profile.tip_preselect_index === 0
+  },
+  { immediate: true },
+)
+
+const serverPresets = computed<number[]>(() =>
+  (businessProfile.value?.tip_default_percentages ?? [10]).map((p: any) => Number(p)),
+)
+const serverPreselect = computed<boolean>(() => businessProfile.value?.tip_preselect_index === 0)
+
+const hasChanges = computed(() => {
+  if (draftPresets.value.length !== serverPresets.value.length) return true
+  for (let i = 0; i < draftPresets.value.length; i++) {
+    if (draftPresets.value[i] !== serverPresets.value[i]) return true
+  }
+  if (draftPreselect.value !== serverPreselect.value) return true
+  return false
+})
+
+const addPreset = () => {
+  presetError.value = ''
+  const raw = newPresetInput.value.trim().replace(',', '.')
+  if (!raw) {
+    presetError.value = 'Ingresa un porcentaje.'
+    return
+  }
+  const value = Number(raw)
+  if (!Number.isFinite(value)) {
+    presetError.value = 'Ingresa un número válido.'
+    return
+  }
+  if (value < 0 || value > 100) {
+    presetError.value = 'El porcentaje debe estar entre 0 y 100.'
+    return
+  }
+  if (draftPresets.value.length >= 5) {
+    presetError.value = 'Máximo 5 sugerencias.'
+    return
+  }
+  // Round to 2 decimals to match DB numeric(5,2) precision and avoid silent rounding.
+  const rounded = Math.round(value * 100) / 100
+  draftPresets.value.push(rounded)
+  newPresetInput.value = ''
+}
+
+const removePreset = (index: number) => {
+  // Removing the preselected first preset turns the toggle off (the index becomes invalid).
+  if (index === 0 && draftPreselect.value) {
+    draftPreselect.value = false
+  }
+  draftPresets.value.splice(index, 1)
+}
+
+const formatPreset = (p: number): string => {
+  return Number.isInteger(p) ? `${p}%` : `${p}%`
+}
+
+const isSavingConfig = ref(false)
+
+const saveConfig = async () => {
+  if (!hasChanges.value || isSavingConfig.value) return
+  if (draftPresets.value.length === 0) {
+    toast.error('Necesitas al menos un preset.', { title: 'Sin presets' })
+    return
+  }
+  isSavingConfig.value = true
+  try {
+    await $fetch('/api/operaciones/tip/config', {
+      method: 'PATCH',
+      body: {
+        percentages: draftPresets.value,
+        preselect_index: draftPreselect.value && draftPresets.value.length > 0 ? 0 : null,
+      },
+    })
+    await invalidateContextCaches()
+    toast.success('Configuración guardada', { title: 'Guardado' })
+  } catch (error: any) {
+    toast.error(error?.data?.detail || 'Error al guardar la configuración', { title: 'Error' })
+  } finally {
+    isSavingConfig.value = false
+  }
+}
+</script>
+
+<template>
+  <div>
+    <!-- Loading -->
+    <div v-if="loading" class="flex items-center justify-center min-h-[400px]">
+      <CommonsTheCustomLoader size="large" />
+    </div>
+
+    <!-- Content -->
+    <div v-else class="flex flex-col gap-3 md:gap-4">
+      <!-- ══════ MASTER TOGGLE ══════ -->
+      <div
+        v-if="businessProfile"
+        class="flex items-center justify-between gap-4 rounded-xl border-2 border-border bg-surface px-4 py-3"
+      >
+        <div class="min-w-0">
+          <p class="text-sm font-semibold leading-snug text-text-primary">
+            {{ businessProfile.tip_enabled ? 'Propinas activadas' : 'Propinas desactivadas' }}
+          </p>
+          <p class="text-xs mt-0.5 leading-snug text-text-secondary">
+            Cuando está activado, los clientes ven sugerencias de propina al cobrar (POS y online). La propina es voluntaria y se asigna al mesero de la orden.
+          </p>
+        </div>
+        <label
+          class="relative inline-flex items-center cursor-pointer flex-shrink-0"
+          :class="isToggling ? 'opacity-50 pointer-events-none' : ''"
+          :aria-label="businessProfile.tip_enabled ? 'Desactivar propinas' : 'Activar propinas'"
+        >
+          <input
+            type="checkbox"
+            class="sr-only peer"
+            :checked="businessProfile.tip_enabled"
+            :disabled="isToggling"
+            @change="toggleTipEnabled"
+          />
+          <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+        </label>
+      </div>
+
+      <!-- ══════ SUB-BLOCK (only when tip_enabled) ══════ -->
+      <template v-if="businessProfile?.tip_enabled">
+        <!-- Fixed informational banner (Ley 1935 framing) -->
+        <div class="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 flex gap-3">
+          <span aria-hidden="true" class="text-amber-700 mt-0.5">⚠</span>
+          <p class="text-sm text-amber-900 leading-snug">
+            En este momento las propinas se asignan directamente al mesero de la orden. La distribución entre el equipo (cocina, auxiliares, etc.) es responsabilidad del dueño.
+          </p>
+        </div>
+
+        <!-- ── Presets section ── -->
+        <div class="rounded-xl border-2 border-border bg-surface px-4 py-4 flex flex-col gap-4">
+          <div class="flex flex-col gap-1">
+            <p class="text-sm font-semibold text-text-primary">Porcentajes sugeridos</p>
+            <p class="text-xs leading-snug text-text-secondary">
+              Hasta 5 opciones, cada una entre 0 y 100. Se muestran como chips en el checkout, calculados sobre el subtotal (antes de impuestos).
+            </p>
+          </div>
+
+          <!-- Chip row -->
+          <div role="group" aria-label="Porcentajes sugeridos" class="flex flex-wrap gap-2">
+            <div
+              v-for="(p, i) in draftPresets"
+              :key="`preset-${i}-${p}`"
+              class="min-h-[44px] inline-flex items-center gap-2 px-3 py-2 rounded-lg border-2 border-primary bg-primary/10 text-primary text-sm font-medium"
+            >
+              <span>{{ formatPreset(p) }}</span>
+              <button
+                type="button"
+                class="text-primary/70 hover:text-primary"
+                :aria-label="`Quitar ${formatPreset(p)}`"
+                @click="removePreset(i)"
+              >
+                ×
+              </button>
+            </div>
+            <p v-if="draftPresets.length === 0" class="text-xs text-text-secondary self-center">
+              Sin presets — agrega al menos uno para que el checkout muestre sugerencias.
+            </p>
+          </div>
+
+          <!-- Add control -->
+          <div class="flex flex-col sm:flex-row gap-2 sm:items-start">
+            <div class="flex-1 flex flex-col gap-1">
+              <label for="new-preset" class="sr-only">Agregar porcentaje</label>
+              <input
+                id="new-preset"
+                v-model="newPresetInput"
+                type="text"
+                inputmode="decimal"
+                placeholder="Ej: 12.5"
+                maxlength="6"
+                :disabled="draftPresets.length >= 5"
+                class="input-base w-full sm:w-40 px-4 py-2 min-h-[44px]"
+                @keydown.enter.prevent="addPreset"
+              />
+              <p v-if="presetError" class="text-xs text-destructive">{{ presetError }}</p>
+            </div>
+            <button
+              type="button"
+              :disabled="draftPresets.length >= 5"
+              class="min-h-[44px] px-4 py-2 rounded-lg border-2 border-border bg-background text-text-primary text-sm font-medium hover:border-primary/40 disabled:opacity-50 disabled:cursor-not-allowed"
+              @click="addPreset"
+            >
+              Agregar
+            </button>
+          </div>
+        </div>
+
+        <!-- ── Preselect toggle ── -->
+        <div class="flex items-center justify-between gap-4 rounded-xl border-2 border-border bg-surface px-4 py-3">
+          <div class="min-w-0">
+            <p class="text-sm font-semibold leading-snug text-text-primary">
+              Pre-seleccionar primer preset
+            </p>
+            <p class="text-xs mt-0.5 leading-snug text-text-secondary">
+              Recomendado: <strong>desactivado</strong>. La Ley 1935 establece que la propina es voluntaria — al no pre-seleccionar, el cliente la elige de forma consciente.
+            </p>
+          </div>
+          <label
+            class="relative inline-flex items-center cursor-pointer flex-shrink-0"
+            :aria-label="draftPreselect ? 'Desactivar pre-selección' : 'Activar pre-selección'"
+          >
+            <input
+              type="checkbox"
+              class="sr-only peer"
+              :checked="draftPreselect"
+              :disabled="draftPresets.length === 0"
+              @change="draftPreselect = !draftPreselect"
+            />
+            <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+          </label>
+        </div>
+
+        <!-- ── Save bar ── -->
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 rounded-xl bg-surface border-2 border-border px-4 py-3">
+          <p class="text-xs text-text-secondary">
+            Los cambios en los porcentajes y la pre-selección se aplican al guardar.
+          </p>
+          <button
+            type="button"
+            :disabled="!hasChanges || isSavingConfig"
+            class="min-h-[44px] px-4 py-2 rounded-lg bg-primary text-primary-foreground font-medium text-sm transition-all hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed active:scale-95"
+            @click="saveConfig"
+          >
+            {{ isSavingConfig ? 'Guardando...' : 'Guardar cambios' }}
+          </button>
+        </div>
+
+        <!-- TODO(#640): unhide when /ventas/propinas/historial (history page) ships
+        <NuxtLink to="/ventas/propinas/historial" class="text-sm text-primary hover:underline self-start">
+          Ver historial de propinas →
+        </NuxtLink>
+        -->
+      </template>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Summary

Tenant-facing tipping configuration page at `/ventas/propinas`. Placed under `/ventas/*` (not `/operaciones/*` as the original issue body proposed) so all tipping UI lives in the same section as the future history view (#640).

Closes warocol.com#638.

## Dependency

**Depends on api-warolabs#246** (`feat(propinas): expose tip config in operaciones aggregator + endpoints`). Until that merges + deploys, the page reads/writes will hit missing fields/endpoints. Merge order: backend first.

## Changes

| File | Action | Purpose |
|---|---|---|
| `pages/ventas/propinas.vue` | new | Config page (toggle + presets + preselect + save) |
| `components/DashboardSidebar.vue` | edit | New Propinas entry in primaryItems + extend activePage type |
| `layouts/dashboard.vue` | edit | Page config for /ventas/propinas (so sidebar highlights correctly) |

332 insertions, 1 deletion. No new composables, no new stores.

## Behavior

- Page lives at `/ventas/propinas`. Reachable via the sidebar (new "Propinas" entry right after "Ventas" in primaryItems, with the `BanknotesIcon`).
- Master toggle `Activar propinas` (default OFF, hidden from checkout until on).
- When ON, a sub-block renders:
  - Amber info banner with Ley 1935 framing about direct attribution.
  - Editable presets chips (max 5, each in [0, 100], decimals rounded to 2).
  - "Pre-seleccionar primer preset" sub-toggle (default OFF, recommended OFF in copy).
  - Explicit Save button, disabled when no local changes.
- Toast feedback on every save success/failure. Inline error on invalid preset input.
- After every save, invalidates BOTH `['operaciones', 'restaurant-context']` and `['pos', 'restaurant-context']` per the CLAUDE.md cross-audience rule (POS reads `tip_enabled` at checkout via api-warolabs#245).

## Out of scope

- **History page** (`/ventas/propinas/historial`) — issue #640. The "Ver historial →" link is rendered as an HTML comment with a TODO referencing #640 — single uncomment when that page exists.
- **Checkout selector UI** — issue #639 (separate frontend work that reads the config we set here).

## Test plan

After both PRs deploy:

- [ ] Click "Propinas" in the sidebar — lands on `/ventas/propinas`.
- [ ] Master toggle ON: sub-block appears with `[10%]` preset and preselect OFF.
- [ ] Toggle OFF: sub-block hides; toggle ON again preserves the stored `[10%]`.
- [ ] Add a preset `12.5` — chip appears.
- [ ] Add `-5` or `150` — inline error appears, no chip added.
- [ ] Add a 6th preset — inline error "Máximo 5 sugerencias".
- [ ] Save with `[10, 15, 20]` + preselect ON — toast success; reload page reflects saved values.
- [ ] Save button disabled while `!hasChanges`.
- [ ] Remove the first chip while preselect is ON — preselect auto-flips OFF (index 0 no longer valid).
- [ ] Open `/pos/checkout` afterwards — its first interaction reads the fresh `tip_enabled` state (verifies cross-audience cache invalidation).
- [ ] Browser back from `/ventas/propinas` returns to `/ventas/ordenes` (sidebar groups them together).