### PR TITLE
Show tip and waiter on order detail + clickable propinas order (#662)

### DIFF
--- a/components/checkout/WaiterSelector.vue
+++ b/components/checkout/WaiterSelector.vue
@@ -26,9 +26,9 @@ const onChange = (event: Event) => {
 <template>
   <div class="flex flex-col gap-3 p-4 rounded-xl bg-surface border-2 border-border">
     <div class="flex flex-col gap-0.5">
-      <p class="text-sm font-semibold text-text-primary">Mesero (opcional)</p>
+      <p class="text-sm font-semibold text-text-primary">Mesero para propina</p>
       <p class="text-xs leading-snug text-text-secondary">
-        Atribuye esta venta para propinas y reportes por mesero.
+        Confirma o cambia quién recibe el crédito de esta venta en propinas y reportes.
       </p>
     </div>
 

--- a/components/checkout/WaiterSelector.vue
+++ b/components/checkout/WaiterSelector.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+interface Member {
+  id: string
+  name: string
+  role: string
+}
+
+const props = withDefaults(defineProps<{
+  members: Member[]
+  modelValue: string | null
+}>(), {
+  members: () => [],
+  modelValue: null,
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string | null): void
+}>()
+
+const onChange = (event: Event) => {
+  const value = (event.target as HTMLSelectElement).value
+  emit('update:modelValue', value || null)
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-3 p-4 rounded-xl bg-surface border-2 border-border">
+    <div class="flex flex-col gap-0.5">
+      <p class="text-sm font-semibold text-text-primary">Mesero (opcional)</p>
+      <p class="text-xs leading-snug text-text-secondary">
+        Atribuye esta venta para propinas y reportes por mesero.
+      </p>
+    </div>
+
+    <p
+      v-if="members.length === 0"
+      class="text-xs text-text-secondary bg-surface-secondary rounded-lg px-3 py-2.5"
+    >
+      No hay miembros activos en el equipo. Puedes continuar sin asignar mesero.
+    </p>
+
+    <div v-else class="flex items-center gap-2">
+      <svg class="w-4 h-4 text-text-tertiary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+      </svg>
+      <select
+        :value="modelValue || ''"
+        class="flex-1 min-h-[44px] px-3 py-2 text-sm font-medium bg-background border border-border rounded-xl focus:ring-2 focus:ring-primary/20 focus:border-primary transition-colors outline-none text-text-primary cursor-pointer"
+        aria-label="Seleccionar mesero para esta venta"
+        @change="onChange"
+      >
+        <option value="">Sin asignar</option>
+        <option v-for="m in members" :key="m.id" :value="m.id">
+          {{ m.name }} ({{ m.role }})
+        </option>
+      </select>
+    </div>
+  </div>
+</template>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -184,15 +184,31 @@ watch([() => posStore.cartId, () => selectedCustomer.value?.id], () => {
   tipModel.value = { amount: 0, source: 'none' }
 })
 
-// warocol.com#663 — checkout waiter picker (mesa without session waiter, or attribution off)
+// warocol.com#663 + #666 — checkout waiter picker before confirm
 const waiterAttributionEnabled = computed(() => settingsData.value?.data?.waiter_attribution_enabled === true)
 const tenantMembers = computed(() => settingsData.value?.data?.members ?? [])
 const showCheckoutWaiterSelector = computed(() => {
-  if (posStore.activeTableSession?.effectiveWaiterMemberId) return false
   if (!waiterAttributionEnabled.value) return true
+  // Mesa: always show so cashier can confirm/override effective session waiter (#666)
   if (isMesaMode.value) return true
+  // Counter/bar: cart chip already set served_by — skip duplicate picker (#663)
   return !posStore.cartServedByMemberId
 })
+// Seed once from session effective waiter so dropdown defaults and body sends explicit id
+const checkoutWaiterSeeded = ref(false)
+const seedCheckoutWaiterFromSession = () => {
+  if (checkoutWaiterSeeded.value || !isMesaMode.value) return
+  const effectiveId = posStore.activeTableSession?.effectiveWaiterMemberId
+  if (effectiveId && !posStore.cartServedByMemberId) {
+    posStore.setCartServedBy(effectiveId)
+    checkoutWaiterSeeded.value = true
+  }
+}
+watch(
+  () => posStore.activeTableSession?.effectiveWaiterMemberId,
+  seedCheckoutWaiterFromSession,
+  { immediate: true },
+)
 const checkoutServedByBody = computed(() =>
   posStore.cartServedByMemberId ? { served_by_member_id: posStore.cartServedByMemberId } : {},
 )

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -184,6 +184,19 @@ watch([() => posStore.cartId, () => selectedCustomer.value?.id], () => {
   tipModel.value = { amount: 0, source: 'none' }
 })
 
+// warocol.com#663 — checkout waiter picker (mesa without session waiter, or attribution off)
+const waiterAttributionEnabled = computed(() => settingsData.value?.data?.waiter_attribution_enabled === true)
+const tenantMembers = computed(() => settingsData.value?.data?.members ?? [])
+const showCheckoutWaiterSelector = computed(() => {
+  if (posStore.activeTableSession?.effectiveWaiterMemberId) return false
+  if (!waiterAttributionEnabled.value) return true
+  if (isMesaMode.value) return true
+  return !posStore.cartServedByMemberId
+})
+const checkoutServedByBody = computed(() =>
+  posStore.cartServedByMemberId ? { served_by_member_id: posStore.cartServedByMemberId } : {},
+)
+
 // Counter mode: not a real table session (no mesa, no bar)
 const isCounterMode = computed(() => !isMesaMode.value && !posStore.activeTableSession?.isBar)
 
@@ -392,6 +405,7 @@ const addSplitPayment = async () => {
             ...(isCashMethod.value
               ? { split_first_cash_received: Number(cashReceivedInput.value) }
               : {}),
+            ...checkoutServedByBody.value,
           }
         }) as any
         paidTotal = response.data.paid_total ?? amountToCharge
@@ -437,10 +451,7 @@ const addSplitPayment = async () => {
             ...(isCashMethod.value
               ? { split_first_cash_received: Number(cashReceivedInput.value) }
               : {}),
-            // Issue #575 — per-order waiter attribution (bar + counter; mesa uses #574 session override)
-            ...(posStore.cartServedByMemberId
-              ? { served_by_member_id: posStore.cartServedByMemberId }
-              : {}),
+            ...checkoutServedByBody.value,
           }
         }) as any
         paidTotal = response.data.paid_total ?? amountToCharge
@@ -730,6 +741,7 @@ const processOrder = async () => {
           ...(tipAmount.value > 0
             ? { tip_amount: tipAmount.value, tip_source: tipSource.value }
             : {}),
+          ...checkoutServedByBody.value,
         },
       }) as any
 
@@ -825,10 +837,7 @@ const processOrder = async () => {
                 : {}),
             }
           : {}),
-        // Issue #575 — per-order waiter attribution (bar + counter; mesa uses #574 session override)
-        ...(posStore.cartServedByMemberId
-          ? { served_by_member_id: posStore.cartServedByMemberId }
-          : {}),
+        ...checkoutServedByBody.value,
         // warocol.com#639 — tip capture (server validates against tenant.tip_enabled)
         ...(tipAmount.value > 0
           ? { tip_amount: tipAmount.value, tip_source: tipSource.value }
@@ -1844,6 +1853,14 @@ onUnmounted(() => {
           :preselect-index="tipPreselectIndex"
           :subtotal="cartTotal"
           v-model="tipModel"
+        />
+
+        <!-- warocol.com#663 — Waiter at checkout when session has no effective waiter -->
+        <CheckoutWaiterSelector
+          v-if="showCheckoutWaiterSelector"
+          :members="tenantMembers"
+          :model-value="posStore.cartServedByMemberId"
+          @update:model-value="posStore.setCartServedBy"
         />
 
         <!-- Section: Domicilio (mostrador or bar — never mesa) -->

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -417,6 +417,15 @@ onUnmounted(() => {
           <p class="text-lg font-bold text-text-primary">{{ order.customer_phone }}</p>
         </div>
 
+        <!-- Waiter (checkout attribution) -->
+        <div
+          v-if="order.served_by_member_id"
+          class="bg-surface border border-border rounded-xl p-4"
+        >
+          <p class="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">Mesero</p>
+          <p class="text-lg font-bold text-text-primary">{{ order.served_by_member_name || 'Asignado' }}</p>
+        </div>
+
         <!-- Payment Method -->
         <component :is="order.split_payments && order.split_payments.length > 0 ? 'button' : 'div'"
           class="bg-surface border-2 border-info rounded-xl p-4 text-left w-full"

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -158,6 +158,27 @@ const order = computed(() => {
   }
 })
 
+// warocol.com#662 — tip display on order detail (API returns tip_amount / tip_source)
+const tipSourceLabel = (source: string | undefined) => {
+  if (source === 'preset') return 'Porcentaje sugerido'
+  if (source === 'custom') return 'Personalizada'
+  return '—'
+}
+
+const orderTipPercent = computed(() => {
+  const o = order.value
+  if (!o?.tip_amount || o.tip_amount <= 0) return null
+  const total = Number(o.total_amount) || 0
+  if (total <= 0) return null
+  return Math.round((Number(o.tip_amount) / total) * 10000) / 100
+})
+
+const orderChargedTotal = computed(() => {
+  const o = order.value
+  if (!o?.tip_amount || o.tip_amount <= 0) return null
+  return Number(o.total_amount) + Number(o.tip_amount)
+})
+
 const items = computed(() => itemsData.value || [])
 
 // Filtered items (excluding deleted ones in edit mode)
@@ -417,13 +438,31 @@ onUnmounted(() => {
           <p class="text-lg font-bold text-text-primary">{{ order.customer_phone }}</p>
         </div>
 
-        <!-- Waiter (checkout attribution) -->
+        <!-- Waiter (checkout / mesa close attribution — #663/#665/#666) -->
         <div
           v-if="order.served_by_member_id"
           class="bg-surface border border-border rounded-xl p-4"
         >
           <p class="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">Mesero</p>
-          <p class="text-lg font-bold text-text-primary">{{ order.served_by_member_name || 'Asignado' }}</p>
+          <NuxtLink
+            :to="`/equipo/miembros/${order.served_by_member_id}`"
+            class="text-lg font-bold text-primary hover:underline"
+          >
+            {{ order.served_by_member_name || 'Asignado' }}
+          </NuxtLink>
+        </div>
+
+        <!-- Tip (warocol.com#662) -->
+        <div
+          v-if="order.tip_amount && order.tip_amount > 0"
+          class="bg-surface border border-border rounded-xl p-4"
+        >
+          <p class="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">Propina</p>
+          <p class="text-lg font-bold text-primary tabular-nums">{{ formatCurrency(order.tip_amount) }}</p>
+          <p class="text-xs text-text-secondary mt-1">
+            {{ tipSourceLabel(order.tip_source) }}
+            <template v-if="orderTipPercent != null"> · {{ orderTipPercent }}% sobre venta</template>
+          </p>
         </div>
 
         <!-- Payment Method -->
@@ -494,6 +533,12 @@ onUnmounted(() => {
           </p>
           <p v-if="isEditMode && hasChanges" class="text-xs text-text-tertiary line-through">
             {{ formatCurrency(order.total_amount) }}
+          </p>
+          <p
+            v-if="!isEditMode && orderChargedTotal != null"
+            class="text-sm font-semibold text-text-primary tabular-nums mt-2 pt-2 border-t border-border"
+          >
+            Total cobrado: {{ formatCurrency(orderChargedTotal) }}
           </p>
         </div>
       </div>

--- a/pages/ventas/propinas/index.vue
+++ b/pages/ventas/propinas/index.vue
@@ -155,6 +155,12 @@ const filterByMember = (memberId: string | null) => {
   memberFilter.value = memberId
 }
 
+// warocol.com#662 — open order detail in the same tab (like /ventas/ordenes)
+const goToOrderDetail = (orderId: string) => {
+  if (!orderId) return
+  navigateTo(`/ventas/${orderId}`)
+}
+
 // ── Export by email ─────────────────────────────────────────────────────────
 const isExporting = ref(false)
 const showExportModal = ref(false)
@@ -437,7 +443,13 @@ onUnmounted(() => clearRefreshHandler(refetch))
             <div class="flex items-center justify-between">
               <div class="flex items-baseline gap-2">
                 <span class="text-xs text-text-secondary">{{ formatDate(item.order_date) }}</span>
-                <span class="text-sm font-semibold text-primary">#{{ item.order_number }}</span>
+                <button
+                  type="button"
+                  class="text-sm font-semibold text-primary hover:underline"
+                  @click.stop="goToOrderDetail(item.id)"
+                >
+                  #{{ item.order_number }}
+                </button>
               </div>
               <UiStatusBadge :variant="channelVariant(item.channel)" size="sm" :value="channelLabel(item.channel)" />
             </div>
@@ -465,8 +477,14 @@ onUnmounted(() => clearRefreshHandler(refetch))
         <template #cell-order_date="{ value }">
           <span class="text-sm text-text-secondary whitespace-nowrap">{{ formatDate(value) }}</span>
         </template>
-        <template #cell-order_number="{ value }">
-          <span class="text-sm font-medium text-primary">#{{ value }}</span>
+        <template #cell-order_number="{ row, value }">
+          <button
+            type="button"
+            class="text-sm font-medium text-primary hover:underline"
+            @click.stop="goToOrderDetail(row.id)"
+          >
+            #{{ value }}
+          </button>
         </template>
         <template #cell-channel="{ row }">
           <UiStatusBadge :variant="channelVariant(row.channel)" size="sm" :value="channelLabel(row.channel)" />


### PR DESCRIPTION
## Summary
Completes #662 UI scope. Waiter assignment on mesa close was already shipped (#665 API, #666 checkout) — not reimplemented here.

## Changes
- `pages/ventas/[id].vue`: Propina card (amount, source, %), total cobrado, mesero link to equipo
- `pages/ventas/propinas/index.vue`: Clickable order # → `/ventas/{orderId}` (same tab)

## Testing
- [ ] Order with tip → detail shows propina + total cobrado
- [ ] `/ventas/propinas` → click order # → opens detail in same window
- [ ] Mesa session: tip still on first order row only (#639) — document if confusing

Requires API PR for tip fields on order detail.

Closes #662

Made with [Cursor](https://cursor.com)