### PR TITLE
feat(ui): cash count history shows shift type, template name, and time window

### DIFF
--- a/components/Finanzas/CierrePanel.vue
+++ b/components/Finanzas/CierrePanel.vue
@@ -42,7 +42,7 @@
                 <p class="text-xs text-text-secondary leading-snug mt-0.5">
                   <span
                     class="inline-block text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded mr-1"
-                    :class="hasTimeWindow(detail) ? 'bg-primary/10 text-primary' : 'bg-surface-secondary text-text-secondary'"
+                    :class="periodBadgeClass(detail)"
                   >{{ periodTypeLabel(detail) }}</span>
                   {{ formatPeriodDates(detail) }}
                 </p>
@@ -237,7 +237,7 @@ const handleDelete = async () => {
 const formatCurrency = (value?: number) =>
   new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(value ?? 0)
 
-const { hasTimeWindow, formatPeriodDates, formatPeriodTimes, periodTypeLabel } = useCierrePeriod()
+const { formatPeriodDates, formatPeriodTimes, periodTypeLabel, periodBadgeClass } = useCierrePeriod()
 
 const formatDate = (iso: string) => {
   if (!iso) return ''

--- a/components/Finanzas/CierrePanel.vue
+++ b/components/Finanzas/CierrePanel.vue
@@ -39,7 +39,14 @@
               </div>
               <div class="min-w-0">
                 <h2 class="text-base font-bold text-text-primary leading-tight">Arqueo de caja</h2>
-                <p class="text-xs text-text-secondary leading-snug mt-0.5">{{ formatPeriod(cierre?.periodStart, cierre?.periodEnd) }}</p>
+                <p class="text-xs text-text-secondary leading-snug mt-0.5">
+                  <span
+                    class="inline-block text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded mr-1"
+                    :class="hasTimeWindow(detail) ? 'bg-primary/10 text-primary' : 'bg-surface-secondary text-text-secondary'"
+                  >{{ periodTypeLabel(detail) }}</span>
+                  {{ formatPeriodDates(detail) }}
+                </p>
+                <p v-if="formatPeriodTimes(detail)" class="text-xs text-text-secondary font-mono mt-0.5">{{ formatPeriodTimes(detail) }}</p>
               </div>
             </div>
             <button
@@ -230,13 +237,7 @@ const handleDelete = async () => {
 const formatCurrency = (value?: number) =>
   new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(value ?? 0)
 
-const formatPeriod = (start?: string, end?: string) => {
-  if (!start) return ''
-  const fmt = (d: string) => new Intl.DateTimeFormat('es-CO', {
-    day: '2-digit', month: 'short', year: 'numeric', timeZone: 'America/Bogota',
-  }).format(new Date(d + 'T12:00:00'))
-  return !end || start === end ? fmt(start) : `${fmt(start)} – ${fmt(end)}`
-}
+const { hasTimeWindow, formatPeriodDates, formatPeriodTimes, periodTypeLabel } = useCierrePeriod()
 
 const formatDate = (iso: string) => {
   if (!iso) return ''

--- a/components/operaciones/ShiftTemplatePanel.vue
+++ b/components/operaciones/ShiftTemplatePanel.vue
@@ -1,0 +1,319 @@
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-200"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="modelValue"
+        class="fixed inset-0 z-40 bg-black/40"
+        aria-hidden="true"
+        @click="close"
+      />
+    </Transition>
+
+    <Transition name="panel">
+      <div
+        v-if="modelValue"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="isEdit ? `Editar turno: ${template?.name}` : 'Crear turno'"
+        class="fixed z-50 flex flex-col bg-surface shadow-2xl inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh] md:inset-y-0 md:right-0 md:bottom-auto md:left-auto md:inset-x-auto md:rounded-none md:w-full md:max-w-md md:max-h-none md:h-full"
+      >
+        <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
+          <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+        </div>
+
+        <div class="flex-shrink-0 bg-surface-secondary/40 border-b border-border px-6 py-4">
+          <div class="flex items-start justify-between gap-3">
+            <div class="flex items-center gap-3 min-w-0 flex-1">
+              <div class="flex-shrink-0 w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
+                <ClockIcon class="w-5 h-5" />
+              </div>
+              <div class="min-w-0">
+                <h2 class="text-base font-bold text-text-primary leading-tight">
+                  {{ isEdit ? 'Editar turno' : 'Nuevo turno' }}
+                </h2>
+                <p class="text-xs text-text-secondary leading-snug mt-0.5">
+                  {{ isEdit ? template?.name : 'Horario reutilizable para arqueos de caja' }}
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              aria-label="Cerrar panel"
+              :disabled="saving"
+              class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50 transition-colors"
+              @click="close"
+            >
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div class="flex-1 overflow-y-auto px-6 py-5 space-y-4">
+          <div class="flex flex-col gap-1.5">
+            <label :for="nameId" class="text-sm font-medium text-text-primary">
+              Nombre <span class="text-destructive">*</span>
+            </label>
+            <input
+              :id="nameId"
+              ref="nameInput"
+              v-model="form.name"
+              type="text"
+              maxlength="80"
+              placeholder="Ej: Mañana, Tarde, Noche..."
+              class="input-base w-full px-4 py-2"
+              @input="clearError('name')"
+            />
+            <p v-if="errors.name" class="text-xs text-destructive">{{ errors.name }}</p>
+          </div>
+
+          <div class="grid grid-cols-2 gap-3">
+            <div class="flex flex-col gap-1.5">
+              <label :for="startId" class="text-sm font-medium text-text-primary">Inicio</label>
+              <input
+                :id="startId"
+                v-model="form.start_time"
+                type="time"
+                class="input-base w-full px-3 py-2"
+                @input="clearError('times')"
+              />
+            </div>
+            <div class="flex flex-col gap-1.5">
+              <label :for="endId" class="text-sm font-medium text-text-primary">Fin</label>
+              <input
+                :id="endId"
+                v-model="form.end_time"
+                type="time"
+                class="input-base w-full px-3 py-2"
+                @input="clearError('times')"
+              />
+            </div>
+          </div>
+
+          <div class="flex items-start justify-between gap-3 py-1">
+            <div>
+              <p class="text-sm font-medium text-text-primary">Cruza medianoche</p>
+              <p class="text-xs text-text-secondary mt-0.5">
+                Actívalo si el turno termina al día siguiente (ej. 22:00 – 06:00).
+              </p>
+            </div>
+            <label class="relative inline-flex items-center cursor-pointer flex-shrink-0 mt-0.5">
+              <input v-model="form.crosses_midnight" type="checkbox" class="sr-only peer" />
+              <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+            </label>
+          </div>
+
+          <p v-if="errors.times" class="text-xs text-destructive">{{ errors.times }}</p>
+          <p v-if="errors.general" class="text-sm text-destructive">{{ errors.general }}</p>
+        </div>
+
+        <div class="flex-shrink-0 border-t border-border bg-surface px-6 py-4">
+          <div class="flex flex-col-reverse sm:flex-row gap-2">
+            <button
+              type="button"
+              :disabled="saving"
+              class="flex-1 min-h-[44px] py-3 px-4 border-2 border-border rounded-lg text-text-primary font-medium hover:bg-background focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+              @click="close"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              :disabled="saving || !form.name.trim()"
+              class="flex-1 min-h-[44px] py-3 px-4 bg-primary text-primary-foreground rounded-lg font-semibold hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-60 disabled:cursor-not-allowed transition-all flex items-center justify-center gap-2"
+              @click="submit"
+            >
+              <UiLoadingDots v-if="saving" size="8px" color="currentColor" />
+              <span>{{ saving ? 'Guardando...' : (isEdit ? 'Guardar cambios' : 'Crear turno') }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { ClockIcon } from '@heroicons/vue/24/outline'
+
+export interface ShiftTemplate {
+  id: string
+  tenant_id: string
+  name: string
+  start_time: string
+  end_time: string
+  crosses_midnight: boolean
+  sort_order: number
+  is_active: boolean
+}
+
+interface Props {
+  modelValue: boolean
+  template?: ShiftTemplate | null
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  template: null,
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'saved'): void
+}>()
+
+const isEdit = computed(() => !!props.template)
+
+const uid = useId()
+const nameId = `shift-name-${uid}`
+const startId = `shift-start-${uid}`
+const endId = `shift-end-${uid}`
+
+const form = ref({
+  name: '',
+  start_time: '06:00',
+  end_time: '14:00',
+  crosses_midnight: false,
+})
+
+const saving = ref(false)
+const errors = ref<Record<string, string>>({})
+const nameInput = ref<HTMLInputElement | null>(null)
+
+const timeToInput = (t: string) => (t?.length >= 5 ? t.slice(0, 5) : '06:00')
+const inputToApiTime = (t: string) => (t.length === 5 ? `${t}:00` : t)
+
+const parseMinutes = (hhmm: string) => {
+  const [h, m] = hhmm.split(':').map(Number)
+  return h * 60 + m
+}
+
+const clearError = (field: string) => {
+  delete errors.value[field]
+  delete errors.value.general
+}
+
+const resetForm = () => {
+  form.value = {
+    name: props.template?.name ?? '',
+    start_time: timeToInput(props.template?.start_time ?? '06:00:00'),
+    end_time: timeToInput(props.template?.end_time ?? '14:00:00'),
+    crosses_midnight: props.template?.crosses_midnight ?? false,
+  }
+  errors.value = {}
+}
+
+watch(
+  () => props.modelValue,
+  async (open) => {
+    if (!open) return
+    resetForm()
+    await nextTick()
+    nameInput.value?.focus()
+  },
+)
+
+watch(
+  () => props.template,
+  () => {
+    if (props.modelValue) resetForm()
+  },
+)
+
+const close = () => {
+  if (saving.value) return
+  emit('update:modelValue', false)
+}
+
+const validate = () => {
+  const name = form.value.name.trim()
+  if (!name) {
+    errors.value = { name: 'El nombre es obligatorio' }
+    return false
+  }
+  if (!form.value.start_time || !form.value.end_time) {
+    errors.value = { times: 'Indica hora de inicio y fin' }
+    return false
+  }
+  if (!form.value.crosses_midnight && parseMinutes(form.value.end_time) <= parseMinutes(form.value.start_time)) {
+    errors.value = { times: 'La hora de fin debe ser posterior al inicio (o activa "Cruza medianoche")' }
+    return false
+  }
+  return true
+}
+
+const submit = async () => {
+  if (!validate()) return
+
+  saving.value = true
+  errors.value = {}
+  const body = {
+    name: form.value.name.trim(),
+    start_time: inputToApiTime(form.value.start_time),
+    end_time: inputToApiTime(form.value.end_time),
+    crosses_midnight: form.value.crosses_midnight,
+    sort_order: props.template?.sort_order ?? 0,
+  }
+
+  try {
+    if (isEdit.value) {
+      await $fetch(`/api/operaciones/shifts/${props.template!.id}`, {
+        method: 'PATCH',
+        body,
+      })
+    } else {
+      await $fetch('/api/operaciones/shifts', {
+        method: 'POST',
+        body,
+      })
+    }
+    emit('saved')
+    emit('update:modelValue', false)
+  } catch (err: any) {
+    if (err?.status === 409) {
+      errors.value = {
+        name: typeof err?.data?.detail === 'string'
+          ? err.data.detail
+          : 'Ya existe un turno con ese nombre',
+      }
+    } else if (err?.status === 422) {
+      errors.value = {
+        times: typeof err?.data?.detail === 'string'
+          ? err.data.detail
+          : 'Horario inválido',
+      }
+    } else {
+      errors.value = {
+        general: err?.data?.detail || 'No se pudo guardar el turno. Inténtalo de nuevo.',
+      }
+    }
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style scoped>
+.panel-enter-active,
+.panel-leave-active {
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+.panel-enter-from,
+.panel-leave-to {
+  opacity: 0;
+  transform: translateY(100%);
+}
+@media (min-width: 768px) {
+  .panel-enter-from,
+  .panel-leave-to {
+    transform: translateX(100%);
+  }
+}
+</style>

--- a/composables/useCierrePeriod.ts
+++ b/composables/useCierrePeriod.ts
@@ -1,0 +1,50 @@
+import { useFormatters } from '~/composables/useFormatters'
+
+export interface CierrePeriodLike {
+  periodStart?: string
+  periodEnd?: string
+  periodStartTime?: string | null
+  periodEndTime?: string | null
+}
+
+const _timeFormatter = new Intl.DateTimeFormat('es-CO', {
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+  timeZone: 'America/Bogota',
+})
+
+export function useCierrePeriod() {
+  const { formatDate } = useFormatters()
+
+  const hasTimeWindow = (cierre: CierrePeriodLike | null | undefined): boolean =>
+    !!(cierre?.periodStartTime || cierre?.periodEndTime)
+
+  const formatPeriodDates = (cierre: CierrePeriodLike | null | undefined): string => {
+    const start = cierre?.periodStart
+    const end = cierre?.periodEnd
+    if (!start) return ''
+    const fmt = (d: string) => formatDate(d + 'T12:00:00')
+    return !end || start === end ? fmt(start) : `${fmt(start)} – ${fmt(end)}`
+  }
+
+  const formatPeriodTimes = (cierre: CierrePeriodLike | null | undefined): string | null => {
+    if (!hasTimeWindow(cierre)) return null
+    const start = cierre?.periodStartTime
+    const end = cierre?.periodEndTime
+    if (start && end) return `${_timeFormatter.format(new Date(start))} – ${_timeFormatter.format(new Date(end))}`
+    if (start) return `Desde ${_timeFormatter.format(new Date(start))}`
+    if (end) return `Hasta ${_timeFormatter.format(new Date(end))}`
+    return null
+  }
+
+  const periodTypeLabel = (cierre: CierrePeriodLike | null | undefined): string =>
+    hasTimeWindow(cierre) ? 'Por horario' : 'Día completo'
+
+  return {
+    hasTimeWindow,
+    formatPeriodDates,
+    formatPeriodTimes,
+    periodTypeLabel,
+  }
+}

--- a/composables/useCierrePeriod.ts
+++ b/composables/useCierrePeriod.ts
@@ -5,6 +5,8 @@ export interface CierrePeriodLike {
   periodEnd?: string
   periodStartTime?: string | null
   periodEndTime?: string | null
+  shiftTemplateId?: string | null
+  shiftTemplateName?: string | null
 }
 
 const _timeFormatter = new Intl.DateTimeFormat('es-CO', {
@@ -19,6 +21,9 @@ export function useCierrePeriod() {
 
   const hasTimeWindow = (cierre: CierrePeriodLike | null | undefined): boolean =>
     !!(cierre?.periodStartTime || cierre?.periodEndTime)
+
+  const isTemplateCierre = (cierre: CierrePeriodLike | null | undefined): boolean =>
+    !!(cierre?.shiftTemplateId && cierre?.shiftTemplateName)
 
   const formatPeriodDates = (cierre: CierrePeriodLike | null | undefined): string => {
     const start = cierre?.periodStart
@@ -38,13 +43,24 @@ export function useCierrePeriod() {
     return null
   }
 
-  const periodTypeLabel = (cierre: CierrePeriodLike | null | undefined): string =>
-    hasTimeWindow(cierre) ? 'Por horario' : 'Día completo'
+  const periodTypeLabel = (cierre: CierrePeriodLike | null | undefined): string => {
+    if (isTemplateCierre(cierre)) return cierre!.shiftTemplateName!
+    if (hasTimeWindow(cierre)) return 'Personalizado'
+    return 'Día completo'
+  }
+
+  const periodBadgeClass = (cierre: CierrePeriodLike | null | undefined): string => {
+    if (isTemplateCierre(cierre)) return 'bg-primary/10 text-primary'
+    if (hasTimeWindow(cierre)) return 'bg-violet-50 text-violet-800 border border-violet-200'
+    return 'bg-surface-secondary text-text-secondary'
+  }
 
   return {
     hasTimeWindow,
+    isTemplateCierre,
     formatPeriodDates,
     formatPeriodTimes,
     periodTypeLabel,
+    periodBadgeClass,
   }
 }

--- a/docs/usuarios/finanzas.md
+++ b/docs/usuarios/finanzas.md
@@ -22,9 +22,23 @@ Menú lateral → **Finanzas**. La pantalla tiene nueve pestañas en este orden:
 
 ## Arqueo de caja
 
-El **arqueo** (también llamado Cierre Z) registra el corte diario del negocio: cuánto vendiste, cuánto efectivo recibiste, cuánto contaste en caja y si hay diferencia. Es el equivalente digital de cuadrar la caja al final del turno.
+El **arqueo** registra el cuadre de caja de un período: cuánto vendiste, cuánto efectivo recibiste, cuánto contaste en caja y si hay diferencia. Es el equivalente digital de cuadrar la caja al final del turno.
 
-> Esta sección es **diaria** y reversible (puedes eliminar un arqueo). El **Cierre contable mensual** (siguiente sección) es distinto e irreversible.
+> Esta sección es **reversible** (puedes eliminar un arqueo). El **Cierre contable mensual** (siguiente sección) es distinto e irreversible.
+
+### Tres formas de arquear
+
+Desde **Finanzas → Arqueo de caja** eliges cómo cerrar:
+
+| Modo | Cuándo usarlo | Cómo iniciarlo |
+|------|---------------|----------------|
+| **Día completo** | Un solo cierre por día calendario (cierre nocturno o negocio de un turno único) | Tarjeta **Arqueo del día** o botón **Día completo** |
+| **Turno u horario** | Varios cortes el mismo día (mañana / tarde / noche) o un rango entre fechas con hora exacta | Tarjeta **Turno u horario** |
+| **Plantillas de turno** *(próximamente)* | Horarios fijos reutilizables (ej. almuerzo 12:00–15:00) configurados en Operaciones | Llegará en **Operaciones → Turnos** |
+
+**Vista previa (Corte X):** revisa ventas y caja en vivo **sin registrar** nada. Enlace al pie de la pantalla principal de arqueo. Desde ahí puedes pasar a registrar con el mismo período.
+
+> Los arqueos por horario muestran la ventana (ej. `14:00 – 22:30`) en el historial con la etiqueta **Por horario**. Los de día completo muestran **Día completo**.
 
 ### Historial de arqueos
 
@@ -47,15 +61,11 @@ Cada fila del historial tiene dos botones:
 | Ojo | Abre el detalle del arqueo en un panel lateral |
 | Papelera | Elimina el arqueo (pide confirmación) |
 
-El panel de detalle muestra: ventas del período, caja (efectivo esperado, contado y diferencia), métodos de pago, notas y fecha de registro.
+El panel de detalle muestra: tipo de cierre (día completo o por horario), fechas y —si aplica— la ventana horaria, ventas del período, caja, métodos de pago, notas y fecha de registro.
 
-### Cierre X (preview sin guardar)
+### Arqueo del día (día completo)
 
-Antes de cerrar puedes consultar el **Cierre X** desde el atajo `/finanzas/arqueo/x`. Es un resumen en vivo de las ventas del día sin registrar nada. Útil para revisar cómo va el turno.
-
-### Registrar un nuevo arqueo
-
-Haz clic en **Nuevo arqueo**. El proceso tiene 5 pasos.
+Haz clic en **Arqueo del día**. El proceso tiene 5 pasos.
 
 **Paso 1 — Período**
 
@@ -100,6 +110,16 @@ Puedes agregar **notas** opcionales (observaciones, incidencias del día).
 
 Confirma el arqueo. El botón se activa solo después de revisar el resumen. Una vez registrado, el arqueo no se puede editar, solo eliminar.
 
+### Arqueo por turno u horario
+
+Haz clic en **Turno u horario**. En el primer paso defines el período:
+
+1. Elige fechas (Hoy, Ayer, últimos 7 días, o un rango personalizado).
+2. Activa **Horario** para acotar por hora (obligatorio si el rango abarca varios días).
+3. Revisa el resumen previo y continúa con los mismos 5 pasos de conteo (efectivo, otros métodos, resumen, cerrar).
+
+Útil cuando cierras caja entre turnos sin esperar al final del día.
+
 ### Eliminar un arqueo
 
 Desde el historial, haz clic en el ícono de papelera. Al eliminar, el período queda liberado y puedes registrar un nuevo arqueo para esas mismas fechas. Los datos de ventas no se borran — solo el registro del arqueo.
@@ -107,7 +127,12 @@ Desde el historial, haz clic en el ícono de papelera. Al eliminar, el período 
 ### Preguntas frecuentes — Arqueo
 
 **¿Puedo hacer arqueo de varios días a la vez?**
-El wizard está diseñado para arqueos de un día. Si necesitas cerrar períodos más largos, registra cada día por separado.
+En **Arqueo del día**, un solo día por registro. En **Turno u horario** puedes elegir un rango de fechas; si abarca más de un día debes indicar hora de inicio y fin.
+
+**¿Cuál modo elijo?**
+- Un cierre al cerrar el local → **Día completo**.
+- Varios cortes el mismo día (ej. almuerzo y cena) → **Turno u horario**.
+- Horarios fijos repetibles → próximamente **Plantillas de turno** en Operaciones.
 
 **¿Qué pasa si hay mesas abiertas?**
 El sistema bloquea el arqueo y muestra cuántas mesas están abiertas. Ve al módulo de Mesas, cierra las sesiones pendientes y regresa.

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -553,8 +553,8 @@ const getPageConfig = () => {
     }
   } else if (path === '/finanzas/arqueo/z') {
     return {
-      pageTitle: 'Corte Z',
-      pageSubtitle: undefined,
+      pageTitle: 'Arqueo por turno u horario',
+      pageSubtitle: 'Ventana personalizada de fechas y horas',
       searchPlaceholder: undefined,
       activePage: 'finanzas' as const,
       showBreadcrumb: false,

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -907,6 +907,16 @@ const getPageConfig = () => {
       breadcrumbPage: undefined,
       backButton: undefined
     }
+  } else if (path === '/operaciones/turnos' || path === '/operaciones/turnos/') {
+    return {
+      pageTitle: 'Turnos',
+      pageSubtitle: 'Horarios reutilizables para arqueos de caja',
+      searchPlaceholder: undefined,
+      activePage: 'operaciones' as const,
+      showBreadcrumb: false,
+      breadcrumbPage: undefined,
+      backButton: undefined
+    }
   } else if (path === '/operaciones/propinas' || path === '/operaciones/propinas/') {
     return {
       pageTitle: 'Configuración de propinas',

--- a/pages/finanzas/arqueo/[id].vue
+++ b/pages/finanzas/arqueo/[id].vue
@@ -21,7 +21,12 @@
               </div>
               <div>
                 <p class="text-xs font-medium text-text-secondary uppercase tracking-wide">Período</p>
-                <p class="text-base font-semibold text-text-primary">{{ formatPeriod(cierre.periodStart, cierre.periodEnd) }}</p>
+                <p class="text-base font-semibold text-text-primary">{{ formatPeriodDates(cierre) }}</p>
+                <p v-if="formatPeriodTimes(cierre)" class="text-xs text-text-secondary font-mono mt-0.5">{{ formatPeriodTimes(cierre) }}</p>
+                <span
+                  class="inline-block mt-1 text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded"
+                  :class="hasTimeWindow(cierre) ? 'bg-primary/10 text-primary' : 'bg-surface-secondary text-text-secondary'"
+                >{{ periodTypeLabel(cierre) }}</span>
               </div>
             </div>
 
@@ -208,22 +213,17 @@ onMounted(() => { setRefreshHandler(refetch) })
 onUnmounted(() => { clearRefreshHandler(refetch) })
 
 useHead(() => ({
-  title: cierre.value ? `Arqueo ${formatPeriod(cierre.value.periodStart, cierre.value.periodEnd)} - Warocol` : 'Arqueo de caja - Warocol',
+  title: cierre.value ? `Arqueo ${formatPeriodDates(cierre.value)} - Warocol` : 'Arqueo de caja - Warocol',
 }))
 
 const formatCurrency = (value?: number) =>
   new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(value ?? 0)
 
-const { formatDate: _fmtDate, formatDateTime: _fmtDateTime } = useFormatters()
+const { formatDateTime: _fmtDateTime } = useFormatters()
+const { hasTimeWindow, formatPeriodDates, formatPeriodTimes, periodTypeLabel } = useCierrePeriod()
 
 const formatDate = (iso: string) => {
   if (!iso) return ''
   return _fmtDateTime(iso)
-}
-
-const formatPeriod = (start: string, end: string) => {
-  if (!start) return ''
-  const fmt = (d: string) => _fmtDate(d + 'T12:00:00')
-  return start === end ? fmt(start) : `${fmt(start)} – ${fmt(end)}`
 }
 </script>

--- a/pages/finanzas/arqueo/[id].vue
+++ b/pages/finanzas/arqueo/[id].vue
@@ -25,7 +25,7 @@
                 <p v-if="formatPeriodTimes(cierre)" class="text-xs text-text-secondary font-mono mt-0.5">{{ formatPeriodTimes(cierre) }}</p>
                 <span
                   class="inline-block mt-1 text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded"
-                  :class="hasTimeWindow(cierre) ? 'bg-primary/10 text-primary' : 'bg-surface-secondary text-text-secondary'"
+                  :class="periodBadgeClass(cierre)"
                 >{{ periodTypeLabel(cierre) }}</span>
               </div>
             </div>
@@ -220,7 +220,7 @@ const formatCurrency = (value?: number) =>
   new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(value ?? 0)
 
 const { formatDateTime: _fmtDateTime } = useFormatters()
-const { hasTimeWindow, formatPeriodDates, formatPeriodTimes, periodTypeLabel } = useCierrePeriod()
+const { formatPeriodDates, formatPeriodTimes, periodTypeLabel, periodBadgeClass } = useCierrePeriod()
 
 const formatDate = (iso: string) => {
   if (!iso) return ''

--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -115,22 +115,6 @@
 
       <!-- ── Historial ─────────────────────────────────────────────────────── -->
       <HealthSemaphore :is-unlocked="true" title="Historial de arqueos">
-        <template #header-actions>
-          <div class="flex flex-wrap items-center gap-2 justify-end">
-            <NuxtLink
-              to="/finanzas/arqueo/nuevo"
-              class="btn-primary px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap"
-            >
-              Día completo
-            </NuxtLink>
-            <NuxtLink
-              to="/finanzas/arqueo/z"
-              class="btn-secondary px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap"
-            >
-              Turno u horario
-            </NuxtLink>
-          </div>
-        </template>
       <UiResponsiveDataView
         :data="filteredHistorial"
         :columns="historialColumns"

--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -77,19 +77,59 @@
         </div>
       </div>
 
+      <!-- ── Entry CTAs ──────────────────────────────────────────────────────── -->
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <NuxtLink
+          to="/finanzas/arqueo/nuevo"
+          class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/30 bg-primary/5 hover:bg-primary/10 transition-colors"
+        >
+          <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-primary/15 flex items-center justify-center text-primary" aria-hidden="true">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+          </div>
+          <div>
+            <p class="text-sm font-semibold text-text-primary">Arqueo del día</p>
+            <p class="text-xs text-text-secondary mt-0.5">Cierra un día calendario completo (turno único o cierre nocturno).</p>
+          </div>
+        </NuxtLink>
+        <NuxtLink
+          to="/finanzas/arqueo/z"
+          class="flex items-start gap-3 p-4 rounded-lg border-2 border-border bg-surface hover:border-primary/40 transition-colors"
+        >
+          <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-background border border-border flex items-center justify-center text-primary" aria-hidden="true">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </div>
+          <div>
+            <p class="text-sm font-semibold text-text-primary">Turno u horario</p>
+            <p class="text-xs text-text-secondary mt-0.5">Ventana personalizada por horas (mañana, tarde, o rango entre días).</p>
+          </div>
+        </NuxtLink>
+      </div>
+      <p class="text-xs text-text-secondary">
+        ¿Solo quieres revisar sin cerrar?
+        <NuxtLink to="/finanzas/arqueo/x" class="text-primary font-medium hover:underline">Vista previa (Corte X)</NuxtLink>
+      </p>
+
       <!-- ── Historial ─────────────────────────────────────────────────────── -->
       <HealthSemaphore :is-unlocked="true" title="Historial de arqueos">
         <template #header-actions>
-          <NuxtLink
-            to="/finanzas/arqueo/nuevo"
-            class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap flex items-center gap-1.5"
-          >
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-            </svg>
-            <span class="hidden sm:inline">Nuevo arqueo</span>
-            <span class="sm:hidden">Nuevo</span>
-          </NuxtLink>
+          <div class="flex flex-wrap items-center gap-2 justify-end">
+            <NuxtLink
+              to="/finanzas/arqueo/nuevo"
+              class="btn-primary px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap"
+            >
+              Día completo
+            </NuxtLink>
+            <NuxtLink
+              to="/finanzas/arqueo/z"
+              class="btn-secondary px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap"
+            >
+              Turno u horario
+            </NuxtLink>
+          </div>
         </template>
       <UiResponsiveDataView
         :data="filteredHistorial"
@@ -104,8 +144,15 @@
             @click="openPanel(item.id)"
           >
             <div class="flex-1 min-w-0">
-              <span class="text-sm font-bold text-text-primary">{{ formatDay(item.periodStart) }}</span>
-              <p class="text-xs text-text-secondary mt-0.5">{{ formatDay(item.periodEnd) }} · {{ formatDate(item.closedAt) }}</p>
+              <div class="flex flex-wrap items-center gap-1.5">
+                <span
+                  class="text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded"
+                  :class="hasTimeWindow(item) ? 'bg-primary/10 text-primary' : 'bg-surface-secondary text-text-secondary'"
+                >{{ periodTypeLabel(item) }}</span>
+                <span class="text-sm font-bold text-text-primary">{{ formatPeriodDates(item) }}</span>
+              </div>
+              <p v-if="formatPeriodTimes(item)" class="text-xs text-text-secondary mt-0.5 font-mono">{{ formatPeriodTimes(item) }}</p>
+              <p class="text-xs text-text-secondary mt-0.5">Registrado {{ formatDate(item.closedAt) }}</p>
             </div>
             <div class="flex flex-col items-end gap-1.5 flex-shrink-0">
               <span class="text-sm font-bold text-primary tabular-nums">{{ formatCurrency(item.totalSales) }}</span>
@@ -117,10 +164,20 @@
         </template>
 
         <template #cell-periodStart="{ row }">
-          <span class="text-sm font-bold text-text-primary">{{ formatDay(row.periodStart) }}</span>
+          <div class="flex flex-col gap-0.5 min-w-0">
+            <div class="flex flex-wrap items-center gap-1.5">
+              <span
+                class="text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded flex-shrink-0"
+                :class="hasTimeWindow(row) ? 'bg-primary/10 text-primary' : 'bg-surface-secondary text-text-secondary'"
+              >{{ periodTypeLabel(row) }}</span>
+              <span class="text-sm font-bold text-text-primary">{{ formatPeriodDates(row) }}</span>
+            </div>
+            <span v-if="formatPeriodTimes(row)" class="text-xs text-text-secondary font-mono">{{ formatPeriodTimes(row) }}</span>
+          </div>
         </template>
         <template #cell-periodEnd="{ row }">
-          <span class="text-sm text-text-secondary">{{ formatDay(row.periodEnd) }}</span>
+          <span v-if="row.periodStart !== row.periodEnd" class="text-sm text-text-secondary">{{ formatDay(row.periodEnd) }}</span>
+          <span v-else class="text-xs text-text-tertiary">—</span>
         </template>
         <template #cell-totalSales="{ value }">
           <span class="text-sm font-bold text-primary">{{ formatCurrency(value) }}</span>
@@ -186,7 +243,7 @@
           </div>
           <h3 class="text-lg font-bold text-text-primary mb-1">Eliminar arqueo</h3>
           <p class="text-sm text-text-secondary mb-6">
-            ¿Eliminar el arqueo del período <strong>{{ formatPeriod(cierreToDelete?.periodStart, cierreToDelete?.periodEnd) }}</strong>? Esta acción no se puede deshacer.
+            ¿Eliminar el arqueo del período <strong>{{ formatPeriodDates(cierreToDelete) }}</strong><template v-if="formatPeriodTimes(cierreToDelete)"> ({{ formatPeriodTimes(cierreToDelete) }})</template>? Esta acción no se puede deshacer.
           </p>
           <div class="flex gap-3">
             <button
@@ -298,8 +355,8 @@ const summaryStats = computed(() => {
 })
 
 const historialColumns = [
-  { key: 'periodStart',    title: 'Período inicial', sortable: false },
-  { key: 'periodEnd',      title: 'Período final',   sortable: false },
+  { key: 'periodStart',    title: 'Período',         sortable: false },
+  { key: 'periodEnd',      title: 'Hasta',           sortable: false },
   { key: 'totalSales',     title: 'Ventas',          sortable: false },
   { key: 'gastosEfectivo', title: 'Gastos',          sortable: false },
   { key: 'cashDifference', title: 'Diferencia',      sortable: false },
@@ -325,7 +382,8 @@ const isCurrentMonthActive = computed(() => {
   return activeStart.value === first && activeEnd.value === last
 })
 
-const { formatDate: _fmtDate, formatDateTime: _fmtDateTime } = useFormatters()
+const { formatDateTime: _fmtDateTime } = useFormatters()
+const { hasTimeWindow, formatPeriodDates, formatPeriodTimes, periodTypeLabel } = useCierrePeriod()
 
 const formatDay = (d: string) => {
   if (!d) return ''
@@ -335,12 +393,6 @@ const formatDay = (d: string) => {
 const formatDate = (iso: string) => {
   if (!iso) return ''
   return _fmtDateTime(iso)
-}
-
-const formatPeriod = (start: string, end: string) => {
-  if (!start) return ''
-  const fmt = (d: string) => _fmtDate(d + 'T12:00:00')
-  return start === end ? fmt(start) : `${fmt(start)} – ${fmt(end)}`
 }
 
 // ── Panel ─────────────────────────────────────────────────────────────────

--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -131,7 +131,7 @@
               <div class="flex flex-wrap items-center gap-1.5">
                 <span
                   class="text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded"
-                  :class="hasTimeWindow(item) ? 'bg-primary/10 text-primary' : 'bg-surface-secondary text-text-secondary'"
+                  :class="periodBadgeClass(item)"
                 >{{ periodTypeLabel(item) }}</span>
                 <span class="text-sm font-bold text-text-primary">{{ formatPeriodDates(item) }}</span>
               </div>
@@ -152,7 +152,7 @@
             <div class="flex flex-wrap items-center gap-1.5">
               <span
                 class="text-[10px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded flex-shrink-0"
-                :class="hasTimeWindow(row) ? 'bg-primary/10 text-primary' : 'bg-surface-secondary text-text-secondary'"
+                :class="periodBadgeClass(row)"
               >{{ periodTypeLabel(row) }}</span>
               <span class="text-sm font-bold text-text-primary">{{ formatPeriodDates(row) }}</span>
             </div>
@@ -367,7 +367,7 @@ const isCurrentMonthActive = computed(() => {
 })
 
 const { formatDateTime: _fmtDateTime } = useFormatters()
-const { hasTimeWindow, formatPeriodDates, formatPeriodTimes, periodTypeLabel } = useCierrePeriod()
+const { formatPeriodDates, formatPeriodTimes, periodTypeLabel, periodBadgeClass } = useCierrePeriod()
 
 const formatDay = (d: string) => {
   if (!d) return ''

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -111,12 +111,34 @@
         >{{ p.label }}</button>
 
         <VueDatePicker
+          v-if="arqueoWindowMode === 'template'"
+          v-model="templateAnchorDate"
+          :teleport="true"
+          :enable-time-picker="false"
+          :locale="es"
+          auto-apply
+          :max-date="new Date()"
+          :format="formatTemplatePickerInput"
+          input-class-name="dp-custom-input !min-w-[10.5rem] sm:!min-w-[12rem]"
+          menu-class-name="dp-custom-menu"
+          calendar-cell-class-name="dp-custom-cell"
+          @update:model-value="onTemplateAnchorPick"
+        />
+
+        <VueDatePicker
+          v-else
           v-model="dateRangeDates"
           range
-          :teleport="true" :preset-dates="dpPresets" :enable-time-picker="false" :locale="es"
-          auto-apply :max-date="new Date()" :format="formatDateRange"
-          :input-class-name="arqueoWindowMode === 'template' ? 'dp-custom-input !w-[7.5rem] sm:!w-[8.5rem]' : 'dp-custom-input'"
-          menu-class-name="dp-custom-menu" calendar-cell-class-name="dp-custom-cell"
+          :teleport="true"
+          :preset-dates="dpPresets"
+          :enable-time-picker="false"
+          :locale="es"
+          auto-apply
+          :max-date="new Date()"
+          :format="formatDateRange"
+          input-class-name="dp-custom-input"
+          menu-class-name="dp-custom-menu"
+          calendar-cell-class-name="dp-custom-cell"
           @update:model-value="activePreset = null"
         />
 
@@ -883,7 +905,12 @@ const dpPresets    = presets.map(p => ({ label: p.label, value: [p.start, p.end]
 
 const applyPreset = (p: Preset) => {
   activePreset.value = p.key
-  dateRangeDates.value = [new Date(p.start), new Date(p.end)]
+  const anchor = new Date(p.start)
+  if (arqueoWindowMode.value === 'template') {
+    dateRangeDates.value = [anchor, anchor]
+  } else {
+    dateRangeDates.value = [anchor, new Date(p.end)]
+  }
 }
 
 const formatDateRange = (dates: Date[]) => {
@@ -975,6 +1002,56 @@ const { data: rawShiftTemplates, status: templatesStatus } = useQuery({
 })
 const shiftTemplates = computed(() => rawShiftTemplates.value?.data ?? [])
 const templatesLoading = computed(() => templatesStatus.value === 'pending')
+
+const templateAnchorDate = computed({
+  get: () => dateRangeDates.value[0] ?? new Date(),
+  set: (d: Date) => {
+    if (!d) return
+    dateRangeDates.value = [d, d]
+  },
+})
+
+const { data: rawTemplateWindow, status: templateWindowStatus } = useQuery({
+  key: () => ['cierre', 'shift-window', currentTenant.value?.id, selectedTemplateId.value, periodStart.value],
+  query: () => $fetch<{
+    success: boolean
+    data: { periodStartTime: string; periodEndTime: string; crossesMidnight?: boolean }
+  }>('/api/cierre/shift-window', {
+    params: { shift_template_id: selectedTemplateId.value, date: periodStart.value },
+  }),
+  enabled: () =>
+    !!currentTenant.value
+    && arqueoWindowMode.value === 'template'
+    && !!selectedTemplateId.value,
+  staleTime: 30_000,
+})
+
+const templatePeriodDisplay = computed(() => {
+  const w = rawTemplateWindow.value?.data
+  if (!w?.periodStartTime || !w?.periodEndTime) {
+    if (templateWindowStatus.value === 'pending' && selectedTemplateId.value) return 'Calculando…'
+    return fnsFormat(templateAnchorDate.value, 'dd/MM/yy', { locale: es })
+  }
+  const start = new Date(w.periodStartTime)
+  const end = new Date(w.periodEndTime)
+  const anchor = fnsFormat(start, 'dd/MM/yy', { locale: es })
+  const startT = fnsFormat(start, 'HH:mm')
+  const endT = fnsFormat(end, 'HH:mm')
+  const endDay = fnsFormat(end, 'dd/MM/yy', { locale: es })
+  if (anchor === endDay) return `${anchor} · ${startT} – ${endT}`
+  return `${anchor} ${startT} – ${endDay} ${endT}`
+})
+
+const formatTemplatePickerInput = () => templatePeriodDisplay.value
+
+const onTemplateAnchorPick = () => {
+  const anchor = fnsFormat(templateAnchorDate.value, 'yyyy-MM-dd')
+  if (anchor === today) activePreset.value = 'today'
+  else {
+    const y = new Date(); y.setDate(y.getDate() - 1)
+    activePreset.value = anchor === fnsFormat(y, 'yyyy-MM-dd') ? 'yesterday' : null
+  }
+}
 
 const applySuggestedWindow = async () => {
   suggestedLoading.value = true

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -110,34 +110,47 @@
           @click="applyPreset(p)"
         >{{ p.label }}</button>
 
-        <!-- Plantilla: calendario = solo día; horas = ventana del turno (solo lectura) -->
+        <!-- Plantilla: un solo control — día (calendario) + horas del turno (solo lectura) -->
         <div
           v-if="arqueoWindowMode === 'template'"
-          class="flex items-stretch h-10 rounded-lg border-2 border-border bg-background overflow-hidden flex-shrink-0"
+          class="arqueo-template-period relative flex items-center h-10 rounded-lg border-2 border-border bg-background flex-shrink-0"
         >
           <VueDatePicker
             v-model="templateAnchorDate"
             :teleport="true"
             :enable-time-picker="false"
+            :formats="dateOnlyFormats"
             :locale="es"
             auto-apply
             :max-date="new Date()"
-            :format="formatTemplateDateOnly"
-            input-class-name="dp-custom-input !border-0 !rounded-none !shadow-none !min-w-[5.25rem] !w-[5.25rem] sm:!min-w-[5.75rem] sm:!w-[5.75rem]"
+            :clearable="false"
             menu-class-name="dp-custom-menu"
             calendar-cell-class-name="dp-custom-cell"
+            class="arqueo-template-dp-trigger flex-shrink-0"
             @update:model-value="onTemplateAnchorPick"
-          />
+          >
+            <template #trigger>
+              <button
+                type="button"
+                class="flex items-center gap-1.5 h-10 px-3 text-sm text-text-primary hover:bg-surface-secondary/60 transition-colors rounded-l-md"
+              >
+                <svg class="w-4 h-4 text-text-secondary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                <span class="font-medium tabular-nums whitespace-nowrap">{{ formatTemplateDateOnly() }}</span>
+              </button>
+            </template>
+          </VueDatePicker>
           <span
             v-if="templateHoursLabel"
-            class="flex items-center px-2.5 text-sm font-mono text-text-secondary border-l border-border whitespace-nowrap"
+            class="flex items-center h-full px-2.5 text-sm font-mono text-text-secondary border-l border-border whitespace-nowrap"
             title="Horario definido por el turno"
           >
             {{ templateHoursLabel }}
           </span>
           <span
             v-else-if="selectedTemplateId && templateWindowStatus === 'pending'"
-            class="flex items-center px-2.5 text-xs text-text-secondary border-l border-border"
+            class="flex items-center h-full px-2.5 text-xs text-text-secondary border-l border-border"
           >
             …
           </span>
@@ -153,7 +166,7 @@
           :locale="es"
           auto-apply
           :max-date="new Date()"
-          :format="formatDateRange"
+          :formats="dateOnlyFormats"
           input-class-name="dp-custom-input"
           menu-class-name="dp-custom-menu"
           calendar-cell-class-name="dp-custom-cell"
@@ -931,11 +944,14 @@ const applyPreset = (p: Preset) => {
   }
 }
 
+/** Vue Datepicker v12 — sin componente de hora en el input */
+const dateOnlyFormats = { input: 'dd/MM/yyyy', preview: 'dd/MM/yyyy' }
+
 const formatDateRange = (dates: Date[]) => {
   if (!dates?.[0]) return ''
-  const from = fnsFormat(dates[0], 'dd/MM/yy', { locale: es })
+  const from = fnsFormat(dates[0], 'dd/MM/yyyy', { locale: es })
   if (!dates[1]) return from
-  const to = fnsFormat(dates[1], 'dd/MM/yy', { locale: es })
+  const to = fnsFormat(dates[1], 'dd/MM/yyyy', { locale: es })
   if (from === to) return from
   return `${from} – ${to}`
 }
@@ -1045,7 +1061,7 @@ const { data: rawTemplateWindow, status: templateWindowStatus } = useQuery({
 })
 
 const formatTemplateDateOnly = (date?: Date) =>
-  fnsFormat(date ?? templateAnchorDate.value, 'dd/MM/yy', { locale: es })
+  fnsFormat(date ?? templateAnchorDate.value, 'dd/MM/yyyy', { locale: es })
 
 /** Horas del turno resueltas en servidor — no editables en plantilla */
 const templateHoursLabel = computed(() => {
@@ -1428,3 +1444,15 @@ const formatPeriod = (start: string, end: string) => {
   return start === end ? fmt(start) : `${fmt(start)} – ${fmt(end)}`
 }
 </script>
+
+<style>
+.arqueo-template-dp-trigger :deep(.dp__input_wrap),
+.arqueo-template-dp-trigger :deep(.dp__input),
+.arqueo-template-dp-trigger :deep(.dp--clear-btn) {
+  display: none !important;
+}
+.arqueo-template-dp-trigger :deep(.dp__main) {
+  border: none !important;
+  background: transparent !important;
+}
+</style>

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -59,53 +59,50 @@
 
     <!-- ── PASO 0: Seleccionar período ─────────────────────────────────── -->
     <template v-else-if="currentStep === 0">
-      <div class="flex flex-wrap items-center gap-2 mb-2">
-        <span class="text-xs font-medium text-text-secondary uppercase tracking-wide">Modo</span>
+      <div class="flex items-center gap-2 w-full overflow-x-auto scrollbar-hide mb-2">
+        <span class="text-xs font-medium text-text-secondary uppercase tracking-wide flex-shrink-0">Modo</span>
         <button
           type="button"
-          class="h-9 px-3 rounded-lg border-2 text-sm font-medium transition-colors"
+          class="h-10 px-3 rounded-lg border-2 text-sm font-medium transition-colors flex-shrink-0"
           :class="arqueoWindowMode === 'template' ? 'border-primary bg-primary text-primary-foreground' : 'border-border bg-background text-text-secondary hover:border-primary/50'"
           @click="setArqueoMode('template')"
         >Plantilla</button>
         <button
           type="button"
-          class="h-9 px-3 rounded-lg border-2 text-sm font-medium transition-colors"
+          class="h-10 px-3 rounded-lg border-2 text-sm font-medium transition-colors flex-shrink-0"
           :class="arqueoWindowMode === 'custom' ? 'border-primary bg-primary text-primary-foreground' : 'border-border bg-background text-text-secondary hover:border-primary/50'"
           @click="setArqueoMode('custom')"
         >Personalizado</button>
+
+        <select
+          v-if="arqueoWindowMode === 'template'"
+          v-model="selectedTemplateId"
+          class="h-10 pl-3 pr-8 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/40 flex-shrink-0 max-w-[11rem] sm:max-w-[13rem]"
+        >
+          <option value="">Turno…</option>
+          <option v-for="t in shiftTemplates" :key="t.id" :value="t.id">
+            {{ t.name }} ({{ t.startTime }}–{{ t.endTime }})
+          </option>
+        </select>
+
         <button
           type="button"
-          class="h-9 px-3 rounded-lg border-2 border-border text-sm text-text-secondary hover:border-primary/50 hover:text-text-primary transition-colors ml-auto"
+          class="h-10 px-3 rounded-lg border-2 border-border text-sm text-text-secondary hover:border-primary/50 hover:text-text-primary transition-colors flex-shrink-0 whitespace-nowrap"
           :disabled="suggestedLoading"
           @click="applySuggestedWindow"
         >
           {{ suggestedLoading ? 'Cargando…' : 'Desde último arqueo' }}
         </button>
-      </div>
 
-      <div v-if="arqueoWindowMode === 'template'" class="flex flex-wrap items-end gap-2 mb-2">
-        <div class="flex flex-col gap-0.5 min-w-[180px]">
-          <label class="text-xs text-text-secondary">Turno</label>
-          <select
-            v-model="selectedTemplateId"
-            class="h-10 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
-          >
-            <option value="">Seleccionar turno…</option>
-            <option v-for="t in shiftTemplates" :key="t.id" :value="t.id">
-              {{ t.name }} ({{ t.startTime }}–{{ t.endTime }})
-            </option>
-          </select>
-        </div>
-        <p v-if="templateWindowLabel" class="text-sm text-text-secondary self-end pb-2">
-          {{ templateWindowLabel }}
+        <p
+          v-if="arqueoWindowMode === 'template' && shiftTemplates.length === 0 && !templatesLoading"
+          class="text-xs text-amber-700 whitespace-nowrap flex-shrink-0"
+        >
+          Sin turnos activos
         </p>
-        <p v-else-if="shiftTemplates.length === 0 && !templatesLoading" class="text-sm text-amber-700 self-end pb-2">
-          No hay turnos activos. Configúralos en Operaciones → Turnos.
-        </p>
-      </div>
 
-      <!-- Filter bar -->
-      <div class="flex items-end gap-2 w-full overflow-x-auto scrollbar-hide">
+        <div class="h-10 w-px bg-border flex-shrink-0" aria-hidden="true" />
+
         <button
           v-for="p in visiblePresets" :key="p.key"
           class="h-10 px-3 rounded-lg border-2 text-sm font-medium transition-colors flex-shrink-0"
@@ -118,11 +115,12 @@
           range
           :teleport="true" :preset-dates="dpPresets" :enable-time-picker="false" :locale="es"
           auto-apply :max-date="new Date()" :format="formatDateRange"
-          input-class-name="dp-custom-input" menu-class-name="dp-custom-menu" calendar-cell-class-name="dp-custom-cell"
+          :input-class-name="arqueoWindowMode === 'template' ? 'dp-custom-input !w-[7.5rem] sm:!w-[8.5rem]' : 'dp-custom-input'"
+          menu-class-name="dp-custom-menu" calendar-cell-class-name="dp-custom-cell"
           @update:model-value="activePreset = null"
         />
 
-        <div v-if="arqueoWindowMode === 'custom'" class="h-10 w-px bg-border flex-shrink-0 self-end" />
+        <div v-if="arqueoWindowMode === 'custom'" class="h-10 w-px bg-border flex-shrink-0" aria-hidden="true" />
 
         <button
           v-if="arqueoWindowMode === 'custom' && !isMultiDay"
@@ -159,7 +157,7 @@
               </ul>
             </div>
           </div>
-          <span v-if="shiftLabel" class="text-xs text-text-secondary whitespace-nowrap flex-shrink-0 self-end pb-2">{{ shiftLabel }}</span>
+          <span v-if="shiftLabel" class="text-xs text-text-secondary whitespace-nowrap flex-shrink-0">{{ shiftLabel }}</span>
         </template>
       </div>
 
@@ -892,7 +890,9 @@ const formatDateRange = (dates: Date[]) => {
   if (!dates?.[0]) return ''
   const from = fnsFormat(dates[0], 'dd/MM/yy', { locale: es })
   if (!dates[1]) return from
-  return `${from} – ${fnsFormat(dates[1], 'dd/MM/yy', { locale: es })}`
+  const to = fnsFormat(dates[1], 'dd/MM/yy', { locale: es })
+  if (from === to) return from
+  return `${from} – ${to}`
 }
 
 // Time inputs
@@ -975,28 +975,6 @@ const { data: rawShiftTemplates, status: templatesStatus } = useQuery({
 })
 const shiftTemplates = computed(() => rawShiftTemplates.value?.data ?? [])
 const templatesLoading = computed(() => templatesStatus.value === 'pending')
-
-const { data: rawTemplateWindow } = useQuery({
-  key: () => ['cierre', 'shift-window', currentTenant.value?.id, selectedTemplateId.value, periodStart.value],
-  query: () => $fetch<{ success: boolean; data: { periodStartTime: string; periodEndTime: string; templateName?: string } }>(
-    '/api/cierre/shift-window',
-    { params: { shift_template_id: selectedTemplateId.value, date: periodStart.value } },
-  ),
-  enabled: () =>
-    !!currentTenant.value
-    && arqueoWindowMode.value === 'template'
-    && !!selectedTemplateId.value,
-  staleTime: 30_000,
-})
-
-const templateWindowLabel = computed(() => {
-  const w = rawTemplateWindow.value?.data
-  if (!w?.periodStartTime || !w?.periodEndTime) return null
-  const start = new Date(w.periodStartTime)
-  const end = new Date(w.periodEndTime)
-  const name = w.templateName ? `${w.templateName}: ` : ''
-  return `${name}${fnsFormat(start, 'dd/MM HH:mm', { locale: es })} – ${fnsFormat(end, 'dd/MM HH:mm', { locale: es })}`
-})
 
 const applySuggestedWindow = async () => {
   suggestedLoading.value = true

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -59,10 +59,55 @@
 
     <!-- ── PASO 0: Seleccionar período ─────────────────────────────────── -->
     <template v-else-if="currentStep === 0">
+      <div class="flex flex-wrap items-center gap-2 mb-2">
+        <span class="text-xs font-medium text-text-secondary uppercase tracking-wide">Modo</span>
+        <button
+          type="button"
+          class="h-9 px-3 rounded-lg border-2 text-sm font-medium transition-colors"
+          :class="arqueoWindowMode === 'template' ? 'border-primary bg-primary text-primary-foreground' : 'border-border bg-background text-text-secondary hover:border-primary/50'"
+          @click="setArqueoMode('template')"
+        >Plantilla</button>
+        <button
+          type="button"
+          class="h-9 px-3 rounded-lg border-2 text-sm font-medium transition-colors"
+          :class="arqueoWindowMode === 'custom' ? 'border-primary bg-primary text-primary-foreground' : 'border-border bg-background text-text-secondary hover:border-primary/50'"
+          @click="setArqueoMode('custom')"
+        >Personalizado</button>
+        <button
+          type="button"
+          class="h-9 px-3 rounded-lg border-2 border-border text-sm text-text-secondary hover:border-primary/50 hover:text-text-primary transition-colors ml-auto"
+          :disabled="suggestedLoading"
+          @click="applySuggestedWindow"
+        >
+          {{ suggestedLoading ? 'Cargando…' : 'Desde último arqueo' }}
+        </button>
+      </div>
+
+      <div v-if="arqueoWindowMode === 'template'" class="flex flex-wrap items-end gap-2 mb-2">
+        <div class="flex flex-col gap-0.5 min-w-[180px]">
+          <label class="text-xs text-text-secondary">Turno</label>
+          <select
+            v-model="selectedTemplateId"
+            class="h-10 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+          >
+            <option value="">Seleccionar turno…</option>
+            <option v-for="t in shiftTemplates" :key="t.id" :value="t.id">
+              {{ t.name }} ({{ t.startTime }}–{{ t.endTime }})
+            </option>
+          </select>
+        </div>
+        <p v-if="templateWindowLabel" class="text-sm text-text-secondary self-end pb-2">
+          {{ templateWindowLabel }}
+        </p>
+        <p v-else-if="shiftTemplates.length === 0 && !templatesLoading" class="text-sm text-amber-700 self-end pb-2">
+          No hay turnos activos. Configúralos en Operaciones → Turnos.
+        </p>
+      </div>
+
       <!-- Filter bar -->
       <div class="flex items-end gap-2 w-full overflow-x-auto scrollbar-hide">
         <button
-          v-for="p in presets" :key="p.key"
+          v-for="p in visiblePresets" :key="p.key"
           class="h-10 px-3 rounded-lg border-2 text-sm font-medium transition-colors flex-shrink-0"
           :class="activePreset === p.key ? 'border-primary bg-primary text-primary-foreground' : 'border-border bg-background text-text-secondary hover:border-primary/50 hover:text-text-primary'"
           @click="applyPreset(p)"
@@ -70,16 +115,17 @@
 
         <VueDatePicker
           v-model="dateRangeDates"
-          range :teleport="true" :preset-dates="dpPresets" :enable-time-picker="false" :locale="es"
+          range
+          :teleport="true" :preset-dates="dpPresets" :enable-time-picker="false" :locale="es"
           auto-apply :max-date="new Date()" :format="formatDateRange"
           input-class-name="dp-custom-input" menu-class-name="dp-custom-menu" calendar-cell-class-name="dp-custom-cell"
           @update:model-value="activePreset = null"
         />
 
-        <div class="h-10 w-px bg-border flex-shrink-0 self-end" />
+        <div v-if="arqueoWindowMode === 'custom'" class="h-10 w-px bg-border flex-shrink-0 self-end" />
 
         <button
-          v-if="!isMultiDay"
+          v-if="arqueoWindowMode === 'custom' && !isMultiDay"
           @click="toggleTimePicker"
           class="h-10 px-3 rounded-lg border-2 text-sm font-medium transition-colors flex-shrink-0 flex items-center gap-1.5"
           :class="enableTimePicker ? 'border-primary bg-primary/10 text-primary' : 'border-border bg-background text-text-secondary hover:border-primary/50'"
@@ -88,7 +134,7 @@
           Horario
         </button>
 
-        <template v-if="isMultiDay || enableTimePicker">
+        <template v-if="arqueoWindowMode === 'custom' && (isMultiDay || enableTimePicker)">
           <div class="flex flex-col gap-0.5 flex-shrink-0">
             <label class="text-xs text-text-secondary">Desde</label>
             <div class="relative">
@@ -788,6 +834,21 @@ const { currentTenant } = useTenantReactive()
 const { singular: tableSingular, plural: tablePlural } = useTableLabel()
 const route = useRoute()
 
+type ArqueoWindowMode = 'template' | 'custom'
+interface ShiftTemplateOption {
+  id: string
+  name: string
+  startTime: string
+  endTime: string
+  crossesMidnight: boolean
+}
+
+const arqueoWindowMode = ref<ArqueoWindowMode>(
+  (route.query.mode as string) === 'template' ? 'template' : 'custom',
+)
+const selectedTemplateId = ref<string>('')
+const suggestedLoading = ref(false)
+
 const today = new Date().toISOString().split('T')[0]
 
 // ── Date picker state (paso 0) ─────────────────────────────────────────────
@@ -814,6 +875,11 @@ const buildPresets = (): Preset[] => {
   ]
 }
 const presets      = buildPresets()
+const visiblePresets = computed(() =>
+  arqueoWindowMode.value === 'template'
+    ? presets.filter(p => p.key === 'today' || p.key === 'yesterday')
+    : presets,
+)
 const activePreset = ref<string | null>(initStart === today && initEnd === today ? 'today' : null)
 const dpPresets    = presets.map(p => ({ label: p.label, value: [p.start, p.end] }))
 
@@ -872,16 +938,122 @@ const periodStart = computed(() => fnsFormat(dateRangeDates.value[0], 'yyyy-MM-d
 const periodEnd   = computed(() => fnsFormat(dateRangeDates.value[1] ?? dateRangeDates.value[0], 'yyyy-MM-dd'))
 const isMultiDay  = computed(() => periodStart.value !== periodEnd.value)
 
-watch(isMultiDay, (multi) => { if (multi) enableTimePicker.value = true })
+const previewShiftTemplateId = computed(() =>
+  arqueoWindowMode.value === 'template' && selectedTemplateId.value
+    ? selectedTemplateId.value
+    : null,
+)
+
+watch(isMultiDay, (multi) => {
+  if (multi && arqueoWindowMode.value === 'custom') enableTimePicker.value = true
+})
+
+watch(dateRangeDates, (dates) => {
+  if (arqueoWindowMode.value !== 'template' || !dates?.[0] || !dates?.[1]) return
+  const a = fnsFormat(dates[0], 'yyyy-MM-dd')
+  const b = fnsFormat(dates[1], 'yyyy-MM-dd')
+  if (a !== b) dateRangeDates.value = [dates[0], dates[0]]
+}, { deep: true })
+
+const setArqueoMode = (mode: ArqueoWindowMode) => {
+  arqueoWindowMode.value = mode
+  timeError.value = null
+  if (mode === 'template') {
+    const d = dateRangeDates.value[0] ?? new Date()
+    dateRangeDates.value = [d, d]
+    enableTimePicker.value = false
+    startTimeInput.value = ''
+    endTimeInput.value = ''
+  }
+}
+
+const { data: rawShiftTemplates, status: templatesStatus } = useQuery({
+  key: () => ['cierre', 'shift-templates', currentTenant.value?.id],
+  query: () => $fetch<{ success: boolean; data: ShiftTemplateOption[] }>('/api/cierre/shift-templates'),
+  enabled: () => !!currentTenant.value,
+  staleTime: 120_000,
+})
+const shiftTemplates = computed(() => rawShiftTemplates.value?.data ?? [])
+const templatesLoading = computed(() => templatesStatus.value === 'pending')
+
+const { data: rawTemplateWindow } = useQuery({
+  key: () => ['cierre', 'shift-window', currentTenant.value?.id, selectedTemplateId.value, periodStart.value],
+  query: () => $fetch<{ success: boolean; data: { periodStartTime: string; periodEndTime: string; templateName?: string } }>(
+    '/api/cierre/shift-window',
+    { params: { shift_template_id: selectedTemplateId.value, date: periodStart.value } },
+  ),
+  enabled: () =>
+    !!currentTenant.value
+    && arqueoWindowMode.value === 'template'
+    && !!selectedTemplateId.value,
+  staleTime: 30_000,
+})
+
+const templateWindowLabel = computed(() => {
+  const w = rawTemplateWindow.value?.data
+  if (!w?.periodStartTime || !w?.periodEndTime) return null
+  const start = new Date(w.periodStartTime)
+  const end = new Date(w.periodEndTime)
+  const name = w.templateName ? `${w.templateName}: ` : ''
+  return `${name}${fnsFormat(start, 'dd/MM HH:mm', { locale: es })} – ${fnsFormat(end, 'dd/MM HH:mm', { locale: es })}`
+})
+
+const applySuggestedWindow = async () => {
+  suggestedLoading.value = true
+  timeError.value = null
+  try {
+    const res = await $fetch<{ success: boolean; data: {
+      periodStart: string
+      periodEnd: string
+      periodStartTime: string
+      periodEndTime: string
+    } }>('/api/cierre/suggested-window', { params: { date: periodStart.value } })
+    const d = res.data
+    if (arqueoWindowMode.value === 'template') {
+      const anchor = new Date(`${d.periodStart}T12:00:00`)
+      dateRangeDates.value = [anchor, anchor]
+    } else {
+      dateRangeDates.value = [
+        new Date(`${d.periodStart}T12:00:00`),
+        new Date(`${d.periodEnd}T12:00:00`),
+      ]
+      enableTimePicker.value = true
+      startTimeInput.value = fnsFormat(new Date(d.periodStartTime), 'HH:mm')
+      endTimeInput.value = fnsFormat(new Date(d.periodEndTime), 'HH:mm')
+    }
+    activePreset.value = null
+  } catch (err: any) {
+    timeError.value = err?.data?.detail ?? err?.data?.message ?? 'No hay ventana sugerida desde el último arqueo.'
+  } finally {
+    suggestedLoading.value = false
+  }
+}
 
 const periodStartTime = computed((): string | null => {
+  if (arqueoWindowMode.value === 'template') return null
   if (!enableTimePicker.value) return null
   return buildDateTime(dateRangeDates.value[0], startTimeInput.value)?.toISOString() ?? null
 })
 const periodEndTime = computed((): string | null => {
+  if (arqueoWindowMode.value === 'template') return null
   if (!enableTimePicker.value) return null
   return buildDateTime(dateRangeDates.value[1] ?? dateRangeDates.value[0], endTimeInput.value)?.toISOString() ?? null
 })
+
+const buildPreviewParams = (completedOnly: boolean) => {
+  const base: Record<string, string | boolean> = {
+    period_start: periodStart.value,
+    period_end: periodEnd.value,
+  }
+  if (completedOnly) base.completed_only = true
+  if (previewShiftTemplateId.value) {
+    base.shift_template_id = previewShiftTemplateId.value
+    return base
+  }
+  if (periodStartTime.value) base.period_start_time = periodStartTime.value
+  if (periodEndTime.value) base.period_end_time = periodEndTime.value
+  return base
+}
 
 const shiftLabel = computed(() => {
   if (!enableTimePicker.value) return null
@@ -893,16 +1065,11 @@ const shiftLabel = computed(() => {
 
 // X preview (paso 0 — all orders, not completed_only)
 const { data: rawXPreview, status: xPreviewStatus, error: xPreviewError } = useQuery({
-  key: () => ['cierre', 'preview-x0', currentTenant.value?.id, periodStart.value, periodEnd.value, periodStartTime.value, periodEndTime.value],
+  key: () => ['cierre', 'preview-x0', currentTenant.value?.id, arqueoWindowMode.value, previewShiftTemplateId.value, periodStart.value, periodEnd.value, periodStartTime.value, periodEndTime.value],
   query: () => $fetch<{ success: boolean; data: Record<string, any> }>('/api/cierre/preview', {
-    params: {
-      period_start: periodStart.value,
-      period_end:   periodEnd.value,
-      ...(periodStartTime.value && { period_start_time: periodStartTime.value }),
-      ...(periodEndTime.value   && { period_end_time:   periodEndTime.value   }),
-    },
+    params: buildPreviewParams(false),
   }),
-  enabled: () => !!currentTenant.value,
+  enabled: () => !!currentTenant.value && (arqueoWindowMode.value !== 'template' || !!selectedTemplateId.value),
   staleTime: 60_000,
 })
 const xPreviewData    = computed(() => rawXPreview.value?.data ?? null)
@@ -911,7 +1078,16 @@ const xPreviewLoading = computed(() => xPreviewStatus.value === 'pending' && !xP
 // Navigate to step 1
 const goToStep1 = () => {
   timeError.value = null
-  if (isMultiDay.value && (!startTimeInput.value || !endTimeInput.value)) {
+  if (arqueoWindowMode.value === 'template') {
+    if (!selectedTemplateId.value) {
+      timeError.value = 'Selecciona un turno para continuar'
+      return
+    }
+    if (isMultiDay.value) {
+      timeError.value = 'La plantilla de turno solo aplica a un solo día'
+      return
+    }
+  } else if (isMultiDay.value && (!startTimeInput.value || !endTimeInput.value)) {
     timeError.value = 'Para períodos de varios días debes especificar hora de inicio y fin'
     return
   }
@@ -957,17 +1133,11 @@ const totalCounted = computed(() =>
 
 // ── Preview API (completed orders only — cash already in drawer) ───────────
 const { data: rawPreview, status: previewStatus, asyncStatus: previewAsyncStatus, refetch: refetchPreview } = useQuery({
-  key: () => ['cierre', 'preview-z', currentTenant.value?.id, periodStart.value, periodEnd.value, periodStartTime.value, periodEndTime.value],
+  key: () => ['cierre', 'preview-z', currentTenant.value?.id, arqueoWindowMode.value, previewShiftTemplateId.value, periodStart.value, periodEnd.value, periodStartTime.value, periodEndTime.value],
   query: () => $fetch<{ success: boolean; data: Record<string, any> }>('/api/cierre/preview', {
-    params: {
-      period_start:  periodStart.value,
-      period_end:    periodEnd.value,
-      completed_only: true,
-      ...(periodStartTime.value && { period_start_time: periodStartTime.value }),
-      ...(periodEndTime.value   && { period_end_time:   periodEndTime.value   }),
-    },
+    params: buildPreviewParams(true),
   }),
-  enabled: () => !!currentTenant.value,
+  enabled: () => !!currentTenant.value && currentStep.value >= 1 && (arqueoWindowMode.value !== 'template' || !!selectedTemplateId.value),
   staleTime: 0,
 })
 
@@ -1072,16 +1242,21 @@ const submitCierre = async () => {
   isSubmitting.value = true
   submitError.value  = null
   try {
+    const body: Record<string, unknown> = {
+      periodStart: periodStart.value,
+      periodEnd: periodEnd.value,
+      cashCounted: totalCounted.value,
+      notes: notes.value || null,
+    }
+    if (arqueoWindowMode.value === 'template' && selectedTemplateId.value) {
+      body.shiftTemplateId = selectedTemplateId.value
+    } else {
+      if (periodStartTime.value) body.periodStartTime = periodStartTime.value
+      if (periodEndTime.value) body.periodEndTime = periodEndTime.value
+    }
     const result = await $fetch<{ success: boolean; data: Record<string, any> }>('/api/cierre', {
       method: 'POST',
-      body: {
-        periodStart:      periodStart.value,
-        periodEnd:        periodEnd.value,
-        ...(periodStartTime.value && { periodStartTime: periodStartTime.value }),
-        ...(periodEndTime.value   && { periodEndTime:   periodEndTime.value   }),
-        cashCounted:      totalCounted.value,
-        notes:            notes.value || null,
-      },
+      body,
     })
     successData.value = result.data
     cierreSuccess.value = true

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -112,7 +112,7 @@
         <!-- Plantilla: un solo control — día (calendario) + horas del turno (solo lectura) -->
         <div
           v-if="arqueoWindowMode === 'template'"
-          class="arqueo-template-period relative flex items-center h-10 rounded-lg border-2 border-border bg-background flex-shrink-0"
+          class="arqueo-template-period relative flex items-center h-10 w-fit rounded-lg border-2 border-border bg-background flex-shrink-0"
         >
           <VueDatePicker
             v-model="templateAnchorDate"
@@ -125,13 +125,13 @@
             :clearable="false"
             menu-class-name="dp-custom-menu"
             calendar-cell-class-name="dp-custom-cell"
-            class="arqueo-template-dp-trigger flex-shrink-0"
+            class="arqueo-template-dp-trigger w-fit flex-shrink-0"
             @update:model-value="onTemplateAnchorPick"
           >
             <template #trigger>
               <button
                 type="button"
-                class="flex items-center gap-1.5 h-10 px-3 text-sm text-text-primary hover:bg-surface-secondary/60 transition-colors rounded-l-md"
+                class="flex w-fit items-center gap-1.5 h-10 px-3 text-sm text-text-primary hover:bg-surface-secondary/60 transition-colors rounded-l-md"
               >
                 <svg class="w-4 h-4 text-text-secondary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
@@ -1446,8 +1446,10 @@ const formatPeriod = (start: string, end: string) => {
 
 <style>
 .arqueo-template-dp-trigger {
-  display: inline-flex;
-  height: 2.5rem;
+  display: inline-flex !important;
+  width: fit-content !important;
+  max-width: fit-content !important;
+  height: 2.5rem !important;
   flex-shrink: 0;
 }
 .arqueo-template-dp-trigger :deep(.dp__input_wrap),
@@ -1459,14 +1461,19 @@ const formatPeriod = (start: string, end: string) => {
 .arqueo-template-dp-trigger :deep(.dp__main > div) {
   display: inline-flex !important;
   align-items: stretch !important;
+  width: fit-content !important;
+  max-width: fit-content !important;
   height: 2.5rem !important;
-  width: auto !important;
-  min-width: 0 !important;
+  min-width: unset !important;
   min-height: 0 !important;
   padding: 0 !important;
   margin: 0 !important;
   border: none !important;
   background: transparent !important;
   box-shadow: none !important;
+}
+.arqueo-template-dp-trigger :deep(.dp__main > div > button) {
+  width: fit-content !important;
+  min-width: unset !important;
 }
 </style>

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -110,20 +110,38 @@
           @click="applyPreset(p)"
         >{{ p.label }}</button>
 
-        <VueDatePicker
+        <!-- Plantilla: calendario = solo día; horas = ventana del turno (solo lectura) -->
+        <div
           v-if="arqueoWindowMode === 'template'"
-          v-model="templateAnchorDate"
-          :teleport="true"
-          :enable-time-picker="false"
-          :locale="es"
-          auto-apply
-          :max-date="new Date()"
-          :format="formatTemplatePickerInput"
-          input-class-name="dp-custom-input !min-w-[10.5rem] sm:!min-w-[12rem]"
-          menu-class-name="dp-custom-menu"
-          calendar-cell-class-name="dp-custom-cell"
-          @update:model-value="onTemplateAnchorPick"
-        />
+          class="flex items-stretch h-10 rounded-lg border-2 border-border bg-background overflow-hidden flex-shrink-0"
+        >
+          <VueDatePicker
+            v-model="templateAnchorDate"
+            :teleport="true"
+            :enable-time-picker="false"
+            :locale="es"
+            auto-apply
+            :max-date="new Date()"
+            :format="formatTemplateDateOnly"
+            input-class-name="dp-custom-input !border-0 !rounded-none !shadow-none !min-w-[5.25rem] !w-[5.25rem] sm:!min-w-[5.75rem] sm:!w-[5.75rem]"
+            menu-class-name="dp-custom-menu"
+            calendar-cell-class-name="dp-custom-cell"
+            @update:model-value="onTemplateAnchorPick"
+          />
+          <span
+            v-if="templateHoursLabel"
+            class="flex items-center px-2.5 text-sm font-mono text-text-secondary border-l border-border whitespace-nowrap"
+            title="Horario definido por el turno"
+          >
+            {{ templateHoursLabel }}
+          </span>
+          <span
+            v-else-if="selectedTemplateId && templateWindowStatus === 'pending'"
+            class="flex items-center px-2.5 text-xs text-text-secondary border-l border-border"
+          >
+            …
+          </span>
+        </div>
 
         <VueDatePicker
           v-else
@@ -1026,23 +1044,22 @@ const { data: rawTemplateWindow, status: templateWindowStatus } = useQuery({
   staleTime: 30_000,
 })
 
-const templatePeriodDisplay = computed(() => {
+const formatTemplateDateOnly = (date?: Date) =>
+  fnsFormat(date ?? templateAnchorDate.value, 'dd/MM/yy', { locale: es })
+
+/** Horas del turno resueltas en servidor — no editables en plantilla */
+const templateHoursLabel = computed(() => {
   const w = rawTemplateWindow.value?.data
-  if (!w?.periodStartTime || !w?.periodEndTime) {
-    if (templateWindowStatus.value === 'pending' && selectedTemplateId.value) return 'Calculando…'
-    return fnsFormat(templateAnchorDate.value, 'dd/MM/yy', { locale: es })
-  }
+  if (!w?.periodStartTime || !w?.periodEndTime) return null
   const start = new Date(w.periodStartTime)
   const end = new Date(w.periodEndTime)
-  const anchor = fnsFormat(start, 'dd/MM/yy', { locale: es })
   const startT = fnsFormat(start, 'HH:mm')
   const endT = fnsFormat(end, 'HH:mm')
-  const endDay = fnsFormat(end, 'dd/MM/yy', { locale: es })
-  if (anchor === endDay) return `${anchor} · ${startT} – ${endT}`
-  return `${anchor} ${startT} – ${endDay} ${endT}`
+  const endDay = fnsFormat(end, 'dd/MM', { locale: es })
+  const anchorDay = fnsFormat(start, 'dd/MM', { locale: es })
+  if (anchorDay === endDay) return `${startT} – ${endT}`
+  return `${startT} – ${endDay} ${endT}`
 })
-
-const formatTemplatePickerInput = () => templatePeriodDisplay.value
 
 const onTemplateAnchorPick = () => {
   const anchor = fnsFormat(templateAnchorDate.value, 'yyyy-MM-dd')

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -60,7 +60,6 @@
     <!-- ── PASO 0: Seleccionar período ─────────────────────────────────── -->
     <template v-else-if="currentStep === 0">
       <div class="flex items-center gap-2 w-full overflow-x-auto scrollbar-hide mb-2">
-        <span class="text-xs font-medium text-text-secondary uppercase tracking-wide flex-shrink-0">Modo</span>
         <button
           type="button"
           class="h-10 px-3 rounded-lg border-2 text-sm font-medium transition-colors flex-shrink-0"
@@ -1446,13 +1445,28 @@ const formatPeriod = (start: string, end: string) => {
 </script>
 
 <style>
+.arqueo-template-dp-trigger {
+  display: inline-flex;
+  height: 2.5rem;
+  flex-shrink: 0;
+}
 .arqueo-template-dp-trigger :deep(.dp__input_wrap),
 .arqueo-template-dp-trigger :deep(.dp__input),
 .arqueo-template-dp-trigger :deep(.dp--clear-btn) {
   display: none !important;
 }
-.arqueo-template-dp-trigger :deep(.dp__main) {
+.arqueo-template-dp-trigger :deep(.dp__main),
+.arqueo-template-dp-trigger :deep(.dp__main > div) {
+  display: inline-flex !important;
+  align-items: stretch !important;
+  height: 2.5rem !important;
+  width: auto !important;
+  min-width: 0 !important;
+  min-height: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
   border: none !important;
   background: transparent !important;
+  box-shadow: none !important;
 }
 </style>

--- a/pages/operaciones.vue
+++ b/pages/operaciones.vue
@@ -17,6 +17,7 @@ definePageMeta({
 const navigationItems = computed(() => [
   { to: '/operaciones/comandas', label: 'Comandas & Cocina' },
   { to: '/operaciones/mesas', label: plural.value },
+  { to: '/operaciones/turnos', label: 'Turnos' },
   { to: '/operaciones/personalizar', label: 'Personalizar' },
   { to: '/operaciones/propinas', label: 'Propinas' },
 ])

--- a/pages/operaciones/turnos.vue
+++ b/pages/operaciones/turnos.vue
@@ -7,15 +7,6 @@
     <CommonsTheErrorState v-else-if="fetchError" />
 
     <template v-else>
-      <p class="text-sm text-text-secondary leading-relaxed">
-        Define turnos reutilizables para arqueos de caja por horario.
-        Para ventanas únicas sin plantilla, usa
-        <NuxtLink to="/finanzas/arqueo/z" class="text-primary font-medium hover:underline">
-          arqueo por turno u horario
-        </NuxtLink>
-        en Finanzas.
-      </p>
-
       <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <p class="text-sm text-text-secondary">
           {{ activeCount }} activo{{ activeCount === 1 ? '' : 's' }}
@@ -40,12 +31,11 @@
         <template #card="{ item, index }">
           <div
             v-if="item"
-            class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors cursor-pointer hover:bg-surface-secondary"
+            class="flex items-center gap-2 py-3 px-3 border-b border-border"
             :class="[
               index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30',
               !item.is_active && 'opacity-60',
             ]"
-            @click="openEdit(item)"
           >
             <div class="flex-1 min-w-0">
               <span class="text-sm font-semibold text-text-primary">{{ item.name }}</span>
@@ -57,6 +47,37 @@
               :variant="item.is_active ? 'success' : 'secondary'"
               size="sm"
             />
+            <div class="flex items-center gap-0.5 flex-shrink-0">
+              <button
+                type="button"
+                :aria-label="`Editar ${item.name}`"
+                title="Editar"
+                class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
+                @click="openEdit(item)"
+              >
+                <PencilSquareIcon class="w-4 h-4" />
+              </button>
+              <button
+                v-if="item.is_active"
+                type="button"
+                :aria-label="`Desactivar ${item.name}`"
+                title="Desactivar"
+                class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-amber-600 hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-400/30 transition-colors"
+                @click="requestDeactivate(item)"
+              >
+                <NoSymbolIcon class="w-4 h-4" />
+              </button>
+              <button
+                v-else
+                type="button"
+                :aria-label="`Reactivar ${item.name}`"
+                title="Reactivar"
+                class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-primary hover:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
+                @click="reactivate(item)"
+              >
+                <ArrowPathIcon class="w-4 h-4" />
+              </button>
+            </div>
           </div>
         </template>
 
@@ -78,29 +99,35 @@
         </template>
 
         <template #cell-actions="{ row }">
-          <div class="flex items-center justify-end gap-1" @click.stop>
+          <div class="flex items-center justify-end gap-0.5">
             <button
               type="button"
-              class="min-h-[36px] px-2.5 text-xs font-medium rounded-lg text-text-secondary hover:bg-surface-secondary"
+              :aria-label="`Editar ${row.name}`"
+              title="Editar"
+              class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
               @click="openEdit(row)"
             >
-              Editar
+              <PencilSquareIcon class="w-4 h-4" />
             </button>
             <button
               v-if="row.is_active"
               type="button"
-              class="min-h-[36px] px-2.5 text-xs font-medium rounded-lg text-destructive hover:bg-destructive/10"
+              :aria-label="`Desactivar ${row.name}`"
+              title="Desactivar"
+              class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-amber-600 hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-400/30 transition-colors"
               @click="requestDeactivate(row)"
             >
-              Desactivar
+              <NoSymbolIcon class="w-4 h-4" />
             </button>
             <button
               v-else
               type="button"
-              class="min-h-[36px] px-2.5 text-xs font-medium rounded-lg text-primary hover:bg-primary/10"
+              :aria-label="`Reactivar ${row.name}`"
+              title="Reactivar"
+              class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-primary hover:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
               @click="reactivate(row)"
             >
-              Reactivar
+              <ArrowPathIcon class="w-4 h-4" />
             </button>
           </div>
         </template>
@@ -127,6 +154,7 @@
 </template>
 
 <script setup lang="ts">
+import { ArrowPathIcon, NoSymbolIcon, PencilSquareIcon } from '@heroicons/vue/24/outline'
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
 import type { ShiftTemplate } from '~/components/operaciones/ShiftTemplatePanel.vue'
 

--- a/pages/operaciones/turnos.vue
+++ b/pages/operaciones/turnos.vue
@@ -1,0 +1,241 @@
+<template>
+  <div class="space-y-4">
+    <div v-if="isLoading" class="flex items-center justify-center min-h-[300px]">
+      <CommonsTheCustomLoader size="large" />
+    </div>
+
+    <CommonsTheErrorState v-else-if="fetchError" />
+
+    <template v-else>
+      <p class="text-sm text-text-secondary leading-relaxed">
+        Define turnos reutilizables para arqueos de caja por horario.
+        Para ventanas únicas sin plantilla, usa
+        <NuxtLink to="/finanzas/arqueo/z" class="text-primary font-medium hover:underline">
+          arqueo por turno u horario
+        </NuxtLink>
+        en Finanzas.
+      </p>
+
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p class="text-sm text-text-secondary">
+          {{ activeCount }} activo{{ activeCount === 1 ? '' : 's' }}
+          <span v-if="inactiveCount"> · {{ inactiveCount }} inactivo{{ inactiveCount === 1 ? '' : 's' }}</span>
+        </p>
+        <button
+          type="button"
+          class="btn-primary px-4 py-2 rounded-lg text-sm font-medium min-h-[44px] whitespace-nowrap"
+          @click="openCreate"
+        >
+          + Nuevo turno
+        </button>
+      </div>
+
+      <UiResponsiveDataView
+        :columns="columns"
+        :data="templates"
+        empty-message="No hay turnos configurados"
+        empty-sub-message='Crea el primero, por ejemplo "Mañana 06:00–14:00".'
+        row-size="sm"
+      >
+        <template #card="{ item, index }">
+          <div
+            v-if="item"
+            class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors cursor-pointer hover:bg-surface-secondary"
+            :class="[
+              index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30',
+              !item.is_active && 'opacity-60',
+            ]"
+            @click="openEdit(item)"
+          >
+            <div class="flex-1 min-w-0">
+              <span class="text-sm font-semibold text-text-primary">{{ item.name }}</span>
+              <p class="text-xs text-text-secondary mt-0.5">{{ formatSchedule(item) }}</p>
+            </div>
+            <UiStatusBadge
+              :value="item.is_active ? 'Activo' : 'Inactivo'"
+              format="text"
+              :variant="item.is_active ? 'success' : 'secondary'"
+              size="sm"
+            />
+          </div>
+        </template>
+
+        <template #cell-name="{ row }">
+          <span class="font-medium text-text-primary" :class="{ 'opacity-60': !row.is_active }">{{ row.name }}</span>
+        </template>
+
+        <template #cell-schedule="{ row }">
+          <span class="text-sm text-text-secondary">{{ formatSchedule(row) }}</span>
+        </template>
+
+        <template #cell-status="{ row }">
+          <UiStatusBadge
+            :value="row.is_active ? 'Activo' : 'Inactivo'"
+            format="text"
+            :variant="row.is_active ? 'success' : 'secondary'"
+            size="sm"
+          />
+        </template>
+
+        <template #cell-actions="{ row }">
+          <div class="flex items-center justify-end gap-1" @click.stop>
+            <button
+              type="button"
+              class="min-h-[36px] px-2.5 text-xs font-medium rounded-lg text-text-secondary hover:bg-surface-secondary"
+              @click="openEdit(row)"
+            >
+              Editar
+            </button>
+            <button
+              v-if="row.is_active"
+              type="button"
+              class="min-h-[36px] px-2.5 text-xs font-medium rounded-lg text-destructive hover:bg-destructive/10"
+              @click="requestDeactivate(row)"
+            >
+              Desactivar
+            </button>
+            <button
+              v-else
+              type="button"
+              class="min-h-[36px] px-2.5 text-xs font-medium rounded-lg text-primary hover:bg-primary/10"
+              @click="reactivate(row)"
+            >
+              Reactivar
+            </button>
+          </div>
+        </template>
+      </UiResponsiveDataView>
+    </template>
+
+    <OperacionesShiftTemplatePanel
+      v-model="panelOpen"
+      :template="panelTemplate"
+      @saved="onSaved"
+    />
+
+    <UiConfirmActionModal
+      v-model="confirmOpen"
+      title="Desactivar turno"
+      :message="confirmMessage"
+      confirm-label="Desactivar"
+      loading-label="Desactivando..."
+      variant="destructive"
+      :loading="isDeactivating"
+      @confirm="performDeactivate"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Column } from '~/components/ui/ResponsiveDataView.vue'
+import type { ShiftTemplate } from '~/components/operaciones/ShiftTemplatePanel.vue'
+
+definePageMeta({ layout: 'dashboard' })
+useHead({ title: 'Turnos | Operaciones' })
+
+const { currentTenant } = useTenantReactive()
+const cache = useQueryCache()
+const toast = useToast()
+const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
+
+const columns: Column[] = [
+  { key: 'name', title: 'Turno', sortable: false },
+  { key: 'schedule', title: 'Horario', sortable: false },
+  { key: 'status', title: 'Estado', sortable: false, align: 'center' },
+  { key: 'actions', title: '', sortable: false, align: 'right' },
+]
+
+const {
+  data: shiftsData,
+  status: shiftsStatus,
+  asyncStatus: shiftsAsyncStatus,
+  error: fetchError,
+  refetch,
+} = useQuery({
+  key: () => ['operaciones', 'shifts', currentTenant.value?.id],
+  query: () => $fetch<{ success: boolean; data: ShiftTemplate[] }>(
+    '/api/operaciones/shifts',
+    { query: { include_inactive: true } },
+  ),
+  enabled: () => !!currentTenant.value,
+  staleTime: 30_000,
+})
+
+const templates = computed(() => shiftsData.value?.data ?? [])
+const isLoading = computed(() => shiftsStatus.value === 'pending' && !shiftsData.value)
+const isRefreshing = computed(() => shiftsAsyncStatus.value === 'loading' && !!shiftsData.value)
+const activeCount = computed(() => templates.value.filter(t => t.is_active).length)
+const inactiveCount = computed(() => templates.value.filter(t => !t.is_active).length)
+
+registerProgressiveLoading(isRefreshing)
+onMounted(() => setRefreshHandler(refetch))
+onUnmounted(() => clearRefreshHandler())
+
+const formatTime = (t: string) => (t?.length >= 5 ? t.slice(0, 5) : t)
+const formatSchedule = (row: ShiftTemplate) => {
+  const start = formatTime(row.start_time)
+  const end = formatTime(row.end_time)
+  return row.crosses_midnight ? `${start} – ${end} (día siguiente)` : `${start} – ${end}`
+}
+
+const panelOpen = ref(false)
+const panelTemplate = ref<ShiftTemplate | null>(null)
+
+const openCreate = () => {
+  panelTemplate.value = null
+  panelOpen.value = true
+}
+
+const openEdit = (row: ShiftTemplate) => {
+  panelTemplate.value = row
+  panelOpen.value = true
+}
+
+const onSaved = async () => {
+  await cache.invalidateQueries({ key: ['operaciones', 'shifts'] })
+  toast.success('Turno guardado correctamente')
+}
+
+const confirmOpen = ref(false)
+const confirmMessage = ref('')
+const pendingDeactivate = ref<ShiftTemplate | null>(null)
+const isDeactivating = ref(false)
+
+const requestDeactivate = (row: ShiftTemplate) => {
+  pendingDeactivate.value = row
+  confirmMessage.value = `¿Desactivar "${row.name}"? No aparecerá al cerrar caja, pero los arqueos pasados no se modifican.`
+  confirmOpen.value = true
+}
+
+const performDeactivate = async () => {
+  const row = pendingDeactivate.value
+  if (!row) return
+  isDeactivating.value = true
+  try {
+    await $fetch(`/api/operaciones/shifts/${row.id}`, {
+      method: 'PATCH',
+      body: { is_active: false },
+    })
+    await cache.invalidateQueries({ key: ['operaciones', 'shifts'] })
+    toast.success(`Turno "${row.name}" desactivado`)
+    confirmOpen.value = false
+  } catch (err: any) {
+    toast.error(err?.data?.detail || 'No se pudo desactivar el turno', { title: 'Error' })
+  } finally {
+    isDeactivating.value = false
+  }
+}
+
+const reactivate = async (row: ShiftTemplate) => {
+  try {
+    await $fetch(`/api/operaciones/shifts/${row.id}`, {
+      method: 'PATCH',
+      body: { is_active: true },
+    })
+    await cache.invalidateQueries({ key: ['operaciones', 'shifts'] })
+    toast.success(`Turno "${row.name}" reactivado`)
+  } catch (err: any) {
+    toast.error(err?.data?.detail || 'No se pudo reactivar el turno', { title: 'Error' })
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
- Extend `useCierrePeriod` with three-way labels: template name | Personalizado | Día completo
- Badge styling distinguishes template (primary), custom (violet), and full-day (neutral)
- Historial, detail page, and `CierrePanel` use `periodBadgeClass` and API `shiftTemplateName`

## Testing
- Open `/finanzas/arqueo` with mixed arqueos (template, custom window, full day)
- Verify badge text and `HH:mm – HH:mm` line under each row

Closes #687

Made with [Cursor](https://cursor.com)