### PR TITLE
feat(propinas): tip selector at checkout (POS + online)

### DIFF
--- a/components/checkout/TipSelector.vue
+++ b/components/checkout/TipSelector.vue
@@ -1,0 +1,189 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+
+// Reusable tip selector for POS and online checkouts (warocol.com#639).
+// Props-driven, layout-agnostic — fills the parent container.
+
+interface TipModel {
+  amount: number
+  source: 'preset' | 'custom' | 'none'
+}
+
+const props = withDefaults(defineProps<{
+  enabled: boolean
+  presets: number[]
+  preselectIndex: number | null
+  subtotal: number
+  modelValue: TipModel
+}>(), {
+  enabled: false,
+  presets: () => [10],
+  preselectIndex: null,
+  subtotal: 0,
+  modelValue: () => ({ amount: 0, source: 'none' }),
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: TipModel): void
+}>()
+
+type Mode = { kind: 'preset'; index: number } | { kind: 'custom' } | { kind: 'none' }
+
+// Internal state — derived shape that maps cleanly to which chip is highlighted
+const activeMode = ref<Mode>({ kind: 'none' })
+const customAmount = ref<number>(0)
+const hydrated = ref(false)
+
+// Hydrate from props.preselectIndex on first render. Once hydrated, the user's
+// choice wins and we don't auto-flip back even if props change.
+watch(
+  [() => props.enabled, () => props.preselectIndex, () => props.presets.length],
+  () => {
+    if (hydrated.value) return
+    if (!props.enabled) return
+    if (
+      props.preselectIndex !== null
+      && props.preselectIndex >= 0
+      && props.preselectIndex < props.presets.length
+    ) {
+      activeMode.value = { kind: 'preset', index: props.preselectIndex }
+    } else {
+      activeMode.value = { kind: 'none' }
+    }
+    hydrated.value = true
+  },
+  { immediate: true },
+)
+
+// Compute the resolved tip amount in COP, in cents-free integer (round to whole pesos
+// because the DB column is numeric(12,2) but COP UI is integer-only).
+const presetAmount = (i: number): number => {
+  const p = props.presets[i]
+  if (p === undefined || p === null) return 0
+  return Math.round(props.subtotal * (Number(p) / 100))
+}
+
+const tipAmount = computed<number>(() => {
+  if (!props.enabled) return 0
+  if (activeMode.value.kind === 'preset') return presetAmount(activeMode.value.index)
+  if (activeMode.value.kind === 'custom') return Math.max(0, Math.round(customAmount.value || 0))
+  return 0
+})
+
+const tipSource = computed<'preset' | 'custom' | 'none'>(() => {
+  if (!props.enabled || activeMode.value.kind === 'none' || tipAmount.value === 0) return 'none'
+  return activeMode.value.kind === 'preset' ? 'preset' : 'custom'
+})
+
+// Emit on every change
+watch([tipAmount, tipSource], () => {
+  emit('update:modelValue', { amount: tipAmount.value, source: tipSource.value })
+}, { immediate: false })
+
+const formatCurrency = (value: number): string =>
+  new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    minimumFractionDigits: 0,
+  }).format(value)
+
+const formatPercentLabel = (p: number): string =>
+  Number.isInteger(p) ? `${p}%` : `${p}%`
+
+const selectPreset = (i: number) => {
+  activeMode.value = { kind: 'preset', index: i }
+}
+const selectCustom = () => {
+  activeMode.value = { kind: 'custom' }
+}
+const selectNone = () => {
+  activeMode.value = { kind: 'none' }
+  customAmount.value = 0
+}
+
+const onCustomInput = (e: Event) => {
+  const input = e.target as HTMLInputElement
+  const raw = Number(input.value.replace(/\./g, '').replace(/\D/g, ''))
+  customAmount.value = Number.isFinite(raw) ? raw : 0
+  input.value = raw ? raw.toLocaleString('es-CO') : ''
+}
+
+const customDisplay = computed(() =>
+  customAmount.value > 0 ? customAmount.value.toLocaleString('es-CO') : ''
+)
+
+const isActivePreset = (i: number) => activeMode.value.kind === 'preset' && activeMode.value.index === i
+const isActiveCustom = computed(() => activeMode.value.kind === 'custom')
+const isActiveNone = computed(() => activeMode.value.kind === 'none')
+</script>
+
+<template>
+  <div v-if="enabled" class="flex flex-col gap-3 p-4 rounded-xl bg-surface border-2 border-border">
+    <div class="flex flex-col gap-0.5">
+      <p class="text-sm font-semibold text-text-primary">Propina (opcional)</p>
+      <p class="text-xs leading-snug text-text-secondary">
+        Voluntaria — Ley 1935. Se calcula sobre el subtotal antes de impuestos.
+      </p>
+    </div>
+
+    <!-- Chip row: presets + Personalizado + Sin propina -->
+    <div role="group" aria-label="Opciones de propina" class="flex flex-wrap gap-2">
+      <button
+        v-for="(p, i) in presets"
+        :key="`preset-${i}`"
+        type="button"
+        :aria-pressed="isActivePreset(i)"
+        class="min-h-[56px] flex flex-col items-center justify-center gap-0.5 px-4 py-2 rounded-lg border-2 text-sm font-semibold transition-all active:scale-95"
+        :class="isActivePreset(i)
+          ? 'border-primary bg-primary/10 text-primary shadow-sm'
+          : 'border-border bg-background text-text-secondary hover:border-primary/40 hover:text-text-primary'"
+        @click="selectPreset(i)"
+      >
+        <span>{{ formatPercentLabel(p) }}</span>
+        <span class="text-xs font-normal opacity-70 tabular-nums">{{ formatCurrency(presetAmount(i)) }}</span>
+      </button>
+
+      <button
+        type="button"
+        :aria-pressed="isActiveCustom"
+        class="min-h-[56px] px-4 py-2 rounded-lg border-2 text-sm font-semibold transition-all active:scale-95"
+        :class="isActiveCustom
+          ? 'border-primary bg-primary/10 text-primary shadow-sm'
+          : 'border-border bg-background text-text-secondary hover:border-primary/40 hover:text-text-primary'"
+        @click="selectCustom"
+      >
+        Personalizado
+      </button>
+
+      <button
+        type="button"
+        :aria-pressed="isActiveNone"
+        class="min-h-[56px] px-4 py-2 rounded-lg border-2 text-sm font-semibold transition-all active:scale-95"
+        :class="isActiveNone
+          ? 'border-primary bg-primary/10 text-primary shadow-sm'
+          : 'border-border bg-background text-text-secondary hover:border-primary/40 hover:text-text-primary'"
+        @click="selectNone"
+      >
+        Sin propina
+      </button>
+    </div>
+
+    <!-- Custom input — only when Personalizado is active -->
+    <div v-if="isActiveCustom" class="flex flex-col gap-1">
+      <label for="tip-custom-input" class="sr-only">Monto personalizado</label>
+      <div class="relative">
+        <input
+          id="tip-custom-input"
+          type="text"
+          inputmode="numeric"
+          :value="customDisplay"
+          placeholder="0"
+          maxlength="10"
+          class="input-base w-full min-h-[48px] pl-4 pr-10 py-2 text-lg font-semibold tabular-nums"
+          @input="onCustomInput"
+        />
+        <span class="absolute right-4 top-1/2 -translate-y-1/2 text-lg font-semibold text-text-secondary pointer-events-none">$</span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/online/checkout/StepConfirm.vue
+++ b/components/online/checkout/StepConfirm.vue
@@ -107,6 +107,18 @@
       :show-checkout-button="false"
     />
 
+    <!-- warocol.com#639 — Tip selector (hidden when tenant has tip_enabled=false).
+         Placed between cart summary and payment method so the customer sees the
+         total they're committing to before choosing how to pay. -->
+    <TipSelector
+      v-if="tipEnabled"
+      :enabled="tipEnabled"
+      :presets="tipPresets"
+      :preselect-index="tipPreselectIndex"
+      :subtotal="cartStore.subtotal"
+      v-model="tipModel"
+    />
+
     <!-- WaRos card -->
     <div
       v-if="warosSystemEnabled === true"
@@ -272,6 +284,28 @@ const minOrderAmount = computed(
   () => (tenantProfile.value as { data?: { min_order_amount?: number | string } } | null)
     ?.data?.min_order_amount ?? 0,
 )
+
+// warocol.com#639 — tipping config (read from the same tenantProfile query;
+// backend exposes the 3 fields in api-warolabs#247). Hidden by default until
+// the tenant opts in via /ventas/propinas (warocol.com#638).
+type TipProfile = {
+  tip_enabled?: boolean
+  tip_default_percentages?: number[]
+  tip_preselect_index?: number | null
+}
+const tipEnabled = computed(
+  () => (tenantProfile.value as { data?: TipProfile } | null)?.data?.tip_enabled === true,
+)
+const tipPresets = computed<number[]>(
+  () => (tenantProfile.value as { data?: TipProfile } | null)?.data?.tip_default_percentages ?? [10],
+)
+const tipPreselectIndex = computed<number | null>(
+  () => (tenantProfile.value as { data?: TipProfile } | null)?.data?.tip_preselect_index ?? null,
+)
+const tipModel = ref<{ amount: number; source: 'preset' | 'custom' | 'none' }>({
+  amount: 0,
+  source: 'none',
+})
 
 // ── Display helpers ───────────────────────────────────────────────────────
 
@@ -449,6 +483,10 @@ const submitOrder = async () => {
         body: {
           payment_method: paymentSelection.value.slug,
           payment_method_id: paymentSelection.value.id,
+          // warocol.com#639 — tip capture (server validates against tenant.tip_enabled)
+          ...(tipModel.value.amount > 0
+            ? { tip_amount: tipModel.value.amount, tip_source: tipModel.value.source }
+            : {}),
         },
       },
     )

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -59,7 +59,7 @@ const discountInput = ref('')
 
 // Success modal state
 const showSuccessModal = ref(false)
-const orderResult = ref<{ order_number: number; total_amount: number; payment_method: string; payment_method_name?: string; customer_id?: string; discount_amount?: number; subtotal?: number; standard_tax?: number; liquor_tax?: number; standard_tax_label?: string; order_id?: string; order_ids?: string[] } | null>(null)
+const orderResult = ref<{ order_number: number; total_amount: number; payment_method: string; payment_method_name?: string; customer_id?: string; discount_amount?: number; subtotal?: number; standard_tax?: number; liquor_tax?: number; standard_tax_label?: string; order_id?: string; order_ids?: string[]; tip_amount?: number; charged_amount?: number } | null>(null)
 const wasMesaMode = ref(false)
 const receiptEmail = ref('')
 const emailSent = ref(false)
@@ -198,6 +198,19 @@ const expediterEnabled = computed(() => settingsData.value?.data?.expediter_enab
 const showExpediterPanel = ref(false)
 const acceptsOnlineOrders = computed(() => settingsData.value?.data?.accepts_online_orders === true)
 
+// warocol.com#639 — tipping config (gated by tenant; defaults keep selector hidden)
+const tipEnabled = computed(() => settingsData.value?.data?.tip_enabled === true)
+const tipPresets = computed<number[]>(() => settingsData.value?.data?.tip_default_percentages ?? [10])
+const tipPreselectIndex = computed<number | null>(() => settingsData.value?.data?.tip_preselect_index ?? null)
+const tipModel = ref<{ amount: number; source: 'preset' | 'custom' | 'none' }>({ amount: 0, source: 'none' })
+const tipAmount = computed(() => tipModel.value.amount)
+const tipSource = computed(() => tipModel.value.source)
+// Reset whenever the cart is cleared / customer changes so a previous tip
+// doesn't bleed into the next sale.
+watch([() => posStore.cartId, () => selectedCustomer.value?.id], () => {
+  tipModel.value = { amount: 0, source: 'none' }
+})
+
 // Counter mode: not a real table session (no mesa, no bar)
 const isCounterMode = computed(() => !isMesaMode.value && !posStore.activeTableSession?.isBar)
 
@@ -233,6 +246,10 @@ const discountAmount = computed(() => {
   return Math.min(Math.round(val), Math.round(cartTotal.value))
 })
 const discountedTotal = computed(() => cartTotal.value - discountAmount.value)
+// warocol.com#639 — final amount charged to the customer when tipping is enabled.
+// total_amount on orders never includes tip (tax-base invariant from migration 079);
+// charged_amount = total_amount + tip_amount lives at the payment layer only.
+const finalChargedAmount = computed(() => discountedTotal.value + tipAmount.value)
 
 // Tax preview — runs for all 3 modes (mesa / counter / bar). Debounced to
 // avoid flooding when items / discount change rapidly.
@@ -689,6 +706,10 @@ const processOrder = async () => {
         ...(posStore.cartServedByMemberId
           ? { served_by_member_id: posStore.cartServedByMemberId }
           : {}),
+        // warocol.com#639 — tip capture (server validates against tenant.tip_enabled)
+        ...(tipAmount.value > 0
+          ? { tip_amount: tipAmount.value, tip_source: tipSource.value }
+          : {}),
       }
     }) as {
       success: boolean
@@ -697,6 +718,9 @@ const processOrder = async () => {
         order_id: string
         order_number: number
         total_amount: number
+        tip_amount?: number
+        tip_source?: string
+        charged_amount?: number
         payment_method: string
         items_count: number
         standard_tax?: number
@@ -722,7 +746,11 @@ const processOrder = async () => {
         standard_tax_label: response.data.standard_tax_label ?? 'Impuesto',
         ...(discountEnabled.value && _discountAmtPos > 0
           ? { discount_amount: _discountAmtPos, subtotal: _subtotalPos }
-          : {})
+          : {}),
+        // warocol.com#639 — surface tip in the success modal when present
+        ...(response.data.tip_amount && response.data.tip_amount > 0
+          ? { tip_amount: response.data.tip_amount, charged_amount: response.data.charged_amount }
+          : {}),
       }
       cartItemsSnapshot.value = [...cartItems.value]
       receiptEmail.value = emailForReceipt ?? ''
@@ -770,8 +798,10 @@ watch(selectedPaymentMethod, () => {
 const isCashMethod = computed(() => selectedGroup.value?.slug === 'cash')
 const cashReceivedInput = ref<number>(0)
 
+// warocol.com#639 — single-payment cash flow must cover total + tip (split mode
+// disallows tips, enforced by the backend in api-warolabs#245).
 const cashAmountToCharge = computed(() =>
-  splitMode.value ? splitAmountToCharge.value : discountedTotal.value
+  splitMode.value ? splitAmountToCharge.value : finalChargedAmount.value
 )
 
 const cashChange = computed(() =>
@@ -2038,6 +2068,19 @@ onUnmounted(() => {
           </div>
         </div>
 
+        <!-- warocol.com#639 — Tip selector (hidden when tenant has tip_enabled=false).
+             Placed between totals and payment so cashier-controlled tipping in POS
+             stays visible right where the operator confirms the order. Split mode
+             intentionally excluded — backend rejects tips in split payments. -->
+        <TipSelector
+          v-if="tipEnabled && !splitMode"
+          :enabled="tipEnabled"
+          :presets="tipPresets"
+          :preselect-index="tipPreselectIndex"
+          :subtotal="cartTotal"
+          v-model="tipModel"
+        />
+
         <!-- Issue #524 — Cash tender + change calculation (single-payment mode) -->
         <div v-if="!splitMode && isCashMethod && selectedCustomer" class="flex flex-col gap-3 p-4 rounded-xl bg-surface border border-border">
           <label for="cash-received-input-single" class="text-sm font-medium text-text-primary">
@@ -2123,7 +2166,13 @@ onUnmounted(() => {
             <svg v-else class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
             </svg>
-            <span v-if="!isProcessing">{{ selectedPaymentMethod === 'credit' ? 'Registrar como crédito' : 'Confirmar Orden' }}</span>
+            <span v-if="!isProcessing">
+              {{ selectedPaymentMethod === 'credit'
+                ? 'Registrar como crédito'
+                : tipAmount > 0
+                  ? `Confirmar — ${formatCurrency(finalChargedAmount)}`
+                  : 'Confirmar Orden' }}
+            </span>
             <svg v-if="!isProcessing" class="h-5 w-5 opacity-0 -ml-4 group-hover:opacity-100 group-hover:ml-0 transition-all" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
             </svg>
@@ -2443,6 +2492,15 @@ onUnmounted(() => {
             <div class="flex items-center justify-between" :class="(orderResult.discount_amount || orderResult.standard_tax || orderResult.liquor_tax) ? 'border-t border-border pt-3' : ''">
               <span class="text-sm text-text-secondary">Total</span>
               <span class="text-lg font-bold text-text-primary">{{ formatCurrency(orderResult.total_amount) }}</span>
+            </div>
+            <!-- warocol.com#639 — show tip on a separate line + the total charged to the customer -->
+            <div v-if="orderResult.tip_amount && orderResult.tip_amount > 0" class="flex items-center justify-between">
+              <span class="text-sm text-text-secondary">Propina</span>
+              <span class="text-sm font-medium text-text-primary">{{ formatCurrency(orderResult.tip_amount) }}</span>
+            </div>
+            <div v-if="orderResult.tip_amount && orderResult.tip_amount > 0 && orderResult.charged_amount" class="flex items-center justify-between border-t border-border pt-3">
+              <span class="text-sm text-text-secondary">Total cobrado</span>
+              <span class="text-lg font-bold text-primary">{{ formatCurrency(orderResult.charged_amount) }}</span>
             </div>
             <div class="flex items-center justify-between">
               <span class="text-sm text-text-secondary">Método de Pago</span>


### PR DESCRIPTION
## Summary

Customer-facing tip selector wired into both checkouts (POS internal + storefront online). Reusable component drops in between cart totals and payment selection in both contexts.

Closes warocol.com#639.

## Dependencies (merge order)

1. **api-warolabs#247** — exposes \`tip_*\` fields in the public restaurant endpoint (required for online).
2. **api-warolabs#246** — exposes \`tip_*\` fields in POS aggregator + adds \`/operaciones/toggles/tip\` + \`/operaciones/tip/config\` (required for POS to read config).
3. **api-warolabs#245** — POST checkout endpoints accept \`tip_amount\` + \`tip_source\` and persist them.

Until these are deployed, the selector will be hidden (\`tip_enabled\` is undefined → falsy → no render) and the existing checkout behaviour is unchanged. Safe to merge frontend independently — degrades gracefully.

## Changes (3 atomic commits)

| # | Commit | Phase |
|---|---|---|
| 1 | \`8a5a383\` | TipSelector reusable component |
| 2 | \`93486a8\` | POS checkout wiring |
| 3 | \`d740f45\` | Online checkout wiring |

## Files

| File | Action | Notes |
|---|---|---|
| \`components/checkout/TipSelector.vue\` | **Create** | 189 lines, props-driven, v-model pair \`{ amount, source }\` |
| \`pages/pos/checkout.vue\` | Edit | +62/-4: config read, render, finalChargedAmount, cash flow, success modal, button label, POST body |
| \`components/online/checkout/StepConfirm.vue\` | Edit | +38: read tip_* from tenantProfile, render, POST body |

No new composables, no new stores, no new modules.

## Behavior

- **Hidden when disabled:** with \`tip_enabled = false\`, both checkouts look identical to today.
- **Presets render with COP sub-label:** "10%" + "\$1.500" (computed on \`subtotal\` pre-tax) for each chip.
- **Three chip groups:** presets + Personalizado (custom integer COP) + Sin propina.
- **No auto-preselect by default:** unless tenant sets \`tip_preselect_index\`. Customer always wins after first render.
- **POS pay button:** label switches to "Confirmar — \$22.000" when tip > 0; default "Confirmar Orden" otherwise.
- **POS cash flow:** \`cashAmountToCharge\` becomes \`discountedTotal + tipAmount\` so the "Sin vuelto" preset + cash input + change/shortfall logic all target the right number.
- **POS success modal:** new "Propina: \$X" + "Total cobrado: \$Y" rows when tip > 0.
- **Split mode + tip:** selector hidden (backend rejects this combo).
- **POST body:** sends \`tip_amount\` + \`tip_source\` only when tip > 0 (idempotent shape).

## Test plan

After backend PRs deploy:

- [ ] With \`tip_enabled=false\`, both POS and online checkouts look identical to today. No selector, no extra rows, button shows just the total.
- [ ] With \`tip_enabled=true\` and presets \`[10, 15, 20]\`, three chips render in both checkouts with the right COP sub-labels.
- [ ] Tapping "Personalizado" reveals a numeric COP input; entering 3000 sets \`(amount=3000, source='custom')\`.
- [ ] Tapping "Sin propina" sets \`(amount=0, source='none')\` and visually clears any selected preset.
- [ ] With \`tip_preselect_index = 0\`, the first chip is highlighted on first render. Tapping "Sin propina" clears it.
- [ ] POS: subtotal=20000, tip=2000, button shows "Confirmar — \$22.000".
- [ ] POS cash: "Sin vuelto" sets \`cashReceivedInput = 22000\` (was 20000 pre-tip).
- [ ] POS cash with \`cashReceivedInput < 22000\` blocks submit ("Falta cobrar \$X").
- [ ] POS POST persists \`tip_amount=2000, tip_source='preset'\`. \`total_amount\` stays as discounted subtotal (unchanged from pre-tip era).
- [ ] POS success modal shows "Propina: \$2.000" and "Total cobrado: \$22.000" lines.
- [ ] POS split mode hides the selector entirely.
- [ ] Online POST persists \`tip_amount\` and \`tip_source\` to the order row.
- [ ] Tax preview (POS) returns identical numbers before/after a tip is set — tax computes from order_items, not total.

## Out of scope (deferred)

- **\`/mis-pedidos/{order_id}\`** (online success page) — show the tip there. Trivial follow-up.
- **Tests** — repo precedent is light coverage; manual QA.

## Notes for the reviewer

- The \`tipModel\` ref in POS resets when \`posStore.cartId\` or \`selectedCustomer.value.id\` changes, so a previous tip cannot leak into the next sale.
- The \`finalChargedAmount\` computed is the single place to bind the customer-facing total; \`total_amount\` on orders is never folded in (tax-base invariant from migration 079, see api-warolabs#244/#245).
- Online \`StepConfirm\` reuses the existing \`tenantProfile\` query (same cache key as the parent page) — no extra network call thanks to Pinia Colada dedup.