### PR TITLE
docs: document and surface daily, template, and custom cash count flows

### DIFF
--- a/components/Finanzas/CierrePanel.vue
+++ b/components/Finanzas/CierrePanel.vue
@@ -39,7 +39,14 @@
               </div>
               <div class="min-w-0">
                 <h2 class="text-base font-bold text-text-primary leading-tight">Arqueo de caja</h2>
-                <p class="text-xs text-text-secondary leading-snug mt-0.5">{{ formatPeriod(cierre?.periodStart, cierre?.periodEnd) }}</p>
+                <p class="text-xs text-text-secondary leading-snug mt-0.5">
+                  <span
+                    class="inline-block text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded mr-1"
+                    :class="hasTimeWindow(detail) ? 'bg-primary/10 text-primary' : 'bg-surface-secondary text-text-secondary'"
+                  >{{ periodTypeLabel(detail) }}</span>
+                  {{ formatPeriodDates(detail) }}
+                </p>
+                <p v-if="formatPeriodTimes(detail)" class="text-xs text-text-secondary font-mono mt-0.5">{{ formatPeriodTimes(detail) }}</p>
               </div>
             </div>
             <button
@@ -230,13 +237,7 @@ const handleDelete = async () => {
 const formatCurrency = (value?: number) =>
   new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(value ?? 0)
 
-const formatPeriod = (start?: string, end?: string) => {
-  if (!start) return ''
-  const fmt = (d: string) => new Intl.DateTimeFormat('es-CO', {
-    day: '2-digit', month: 'short', year: 'numeric', timeZone: 'America/Bogota',
-  }).format(new Date(d + 'T12:00:00'))
-  return !end || start === end ? fmt(start) : `${fmt(start)} – ${fmt(end)}`
-}
+const { hasTimeWindow, formatPeriodDates, formatPeriodTimes, periodTypeLabel } = useCierrePeriod()
 
 const formatDate = (iso: string) => {
   if (!iso) return ''

--- a/composables/useCierrePeriod.ts
+++ b/composables/useCierrePeriod.ts
@@ -1,0 +1,50 @@
+import { useFormatters } from '~/composables/useFormatters'
+
+export interface CierrePeriodLike {
+  periodStart?: string
+  periodEnd?: string
+  periodStartTime?: string | null
+  periodEndTime?: string | null
+}
+
+const _timeFormatter = new Intl.DateTimeFormat('es-CO', {
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+  timeZone: 'America/Bogota',
+})
+
+export function useCierrePeriod() {
+  const { formatDate } = useFormatters()
+
+  const hasTimeWindow = (cierre: CierrePeriodLike | null | undefined): boolean =>
+    !!(cierre?.periodStartTime || cierre?.periodEndTime)
+
+  const formatPeriodDates = (cierre: CierrePeriodLike | null | undefined): string => {
+    const start = cierre?.periodStart
+    const end = cierre?.periodEnd
+    if (!start) return ''
+    const fmt = (d: string) => formatDate(d + 'T12:00:00')
+    return !end || start === end ? fmt(start) : `${fmt(start)} – ${fmt(end)}`
+  }
+
+  const formatPeriodTimes = (cierre: CierrePeriodLike | null | undefined): string | null => {
+    if (!hasTimeWindow(cierre)) return null
+    const start = cierre?.periodStartTime
+    const end = cierre?.periodEndTime
+    if (start && end) return `${_timeFormatter.format(new Date(start))} – ${_timeFormatter.format(new Date(end))}`
+    if (start) return `Desde ${_timeFormatter.format(new Date(start))}`
+    if (end) return `Hasta ${_timeFormatter.format(new Date(end))}`
+    return null
+  }
+
+  const periodTypeLabel = (cierre: CierrePeriodLike | null | undefined): string =>
+    hasTimeWindow(cierre) ? 'Por horario' : 'Día completo'
+
+  return {
+    hasTimeWindow,
+    formatPeriodDates,
+    formatPeriodTimes,
+    periodTypeLabel,
+  }
+}

--- a/docs/usuarios/finanzas.md
+++ b/docs/usuarios/finanzas.md
@@ -22,9 +22,23 @@ Menú lateral → **Finanzas**. La pantalla tiene nueve pestañas en este orden:
 
 ## Arqueo de caja
 
-El **arqueo** (también llamado Cierre Z) registra el corte diario del negocio: cuánto vendiste, cuánto efectivo recibiste, cuánto contaste en caja y si hay diferencia. Es el equivalente digital de cuadrar la caja al final del turno.
+El **arqueo** registra el cuadre de caja de un período: cuánto vendiste, cuánto efectivo recibiste, cuánto contaste en caja y si hay diferencia. Es el equivalente digital de cuadrar la caja al final del turno.
 
-> Esta sección es **diaria** y reversible (puedes eliminar un arqueo). El **Cierre contable mensual** (siguiente sección) es distinto e irreversible.
+> Esta sección es **reversible** (puedes eliminar un arqueo). El **Cierre contable mensual** (siguiente sección) es distinto e irreversible.
+
+### Tres formas de arquear
+
+Desde **Finanzas → Arqueo de caja** eliges cómo cerrar:
+
+| Modo | Cuándo usarlo | Cómo iniciarlo |
+|------|---------------|----------------|
+| **Día completo** | Un solo cierre por día calendario (cierre nocturno o negocio de un turno único) | Tarjeta **Arqueo del día** o botón **Día completo** |
+| **Turno u horario** | Varios cortes el mismo día (mañana / tarde / noche) o un rango entre fechas con hora exacta | Tarjeta **Turno u horario** |
+| **Plantillas de turno** *(próximamente)* | Horarios fijos reutilizables (ej. almuerzo 12:00–15:00) configurados en Operaciones | Llegará en **Operaciones → Turnos** |
+
+**Vista previa (Corte X):** revisa ventas y caja en vivo **sin registrar** nada. Enlace al pie de la pantalla principal de arqueo. Desde ahí puedes pasar a registrar con el mismo período.
+
+> Los arqueos por horario muestran la ventana (ej. `14:00 – 22:30`) en el historial con la etiqueta **Por horario**. Los de día completo muestran **Día completo**.
 
 ### Historial de arqueos
 
@@ -47,15 +61,11 @@ Cada fila del historial tiene dos botones:
 | Ojo | Abre el detalle del arqueo en un panel lateral |
 | Papelera | Elimina el arqueo (pide confirmación) |
 
-El panel de detalle muestra: ventas del período, caja (efectivo esperado, contado y diferencia), métodos de pago, notas y fecha de registro.
+El panel de detalle muestra: tipo de cierre (día completo o por horario), fechas y —si aplica— la ventana horaria, ventas del período, caja, métodos de pago, notas y fecha de registro.
 
-### Cierre X (preview sin guardar)
+### Arqueo del día (día completo)
 
-Antes de cerrar puedes consultar el **Cierre X** desde el atajo `/finanzas/arqueo/x`. Es un resumen en vivo de las ventas del día sin registrar nada. Útil para revisar cómo va el turno.
-
-### Registrar un nuevo arqueo
-
-Haz clic en **Nuevo arqueo**. El proceso tiene 5 pasos.
+Haz clic en **Arqueo del día**. El proceso tiene 5 pasos.
 
 **Paso 1 — Período**
 
@@ -100,6 +110,16 @@ Puedes agregar **notas** opcionales (observaciones, incidencias del día).
 
 Confirma el arqueo. El botón se activa solo después de revisar el resumen. Una vez registrado, el arqueo no se puede editar, solo eliminar.
 
+### Arqueo por turno u horario
+
+Haz clic en **Turno u horario**. En el primer paso defines el período:
+
+1. Elige fechas (Hoy, Ayer, últimos 7 días, o un rango personalizado).
+2. Activa **Horario** para acotar por hora (obligatorio si el rango abarca varios días).
+3. Revisa el resumen previo y continúa con los mismos 5 pasos de conteo (efectivo, otros métodos, resumen, cerrar).
+
+Útil cuando cierras caja entre turnos sin esperar al final del día.
+
 ### Eliminar un arqueo
 
 Desde el historial, haz clic en el ícono de papelera. Al eliminar, el período queda liberado y puedes registrar un nuevo arqueo para esas mismas fechas. Los datos de ventas no se borran — solo el registro del arqueo.
@@ -107,7 +127,12 @@ Desde el historial, haz clic en el ícono de papelera. Al eliminar, el período 
 ### Preguntas frecuentes — Arqueo
 
 **¿Puedo hacer arqueo de varios días a la vez?**
-El wizard está diseñado para arqueos de un día. Si necesitas cerrar períodos más largos, registra cada día por separado.
+En **Arqueo del día**, un solo día por registro. En **Turno u horario** puedes elegir un rango de fechas; si abarca más de un día debes indicar hora de inicio y fin.
+
+**¿Cuál modo elijo?**
+- Un cierre al cerrar el local → **Día completo**.
+- Varios cortes el mismo día (ej. almuerzo y cena) → **Turno u horario**.
+- Horarios fijos repetibles → próximamente **Plantillas de turno** en Operaciones.
 
 **¿Qué pasa si hay mesas abiertas?**
 El sistema bloquea el arqueo y muestra cuántas mesas están abiertas. Ve al módulo de Mesas, cierra las sesiones pendientes y regresa.

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -553,8 +553,8 @@ const getPageConfig = () => {
     }
   } else if (path === '/finanzas/arqueo/z') {
     return {
-      pageTitle: 'Corte Z',
-      pageSubtitle: undefined,
+      pageTitle: 'Arqueo por turno u horario',
+      pageSubtitle: 'Ventana personalizada de fechas y horas',
       searchPlaceholder: undefined,
       activePage: 'finanzas' as const,
       showBreadcrumb: false,

--- a/pages/finanzas/arqueo/[id].vue
+++ b/pages/finanzas/arqueo/[id].vue
@@ -21,7 +21,12 @@
               </div>
               <div>
                 <p class="text-xs font-medium text-text-secondary uppercase tracking-wide">Período</p>
-                <p class="text-base font-semibold text-text-primary">{{ formatPeriod(cierre.periodStart, cierre.periodEnd) }}</p>
+                <p class="text-base font-semibold text-text-primary">{{ formatPeriodDates(cierre) }}</p>
+                <p v-if="formatPeriodTimes(cierre)" class="text-xs text-text-secondary font-mono mt-0.5">{{ formatPeriodTimes(cierre) }}</p>
+                <span
+                  class="inline-block mt-1 text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded"
+                  :class="hasTimeWindow(cierre) ? 'bg-primary/10 text-primary' : 'bg-surface-secondary text-text-secondary'"
+                >{{ periodTypeLabel(cierre) }}</span>
               </div>
             </div>
 
@@ -208,22 +213,17 @@ onMounted(() => { setRefreshHandler(refetch) })
 onUnmounted(() => { clearRefreshHandler(refetch) })
 
 useHead(() => ({
-  title: cierre.value ? `Arqueo ${formatPeriod(cierre.value.periodStart, cierre.value.periodEnd)} - Warocol` : 'Arqueo de caja - Warocol',
+  title: cierre.value ? `Arqueo ${formatPeriodDates(cierre.value)} - Warocol` : 'Arqueo de caja - Warocol',
 }))
 
 const formatCurrency = (value?: number) =>
   new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(value ?? 0)
 
-const { formatDate: _fmtDate, formatDateTime: _fmtDateTime } = useFormatters()
+const { formatDateTime: _fmtDateTime } = useFormatters()
+const { hasTimeWindow, formatPeriodDates, formatPeriodTimes, periodTypeLabel } = useCierrePeriod()
 
 const formatDate = (iso: string) => {
   if (!iso) return ''
   return _fmtDateTime(iso)
-}
-
-const formatPeriod = (start: string, end: string) => {
-  if (!start) return ''
-  const fmt = (d: string) => _fmtDate(d + 'T12:00:00')
-  return start === end ? fmt(start) : `${fmt(start)} – ${fmt(end)}`
 }
 </script>

--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -77,19 +77,59 @@
         </div>
       </div>
 
+      <!-- ── Entry CTAs ──────────────────────────────────────────────────────── -->
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <NuxtLink
+          to="/finanzas/arqueo/nuevo"
+          class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/30 bg-primary/5 hover:bg-primary/10 transition-colors"
+        >
+          <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-primary/15 flex items-center justify-center text-primary" aria-hidden="true">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+          </div>
+          <div>
+            <p class="text-sm font-semibold text-text-primary">Arqueo del día</p>
+            <p class="text-xs text-text-secondary mt-0.5">Cierra un día calendario completo (turno único o cierre nocturno).</p>
+          </div>
+        </NuxtLink>
+        <NuxtLink
+          to="/finanzas/arqueo/z"
+          class="flex items-start gap-3 p-4 rounded-lg border-2 border-border bg-surface hover:border-primary/40 transition-colors"
+        >
+          <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-background border border-border flex items-center justify-center text-primary" aria-hidden="true">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </div>
+          <div>
+            <p class="text-sm font-semibold text-text-primary">Turno u horario</p>
+            <p class="text-xs text-text-secondary mt-0.5">Ventana personalizada por horas (mañana, tarde, o rango entre días).</p>
+          </div>
+        </NuxtLink>
+      </div>
+      <p class="text-xs text-text-secondary">
+        ¿Solo quieres revisar sin cerrar?
+        <NuxtLink to="/finanzas/arqueo/x" class="text-primary font-medium hover:underline">Vista previa (Corte X)</NuxtLink>
+      </p>
+
       <!-- ── Historial ─────────────────────────────────────────────────────── -->
       <HealthSemaphore :is-unlocked="true" title="Historial de arqueos">
         <template #header-actions>
-          <NuxtLink
-            to="/finanzas/arqueo/nuevo"
-            class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap flex items-center gap-1.5"
-          >
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-            </svg>
-            <span class="hidden sm:inline">Nuevo arqueo</span>
-            <span class="sm:hidden">Nuevo</span>
-          </NuxtLink>
+          <div class="flex flex-wrap items-center gap-2 justify-end">
+            <NuxtLink
+              to="/finanzas/arqueo/nuevo"
+              class="btn-primary px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap"
+            >
+              Día completo
+            </NuxtLink>
+            <NuxtLink
+              to="/finanzas/arqueo/z"
+              class="btn-secondary px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap"
+            >
+              Turno u horario
+            </NuxtLink>
+          </div>
         </template>
       <UiResponsiveDataView
         :data="filteredHistorial"
@@ -104,8 +144,15 @@
             @click="openPanel(item.id)"
           >
             <div class="flex-1 min-w-0">
-              <span class="text-sm font-bold text-text-primary">{{ formatDay(item.periodStart) }}</span>
-              <p class="text-xs text-text-secondary mt-0.5">{{ formatDay(item.periodEnd) }} · {{ formatDate(item.closedAt) }}</p>
+              <div class="flex flex-wrap items-center gap-1.5">
+                <span
+                  class="text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded"
+                  :class="hasTimeWindow(item) ? 'bg-primary/10 text-primary' : 'bg-surface-secondary text-text-secondary'"
+                >{{ periodTypeLabel(item) }}</span>
+                <span class="text-sm font-bold text-text-primary">{{ formatPeriodDates(item) }}</span>
+              </div>
+              <p v-if="formatPeriodTimes(item)" class="text-xs text-text-secondary mt-0.5 font-mono">{{ formatPeriodTimes(item) }}</p>
+              <p class="text-xs text-text-secondary mt-0.5">Registrado {{ formatDate(item.closedAt) }}</p>
             </div>
             <div class="flex flex-col items-end gap-1.5 flex-shrink-0">
               <span class="text-sm font-bold text-primary tabular-nums">{{ formatCurrency(item.totalSales) }}</span>
@@ -117,10 +164,20 @@
         </template>
 
         <template #cell-periodStart="{ row }">
-          <span class="text-sm font-bold text-text-primary">{{ formatDay(row.periodStart) }}</span>
+          <div class="flex flex-col gap-0.5 min-w-0">
+            <div class="flex flex-wrap items-center gap-1.5">
+              <span
+                class="text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded flex-shrink-0"
+                :class="hasTimeWindow(row) ? 'bg-primary/10 text-primary' : 'bg-surface-secondary text-text-secondary'"
+              >{{ periodTypeLabel(row) }}</span>
+              <span class="text-sm font-bold text-text-primary">{{ formatPeriodDates(row) }}</span>
+            </div>
+            <span v-if="formatPeriodTimes(row)" class="text-xs text-text-secondary font-mono">{{ formatPeriodTimes(row) }}</span>
+          </div>
         </template>
         <template #cell-periodEnd="{ row }">
-          <span class="text-sm text-text-secondary">{{ formatDay(row.periodEnd) }}</span>
+          <span v-if="row.periodStart !== row.periodEnd" class="text-sm text-text-secondary">{{ formatDay(row.periodEnd) }}</span>
+          <span v-else class="text-xs text-text-tertiary">—</span>
         </template>
         <template #cell-totalSales="{ value }">
           <span class="text-sm font-bold text-primary">{{ formatCurrency(value) }}</span>
@@ -186,7 +243,7 @@
           </div>
           <h3 class="text-lg font-bold text-text-primary mb-1">Eliminar arqueo</h3>
           <p class="text-sm text-text-secondary mb-6">
-            ¿Eliminar el arqueo del período <strong>{{ formatPeriod(cierreToDelete?.periodStart, cierreToDelete?.periodEnd) }}</strong>? Esta acción no se puede deshacer.
+            ¿Eliminar el arqueo del período <strong>{{ formatPeriodDates(cierreToDelete) }}</strong><template v-if="formatPeriodTimes(cierreToDelete)"> ({{ formatPeriodTimes(cierreToDelete) }})</template>? Esta acción no se puede deshacer.
           </p>
           <div class="flex gap-3">
             <button
@@ -298,8 +355,8 @@ const summaryStats = computed(() => {
 })
 
 const historialColumns = [
-  { key: 'periodStart',    title: 'Período inicial', sortable: false },
-  { key: 'periodEnd',      title: 'Período final',   sortable: false },
+  { key: 'periodStart',    title: 'Período',         sortable: false },
+  { key: 'periodEnd',      title: 'Hasta',           sortable: false },
   { key: 'totalSales',     title: 'Ventas',          sortable: false },
   { key: 'gastosEfectivo', title: 'Gastos',          sortable: false },
   { key: 'cashDifference', title: 'Diferencia',      sortable: false },
@@ -325,7 +382,8 @@ const isCurrentMonthActive = computed(() => {
   return activeStart.value === first && activeEnd.value === last
 })
 
-const { formatDate: _fmtDate, formatDateTime: _fmtDateTime } = useFormatters()
+const { formatDateTime: _fmtDateTime } = useFormatters()
+const { hasTimeWindow, formatPeriodDates, formatPeriodTimes, periodTypeLabel } = useCierrePeriod()
 
 const formatDay = (d: string) => {
   if (!d) return ''
@@ -335,12 +393,6 @@ const formatDay = (d: string) => {
 const formatDate = (iso: string) => {
   if (!iso) return ''
   return _fmtDateTime(iso)
-}
-
-const formatPeriod = (start: string, end: string) => {
-  if (!start) return ''
-  const fmt = (d: string) => _fmtDate(d + 'T12:00:00')
-  return start === end ? fmt(start) : `${fmt(start)} – ${fmt(end)}`
 }
 
 // ── Panel ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Surfaces **Arqueo del día** (`/nuevo`) and **Turno u horario** (`/z`) from the arqueo index with entry cards, header buttons, and a Corte X preview link.
- Historial, detail panel, and detail page distinguish **Día completo** vs **Por horario** and show `periodStartTime`–`periodEndTime` when present.
- User docs describe all three modes (full day, custom window, shift templates coming soon).

## Stack

Nuxt 3 / Vue (frontend + user docs)

## Changes

- `composables/useCierrePeriod.ts`: shared period date/time formatting
- `pages/finanzas/arqueo/index.vue`: entry CTAs + historial badges/times
- `components/Finanzas/CierrePanel.vue`: period type + time window in panel header
- `pages/finanzas/arqueo/[id].vue`: aligned period display
- `layouts/dashboard.vue`: friendlier title for `/z`
- `docs/usuarios/finanzas.md`: three-mode guide

## Testing

- [ ] Open `/finanzas/arqueo` — see two entry cards and header buttons
- [ ] **Día completo** → `/nuevo`; **Turno u horario** → `/z`
- [ ] Historial row with time-window close shows **Por horario** + `HH:mm – HH:mm`
- [ ] Calendar-day close shows **Día completo** without time line
- [ ] Panel detail shows same period info
- [ ] Docs section "Tres formas de arquear" reads correctly

Closes #679

Made with [Cursor](https://cursor.com)