### PR TITLE
Allow assigning a waiter at checkout when the table has none

### DIFF
--- a/components/checkout/WaiterSelector.vue
+++ b/components/checkout/WaiterSelector.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+interface Member {
+  id: string
+  name: string
+  role: string
+}
+
+const props = withDefaults(defineProps<{
+  members: Member[]
+  modelValue: string | null
+}>(), {
+  members: () => [],
+  modelValue: null,
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string | null): void
+}>()
+
+const onChange = (event: Event) => {
+  const value = (event.target as HTMLSelectElement).value
+  emit('update:modelValue', value || null)
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-3 p-4 rounded-xl bg-surface border-2 border-border">
+    <div class="flex flex-col gap-0.5">
+      <p class="text-sm font-semibold text-text-primary">Mesero (opcional)</p>
+      <p class="text-xs leading-snug text-text-secondary">
+        Atribuye esta venta para propinas y reportes por mesero.
+      </p>
+    </div>
+
+    <p
+      v-if="members.length === 0"
+      class="text-xs text-text-secondary bg-surface-secondary rounded-lg px-3 py-2.5"
+    >
+      No hay miembros activos en el equipo. Puedes continuar sin asignar mesero.
+    </p>
+
+    <div v-else class="flex items-center gap-2">
+      <svg class="w-4 h-4 text-text-tertiary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+      </svg>
+      <select
+        :value="modelValue || ''"
+        class="flex-1 min-h-[44px] px-3 py-2 text-sm font-medium bg-background border border-border rounded-xl focus:ring-2 focus:ring-primary/20 focus:border-primary transition-colors outline-none text-text-primary cursor-pointer"
+        aria-label="Seleccionar mesero para esta venta"
+        @change="onChange"
+      >
+        <option value="">Sin asignar</option>
+        <option v-for="m in members" :key="m.id" :value="m.id">
+          {{ m.name }} ({{ m.role }})
+        </option>
+      </select>
+    </div>
+  </div>
+</template>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -184,6 +184,19 @@ watch([() => posStore.cartId, () => selectedCustomer.value?.id], () => {
   tipModel.value = { amount: 0, source: 'none' }
 })
 
+// warocol.com#663 — checkout waiter picker (mesa without session waiter, or attribution off)
+const waiterAttributionEnabled = computed(() => settingsData.value?.data?.waiter_attribution_enabled === true)
+const tenantMembers = computed(() => settingsData.value?.data?.members ?? [])
+const showCheckoutWaiterSelector = computed(() => {
+  if (posStore.activeTableSession?.effectiveWaiterMemberId) return false
+  if (!waiterAttributionEnabled.value) return true
+  if (isMesaMode.value) return true
+  return !posStore.cartServedByMemberId
+})
+const checkoutServedByBody = computed(() =>
+  posStore.cartServedByMemberId ? { served_by_member_id: posStore.cartServedByMemberId } : {},
+)
+
 // Counter mode: not a real table session (no mesa, no bar)
 const isCounterMode = computed(() => !isMesaMode.value && !posStore.activeTableSession?.isBar)
 
@@ -392,6 +405,7 @@ const addSplitPayment = async () => {
             ...(isCashMethod.value
               ? { split_first_cash_received: Number(cashReceivedInput.value) }
               : {}),
+            ...checkoutServedByBody.value,
           }
         }) as any
         paidTotal = response.data.paid_total ?? amountToCharge
@@ -437,10 +451,7 @@ const addSplitPayment = async () => {
             ...(isCashMethod.value
               ? { split_first_cash_received: Number(cashReceivedInput.value) }
               : {}),
-            // Issue #575 — per-order waiter attribution (bar + counter; mesa uses #574 session override)
-            ...(posStore.cartServedByMemberId
-              ? { served_by_member_id: posStore.cartServedByMemberId }
-              : {}),
+            ...checkoutServedByBody.value,
           }
         }) as any
         paidTotal = response.data.paid_total ?? amountToCharge
@@ -730,6 +741,7 @@ const processOrder = async () => {
           ...(tipAmount.value > 0
             ? { tip_amount: tipAmount.value, tip_source: tipSource.value }
             : {}),
+          ...checkoutServedByBody.value,
         },
       }) as any
 
@@ -825,10 +837,7 @@ const processOrder = async () => {
                 : {}),
             }
           : {}),
-        // Issue #575 — per-order waiter attribution (bar + counter; mesa uses #574 session override)
-        ...(posStore.cartServedByMemberId
-          ? { served_by_member_id: posStore.cartServedByMemberId }
-          : {}),
+        ...checkoutServedByBody.value,
         // warocol.com#639 — tip capture (server validates against tenant.tip_enabled)
         ...(tipAmount.value > 0
           ? { tip_amount: tipAmount.value, tip_source: tipSource.value }
@@ -1844,6 +1853,14 @@ onUnmounted(() => {
           :preselect-index="tipPreselectIndex"
           :subtotal="cartTotal"
           v-model="tipModel"
+        />
+
+        <!-- warocol.com#663 — Waiter at checkout when session has no effective waiter -->
+        <CheckoutWaiterSelector
+          v-if="showCheckoutWaiterSelector"
+          :members="tenantMembers"
+          :model-value="posStore.cartServedByMemberId"
+          @update:model-value="posStore.setCartServedBy"
         />
 
         <!-- Section: Domicilio (mostrador or bar — never mesa) -->

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -417,6 +417,15 @@ onUnmounted(() => {
           <p class="text-lg font-bold text-text-primary">{{ order.customer_phone }}</p>
         </div>
 
+        <!-- Waiter (checkout attribution) -->
+        <div
+          v-if="order.served_by_member_id"
+          class="bg-surface border border-border rounded-xl p-4"
+        >
+          <p class="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">Mesero</p>
+          <p class="text-lg font-bold text-text-primary">{{ order.served_by_member_name || 'Asignado' }}</p>
+        </div>
+
         <!-- Payment Method -->
         <component :is="order.split_payments && order.split_payments.length > 0 ? 'button' : 'div'"
           class="bg-surface border-2 border-info rounded-xl p-4 text-left w-full"


### PR DESCRIPTION
## Summary

Adds a compact waiter selector in POS checkout (next to the tip selector) when the mesa session has no effective waiter or per-table attribution is disabled. Sends `served_by_member_id` on cart complete and mesa session close. Shows the assigned waiter on the order detail page.

**Requires API PR:** uno0uno/api-warolabs#??? (deploy `gh-663-checkout-waiter-selector` on api-warolabs first or together)

## Changes

- `components/checkout/WaiterSelector.vue` — new selector with empty-members message
- `pages/pos/checkout.vue` — visibility rules + payload on all payment paths
- `pages/ventas/[id].vue` — Mesero card when `served_by_member_id` is set

## Testing

- [ ] Mesa without assigned waiter → checkout shows selector → close → order appears in `/ventas/propinas` with mesero
- [ ] Mesa with effective waiter → selector hidden
- [ ] Bar/counter with attribution ON and cart chip set → selector hidden at checkout
- [ ] Tenant with zero active members → friendly message, sale completes
- [ ] Order detail `/ventas/[id]` shows Mesero when attributed

Closes #663

Made with [Cursor](https://cursor.com)