### PR TITLE
feat(pos-checkout): trash button on partial-payment rows (#649)

### DIFF
--- a/components/checkout/TipSelector.vue
+++ b/components/checkout/TipSelector.vue
@@ -1,0 +1,189 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+
+// Reusable tip selector for POS and online checkouts (warocol.com#639).
+// Props-driven, layout-agnostic — fills the parent container.
+
+interface TipModel {
+  amount: number
+  source: 'preset' | 'custom' | 'none'
+}
+
+const props = withDefaults(defineProps<{
+  enabled: boolean
+  presets: number[]
+  preselectIndex: number | null
+  subtotal: number
+  modelValue: TipModel
+}>(), {
+  enabled: false,
+  presets: () => [10],
+  preselectIndex: null,
+  subtotal: 0,
+  modelValue: () => ({ amount: 0, source: 'none' }),
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: TipModel): void
+}>()
+
+type Mode = { kind: 'preset'; index: number } | { kind: 'custom' } | { kind: 'none' }
+
+// Internal state — derived shape that maps cleanly to which chip is highlighted
+const activeMode = ref<Mode>({ kind: 'none' })
+const customAmount = ref<number>(0)
+const hydrated = ref(false)
+
+// Hydrate from props.preselectIndex on first render. Once hydrated, the user's
+// choice wins and we don't auto-flip back even if props change.
+watch(
+  [() => props.enabled, () => props.preselectIndex, () => props.presets.length],
+  () => {
+    if (hydrated.value) return
+    if (!props.enabled) return
+    if (
+      props.preselectIndex !== null
+      && props.preselectIndex >= 0
+      && props.preselectIndex < props.presets.length
+    ) {
+      activeMode.value = { kind: 'preset', index: props.preselectIndex }
+    } else {
+      activeMode.value = { kind: 'none' }
+    }
+    hydrated.value = true
+  },
+  { immediate: true },
+)
+
+// Compute the resolved tip amount in COP, in cents-free integer (round to whole pesos
+// because the DB column is numeric(12,2) but COP UI is integer-only).
+const presetAmount = (i: number): number => {
+  const p = props.presets[i]
+  if (p === undefined || p === null) return 0
+  return Math.round(props.subtotal * (Number(p) / 100))
+}
+
+const tipAmount = computed<number>(() => {
+  if (!props.enabled) return 0
+  if (activeMode.value.kind === 'preset') return presetAmount(activeMode.value.index)
+  if (activeMode.value.kind === 'custom') return Math.max(0, Math.round(customAmount.value || 0))
+  return 0
+})
+
+const tipSource = computed<'preset' | 'custom' | 'none'>(() => {
+  if (!props.enabled || activeMode.value.kind === 'none' || tipAmount.value === 0) return 'none'
+  return activeMode.value.kind === 'preset' ? 'preset' : 'custom'
+})
+
+// Emit on every change
+watch([tipAmount, tipSource], () => {
+  emit('update:modelValue', { amount: tipAmount.value, source: tipSource.value })
+}, { immediate: false })
+
+const formatCurrency = (value: number): string =>
+  new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    minimumFractionDigits: 0,
+  }).format(value)
+
+const formatPercentLabel = (p: number): string =>
+  Number.isInteger(p) ? `${p}%` : `${p}%`
+
+const selectPreset = (i: number) => {
+  activeMode.value = { kind: 'preset', index: i }
+}
+const selectCustom = () => {
+  activeMode.value = { kind: 'custom' }
+}
+const selectNone = () => {
+  activeMode.value = { kind: 'none' }
+  customAmount.value = 0
+}
+
+const onCustomInput = (e: Event) => {
+  const input = e.target as HTMLInputElement
+  const raw = Number(input.value.replace(/\./g, '').replace(/\D/g, ''))
+  customAmount.value = Number.isFinite(raw) ? raw : 0
+  input.value = raw ? raw.toLocaleString('es-CO') : ''
+}
+
+const customDisplay = computed(() =>
+  customAmount.value > 0 ? customAmount.value.toLocaleString('es-CO') : ''
+)
+
+const isActivePreset = (i: number) => activeMode.value.kind === 'preset' && activeMode.value.index === i
+const isActiveCustom = computed(() => activeMode.value.kind === 'custom')
+const isActiveNone = computed(() => activeMode.value.kind === 'none')
+</script>
+
+<template>
+  <div v-if="enabled" class="flex flex-col gap-3 p-4 rounded-xl bg-surface border-2 border-border">
+    <div class="flex flex-col gap-0.5">
+      <p class="text-sm font-semibold text-text-primary">Propina (opcional)</p>
+      <p class="text-xs leading-snug text-text-secondary">
+        Voluntaria — Ley 1935. Se calcula sobre el subtotal antes de impuestos.
+      </p>
+    </div>
+
+    <!-- Chip row: presets + Personalizado + Sin propina -->
+    <div role="group" aria-label="Opciones de propina" class="flex flex-wrap gap-2">
+      <button
+        v-for="(p, i) in presets"
+        :key="`preset-${i}`"
+        type="button"
+        :aria-pressed="isActivePreset(i)"
+        class="min-h-[56px] flex flex-col items-center justify-center gap-0.5 px-4 py-2 rounded-lg border-2 text-sm font-semibold transition-all active:scale-95"
+        :class="isActivePreset(i)
+          ? 'border-primary bg-primary/10 text-primary shadow-sm'
+          : 'border-border bg-background text-text-secondary hover:border-primary/40 hover:text-text-primary'"
+        @click="selectPreset(i)"
+      >
+        <span>{{ formatPercentLabel(p) }}</span>
+        <span class="text-xs font-normal opacity-70 tabular-nums">{{ formatCurrency(presetAmount(i)) }}</span>
+      </button>
+
+      <button
+        type="button"
+        :aria-pressed="isActiveCustom"
+        class="min-h-[56px] px-4 py-2 rounded-lg border-2 text-sm font-semibold transition-all active:scale-95"
+        :class="isActiveCustom
+          ? 'border-primary bg-primary/10 text-primary shadow-sm'
+          : 'border-border bg-background text-text-secondary hover:border-primary/40 hover:text-text-primary'"
+        @click="selectCustom"
+      >
+        Personalizado
+      </button>
+
+      <button
+        type="button"
+        :aria-pressed="isActiveNone"
+        class="min-h-[56px] px-4 py-2 rounded-lg border-2 text-sm font-semibold transition-all active:scale-95"
+        :class="isActiveNone
+          ? 'border-primary bg-primary/10 text-primary shadow-sm'
+          : 'border-border bg-background text-text-secondary hover:border-primary/40 hover:text-text-primary'"
+        @click="selectNone"
+      >
+        Sin propina
+      </button>
+    </div>
+
+    <!-- Custom input — only when Personalizado is active -->
+    <div v-if="isActiveCustom" class="flex flex-col gap-1">
+      <label for="tip-custom-input" class="sr-only">Monto personalizado</label>
+      <div class="relative">
+        <input
+          id="tip-custom-input"
+          type="text"
+          inputmode="numeric"
+          :value="customDisplay"
+          placeholder="0"
+          maxlength="10"
+          class="input-base w-full min-h-[48px] pl-4 pr-10 py-2 text-lg font-semibold tabular-nums"
+          @input="onCustomInput"
+        />
+        <span class="absolute right-4 top-1/2 -translate-y-1/2 text-lg font-semibold text-text-secondary pointer-events-none">$</span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/online/checkout/StepConfirm.vue
+++ b/components/online/checkout/StepConfirm.vue
@@ -107,6 +107,18 @@
       :show-checkout-button="false"
     />
 
+    <!-- warocol.com#639 — Tip selector (hidden when tenant has tip_enabled=false).
+         Placed between cart summary and payment method so the customer sees the
+         total they're committing to before choosing how to pay. -->
+    <TipSelector
+      v-if="tipEnabled"
+      :enabled="tipEnabled"
+      :presets="tipPresets"
+      :preselect-index="tipPreselectIndex"
+      :subtotal="cartStore.subtotal"
+      v-model="tipModel"
+    />
+
     <!-- WaRos card -->
     <div
       v-if="warosSystemEnabled === true"
@@ -272,6 +284,28 @@ const minOrderAmount = computed(
   () => (tenantProfile.value as { data?: { min_order_amount?: number | string } } | null)
     ?.data?.min_order_amount ?? 0,
 )
+
+// warocol.com#639 — tipping config (read from the same tenantProfile query;
+// backend exposes the 3 fields in api-warolabs#247). Hidden by default until
+// the tenant opts in via /ventas/propinas (warocol.com#638).
+type TipProfile = {
+  tip_enabled?: boolean
+  tip_default_percentages?: number[]
+  tip_preselect_index?: number | null
+}
+const tipEnabled = computed(
+  () => (tenantProfile.value as { data?: TipProfile } | null)?.data?.tip_enabled === true,
+)
+const tipPresets = computed<number[]>(
+  () => (tenantProfile.value as { data?: TipProfile } | null)?.data?.tip_default_percentages ?? [10],
+)
+const tipPreselectIndex = computed<number | null>(
+  () => (tenantProfile.value as { data?: TipProfile } | null)?.data?.tip_preselect_index ?? null,
+)
+const tipModel = ref<{ amount: number; source: 'preset' | 'custom' | 'none' }>({
+  amount: 0,
+  source: 'none',
+})
 
 // ── Display helpers ───────────────────────────────────────────────────────
 
@@ -449,6 +483,10 @@ const submitOrder = async () => {
         body: {
           payment_method: paymentSelection.value.slug,
           payment_method_id: paymentSelection.value.id,
+          // warocol.com#639 — tip capture (server validates against tenant.tip_enabled)
+          ...(tipModel.value.amount > 0
+            ? { tip_amount: tipModel.value.amount, tip_source: tipModel.value.source }
+            : {}),
         },
       },
     )

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -278,6 +278,8 @@ onUnmounted(() => {
 const splitMode = ref(false)
 const splitPayments = ref<Array<{ id: string; amount: number; payment_method: string; payment_method_name: string }>>([])
 const splitPaidTotal = ref(0)
+// Issue warocol.com#649 — track the id being voided so we can disable the row's button
+const isVoidingPayment = ref<string | null>(null)
 const splitRemaining = computed(() => Math.max(0, discountedTotal.value - splitPaidTotal.value))
 const splitIsComplete = computed(() => splitRemaining.value <= 0.01)
 
@@ -456,6 +458,41 @@ const addSplitPayment = async () => {
     processingError.value = e.data?.message || 'Error al registrar el pago parcial'
   } finally {
     isAddingPayment.value = false
+  }
+}
+
+// Issue warocol.com#649 — void an already-registered partial payment.
+// Backend voids the row (soft-delete via voided_at), recomputes paid_total,
+// reopens the cart/session if the void cleared the closing payment, and
+// reverses the posted GL entry atomically. For mesa it voids the entire
+// proportional sibling group; voided_ids in the response drives the splice.
+const onVoidSplitPayment = async (p: { id: string; amount: number; payment_method: string; payment_method_name: string }) => {
+  if (isVoidingPayment.value) return
+  const reason = window.prompt(
+    `¿Eliminar el pago de ${formatCurrency(p.amount)} (${p.payment_method_name})?\n\nEscribe el motivo:`,
+  )
+  if (!reason || !reason.trim()) return
+  if (p.payment_method === 'cash') {
+    if (!window.confirm('Pago en efectivo: asegúrate de devolver físicamente el dinero al cliente antes de continuar. ¿Confirmar?')) return
+  }
+
+  isVoidingPayment.value = p.id
+  processingError.value = ''
+  try {
+    const endpoint = isMesaMode.value
+      ? `/api/tables/${posStore.activeTableSession!.tableId}/payments/${p.id}`
+      : `/api/pos/cart/${posStore.cartId}/payments/${p.id}`
+    const res = await $fetch(endpoint, {
+      method: 'DELETE',
+      body: { reason: reason.trim() },
+    }) as any
+    const voidedIds: string[] = res.data?.voided_ids ?? [p.id]
+    splitPayments.value = splitPayments.value.filter(row => !voidedIds.includes(row.id))
+    splitPaidTotal.value = Number(res.data?.paid_total ?? 0)
+  } catch (e: any) {
+    processingError.value = e.data?.message || 'No se pudo eliminar el pago'
+  } finally {
+    isVoidingPayment.value = null
   }
 }
 
@@ -1948,6 +1985,22 @@ onUnmounted(() => {
                   </svg>
                   <span class="text-text-secondary flex-1">#{{ idx + 1 }} · {{ p.payment_method_name }}</span>
                   <span class="font-semibold text-text-primary tabular-nums">{{ formatCurrency(p.amount) }}</span>
+                  <!-- Issue warocol.com#649 — void this partial payment -->
+                  <button
+                    type="button"
+                    :disabled="isVoidingPayment === p.id"
+                    @click="onVoidSplitPayment(p)"
+                    :aria-label="`Eliminar pago #${idx + 1} de ${formatCurrency(p.amount)}`"
+                    class="ml-1 p-1 rounded text-text-tertiary hover:text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-40 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-destructive/30"
+                  >
+                    <svg v-if="isVoidingPayment === p.id" class="h-4 w-4 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+                      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+                    </svg>
+                    <svg v-else class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                    </svg>
+                  </button>
                 </div>
               </div>
             </div>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -59,7 +59,7 @@ const discountInput = ref('')
 
 // Success modal state
 const showSuccessModal = ref(false)
-const orderResult = ref<{ order_number: number; total_amount: number; payment_method: string; payment_method_name?: string; customer_id?: string; discount_amount?: number; subtotal?: number; standard_tax?: number; liquor_tax?: number; standard_tax_label?: string; order_id?: string; order_ids?: string[] } | null>(null)
+const orderResult = ref<{ order_number: number; total_amount: number; payment_method: string; payment_method_name?: string; customer_id?: string; discount_amount?: number; subtotal?: number; standard_tax?: number; liquor_tax?: number; standard_tax_label?: string; order_id?: string; order_ids?: string[]; tip_amount?: number; charged_amount?: number } | null>(null)
 const wasMesaMode = ref(false)
 const receiptEmail = ref('')
 const emailSent = ref(false)
@@ -198,6 +198,19 @@ const expediterEnabled = computed(() => settingsData.value?.data?.expediter_enab
 const showExpediterPanel = ref(false)
 const acceptsOnlineOrders = computed(() => settingsData.value?.data?.accepts_online_orders === true)
 
+// warocol.com#639 — tipping config (gated by tenant; defaults keep selector hidden)
+const tipEnabled = computed(() => settingsData.value?.data?.tip_enabled === true)
+const tipPresets = computed<number[]>(() => settingsData.value?.data?.tip_default_percentages ?? [10])
+const tipPreselectIndex = computed<number | null>(() => settingsData.value?.data?.tip_preselect_index ?? null)
+const tipModel = ref<{ amount: number; source: 'preset' | 'custom' | 'none' }>({ amount: 0, source: 'none' })
+const tipAmount = computed(() => tipModel.value.amount)
+const tipSource = computed(() => tipModel.value.source)
+// Reset whenever the cart is cleared / customer changes so a previous tip
+// doesn't bleed into the next sale.
+watch([() => posStore.cartId, () => selectedCustomer.value?.id], () => {
+  tipModel.value = { amount: 0, source: 'none' }
+})
+
 // Counter mode: not a real table session (no mesa, no bar)
 const isCounterMode = computed(() => !isMesaMode.value && !posStore.activeTableSession?.isBar)
 
@@ -233,6 +246,10 @@ const discountAmount = computed(() => {
   return Math.min(Math.round(val), Math.round(cartTotal.value))
 })
 const discountedTotal = computed(() => cartTotal.value - discountAmount.value)
+// warocol.com#639 — final amount charged to the customer when tipping is enabled.
+// total_amount on orders never includes tip (tax-base invariant from migration 079);
+// charged_amount = total_amount + tip_amount lives at the payment layer only.
+const finalChargedAmount = computed(() => discountedTotal.value + tipAmount.value)
 
 // Tax preview — runs for all 3 modes (mesa / counter / bar). Debounced to
 // avoid flooding when items / discount change rapidly.
@@ -689,6 +706,10 @@ const processOrder = async () => {
         ...(posStore.cartServedByMemberId
           ? { served_by_member_id: posStore.cartServedByMemberId }
           : {}),
+        // warocol.com#639 — tip capture (server validates against tenant.tip_enabled)
+        ...(tipAmount.value > 0
+          ? { tip_amount: tipAmount.value, tip_source: tipSource.value }
+          : {}),
       }
     }) as {
       success: boolean
@@ -697,6 +718,9 @@ const processOrder = async () => {
         order_id: string
         order_number: number
         total_amount: number
+        tip_amount?: number
+        tip_source?: string
+        charged_amount?: number
         payment_method: string
         items_count: number
         standard_tax?: number
@@ -722,7 +746,11 @@ const processOrder = async () => {
         standard_tax_label: response.data.standard_tax_label ?? 'Impuesto',
         ...(discountEnabled.value && _discountAmtPos > 0
           ? { discount_amount: _discountAmtPos, subtotal: _subtotalPos }
-          : {})
+          : {}),
+        // warocol.com#639 — surface tip in the success modal when present
+        ...(response.data.tip_amount && response.data.tip_amount > 0
+          ? { tip_amount: response.data.tip_amount, charged_amount: response.data.charged_amount }
+          : {}),
       }
       cartItemsSnapshot.value = [...cartItems.value]
       receiptEmail.value = emailForReceipt ?? ''
@@ -770,8 +798,10 @@ watch(selectedPaymentMethod, () => {
 const isCashMethod = computed(() => selectedGroup.value?.slug === 'cash')
 const cashReceivedInput = ref<number>(0)
 
+// warocol.com#639 — single-payment cash flow must cover total + tip (split mode
+// disallows tips, enforced by the backend in api-warolabs#245).
 const cashAmountToCharge = computed(() =>
-  splitMode.value ? splitAmountToCharge.value : discountedTotal.value
+  splitMode.value ? splitAmountToCharge.value : finalChargedAmount.value
 )
 
 const cashChange = computed(() =>
@@ -2038,6 +2068,19 @@ onUnmounted(() => {
           </div>
         </div>
 
+        <!-- warocol.com#639 — Tip selector (hidden when tenant has tip_enabled=false).
+             Placed between totals and payment so cashier-controlled tipping in POS
+             stays visible right where the operator confirms the order. Split mode
+             intentionally excluded — backend rejects tips in split payments. -->
+        <TipSelector
+          v-if="tipEnabled && !splitMode"
+          :enabled="tipEnabled"
+          :presets="tipPresets"
+          :preselect-index="tipPreselectIndex"
+          :subtotal="cartTotal"
+          v-model="tipModel"
+        />
+
         <!-- Issue #524 — Cash tender + change calculation (single-payment mode) -->
         <div v-if="!splitMode && isCashMethod && selectedCustomer" class="flex flex-col gap-3 p-4 rounded-xl bg-surface border border-border">
           <label for="cash-received-input-single" class="text-sm font-medium text-text-primary">
@@ -2123,7 +2166,13 @@ onUnmounted(() => {
             <svg v-else class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
             </svg>
-            <span v-if="!isProcessing">{{ selectedPaymentMethod === 'credit' ? 'Registrar como crédito' : 'Confirmar Orden' }}</span>
+            <span v-if="!isProcessing">
+              {{ selectedPaymentMethod === 'credit'
+                ? 'Registrar como crédito'
+                : tipAmount > 0
+                  ? `Confirmar — ${formatCurrency(finalChargedAmount)}`
+                  : 'Confirmar Orden' }}
+            </span>
             <svg v-if="!isProcessing" class="h-5 w-5 opacity-0 -ml-4 group-hover:opacity-100 group-hover:ml-0 transition-all" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
             </svg>
@@ -2443,6 +2492,15 @@ onUnmounted(() => {
             <div class="flex items-center justify-between" :class="(orderResult.discount_amount || orderResult.standard_tax || orderResult.liquor_tax) ? 'border-t border-border pt-3' : ''">
               <span class="text-sm text-text-secondary">Total</span>
               <span class="text-lg font-bold text-text-primary">{{ formatCurrency(orderResult.total_amount) }}</span>
+            </div>
+            <!-- warocol.com#639 — show tip on a separate line + the total charged to the customer -->
+            <div v-if="orderResult.tip_amount && orderResult.tip_amount > 0" class="flex items-center justify-between">
+              <span class="text-sm text-text-secondary">Propina</span>
+              <span class="text-sm font-medium text-text-primary">{{ formatCurrency(orderResult.tip_amount) }}</span>
+            </div>
+            <div v-if="orderResult.tip_amount && orderResult.tip_amount > 0 && orderResult.charged_amount" class="flex items-center justify-between border-t border-border pt-3">
+              <span class="text-sm text-text-secondary">Total cobrado</span>
+              <span class="text-lg font-bold text-primary">{{ formatCurrency(orderResult.charged_amount) }}</span>
             </div>
             <div class="flex items-center justify-between">
               <span class="text-sm text-text-secondary">Método de Pago</span>


### PR DESCRIPTION
## Summary

Frontend half of #649. Adds a delete (trash) control to each row in the **Pagos registrados** list inside `/pos/checkout`. Tapping it asks for a motivo, calls the new backend DELETE endpoint (mesa or POS depending on context), and on success splices the voided row(s) from the list and updates the running paid total from the API response.

Backend half: `uno0uno/api-warolabs` PR #248 (branch `gh-649-void-partial-payments`).

## Changes

`front_nuxt/pages/pos/checkout.vue` (+53):

- New `isVoidingPayment` ref to disable the row's button while in flight.
- New `onVoidSplitPayment(p)` handler:
  - `window.prompt` for motivo (required by backend).
  - Extra `window.confirm` for cash payments — physical-vuelto reminder.
  - DELETE to `/api/tables/{table_id}/payments/{payment_id}` in mesa mode, `/api/pos/cart/{cart_id}/payments/{payment_id}` otherwise.
  - Splices `voided_ids` from `splitPayments` and updates `splitPaidTotal` from the backend response.
- New trash button per row in the `Pagos registrados` template, with spinner while voiding.

## Test plan

Backend PR must be merged + migration applied for this to work end-to-end.

- [ ] POS counter: register 1 partial → tap X → enter motivo → row disappears, cart stays open.
- [ ] POS counter: register the closing partial → tap X → cart reopens, GL entry voided in DB.
- [ ] Mesa: register a partial that distributes across multiple orders → tap X → all sibling rows disappear at once.
- [ ] Mesa closing partial → tap X → session reopens (`closed_at = NULL`), table back to `open`.
- [ ] Cash partial → tap X → second confirm appears mentioning physical vuelto.
- [ ] Non-creator user with cashier role → backend returns 403 → error surfaced in `processingError`.

## Dependencies

- Backend PR #248 in `uno0uno/api-warolabs` (must merge first).
- DB migration `077_add_voided_at_to_order_payments.sql` applied to the target environment.

Closes #649