### PR TITLE
refactor(pos-checkout): parallel loading via useQuery + layout-aware refresh

### DIFF
--- a/components/checkout/TipSelector.vue
+++ b/components/checkout/TipSelector.vue
@@ -1,0 +1,189 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+
+// Reusable tip selector for POS and online checkouts (warocol.com#639).
+// Props-driven, layout-agnostic — fills the parent container.
+
+interface TipModel {
+  amount: number
+  source: 'preset' | 'custom' | 'none'
+}
+
+const props = withDefaults(defineProps<{
+  enabled: boolean
+  presets: number[]
+  preselectIndex: number | null
+  subtotal: number
+  modelValue: TipModel
+}>(), {
+  enabled: false,
+  presets: () => [10],
+  preselectIndex: null,
+  subtotal: 0,
+  modelValue: () => ({ amount: 0, source: 'none' }),
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: TipModel): void
+}>()
+
+type Mode = { kind: 'preset'; index: number } | { kind: 'custom' } | { kind: 'none' }
+
+// Internal state — derived shape that maps cleanly to which chip is highlighted
+const activeMode = ref<Mode>({ kind: 'none' })
+const customAmount = ref<number>(0)
+const hydrated = ref(false)
+
+// Hydrate from props.preselectIndex on first render. Once hydrated, the user's
+// choice wins and we don't auto-flip back even if props change.
+watch(
+  [() => props.enabled, () => props.preselectIndex, () => props.presets.length],
+  () => {
+    if (hydrated.value) return
+    if (!props.enabled) return
+    if (
+      props.preselectIndex !== null
+      && props.preselectIndex >= 0
+      && props.preselectIndex < props.presets.length
+    ) {
+      activeMode.value = { kind: 'preset', index: props.preselectIndex }
+    } else {
+      activeMode.value = { kind: 'none' }
+    }
+    hydrated.value = true
+  },
+  { immediate: true },
+)
+
+// Compute the resolved tip amount in COP, in cents-free integer (round to whole pesos
+// because the DB column is numeric(12,2) but COP UI is integer-only).
+const presetAmount = (i: number): number => {
+  const p = props.presets[i]
+  if (p === undefined || p === null) return 0
+  return Math.round(props.subtotal * (Number(p) / 100))
+}
+
+const tipAmount = computed<number>(() => {
+  if (!props.enabled) return 0
+  if (activeMode.value.kind === 'preset') return presetAmount(activeMode.value.index)
+  if (activeMode.value.kind === 'custom') return Math.max(0, Math.round(customAmount.value || 0))
+  return 0
+})
+
+const tipSource = computed<'preset' | 'custom' | 'none'>(() => {
+  if (!props.enabled || activeMode.value.kind === 'none' || tipAmount.value === 0) return 'none'
+  return activeMode.value.kind === 'preset' ? 'preset' : 'custom'
+})
+
+// Emit on every change
+watch([tipAmount, tipSource], () => {
+  emit('update:modelValue', { amount: tipAmount.value, source: tipSource.value })
+}, { immediate: false })
+
+const formatCurrency = (value: number): string =>
+  new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    minimumFractionDigits: 0,
+  }).format(value)
+
+const formatPercentLabel = (p: number): string =>
+  Number.isInteger(p) ? `${p}%` : `${p}%`
+
+const selectPreset = (i: number) => {
+  activeMode.value = { kind: 'preset', index: i }
+}
+const selectCustom = () => {
+  activeMode.value = { kind: 'custom' }
+}
+const selectNone = () => {
+  activeMode.value = { kind: 'none' }
+  customAmount.value = 0
+}
+
+const onCustomInput = (e: Event) => {
+  const input = e.target as HTMLInputElement
+  const raw = Number(input.value.replace(/\./g, '').replace(/\D/g, ''))
+  customAmount.value = Number.isFinite(raw) ? raw : 0
+  input.value = raw ? raw.toLocaleString('es-CO') : ''
+}
+
+const customDisplay = computed(() =>
+  customAmount.value > 0 ? customAmount.value.toLocaleString('es-CO') : ''
+)
+
+const isActivePreset = (i: number) => activeMode.value.kind === 'preset' && activeMode.value.index === i
+const isActiveCustom = computed(() => activeMode.value.kind === 'custom')
+const isActiveNone = computed(() => activeMode.value.kind === 'none')
+</script>
+
+<template>
+  <div v-if="enabled" class="flex flex-col gap-3 p-4 rounded-xl bg-surface border-2 border-border">
+    <div class="flex flex-col gap-0.5">
+      <p class="text-sm font-semibold text-text-primary">Propina (opcional)</p>
+      <p class="text-xs leading-snug text-text-secondary">
+        Voluntaria — Ley 1935. Se calcula sobre el subtotal antes de impuestos.
+      </p>
+    </div>
+
+    <!-- Chip row: presets + Personalizado + Sin propina -->
+    <div role="group" aria-label="Opciones de propina" class="flex flex-wrap gap-2">
+      <button
+        v-for="(p, i) in presets"
+        :key="`preset-${i}`"
+        type="button"
+        :aria-pressed="isActivePreset(i)"
+        class="min-h-[56px] flex flex-col items-center justify-center gap-0.5 px-4 py-2 rounded-lg border-2 text-sm font-semibold transition-all active:scale-95"
+        :class="isActivePreset(i)
+          ? 'border-primary bg-primary/10 text-primary shadow-sm'
+          : 'border-border bg-background text-text-secondary hover:border-primary/40 hover:text-text-primary'"
+        @click="selectPreset(i)"
+      >
+        <span>{{ formatPercentLabel(p) }}</span>
+        <span class="text-xs font-normal opacity-70 tabular-nums">{{ formatCurrency(presetAmount(i)) }}</span>
+      </button>
+
+      <button
+        type="button"
+        :aria-pressed="isActiveCustom"
+        class="min-h-[56px] px-4 py-2 rounded-lg border-2 text-sm font-semibold transition-all active:scale-95"
+        :class="isActiveCustom
+          ? 'border-primary bg-primary/10 text-primary shadow-sm'
+          : 'border-border bg-background text-text-secondary hover:border-primary/40 hover:text-text-primary'"
+        @click="selectCustom"
+      >
+        Personalizado
+      </button>
+
+      <button
+        type="button"
+        :aria-pressed="isActiveNone"
+        class="min-h-[56px] px-4 py-2 rounded-lg border-2 text-sm font-semibold transition-all active:scale-95"
+        :class="isActiveNone
+          ? 'border-primary bg-primary/10 text-primary shadow-sm'
+          : 'border-border bg-background text-text-secondary hover:border-primary/40 hover:text-text-primary'"
+        @click="selectNone"
+      >
+        Sin propina
+      </button>
+    </div>
+
+    <!-- Custom input — only when Personalizado is active -->
+    <div v-if="isActiveCustom" class="flex flex-col gap-1">
+      <label for="tip-custom-input" class="sr-only">Monto personalizado</label>
+      <div class="relative">
+        <input
+          id="tip-custom-input"
+          type="text"
+          inputmode="numeric"
+          :value="customDisplay"
+          placeholder="0"
+          maxlength="10"
+          class="input-base w-full min-h-[48px] pl-4 pr-10 py-2 text-lg font-semibold tabular-nums"
+          @input="onCustomInput"
+        />
+        <span class="absolute right-4 top-1/2 -translate-y-1/2 text-lg font-semibold text-text-secondary pointer-events-none">$</span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/online/checkout/StepConfirm.vue
+++ b/components/online/checkout/StepConfirm.vue
@@ -107,6 +107,18 @@
       :show-checkout-button="false"
     />
 
+    <!-- warocol.com#639 — Tip selector (hidden when tenant has tip_enabled=false).
+         Placed between cart summary and payment method so the customer sees the
+         total they're committing to before choosing how to pay. -->
+    <TipSelector
+      v-if="tipEnabled"
+      :enabled="tipEnabled"
+      :presets="tipPresets"
+      :preselect-index="tipPreselectIndex"
+      :subtotal="cartStore.subtotal"
+      v-model="tipModel"
+    />
+
     <!-- WaRos card -->
     <div
       v-if="warosSystemEnabled === true"
@@ -272,6 +284,28 @@ const minOrderAmount = computed(
   () => (tenantProfile.value as { data?: { min_order_amount?: number | string } } | null)
     ?.data?.min_order_amount ?? 0,
 )
+
+// warocol.com#639 — tipping config (read from the same tenantProfile query;
+// backend exposes the 3 fields in api-warolabs#247). Hidden by default until
+// the tenant opts in via /ventas/propinas (warocol.com#638).
+type TipProfile = {
+  tip_enabled?: boolean
+  tip_default_percentages?: number[]
+  tip_preselect_index?: number | null
+}
+const tipEnabled = computed(
+  () => (tenantProfile.value as { data?: TipProfile } | null)?.data?.tip_enabled === true,
+)
+const tipPresets = computed<number[]>(
+  () => (tenantProfile.value as { data?: TipProfile } | null)?.data?.tip_default_percentages ?? [10],
+)
+const tipPreselectIndex = computed<number | null>(
+  () => (tenantProfile.value as { data?: TipProfile } | null)?.data?.tip_preselect_index ?? null,
+)
+const tipModel = ref<{ amount: number; source: 'preset' | 'custom' | 'none' }>({
+  amount: 0,
+  source: 'none',
+})
 
 // ── Display helpers ───────────────────────────────────────────────────────
 
@@ -449,6 +483,10 @@ const submitOrder = async () => {
         body: {
           payment_method: paymentSelection.value.slug,
           payment_method_id: paymentSelection.value.id,
+          // warocol.com#639 — tip capture (server validates against tenant.tip_enabled)
+          ...(tipModel.value.amount > 0
+            ? { tip_amount: tipModel.value.amount, tip_source: tipModel.value.source }
+            : {}),
         },
       },
     )

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -278,8 +278,12 @@ onUnmounted(() => {
 const splitMode = ref(false)
 const splitPayments = ref<Array<{ id: string; amount: number; payment_method: string; payment_method_name: string }>>([])
 const splitPaidTotal = ref(0)
-// Issue warocol.com#649 — track the id being voided so we can disable the row's button
+// Issue warocol.com#649 — void partial payment state: modal + per-row spinner.
+// The reason is optional (audit-only); empty string is accepted by the backend.
 const isVoidingPayment = ref<string | null>(null)
+const voidPaymentTarget = ref<{ id: string; amount: number; payment_method: string; payment_method_name: string } | null>(null)
+const voidPaymentReason = ref('')
+const voidPaymentError = ref('')
 const splitRemaining = computed(() => Math.max(0, discountedTotal.value - splitPaidTotal.value))
 const splitIsComplete = computed(() => splitRemaining.value <= 0.01)
 
@@ -462,35 +466,52 @@ const addSplitPayment = async () => {
 }
 
 // Issue warocol.com#649 — void an already-registered partial payment.
-// Backend voids the row (soft-delete via voided_at), recomputes paid_total,
-// reopens the cart/session if the void cleared the closing payment, and
-// reverses the posted GL entry atomically. For mesa it voids the entire
-// proportional sibling group; voided_ids in the response drives the splice.
-const onVoidSplitPayment = async (p: { id: string; amount: number; payment_method: string; payment_method_name: string }) => {
+// Click on the trash icon opens a confirmation modal (no prompt/alert).
+// The motivo is optional; an empty value is accepted by the backend.
+const openVoidPaymentModal = (p: { id: string; amount: number; payment_method: string; payment_method_name: string }) => {
   if (isVoidingPayment.value) return
-  const reason = window.prompt(
-    `¿Eliminar el pago de ${formatCurrency(p.amount)} (${p.payment_method_name})?\n\nEscribe el motivo:`,
-  )
-  if (!reason || !reason.trim()) return
-  if (p.payment_method === 'cash') {
-    if (!window.confirm('Pago en efectivo: asegúrate de devolver físicamente el dinero al cliente antes de continuar. ¿Confirmar?')) return
-  }
+  voidPaymentTarget.value = p
+  voidPaymentReason.value = ''
+  voidPaymentError.value = ''
+}
+
+const closeVoidPaymentModal = () => {
+  if (isVoidingPayment.value) return
+  voidPaymentTarget.value = null
+  voidPaymentReason.value = ''
+  voidPaymentError.value = ''
+}
+
+const confirmVoidPayment = async () => {
+  const p = voidPaymentTarget.value
+  if (!p || isVoidingPayment.value) return
 
   isVoidingPayment.value = p.id
-  processingError.value = ''
+  voidPaymentError.value = ''
   try {
     const endpoint = isMesaMode.value
       ? `/api/tables/${posStore.activeTableSession!.tableId}/payments/${p.id}`
       : `/api/pos/cart/${posStore.cartId}/payments/${p.id}`
     const res = await $fetch(endpoint, {
       method: 'DELETE',
-      body: { reason: reason.trim() },
+      body: { reason: voidPaymentReason.value.trim() || null },
     }) as any
     const voidedIds: string[] = res.data?.voided_ids ?? [p.id]
     splitPayments.value = splitPayments.value.filter(row => !voidedIds.includes(row.id))
     splitPaidTotal.value = Number(res.data?.paid_total ?? 0)
+    voidPaymentTarget.value = null
+    voidPaymentReason.value = ''
   } catch (e: any) {
-    processingError.value = e.data?.message || 'No se pudo eliminar el pago'
+    // Surface whatever the backend returned (FastAPI puts validation errors in
+    // e.data.detail; APIError instances put text in e.data.message). Falls back
+    // to the HTTP status + message so the cashier sees something actionable.
+    const beMessage = e?.data?.message
+      ?? (Array.isArray(e?.data?.detail) ? e.data.detail.map((d: any) => d.msg ?? JSON.stringify(d)).join('; ') : e?.data?.detail)
+      ?? e?.statusMessage
+      ?? e?.message
+    voidPaymentError.value = beMessage || 'No se pudo eliminar el pago'
+    // eslint-disable-next-line no-console
+    console.error('[#649] void payment failed', { status: e?.status, statusCode: e?.statusCode, data: e?.data, message: e?.message })
   } finally {
     isVoidingPayment.value = null
   }
@@ -1989,7 +2010,7 @@ onUnmounted(() => {
                   <button
                     type="button"
                     :disabled="isVoidingPayment === p.id"
-                    @click="onVoidSplitPayment(p)"
+                    @click="openVoidPaymentModal(p)"
                     :aria-label="`Eliminar pago #${idx + 1} de ${formatCurrency(p.amount)}`"
                     class="ml-1 p-1 rounded text-text-tertiary hover:text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-40 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-destructive/30"
                   >
@@ -2478,6 +2499,81 @@ onUnmounted(() => {
     </div>
 
     <!-- Success Modal -->
+    <!-- Issue warocol.com#649 — Void partial payment modal -->
+    <Teleport to="body">
+      <div
+        v-if="voidPaymentTarget"
+        class="fixed inset-0 z-50 flex items-center justify-center p-4"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="void-payment-title"
+      >
+        <div class="absolute inset-0 bg-black/50" @click="closeVoidPaymentModal" />
+        <div class="relative bg-surface rounded-2xl shadow-xl border border-border w-full max-w-md p-6">
+          <div class="flex items-center gap-3 mb-4">
+            <div class="w-12 h-12 rounded-full flex items-center justify-center bg-destructive/10">
+              <svg class="w-6 h-6 text-destructive" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166M19.228 5.79 18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m11.456-.397a48.11 48.11 0 0 0-3.478-.397m0 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+              </svg>
+            </div>
+            <div>
+              <h3 id="void-payment-title" class="font-bold text-text-primary text-lg leading-tight">Eliminar pago</h3>
+              <p class="text-sm text-text-secondary mt-0.5">
+                {{ formatCurrency(voidPaymentTarget.amount) }} · {{ voidPaymentTarget.payment_method_name }}
+              </p>
+            </div>
+          </div>
+
+          <p
+            v-if="voidPaymentTarget.payment_method === 'cash'"
+            class="flex items-start gap-2 text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded-lg p-3 mb-4"
+          >
+            <svg class="w-4 h-4 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+            <span>Pago en efectivo — recuerda devolver físicamente el dinero al cliente antes de confirmar.</span>
+          </p>
+
+          <label for="void-payment-reason" class="block text-xs font-medium text-text-secondary uppercase tracking-wide mb-1.5">
+            Motivo <span class="text-text-tertiary normal-case">(opcional)</span>
+          </label>
+          <textarea
+            id="void-payment-reason"
+            v-model="voidPaymentReason"
+            rows="2"
+            :disabled="isVoidingPayment === voidPaymentTarget.id"
+            placeholder="Ej: cobro registrado por error"
+            class="w-full px-3 py-2 bg-surface-secondary border border-border rounded-lg text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50"
+          />
+
+          <p v-if="voidPaymentError" class="mt-3 text-sm text-destructive flex items-start gap-2">
+            <svg class="w-4 h-4 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+            <span>{{ voidPaymentError }}</span>
+          </p>
+
+          <div class="flex gap-2 mt-5">
+            <button
+              type="button"
+              :disabled="isVoidingPayment === voidPaymentTarget.id"
+              @click="closeVoidPaymentModal"
+              class="flex-1 min-h-[44px] px-4 py-2.5 rounded-lg border border-border bg-surface text-text-primary text-sm font-semibold hover:bg-surface-secondary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >Cancelar</button>
+            <button
+              type="button"
+              :disabled="isVoidingPayment === voidPaymentTarget.id"
+              @click="confirmVoidPayment"
+              class="flex-1 min-h-[44px] px-4 py-2.5 rounded-lg bg-destructive text-white text-sm font-semibold hover:bg-destructive/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
+            >
+              <UiLoadingDots v-if="isVoidingPayment === voidPaymentTarget.id" size="8px" />
+              <span v-else>Eliminar pago</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
     <Teleport to="body">
       <div
         v-if="showSuccessModal"

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -278,6 +278,8 @@ onUnmounted(() => {
 const splitMode = ref(false)
 const splitPayments = ref<Array<{ id: string; amount: number; payment_method: string; payment_method_name: string }>>([])
 const splitPaidTotal = ref(0)
+// Issue warocol.com#649 — track the id being voided so we can disable the row's button
+const isVoidingPayment = ref<string | null>(null)
 const splitRemaining = computed(() => Math.max(0, discountedTotal.value - splitPaidTotal.value))
 const splitIsComplete = computed(() => splitRemaining.value <= 0.01)
 
@@ -456,6 +458,41 @@ const addSplitPayment = async () => {
     processingError.value = e.data?.message || 'Error al registrar el pago parcial'
   } finally {
     isAddingPayment.value = false
+  }
+}
+
+// Issue warocol.com#649 — void an already-registered partial payment.
+// Backend voids the row (soft-delete via voided_at), recomputes paid_total,
+// reopens the cart/session if the void cleared the closing payment, and
+// reverses the posted GL entry atomically. For mesa it voids the entire
+// proportional sibling group; voided_ids in the response drives the splice.
+const onVoidSplitPayment = async (p: { id: string; amount: number; payment_method: string; payment_method_name: string }) => {
+  if (isVoidingPayment.value) return
+  const reason = window.prompt(
+    `¿Eliminar el pago de ${formatCurrency(p.amount)} (${p.payment_method_name})?\n\nEscribe el motivo:`,
+  )
+  if (!reason || !reason.trim()) return
+  if (p.payment_method === 'cash') {
+    if (!window.confirm('Pago en efectivo: asegúrate de devolver físicamente el dinero al cliente antes de continuar. ¿Confirmar?')) return
+  }
+
+  isVoidingPayment.value = p.id
+  processingError.value = ''
+  try {
+    const endpoint = isMesaMode.value
+      ? `/api/tables/${posStore.activeTableSession!.tableId}/payments/${p.id}`
+      : `/api/pos/cart/${posStore.cartId}/payments/${p.id}`
+    const res = await $fetch(endpoint, {
+      method: 'DELETE',
+      body: { reason: reason.trim() },
+    }) as any
+    const voidedIds: string[] = res.data?.voided_ids ?? [p.id]
+    splitPayments.value = splitPayments.value.filter(row => !voidedIds.includes(row.id))
+    splitPaidTotal.value = Number(res.data?.paid_total ?? 0)
+  } catch (e: any) {
+    processingError.value = e.data?.message || 'No se pudo eliminar el pago'
+  } finally {
+    isVoidingPayment.value = null
   }
 }
 
@@ -1948,6 +1985,22 @@ onUnmounted(() => {
                   </svg>
                   <span class="text-text-secondary flex-1">#{{ idx + 1 }} · {{ p.payment_method_name }}</span>
                   <span class="font-semibold text-text-primary tabular-nums">{{ formatCurrency(p.amount) }}</span>
+                  <!-- Issue warocol.com#649 — void this partial payment -->
+                  <button
+                    type="button"
+                    :disabled="isVoidingPayment === p.id"
+                    @click="onVoidSplitPayment(p)"
+                    :aria-label="`Eliminar pago #${idx + 1} de ${formatCurrency(p.amount)}`"
+                    class="ml-1 p-1 rounded text-text-tertiary hover:text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-40 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-destructive/30"
+                  >
+                    <svg v-if="isVoidingPayment === p.id" class="h-4 w-4 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+                      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+                    </svg>
+                    <svg v-else class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                    </svg>
+                  </button>
                 </div>
               </div>
             </div>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -59,7 +59,7 @@ const discountInput = ref('')
 
 // Success modal state
 const showSuccessModal = ref(false)
-const orderResult = ref<{ order_number: number; total_amount: number; payment_method: string; payment_method_name?: string; customer_id?: string; discount_amount?: number; subtotal?: number; standard_tax?: number; liquor_tax?: number; standard_tax_label?: string; order_id?: string; order_ids?: string[] } | null>(null)
+const orderResult = ref<{ order_number: number; total_amount: number; payment_method: string; payment_method_name?: string; customer_id?: string; discount_amount?: number; subtotal?: number; standard_tax?: number; liquor_tax?: number; standard_tax_label?: string; order_id?: string; order_ids?: string[]; tip_amount?: number; charged_amount?: number } | null>(null)
 const wasMesaMode = ref(false)
 const receiptEmail = ref('')
 const emailSent = ref(false)
@@ -198,6 +198,19 @@ const expediterEnabled = computed(() => settingsData.value?.data?.expediter_enab
 const showExpediterPanel = ref(false)
 const acceptsOnlineOrders = computed(() => settingsData.value?.data?.accepts_online_orders === true)
 
+// warocol.com#639 — tipping config (gated by tenant; defaults keep selector hidden)
+const tipEnabled = computed(() => settingsData.value?.data?.tip_enabled === true)
+const tipPresets = computed<number[]>(() => settingsData.value?.data?.tip_default_percentages ?? [10])
+const tipPreselectIndex = computed<number | null>(() => settingsData.value?.data?.tip_preselect_index ?? null)
+const tipModel = ref<{ amount: number; source: 'preset' | 'custom' | 'none' }>({ amount: 0, source: 'none' })
+const tipAmount = computed(() => tipModel.value.amount)
+const tipSource = computed(() => tipModel.value.source)
+// Reset whenever the cart is cleared / customer changes so a previous tip
+// doesn't bleed into the next sale.
+watch([() => posStore.cartId, () => selectedCustomer.value?.id], () => {
+  tipModel.value = { amount: 0, source: 'none' }
+})
+
 // Counter mode: not a real table session (no mesa, no bar)
 const isCounterMode = computed(() => !isMesaMode.value && !posStore.activeTableSession?.isBar)
 
@@ -233,6 +246,10 @@ const discountAmount = computed(() => {
   return Math.min(Math.round(val), Math.round(cartTotal.value))
 })
 const discountedTotal = computed(() => cartTotal.value - discountAmount.value)
+// warocol.com#639 — final amount charged to the customer when tipping is enabled.
+// total_amount on orders never includes tip (tax-base invariant from migration 079);
+// charged_amount = total_amount + tip_amount lives at the payment layer only.
+const finalChargedAmount = computed(() => discountedTotal.value + tipAmount.value)
 
 // Tax preview — runs for all 3 modes (mesa / counter / bar). Debounced to
 // avoid flooding when items / discount change rapidly.
@@ -689,6 +706,10 @@ const processOrder = async () => {
         ...(posStore.cartServedByMemberId
           ? { served_by_member_id: posStore.cartServedByMemberId }
           : {}),
+        // warocol.com#639 — tip capture (server validates against tenant.tip_enabled)
+        ...(tipAmount.value > 0
+          ? { tip_amount: tipAmount.value, tip_source: tipSource.value }
+          : {}),
       }
     }) as {
       success: boolean
@@ -697,6 +718,9 @@ const processOrder = async () => {
         order_id: string
         order_number: number
         total_amount: number
+        tip_amount?: number
+        tip_source?: string
+        charged_amount?: number
         payment_method: string
         items_count: number
         standard_tax?: number
@@ -722,7 +746,11 @@ const processOrder = async () => {
         standard_tax_label: response.data.standard_tax_label ?? 'Impuesto',
         ...(discountEnabled.value && _discountAmtPos > 0
           ? { discount_amount: _discountAmtPos, subtotal: _subtotalPos }
-          : {})
+          : {}),
+        // warocol.com#639 — surface tip in the success modal when present
+        ...(response.data.tip_amount && response.data.tip_amount > 0
+          ? { tip_amount: response.data.tip_amount, charged_amount: response.data.charged_amount }
+          : {}),
       }
       cartItemsSnapshot.value = [...cartItems.value]
       receiptEmail.value = emailForReceipt ?? ''
@@ -770,8 +798,10 @@ watch(selectedPaymentMethod, () => {
 const isCashMethod = computed(() => selectedGroup.value?.slug === 'cash')
 const cashReceivedInput = ref<number>(0)
 
+// warocol.com#639 — single-payment cash flow must cover total + tip (split mode
+// disallows tips, enforced by the backend in api-warolabs#245).
 const cashAmountToCharge = computed(() =>
-  splitMode.value ? splitAmountToCharge.value : discountedTotal.value
+  splitMode.value ? splitAmountToCharge.value : finalChargedAmount.value
 )
 
 const cashChange = computed(() =>
@@ -2038,6 +2068,19 @@ onUnmounted(() => {
           </div>
         </div>
 
+        <!-- warocol.com#639 — Tip selector (hidden when tenant has tip_enabled=false).
+             Placed between totals and payment so cashier-controlled tipping in POS
+             stays visible right where the operator confirms the order. Split mode
+             intentionally excluded — backend rejects tips in split payments. -->
+        <TipSelector
+          v-if="tipEnabled && !splitMode"
+          :enabled="tipEnabled"
+          :presets="tipPresets"
+          :preselect-index="tipPreselectIndex"
+          :subtotal="cartTotal"
+          v-model="tipModel"
+        />
+
         <!-- Issue #524 — Cash tender + change calculation (single-payment mode) -->
         <div v-if="!splitMode && isCashMethod && selectedCustomer" class="flex flex-col gap-3 p-4 rounded-xl bg-surface border border-border">
           <label for="cash-received-input-single" class="text-sm font-medium text-text-primary">
@@ -2123,7 +2166,13 @@ onUnmounted(() => {
             <svg v-else class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
             </svg>
-            <span v-if="!isProcessing">{{ selectedPaymentMethod === 'credit' ? 'Registrar como crédito' : 'Confirmar Orden' }}</span>
+            <span v-if="!isProcessing">
+              {{ selectedPaymentMethod === 'credit'
+                ? 'Registrar como crédito'
+                : tipAmount > 0
+                  ? `Confirmar — ${formatCurrency(finalChargedAmount)}`
+                  : 'Confirmar Orden' }}
+            </span>
             <svg v-if="!isProcessing" class="h-5 w-5 opacity-0 -ml-4 group-hover:opacity-100 group-hover:ml-0 transition-all" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
             </svg>
@@ -2443,6 +2492,15 @@ onUnmounted(() => {
             <div class="flex items-center justify-between" :class="(orderResult.discount_amount || orderResult.standard_tax || orderResult.liquor_tax) ? 'border-t border-border pt-3' : ''">
               <span class="text-sm text-text-secondary">Total</span>
               <span class="text-lg font-bold text-text-primary">{{ formatCurrency(orderResult.total_amount) }}</span>
+            </div>
+            <!-- warocol.com#639 — show tip on a separate line + the total charged to the customer -->
+            <div v-if="orderResult.tip_amount && orderResult.tip_amount > 0" class="flex items-center justify-between">
+              <span class="text-sm text-text-secondary">Propina</span>
+              <span class="text-sm font-medium text-text-primary">{{ formatCurrency(orderResult.tip_amount) }}</span>
+            </div>
+            <div v-if="orderResult.tip_amount && orderResult.tip_amount > 0 && orderResult.charged_amount" class="flex items-center justify-between border-t border-border pt-3">
+              <span class="text-sm text-text-secondary">Total cobrado</span>
+              <span class="text-lg font-bold text-primary">{{ formatCurrency(orderResult.charged_amount) }}</span>
             </div>
             <div class="flex items-center justify-between">
               <span class="text-sm text-text-secondary">Método de Pago</span>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -134,55 +134,10 @@ type TaxPreview = {
   liquor_tax: number
   standard_tax_label: string
 }
-const taxPreview = ref<TaxPreview | null>(null)
-const taxLoading = ref(false)
-const taxError = ref('')
-let taxRefreshTmr: ReturnType<typeof setTimeout> | null = null
-
-const refreshTaxPreview = async () => {
-  taxLoading.value = true
-  taxError.value = ''
-  try {
-    // Mesa: existing endpoint, ignores any in-flight discount (computed
-    // from already-saved orders in the session).
-    if (isMesaMode.value && posStore.activeTableSession?.tableId) {
-      const res = await $fetch<{ success: boolean; data: any }>(
-        `/api/tables/${posStore.activeTableSession.tableId}/current`
-      )
-      const session = res?.data?.session
-      taxPreview.value = {
-        standard_tax: Number(session?.standard_tax) || 0,
-        liquor_tax: Number(session?.liquor_tax) || 0,
-        standard_tax_label: session?.standard_tax_label || 'Impuesto',
-      }
-      return
-    }
-
-    // Counter / Bar: new endpoint, accepts the in-flight discount as a query param.
-    if (posStore.cartId) {
-      const params = new URLSearchParams()
-      if (discountAmount.value > 0) params.set('discount_amount', String(discountAmount.value))
-      const qs = params.toString() ? `?${params.toString()}` : ''
-      const res = await $fetch<{ standard_tax: number; liquor_tax: number; standard_tax_label: string }>(
-        `/api/pos/cart/${posStore.cartId}/tax-preview${qs}`
-      )
-      taxPreview.value = {
-        standard_tax: Number(res?.standard_tax) || 0,
-        liquor_tax: Number(res?.liquor_tax) || 0,
-        standard_tax_label: res?.standard_tax_label || 'Impuesto',
-      }
-      return
-    }
-
-    // No cart yet → clear preview
-    taxPreview.value = null
-  } catch (e: any) {
-    taxError.value = e?.data?.message || e?.message || 'No se pudo calcular impuestos'
-    taxPreview.value = null
-  } finally {
-    taxLoading.value = false
-  }
-}
+// taxPreview is now a computed derived from the mesa/POS useQuery results
+// (declared further down, after discountedTotal). The legacy refreshTaxPreview
+// function + manual debounced watcher were removed in the parallel-loading
+// refactor — keys reactive to cartId/discountAmount drive refetches.
 
 // ── POS restaurant context (BFF aggregator) — reuses same cache key as index.vue (no extra network request)
 // Migrated from /api/api/tenant/public-profile (now owner-only MI_NEGOCIO).
@@ -192,6 +147,24 @@ const { data: settingsData } = useQuery({
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })
+
+// Payment methods — shared cache with /ventas/ordenes (same key).
+// 5 min staleTime: methods change rarely; navigating back to checkout reuses
+// the cache without a network call.
+const {
+  data: paymentMethodsData,
+  asyncStatus: paymentMethodsAsyncStatus,
+} = useQuery({
+  key: () => ['payments', 'groups', currentTenant.value?.id ?? null],
+  query: () => $fetch<{ success: boolean; data: PosPaymentGroup[] }>('/api/pos/payment-methods'),
+  enabled: () => !!currentTenant.value,
+  staleTime: 300_000,
+})
+watch(paymentMethodsData, (data) => {
+  if (data?.success && data.data?.length) {
+    posPaymentGroups.value = data.data
+  }
+}, { immediate: true })
 const comandasEnabled = computed(() => settingsData.value?.data?.comandas_enabled === true)
 // Issue #537 — expediter mode (waiter advances comanda state from POS)
 const expediterEnabled = computed(() => settingsData.value?.data?.expediter_enabled === true)
@@ -251,28 +224,78 @@ const discountedTotal = computed(() => cartTotal.value - discountAmount.value)
 // charged_amount = total_amount + tip_amount lives at the payment layer only.
 const finalChargedAmount = computed(() => discountedTotal.value + tipAmount.value)
 
-// Tax preview — runs for all 3 modes (mesa / counter / bar). Debounced to
-// avoid flooding when items / discount change rapidly.
-watch(
-  [
-    isMesaMode,
-    cartTotal,
-    discountAmount,
-    () => storeTabItems.value.length,
-    () => posStore.cart.length,
-  ],
-  () => {
-    if (taxRefreshTmr) clearTimeout(taxRefreshTmr)
-    taxRefreshTmr = setTimeout(() => {
-      refreshTaxPreview()
-    }, 250)
-  },
-  { immediate: true },
-)
-
-onUnmounted(() => {
-  if (taxRefreshTmr) clearTimeout(taxRefreshTmr)
+// ── Parallel-loading queries (replaces manual refreshTaxPreview + #656 rehydration $fetch).
+//
+// Mesa session — ONE query covers tax preview, running total, AND the #656
+// partial_payments rehydration. Replaces the legacy refreshTaxPreview mesa
+// branch and the manual rehydration $fetch in onMounted.
+const {
+  data: mesaCurrentData,
+  asyncStatus: mesaCurrentAsyncStatus,
+  error: mesaCurrentError,
+} = useQuery({
+  key: () => ['tables', posStore.activeTableSession?.tableId ?? null, 'current'],
+  query: () => $fetch<{ success: boolean; data: any }>(
+    `/api/tables/${posStore.activeTableSession!.tableId}/current`
+  ),
+  enabled: () => isMesaMode.value && !!posStore.activeTableSession?.tableId,
+  staleTime: 5_000,  // short — running_total changes when items are added
 })
+
+// POS cart (counter / bar) — covers the #656 partial_payments rehydration.
+// The endpoint is keyed by customer_id but returns the active cart's order.
+const {
+  data: posCartData,
+  asyncStatus: posCartAsyncStatus,
+  error: posCartError,
+} = useQuery({
+  key: () => ['pos', 'cart', 'by-customer', selectedCustomer.value?.id ?? null],
+  query: () => $fetch<{ success: boolean; data: any }>(
+    `/api/pos/cart/${selectedCustomer.value!.id}`
+  ),
+  enabled: () => !isMesaMode.value && !!posStore.cartId && !!selectedCustomer.value?.id,
+  staleTime: 5_000,
+})
+
+// POS tax preview — only when in counter/bar mode. discountAmount is part of
+// the key so a discount change re-fetches automatically.
+const { data: posTaxPreviewData } = useQuery({
+  key: () => ['pos', 'cart', posStore.cartId ?? null, 'tax-preview', discountAmount.value],
+  query: () => {
+    const params = new URLSearchParams()
+    if (discountAmount.value > 0) params.set('discount_amount', String(discountAmount.value))
+    const qs = params.toString() ? `?${params.toString()}` : ''
+    return $fetch<{ standard_tax: number; liquor_tax: number; standard_tax_label: string }>(
+      `/api/pos/cart/${posStore.cartId}/tax-preview${qs}`
+    )
+  },
+  enabled: () => !isMesaMode.value && !!posStore.cartId,
+  staleTime: 5_000,
+})
+
+// Tax preview derived from whichever query is active (mesa vs POS).
+// Replaces the manually-managed taxPreview ref + refreshTaxPreview function.
+const taxPreview = computed<TaxPreview | null>(() => {
+  if (isMesaMode.value) {
+    const session = mesaCurrentData.value?.data?.session
+    if (!session) return null
+    return {
+      standard_tax: Number(session.standard_tax) || 0,
+      liquor_tax: Number(session.liquor_tax) || 0,
+      standard_tax_label: session.standard_tax_label || 'Impuesto',
+    }
+  }
+  const data = posTaxPreviewData.value
+  if (!data) return null
+  return {
+    standard_tax: Number(data.standard_tax) || 0,
+    liquor_tax: Number(data.liquor_tax) || 0,
+    standard_tax_label: data.standard_tax_label || 'Impuesto',
+  }
+})
+
+// Tax preview is auto-recomputed via useQuery (mesaCurrentData / posTaxPreviewData)
+// — discount/cart changes invalidate the query keys, no manual debounce needed.
 
 // Split payment state
 const splitMode = ref(false)
@@ -458,6 +481,13 @@ const addSplitPayment = async () => {
     })
     splitPaidTotal.value = paidTotal
     cashReceivedInput.value = 0
+    // Invalidate the read query so future reloads see the new partial.
+    // Triggers a background refetch — header shows "Actualizando pagos".
+    cache.invalidateQueries({
+      key: isMesaMode.value
+        ? ['tables', posStore.activeTableSession?.tableId ?? null, 'current']
+        : ['pos', 'cart', 'by-customer', selectedCustomer.value?.id ?? null],
+    })
 
     if (isComplete) {
       orderResult.value = {
@@ -517,6 +547,12 @@ const confirmVoidPayment = async () => {
     const voidedIds: string[] = res.data?.voided_ids ?? [p.id]
     splitPayments.value = splitPayments.value.filter(row => !voidedIds.includes(row.id))
     splitPaidTotal.value = Number(res.data?.paid_total ?? 0)
+    // Invalidate the read query so background refetch syncs the new state.
+    cache.invalidateQueries({
+      key: isMesaMode.value
+        ? ['tables', posStore.activeTableSession?.tableId ?? null, 'current']
+        : ['pos', 'cart', 'by-customer', selectedCustomer.value?.id ?? null],
+    })
     voidPaymentTarget.value = null
     voidPaymentReason.value = ''
   } catch (e: any) {
@@ -1224,22 +1260,12 @@ const sendReceiptEmail = async () => {
   }
 }
 
-// Fetch dynamic payment methods from API — falls back to hardcoded defaults on error
-const isLoadingPaymentMethods = ref(true)
-
-const fetchPaymentMethods = async () => {
-  isLoadingPaymentMethods.value = true
-  try {
-    const response = await $fetch<{ success: boolean; data: PosPaymentGroup[] }>('/api/pos/payment-methods')
-    if (response.success && response.data?.length) {
-      posPaymentGroups.value = response.data
-    }
-  } catch {
-    // Keep PAYMENT_DEFAULTS — POS must never break
-  } finally {
-    isLoadingPaymentMethods.value = false
-  }
-}
+// Payment methods now hydrate from the `paymentMethodsData` useQuery defined
+// at the top of the script (cache shared with /ventas/ordenes). The legacy
+// fetchPaymentMethods() function was removed in the parallel-loading refactor.
+const isLoadingPaymentMethods = computed(() =>
+  paymentMethodsAsyncStatus.value === 'loading' && !paymentMethodsData.value
+)
 
 // Sincronizar carrito al backend cuando carga la página
 const syncCart = async () => {
@@ -1264,50 +1290,80 @@ const syncCart = async () => {
   }
 }
 
-// Set page subtitle and sync cart on mount
+// ── Initial-load + optimistic-refresh wiring (mirrors /ventas/ordenes).
+// isLoading: page is mounting and the relevant backend read is in-flight for
+// the first time. Renders a full-page CommonsTheCustomLoader in the template.
+// isRefreshing: a refetch is in-flight while we already have data. Surfaced
+// in the layout header via registerProgressiveLoading — content stays visible.
+const isLoading = computed(() => {
+  if (isMesaMode.value) {
+    return !mesaCurrentData.value && !mesaCurrentError.value && mesaCurrentAsyncStatus.value === 'loading'
+  }
+  if (posStore.cartId && selectedCustomer.value?.id) {
+    return !posCartData.value && !posCartError.value && posCartAsyncStatus.value === 'loading'
+  }
+  return false
+})
+const isRefreshing = computed(() => {
+  if (isMesaMode.value) {
+    return mesaCurrentAsyncStatus.value === 'loading' && mesaCurrentData.value != null
+  }
+  if (selectedCustomer.value?.id) {
+    return posCartAsyncStatus.value === 'loading' && posCartData.value != null
+  }
+  return false
+})
+const checkoutError = computed(() => isMesaMode.value ? mesaCurrentError.value : posCartError.value)
+
+const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
+const refreshAll = async () => {
+  await Promise.all([
+    cache.invalidateQueries({ key: ['pos', 'payment-methods'] }),
+    isMesaMode.value
+      ? cache.invalidateQueries({ key: ['tables', posStore.activeTableSession?.tableId ?? null, 'current'] })
+      : cache.invalidateQueries({ key: ['pos', 'cart', 'by-customer', selectedCustomer.value?.id ?? null] }),
+  ])
+}
+registerProgressiveLoading(isRefreshing, 'Actualizando pagos')
+
+// Issue warocol.com#656 — rehydrate splitPayments from the active query.
+// The same source of truth feeds both the initial render and any refetch
+// (after a mutation or manual refresh). Replaces the previous one-shot
+// onMounted block that used a separate $fetch and ignored future refreshes.
+const hydratePartialsFrom = (partials: any[] | undefined) => {
+  if (!partials || partials.length === 0) return
+  splitPayments.value = partials.map((p: any) => ({
+    id: p.id,
+    amount: Number(p.amount),
+    payment_method: p.payment_method,
+    payment_method_name: p.payment_method_name ?? getPaymentMethodLabel(p.payment_method),
+  }))
+  splitPaidTotal.value = splitPayments.value.reduce((acc, p) => acc + p.amount, 0)
+  if (!splitMode.value) splitMode.value = true
+}
+watch(() => mesaCurrentData.value?.data?.session?.partial_payments, hydratePartialsFrom)
+watch(() => posCartData.value?.data?.partial_payments, hydratePartialsFrom)
+
+// Set page subtitle and sync cart on mount. payment-methods, mesa /current
+// and pos cart queries are already in flight (declared above as useQuery —
+// they fire from setup, in parallel with the mount).
 onMounted(async () => {
   setPageSubtitle('Checkout')
-
 
   // Siempre regeneramos el carrito backend desde el estado local actual.
   if (posStore.cart.length > 0) {
     isSyncingCart.value = true
   }
 
-  // Fetch dynamic payment methods (fallback to defaults on error)
-  await fetchPaymentMethods()
+  setRefreshHandler(refreshAll)
 
-  // Sincronizar carrito al backend (batch, sin cliente)
+  // Cart sync is the only operation that's genuinely sequential (mutation
+  // local → backend). All read queries already kicked off from setup.
   await syncCart()
+})
 
-  // Issue warocol.com#656 — rehydrate Cobro Parcial state so re-entering
-  // checkout on an order with active partials doesn't reset the list and
-  // risk a double-charge. Mesa reads from /api/tables/<id>/current; POS
-  // reads from /api/pos/cart/<customer_id>. Non-fatal on error — checkout
-  // stays usable; worst case the cashier sees the un-aware totals.
-  try {
-    let partials: any[] = []
-    if (isMesaMode.value && posStore.activeTableSession?.tableId) {
-      const res = await $fetch<any>(`/api/tables/${posStore.activeTableSession.tableId}/current`)
-      partials = res?.data?.session?.partial_payments ?? []
-    } else if (posStore.cartId && selectedCustomer.value?.id) {
-      const res = await $fetch<any>(`/api/pos/cart/${selectedCustomer.value.id}`)
-      partials = res?.data?.partial_payments ?? []
-    }
-    if (partials.length > 0) {
-      splitPayments.value = partials.map((p: any) => ({
-        id: p.id,
-        amount: Number(p.amount),
-        payment_method: p.payment_method,
-        payment_method_name: p.payment_method_name ?? getPaymentMethodLabel(p.payment_method),
-      }))
-      splitPaidTotal.value = splitPayments.value.reduce((acc, p) => acc + p.amount, 0)
-      splitMode.value = true
-    }
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error('[#656] partial-payments rehydration failed', e)
-  }
+onUnmounted(() => {
+  clearRefreshHandler(refreshAll)
 })
 
 // Issue #529 — auto-select Genérico when the tenant flag is on. Applies to
@@ -1350,16 +1406,20 @@ onUnmounted(() => {
 
 <template>
   <div class="w-full pb-32 lg:pb-0">
-    <!-- Loading State (syncing cart) -->
-    <div v-if="isSyncingCart" class="flex items-center justify-center min-h-[70vh]">
+    <!-- Loading State: initial cart sync OR first-read queries in-flight.
+         Optimistic refetches (after mutations) keep content visible and surface
+         in the layout header via registerProgressiveLoading instead. -->
+    <div v-if="isSyncingCart || isLoading" class="flex items-center justify-center min-h-[70vh]">
       <div class="text-center">
         <CommonsTheCustomLoader size="large" />
-        <p class="text-text-secondary font-medium mt-6">Preparando checkout...</p>
+        <p class="text-text-secondary font-medium mt-6">
+          {{ isSyncingCart ? 'Preparando checkout...' : 'Cargando checkout...' }}
+        </p>
       </div>
     </div>
 
-    <!-- Sync Error State -->
-    <CommonsTheErrorState v-else-if="syncError" />
+    <!-- Error State (cart sync OR initial read failure) -->
+    <CommonsTheErrorState v-else-if="syncError || checkoutError" />
 
     <!-- Empty Cart State -->
     <div v-else-if="cartItems.length === 0 && !isMesaMode && !showSuccessModal" class="text-center py-16">

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -314,6 +314,24 @@ watch(splitMode, (val) => {
   }
 })
 
+// Issue warocol.com#656 — toggle split mode without dropping splitPayments
+// when there are already-committed partials. The previous inline handler
+// reset the array unconditionally, which on a freshly-rehydrated checkout
+// would visually erase the DB-backed partials and lead to a double-charge.
+// When the cashier toggles off with partials present, we only hide the panel.
+const toggleSplitMode = () => {
+  const next = !splitMode.value
+  if (!next && splitPayments.value.length > 0) {
+    splitMode.value = false
+    return
+  }
+  splitMode.value = next
+  if (!next) {
+    splitPayments.value = []
+    splitPaidTotal.value = 0
+  }
+}
+
 const splitAmountToCharge = computed(() =>
   splitPartialAmount.value !== null && splitPartialAmount.value > 0
     ? Math.min(splitPartialAmount.value, splitRemaining.value)
@@ -1261,6 +1279,35 @@ onMounted(async () => {
 
   // Sincronizar carrito al backend (batch, sin cliente)
   await syncCart()
+
+  // Issue warocol.com#656 — rehydrate Cobro Parcial state so re-entering
+  // checkout on an order with active partials doesn't reset the list and
+  // risk a double-charge. Mesa reads from /api/tables/<id>/current; POS
+  // reads from /api/pos/cart/<customer_id>. Non-fatal on error — checkout
+  // stays usable; worst case the cashier sees the un-aware totals.
+  try {
+    let partials: any[] = []
+    if (isMesaMode.value && posStore.activeTableSession?.tableId) {
+      const res = await $fetch<any>(`/api/tables/${posStore.activeTableSession.tableId}/current`)
+      partials = res?.data?.session?.partial_payments ?? []
+    } else if (posStore.cartId && selectedCustomer.value?.id) {
+      const res = await $fetch<any>(`/api/pos/cart/${selectedCustomer.value.id}`)
+      partials = res?.data?.partial_payments ?? []
+    }
+    if (partials.length > 0) {
+      splitPayments.value = partials.map((p: any) => ({
+        id: p.id,
+        amount: Number(p.amount),
+        payment_method: p.payment_method,
+        payment_method_name: p.payment_method_name ?? getPaymentMethodLabel(p.payment_method),
+      }))
+      splitPaidTotal.value = splitPayments.value.reduce((acc, p) => acc + p.amount, 0)
+      splitMode.value = true
+    }
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('[#656] partial-payments rehydration failed', e)
+  }
 })
 
 // Issue #529 — auto-select Genérico when the tenant flag is on. Applies to
@@ -1968,7 +2015,7 @@ onUnmounted(() => {
               role="switch"
               :aria-checked="splitMode"
               :aria-label="splitMode ? 'Desactivar cobro parcial' : 'Activar cobro parcial'"
-              @click="splitMode = !splitMode; splitPayments = []; splitPaidTotal = 0"
+              @click="toggleSplitMode"
               class="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
               :class="splitMode ? 'bg-primary' : 'bg-border'"
             >


### PR DESCRIPTION
## Summary

Mirrors the loading pattern from `/ventas/ordenes` on `/pos/checkout`:

- **Initial load** → full-page `CommonsTheCustomLoader` (no per-section skeletons).
- **Optimistic refresh** → header shows `"Actualizando pagos"` via `registerProgressiveLoading`; content stays visible, no layout shift.
- **Parallel reads** → 4 `useQuery` hooks fire from `setup` (in parallel), not sequentially in `onMounted`.
- **Cache invalidation after mutations** → background refetch keeps split payments in sync with the backend across tabs / page revisits.

## Stack

Nuxt 3 / Vue 3 Composition API · `@pinia/colada` (useQuery).

## Changes

`front_nuxt/pages/pos/checkout.vue` (+182 / -122):

| Migrated | Before | After |
|---|---|---|
| Payment methods | `fetchPaymentMethods()` manual loader, awaited in `onMounted` | `useQuery({ key: ['payments', 'groups', tenantId], staleTime: 300_000 })` — cache shared with `/ventas/ordenes`. |
| Mesa `/current` | Two call sites: `refreshTaxPreview` (debounced) + #656 rehydration `$fetch` | **ONE** `useQuery({ key: ['tables', tableId, 'current'], staleTime: 5_000 })` — covers tax preview, running_total, and partial_payments rehydration. |
| POS `/cart/<customer_id>` | #656 rehydration `$fetch` in `onMounted` | `useQuery({ key: ['pos', 'cart', 'by-customer', customerId], staleTime: 5_000 })`. |
| POS `tax-preview` | `refreshTaxPreview` debounced watcher | `useQuery({ key: ['pos', 'cart', cartId, 'tax-preview', discountAmount], staleTime: 5_000 })` — discount change re-fetches automatically. |
| `taxPreview` ref | Mutated manually inside `refreshTaxPreview` | `computed` derived from whichever query is active. |
| `splitPayments` rehydration | One-shot block in `onMounted` (#656) | `watch(mesaCurrentData.value.data.session.partial_payments)` + `watch(posCartData.value.data.partial_payments)` — runs on every refetch, not just mount. |
| Refresh + progressive | None | `setRefreshHandler(refreshAll)` + `registerProgressiveLoading(isRefreshing, 'Actualizando pagos')`. |

Cache invalidation added in `addSplitPayment` (after success) and `confirmVoidPayment` (after success) — triggers background refetch on the active query.

## Net effect on the network panel

Before, `onMounted` was sequential:

```
fetch /payment-methods   → wait
fetch /cart/batch        → wait
fetch /current OR /cart  → wait  (#656 rehydration)
fetch /current OR /tax   → debounced 250ms after the above
```

After, queries fire from `setup` in parallel:

```
fetch /payment-methods   ┐
fetch /current OR /cart  ├─ parallel from setup
fetch /tax-preview       ┘
fetch /cart/batch          (sequential — local mutation → backend)
```

Re-entering checkout within `staleTime` reuses the cache without any network call.

## Test plan

Run frontend with `pnpm dev`, backend with `--reload`.

**Initial load**:
- [ ] First visit on mesa with active partials → full-page CustomLoader → content + Pagos registrados appear together (no progressive section-by-section render).
- [ ] First visit on POS counter (cart empty) → behaviour unchanged, no loader.
- [ ] First visit on POS counter with cart items + customer → CustomLoader → content appears.

**Optimistic refresh**:
- [ ] Register a partial → header momentarily shows "Actualizando pagos" → split list updates with fresh server data, no flicker.
- [ ] Void a partial → same header indicator, row disappears from the list.
- [ ] Click the layout refresh button → triggers `refreshAll`, header shows the indicator while queries re-fetch.

**Cache behavior**:
- [ ] Network tab: 4 reads from `setup` are concurrent (not waterfall).
- [ ] Navigate back to `/pos` then re-enter `/pos/checkout` within 5 min: `payment-methods` and `restaurant-context` served from cache (no network).
- [ ] Mesa `/current` re-fetches if `staleTime` (5 s) elapsed; otherwise served from cache.
- [ ] Change the discount in POS counter → `tax-preview` re-fetches automatically (key changed).

**Edge cases**:
- [ ] Backend down during initial mount → `CommonsTheErrorState` renders (not the loader, not partial UI).
- [ ] Backend down during a mutation → `processingError` shows the message; UI stays usable.
- [ ] Bar mode (`isMesaMode === false` despite `activeTableSession`) → POS cart query path applies.

## Dependencies

- Requires backend `partial_payments` endpoint additions from #656 (already merged on `main`).
- Uses existing `useLayoutActions` composable (no changes).
- Uses existing `CommonsTheCustomLoader` + `CommonsTheErrorState` components (no changes).

## Out of scope

- Backend changes.
- Skeleton-based loading (explicitly rejected in favor of the `/ventas/ordenes` pattern).
- Migrating other POS pages (only `/pos/checkout`).
- Polling / auto-refresh on interval (deferred — agregar después si testing lo justifica).