### PR TITLE
fix(#698): use America/Bogota calendar dates in all arqueo flows

### DIFF
--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -82,7 +82,7 @@
         <h2 class="text-sm font-semibold text-text-primary mb-2">Nuevo arqueo</h2>
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
           <NuxtLink
-            to="/finanzas/arqueo/nuevo"
+            :to="`/finanzas/arqueo/nuevo?start=${today}&end=${today}`"
             class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/30 bg-primary/5 hover:bg-primary/10 transition-colors min-h-[44px]"
           >
             <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-primary/15 flex items-center justify-center text-primary" aria-hidden="true">
@@ -96,7 +96,7 @@
             </div>
           </NuxtLink>
           <NuxtLink
-            to="/finanzas/arqueo/z?mode=template"
+            :to="`/finanzas/arqueo/z?mode=template&start=${today}&end=${today}`"
             class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/20 bg-surface hover:border-primary/40 hover:bg-primary/5 transition-colors min-h-[44px]"
           >
             <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
@@ -110,7 +110,7 @@
             </div>
           </NuxtLink>
           <NuxtLink
-            to="/finanzas/arqueo/z?mode=custom"
+            :to="`/finanzas/arqueo/z?mode=custom&start=${today}&end=${today}`"
             class="flex items-start gap-3 p-4 rounded-lg border-2 border-violet-200 bg-violet-50/40 hover:border-violet-300 hover:bg-violet-50 transition-colors min-h-[44px]"
           >
             <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-violet-100 flex items-center justify-center text-violet-800" aria-hidden="true">
@@ -127,7 +127,7 @@
       </div>
       <p class="text-xs text-text-secondary">
         ¿Solo quieres revisar sin cerrar?
-        <NuxtLink to="/finanzas/arqueo/x" class="text-primary font-medium hover:underline">Vista previa (Corte X)</NuxtLink>
+        <NuxtLink :to="`/finanzas/arqueo/x?start=${today}&end=${today}`" class="text-primary font-medium hover:underline">Vista previa (Corte X)</NuxtLink>
       </p>
 
       <!-- ── Historial ─────────────────────────────────────────────────────── -->
@@ -276,6 +276,13 @@ import { useQueryCache } from '@pinia/colada'
 import { useFormatters } from '~/composables/useFormatters'
 import { es } from 'date-fns/locale'
 import { format as fnsFormat } from 'date-fns'
+import {
+  addDaysBogotaISO,
+  bogotaDateAtNoon,
+  bogotaISOFromDate,
+  bogotaMonthBounds,
+  todayBogotaISO,
+} from '~/utils/bogotaDate'
 import MetricCard from '~/components/shared/MetricCard.vue'
 // @ts-ignore
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
@@ -287,15 +294,16 @@ const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = u
 const { currentTenant } = useTenantReactive()
 const { singular: tableSingular, plural: tablePlural } = useTableLabel()
 
-const today = new Date().toISOString().split('T')[0]
+const today = todayBogotaISO()
+const todayNoon = bogotaDateAtNoon(today)
 
 const dateRangeDates = ref<Date[] | null>(null)
 
 const presetDates = ref([
-  { label: 'Hoy',           value: [new Date(), new Date()] },
-  { label: 'Ayer',          value: (() => { const d = new Date(); d.setDate(d.getDate() - 1); return [d, d] })() },
-  { label: 'Última semana', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 7); return d })(), new Date()] },
-  { label: 'Último mes',    value: [(() => { const d = new Date(); d.setDate(d.getDate() - 30); return d })(), new Date()] },
+  { label: 'Hoy',           value: [new Date(todayNoon), new Date(todayNoon)] },
+  { label: 'Ayer',          value: (() => { const d = bogotaDateAtNoon(addDaysBogotaISO(today, -1)); return [d, d] })() },
+  { label: 'Última semana', value: [bogotaDateAtNoon(addDaysBogotaISO(today, -7)), new Date(todayNoon)] },
+  { label: 'Último mes',    value: [bogotaDateAtNoon(addDaysBogotaISO(today, -30)), new Date(todayNoon)] },
 ])
 
 const formatDateRange = (dates: Date[]) => {
@@ -306,10 +314,10 @@ const formatDateRange = (dates: Date[]) => {
 }
 
 const periodStart = computed(() =>
-  dateRangeDates.value?.[0] ? fnsFormat(dateRangeDates.value[0], 'yyyy-MM-dd') : today
+  dateRangeDates.value?.[0] ? bogotaISOFromDate(dateRangeDates.value[0]) : today
 )
 const periodEnd = computed(() =>
-  dateRangeDates.value?.[1] ? fnsFormat(dateRangeDates.value[1], 'yyyy-MM-dd') : today
+  dateRangeDates.value?.[1] ? bogotaISOFromDate(dateRangeDates.value[1]) : today
 )
 
 const activeStart = computed(() => dateRangeDates.value ? periodStart.value : null)
@@ -369,17 +377,13 @@ const formatCurrency = (value?: number) =>
   new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(value ?? 0)
 
 const filterCurrentMonth = () => {
-  const now = new Date()
-  const first = new Date(now.getFullYear(), now.getMonth(), 1)
-  const last  = new Date(now.getFullYear(), now.getMonth() + 1, 0)
-  dateRangeDates.value = [first, last]
+  const { first, last } = bogotaMonthBounds(today)
+  dateRangeDates.value = [bogotaDateAtNoon(first), bogotaDateAtNoon(last)]
 }
 
 const isCurrentMonthActive = computed(() => {
   if (!dateRangeDates.value?.[0] || !dateRangeDates.value?.[1]) return false
-  const now   = new Date()
-  const first = fnsFormat(new Date(now.getFullYear(), now.getMonth(), 1), 'yyyy-MM-dd')
-  const last  = fnsFormat(new Date(now.getFullYear(), now.getMonth() + 1, 0), 'yyyy-MM-dd')
+  const { first, last } = bogotaMonthBounds(today)
   return activeStart.value === first && activeEnd.value === last
 })
 

--- a/pages/finanzas/arqueo/nuevo.vue
+++ b/pages/finanzas/arqueo/nuevo.vue
@@ -709,6 +709,12 @@ import { useFormatters } from '~/composables/useFormatters'
 import { es } from 'date-fns/locale'
 import { format as fnsFormat } from 'date-fns'
 import { useQueryCache } from '@pinia/colada'
+import {
+  addDaysBogotaISO,
+  bogotaDateAtNoon,
+  bogotaISOFromDate,
+  todayBogotaISO,
+} from '~/utils/bogotaDate'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Nuevo arqueo de caja - Warocol' })
@@ -718,7 +724,7 @@ const { currentTenant } = useTenantReactive()
 const { singular: tableSingular, plural: tablePlural } = useTableLabel()
 const cache = useQueryCache()
 
-const today = new Date().toISOString().split('T')[0]
+const today = todayBogotaISO()
 
 // ── Último cierre ──────────────────────────────────────────────────────────
 
@@ -750,11 +756,9 @@ onUnmounted(() => { clearRefreshHandler(refetchUltimo) })
 // Día sugerido: el día siguiente al último cierre (si es ≤ hoy)
 const suggestedRange = computed(() => {
   if (!ultimoCierre.value) return null
-  const after = new Date(ultimoCierre.value.periodEnd + 'T12:00:00')
-  after.setDate(after.getDate() + 1)
-  const todayDate = new Date(); todayDate.setHours(12, 0, 0, 0)
-  if (after > todayDate) return null
-  return { start: fnsFormat(after, 'yyyy-MM-dd'), startDate: after }
+  const afterIso = addDaysBogotaISO(ultimoCierre.value.periodEnd, 1)
+  if (afterIso > today) return null
+  return { start: afterIso, startDate: bogotaDateAtNoon(afterIso) }
 })
 
 const applySuggested = () => {
@@ -767,17 +771,16 @@ const applySuggested = () => {
 
 interface Preset { key: string; label: string; date: Date }
 const buildPresets = (): Preset[] => {
-  const noon = (d: Date) => { d.setHours(12, 0, 0, 0); return d }
-  const now = noon(new Date())
-  const yesterday = noon(new Date()); yesterday.setDate(yesterday.getDate() - 1)
+  const todayNoon = bogotaDateAtNoon(today)
+  const yesterdayNoon = bogotaDateAtNoon(addDaysBogotaISO(today, -1))
   return [
-    { key: 'today',     label: 'Hoy',  date: new Date(now) },
-    { key: 'yesterday', label: 'Ayer', date: yesterday },
+    { key: 'today',     label: 'Hoy',  date: new Date(todayNoon) },
+    { key: 'yesterday', label: 'Ayer', date: yesterdayNoon },
   ]
 }
 const presets      = buildPresets()
 const activePreset = ref<string | null>('today')
-const selectedDate = ref<Date>(new Date(today + 'T12:00:00'))
+const selectedDate = ref<Date>(bogotaDateAtNoon(today))
 
 const applyPreset = (p: Preset) => {
   activePreset.value = p.key
@@ -788,7 +791,7 @@ const formatSingleDate = (date: Date) =>
   date ? fnsFormat(date, 'dd/MM/yy', { locale: es }) : ''
 
 // Period — siempre un solo día
-const periodStart = computed(() => fnsFormat(selectedDate.value, 'yyyy-MM-dd'))
+const periodStart = computed(() => bogotaISOFromDate(selectedDate.value))
 const periodEnd   = computed(() => periodStart.value)
 
 // X preview (paso 0 — all orders, not completed_only)
@@ -1008,7 +1011,7 @@ const loadFromStorage = () => {
   if (!raw) return
   try {
     const s = JSON.parse(raw)
-    if (s.periodStart) selectedDate.value = new Date(s.periodStart + 'T12:00:00')
+    if (s.periodStart) selectedDate.value = bogotaDateAtNoon(s.periodStart)
     // Never restore step from storage — always start at step 0 (X preview)
     if (s.counts)         counts.value         = s.counts
     if (s.monedasAmount)  monedasAmount.value  = s.monedasAmount

--- a/pages/finanzas/arqueo/x.vue
+++ b/pages/finanzas/arqueo/x.vue
@@ -169,6 +169,12 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 import { es } from 'date-fns/locale'
 import { format as fnsFormat } from 'date-fns'
+import {
+  addDaysBogotaISO,
+  bogotaDateAtNoon,
+  bogotaISOFromDate,
+  todayBogotaISO,
+} from '~/utils/bogotaDate'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Previsualización arqueo - Warocol' })
@@ -178,7 +184,7 @@ const { currentTenant } = useTenantReactive()
 const { plural: tablePlural } = useTableLabel()
 const route = useRoute()
 
-const today = new Date().toISOString().split('T')[0]
+const today = todayBogotaISO()
 
 // Initialise from query params if present
 const initStart     = (route.query.start     as string) || today
@@ -186,17 +192,18 @@ const initEnd       = (route.query.end       as string) || today
 const initStartTime = (route.query.startTime as string) || null
 const initEndTime   = (route.query.endTime   as string) || null
 const dateRangeDates = ref<Date[] | null>([
-  new Date(initStart + 'T12:00:00'),
-  new Date(initEnd   + 'T12:00:00'),
+  bogotaDateAtNoon(initStart),
+  bogotaDateAtNoon(initEnd),
 ])
 const periodStartTime = ref<string | null>(initStartTime)
 const periodEndTime   = ref<string | null>(initEndTime)
 
+const todayNoon = bogotaDateAtNoon(today)
 const presetDates = ref([
-  { label: 'Hoy',           value: [new Date(), new Date()] },
-  { label: 'Ayer',          value: (() => { const d = new Date(); d.setDate(d.getDate() - 1); return [d, d] })() },
-  { label: 'Última semana', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 7); return d })(), new Date()] },
-  { label: 'Último mes',    value: [(() => { const d = new Date(); d.setDate(d.getDate() - 30); return d })(), new Date()] },
+  { label: 'Hoy',           value: [new Date(todayNoon), new Date(todayNoon)] },
+  { label: 'Ayer',          value: (() => { const d = bogotaDateAtNoon(addDaysBogotaISO(today, -1)); return [d, d] })() },
+  { label: 'Última semana', value: [bogotaDateAtNoon(addDaysBogotaISO(today, -7)), new Date(todayNoon)] },
+  { label: 'Último mes',    value: [bogotaDateAtNoon(addDaysBogotaISO(today, -30)), new Date(todayNoon)] },
 ])
 
 const formatDateRange = (dates: Date[]) => {
@@ -207,10 +214,10 @@ const formatDateRange = (dates: Date[]) => {
 }
 
 const periodStart = computed(() =>
-  dateRangeDates.value?.[0] ? fnsFormat(dateRangeDates.value[0], 'yyyy-MM-dd') : today
+  dateRangeDates.value?.[0] ? bogotaISOFromDate(dateRangeDates.value[0]) : today
 )
 const periodEnd = computed(() =>
-  dateRangeDates.value?.[1] ? fnsFormat(dateRangeDates.value[1], 'yyyy-MM-dd') : today
+  dateRangeDates.value?.[1] ? bogotaISOFromDate(dateRangeDates.value[1]) : today
 )
 
 const { data: rawPreview, status: previewStatus, asyncStatus: previewAsyncStatus, error: previewErr, refetch } = useQuery({

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -875,6 +875,14 @@ import { ref, computed, reactive, onMounted, onUnmounted, watch, nextTick } from
 import { useFormatters } from '~/composables/useFormatters'
 import { es } from 'date-fns/locale'
 import { format as fnsFormat, formatDistanceStrict } from 'date-fns'
+import {
+  addDaysBogotaISO,
+  bogotaDateAtNoon,
+  bogotaISOFromDate,
+  bogotaTimeHHMMFromISO,
+  combineBogotaDateAndTimeISO,
+  todayBogotaISO,
+} from '~/utils/bogotaDate'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Arqueo de caja - Warocol' })
@@ -899,29 +907,29 @@ const arqueoWindowMode = ref<ArqueoWindowMode>(
 const selectedTemplateId = ref<string>('')
 const suggestedLoading = ref(false)
 
-const today = new Date().toISOString().split('T')[0]
+const today = todayBogotaISO()
 
 // ── Date picker state (paso 0) ─────────────────────────────────────────────
 const initStart = (route.query.start as string) || today
 const initEnd   = (route.query.end   as string) || today
 
 const dateRangeDates = ref<Date[]>([
-  new Date(initStart + 'T12:00:00'),
-  new Date(initEnd   + 'T12:00:00'),
+  bogotaDateAtNoon(initStart),
+  bogotaDateAtNoon(initEnd),
 ])
 
 interface Preset { key: string; label: string; start: Date; end: Date }
 const buildPresets = (): Preset[] => {
-  const noon = (d: Date) => { d.setHours(12, 0, 0, 0); return d }
-  const now = noon(new Date())
-  const yesterday  = noon(new Date(now)); yesterday.setDate(now.getDate() - 1)
-  const weekStart  = noon(new Date(now)); weekStart.setDate(now.getDate() - 6)
-  const monthStart = noon(new Date(now.getFullYear(), now.getMonth(), 1))
+  const todayNoon = bogotaDateAtNoon(today)
+  const yesterdayNoon = bogotaDateAtNoon(addDaysBogotaISO(today, -1))
+  const weekStartNoon = bogotaDateAtNoon(addDaysBogotaISO(today, -6))
+  const [y, m] = today.split('-').map(Number)
+  const monthStartNoon = bogotaDateAtNoon(`${y}-${String(m).padStart(2, '0')}-01`)
   return [
-    { key: 'today',     label: 'Hoy',           start: new Date(now), end: new Date(now) },
-    { key: 'yesterday', label: 'Ayer',           start: yesterday,     end: yesterday },
-    { key: 'week',      label: 'Últimos 7 días', start: weekStart,     end: new Date(now) },
-    { key: 'month',     label: 'Este mes',        start: monthStart,    end: new Date(now) },
+    { key: 'today',     label: 'Hoy',           start: new Date(todayNoon), end: new Date(todayNoon) },
+    { key: 'yesterday', label: 'Ayer',           start: yesterdayNoon,       end: yesterdayNoon },
+    { key: 'week',      label: 'Últimos 7 días', start: weekStartNoon,       end: new Date(todayNoon) },
+    { key: 'month',     label: 'Este mes',        start: monthStartNoon,      end: new Date(todayNoon) },
   ]
 }
 const presets      = buildPresets()
@@ -987,15 +995,9 @@ const onTimeInput = (e: Event, field: 'start' | 'end') => {
   el.value = v
 }
 
-const buildDateTime = (datePart: Date, timeStr: string): Date | null => {
-  if (!timeStr || timeStr.length < 5) return null
-  const [h, m] = timeStr.split(':').map(Number)
-  const d = new Date(datePart); d.setHours(h, m, 0, 0); return d
-}
-
-// Period computed from date picker
-const periodStart = computed(() => fnsFormat(dateRangeDates.value[0], 'yyyy-MM-dd'))
-const periodEnd   = computed(() => fnsFormat(dateRangeDates.value[1] ?? dateRangeDates.value[0], 'yyyy-MM-dd'))
+// Period computed from date picker (Bogotá calendar day for API)
+const periodStart = computed(() => bogotaISOFromDate(dateRangeDates.value[0]))
+const periodEnd   = computed(() => bogotaISOFromDate(dateRangeDates.value[1] ?? dateRangeDates.value[0]))
 const isMultiDay  = computed(() => periodStart.value !== periodEnd.value)
 
 const previewShiftTemplateId = computed(() =>
@@ -1010,8 +1012,8 @@ watch(isMultiDay, (multi) => {
 
 watch(dateRangeDates, (dates) => {
   if (arqueoWindowMode.value !== 'template' || !dates?.[0] || !dates?.[1]) return
-  const a = fnsFormat(dates[0], 'yyyy-MM-dd')
-  const b = fnsFormat(dates[1], 'yyyy-MM-dd')
+  const a = bogotaISOFromDate(dates[0])
+  const b = bogotaISOFromDate(dates[1])
   if (a !== b) dateRangeDates.value = [dates[0], dates[0]]
 }, { deep: true })
 
@@ -1077,12 +1079,10 @@ const templateHoursLabel = computed(() => {
 })
 
 const onTemplateAnchorPick = () => {
-  const anchor = fnsFormat(templateAnchorDate.value, 'yyyy-MM-dd')
+  const anchor = bogotaISOFromDate(templateAnchorDate.value)
   if (anchor === today) activePreset.value = 'today'
-  else {
-    const y = new Date(); y.setDate(y.getDate() - 1)
-    activePreset.value = anchor === fnsFormat(y, 'yyyy-MM-dd') ? 'yesterday' : null
-  }
+  else if (anchor === addDaysBogotaISO(today, -1)) activePreset.value = 'yesterday'
+  else activePreset.value = null
 }
 
 const applySuggestedWindow = async () => {
@@ -1097,16 +1097,16 @@ const applySuggestedWindow = async () => {
     } }>('/api/cierre/suggested-window', { params: { date: periodStart.value } })
     const d = res.data
     if (arqueoWindowMode.value === 'template') {
-      const anchor = new Date(`${d.periodStart}T12:00:00`)
+      const anchor = bogotaDateAtNoon(d.periodStart)
       dateRangeDates.value = [anchor, anchor]
     } else {
       dateRangeDates.value = [
-        new Date(`${d.periodStart}T12:00:00`),
-        new Date(`${d.periodEnd}T12:00:00`),
+        bogotaDateAtNoon(d.periodStart),
+        bogotaDateAtNoon(d.periodEnd),
       ]
       enableTimePicker.value = true
-      startTimeInput.value = fnsFormat(new Date(d.periodStartTime), 'HH:mm')
-      endTimeInput.value = fnsFormat(new Date(d.periodEndTime), 'HH:mm')
+      startTimeInput.value = bogotaTimeHHMMFromISO(d.periodStartTime)
+      endTimeInput.value = bogotaTimeHHMMFromISO(d.periodEndTime)
     }
     activePreset.value = null
   } catch (err: any) {
@@ -1119,12 +1119,12 @@ const applySuggestedWindow = async () => {
 const periodStartTime = computed((): string | null => {
   if (arqueoWindowMode.value === 'template') return null
   if (!enableTimePicker.value) return null
-  return buildDateTime(dateRangeDates.value[0], startTimeInput.value)?.toISOString() ?? null
+  return combineBogotaDateAndTimeISO(periodStart.value, startTimeInput.value)
 })
 const periodEndTime = computed((): string | null => {
   if (arqueoWindowMode.value === 'template') return null
   if (!enableTimePicker.value) return null
-  return buildDateTime(dateRangeDates.value[1] ?? dateRangeDates.value[0], endTimeInput.value)?.toISOString() ?? null
+  return combineBogotaDateAndTimeISO(periodEnd.value, endTimeInput.value)
 })
 
 const buildPreviewParams = (completedOnly: boolean) => {
@@ -1144,9 +1144,12 @@ const buildPreviewParams = (completedOnly: boolean) => {
 
 const shiftLabel = computed(() => {
   if (!enableTimePicker.value) return null
-  const s = buildDateTime(dateRangeDates.value[0], startTimeInput.value)
-  const e = buildDateTime(dateRangeDates.value[1] ?? dateRangeDates.value[0], endTimeInput.value)
-  if (!s || !e || s >= e) return null
+  const startIso = periodStartTime.value
+  const endIso = periodEndTime.value
+  if (!startIso || !endIso) return null
+  const s = new Date(startIso)
+  const e = new Date(endIso)
+  if (s >= e) return null
   try { return formatDistanceStrict(s, e, { locale: es }) } catch { return null }
 })
 
@@ -1398,8 +1401,8 @@ const loadFromStorage = () => {
     const hasQueryParams = !!route.query.start || !!route.query.end
     if (!hasQueryParams) {
       if (s.periodStart) {
-        const d0 = new Date(s.periodStart + 'T12:00:00')
-        const d1 = s.periodEnd ? new Date(s.periodEnd + 'T12:00:00') : d0
+        const d0 = bogotaDateAtNoon(s.periodStart)
+        const d1 = s.periodEnd ? bogotaDateAtNoon(s.periodEnd) : d0
         dateRangeDates.value = [d0, d1]
       }
       if (s.periodStartTime) { startTimeInput.value = s.periodStartTime; enableTimePicker.value = true }

--- a/utils/bogotaDate.test.ts
+++ b/utils/bogotaDate.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  addDaysBogotaISO,
+  bogotaDateAtNoon,
+  bogotaISOFromDate,
+  combineBogotaDateAndTimeISO,
+  todayBogotaISO,
+} from './bogotaDate.ts'
+
+describe('bogotaDate', () => {
+  it('bogotaISOFromDate uses Bogotá calendar day not UTC', () => {
+    // 2026-05-19 01:30 UTC = 2026-05-18 20:30 Bogotá
+    const d = new Date('2026-05-19T01:30:00Z')
+    assert.equal(bogotaISOFromDate(d), '2026-05-18')
+  })
+
+  it('combineBogotaDateAndTimeISO builds -05:00 offset', () => {
+    assert.equal(
+      combineBogotaDateAndTimeISO('2026-05-18', '14:01'),
+      '2026-05-18T14:01:00-05:00',
+    )
+  })
+
+  it('addDaysBogotaISO shifts calendar days', () => {
+    assert.equal(addDaysBogotaISO('2026-05-18', 1), '2026-05-19')
+    assert.equal(addDaysBogotaISO('2026-05-18', -1), '2026-05-17')
+  })
+
+  it('bogotaDateAtNoon parses anchor', () => {
+    const d = bogotaDateAtNoon('2026-05-18')
+    assert.equal(bogotaISOFromDate(d), '2026-05-18')
+  })
+
+  it('todayBogotaISO returns YYYY-MM-DD', () => {
+    assert.match(todayBogotaISO(), /^\d{4}-\d{2}-\d{2}$/)
+  })
+})

--- a/utils/bogotaDate.ts
+++ b/utils/bogotaDate.ts
@@ -1,0 +1,83 @@
+/** Business calendar dates/times for Colombia (America/Bogota). Issue #698 */
+
+export const BOGOTA_TZ = 'America/Bogota'
+
+type DateParts = {
+  year: string
+  month: string
+  day: string
+  hour: string
+  minute: string
+}
+
+function bogotaParts(date: Date): DateParts {
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: BOGOTA_TZ,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+  const parts = Object.fromEntries(
+    fmt.formatToParts(date).map((p) => [p.type, p.value]),
+  ) as Record<string, string>
+  return {
+    year: parts.year,
+    month: parts.month,
+    day: parts.day,
+    hour: parts.hour,
+    minute: parts.minute,
+  }
+}
+
+/** Today's calendar date in Bogotá as YYYY-MM-DD. */
+export function todayBogotaISO(): string {
+  const p = bogotaParts(new Date())
+  return `${p.year}-${p.month}-${p.day}`
+}
+
+/** Calendar day in Bogotá for any instant (e.g. date-picker value). */
+export function bogotaISOFromDate(date: Date): string {
+  const p = bogotaParts(date)
+  return `${p.year}-${p.month}-${p.day}`
+}
+
+/** Stable noon anchor for date pickers (avoids DST edge cases; Colombia has no DST). */
+export function bogotaDateAtNoon(iso: string): Date {
+  return new Date(`${iso}T12:00:00-05:00`)
+}
+
+/** ISO timestamp for API period_*_time params (Bogotá wall clock). */
+export function combineBogotaDateAndTimeISO(iso: string, hhmm: string): string | null {
+  if (!hhmm || hhmm.length < 5) return null
+  const [h, m] = hhmm.split(':').map(Number)
+  if (Number.isNaN(h) || Number.isNaN(m)) return null
+  const hh = String(h).padStart(2, '0')
+  const mm = String(m).padStart(2, '0')
+  return `${iso}T${hh}:${mm}:00-05:00`
+}
+
+/** Add calendar days to a Bogotá ISO date string. */
+export function addDaysBogotaISO(iso: string, days: number): string {
+  const base = bogotaDateAtNoon(iso)
+  const next = new Date(base.getTime() + days * 24 * 60 * 60 * 1000)
+  return bogotaISOFromDate(next)
+}
+
+/** HH:mm in Bogotá from an ISO timestamp string. */
+export function bogotaTimeHHMMFromISO(iso: string): string {
+  const p = bogotaParts(new Date(iso))
+  return `${p.hour}:${p.minute}`
+}
+
+/** First and last calendar day of the month containing `iso` (Bogotá). */
+export function bogotaMonthBounds(iso?: string): { first: string; last: string } {
+  const base = iso ?? todayBogotaISO()
+  const [y, m] = base.split('-').map(Number)
+  const first = `${y}-${String(m).padStart(2, '0')}-01`
+  const lastDay = new Date(y, m, 0).getDate()
+  const last = `${y}-${String(m).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
+  return { first, last }
+}


### PR DESCRIPTION
## Summary

Fixes arqueo showing $0 sales after ~19:00 COT when UTC date is already tomorrow. All cash-count entry points now use `America/Bogota` for default calendar day, API `period_start`/`period_end`, and custom time windows.

Closes #698

## Changes

- `utils/bogotaDate.ts` — shared helpers (`todayBogotaISO`, `bogotaISOFromDate`, `combineBogotaDateAndTimeISO`, etc.)
- `utils/bogotaDate.test.ts` — node:test unit tests
- `pages/finanzas/arqueo/{index,nuevo,z,x}.vue` — replace UTC `today`; hub links pass `?start=&end=`

## Testing

- `node --experimental-strip-types --test utils/bogotaDate.test.ts` — pass
- Manual: after 19:00 COT, open Por plantilla → tarde-noche → preview shows same-day sales without re-clicking Hoy


Made with [Cursor](https://cursor.com)