### PR TITLE
chore(permissions): gate arqueo under finanzas and turnos under operaciones

### DIFF
--- a/pages/finanzas/arqueo/[id].vue
+++ b/pages/finanzas/arqueo/[id].vue
@@ -171,7 +171,7 @@ const GROUP_LABELS: Record<string, string> = {
   credit:  'Crédito',
 }
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 const { currentTenant } = useTenantReactive()

--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -124,10 +124,6 @@
             </div>
           </NuxtLink>
         </div>
-        <p class="text-xs text-text-secondary mt-2">
-          Los turnos fijos se administran en
-          <NuxtLink to="/operaciones/turnos" class="text-primary font-medium hover:underline">Operaciones → Turnos</NuxtLink>.
-        </p>
       </div>
       <p class="text-xs text-text-secondary">
         ¿Solo quieres revisar sin cerrar?
@@ -284,7 +280,7 @@ import MetricCard from '~/components/shared/MetricCard.vue'
 // @ts-ignore
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Arqueo de caja - Warocol' })
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()

--- a/pages/finanzas/arqueo/nuevo.vue
+++ b/pages/finanzas/arqueo/nuevo.vue
@@ -710,7 +710,7 @@ import { es } from 'date-fns/locale'
 import { format as fnsFormat } from 'date-fns'
 import { useQueryCache } from '@pinia/colada'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Nuevo arqueo de caja - Warocol' })
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()

--- a/pages/finanzas/arqueo/x.vue
+++ b/pages/finanzas/arqueo/x.vue
@@ -170,7 +170,7 @@ import { useFormatters } from '~/composables/useFormatters'
 import { es } from 'date-fns/locale'
 import { format as fnsFormat } from 'date-fns'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Previsualización arqueo - Warocol' })
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -876,7 +876,7 @@ import { useFormatters } from '~/composables/useFormatters'
 import { es } from 'date-fns/locale'
 import { format as fnsFormat, formatDistanceStrict } from 'date-fns'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Arqueo de caja - Warocol' })
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()

--- a/pages/operaciones/turnos.vue
+++ b/pages/operaciones/turnos.vue
@@ -158,7 +158,7 @@ import { ArrowPathIcon, NoSymbolIcon, PencilSquareIcon } from '@heroicons/vue/24
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
 import type { ShiftTemplate } from '~/components/operaciones/ShiftTemplatePanel.vue'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'operaciones' })
 useHead({ title: 'Turnos | Operaciones' })
 
 const { currentTenant } = useTenantReactive()


### PR DESCRIPTION
## What this issue is about (Closes #689)

Epic #678 — **separate config vs execution** for shift-based arqueos:

### Intended behavior
- **Arqueo (cash count)** → module **`finanzas`**: historial, nuevo, plantilla/custom wizards, all `/api/cierre/*`
- **Turn templates (CRUD)** → module **`operaciones`**: `/operaciones/turnos`, `/api/operaciones/shifts`
- Users with **Finanzas only** can arquear using templates (read via `/cierre/shift-templates`) but get **403** if they try to edit templates in Operaciones
- **Operaciones** sub-nav “Turnos” only appears for users who can access Operaciones (parent route already gated)

### Roles (default matrix, when `enforce` is on)
| Role | Finanzas (arqueo) | Operaciones (turnos config) |
|------|-------------------|-----------------------------|
| Owner / Admin | Yes | Yes |
| Supervisor | No | Yes |
| Cashier | No | No |

Arqueo is **not** a separate permission — same as full Finanzas. Tenant owner can grant Finanzas to any role via overrides.

### What this PR does
- Explicit `definePageMeta({ module: 'finanzas' })` on all `/finanzas/arqueo/*` pages
- Explicit `definePageMeta({ module: 'operaciones' })` on `/operaciones/turnos`
- When tenant `enforcement_mode === 'enforce'`, users without the module are redirected to `/403` (middleware + access-watcher)

API gates already exist — see api-warolabs PR for tests.

## Testing
1. With enforce off (default): no change in behavior
2. With enforce on + admin: arqueo + turnos OK
3. With enforce on + supervisor: turnos OK, arqueo → 403
4. With enforce on + cashier: both → 403

Closes #689

Made with [Cursor](https://cursor.com)