### PR TITLE
fix(finanzas): first-load matrix + optimistic refresh on /finanzas/metodos-pago

### DIFF
--- a/pages/finanzas/metodos-pago/[groupId].vue
+++ b/pages/finanzas/metodos-pago/[groupId].vue
@@ -407,6 +407,8 @@ const columns: Column[] = [
 
 const {
   data: groupsData,
+  status: groupsStatus,
+  asyncStatus: groupsAsyncStatus,
   error: groupsError,
   refetch: refetchGroups,
 } = useQuery({
@@ -438,9 +440,22 @@ const methods = computed<PaymentMethod[]>(() =>
     .sort((a, b) => a.sortOrder - b.sortOrder)
 )
 
-const isLoading    = computed(() => methodsStatus.value === 'pending' && !methodsData.value)
-const isRefreshing = computed(() => methodsAsyncStatus.value === 'loading' && methodsData.value != null)
-const fetchError   = computed(() => groupsError.value || methodsError.value)
+const fetchError = computed(() => groupsError.value || methodsError.value)
+
+const hasEverLoaded = ref(false)
+watch(() => methodsData.value, (v) => { if (v != null) hasEverLoaded.value = true })
+watch(() => currentTenant.value?.id, () => { hasEverLoaded.value = false })
+
+const isMethodsFetching = computed(() =>
+  !!currentTenant.value &&
+  (methodsStatus.value === 'pending' || methodsAsyncStatus.value === 'loading'),
+)
+const isGroupsFetching = computed(() =>
+  !!currentTenant.value &&
+  (groupsStatus.value === 'pending' || groupsAsyncStatus.value === 'loading'),
+)
+const isFetching = computed(() => isMethodsFetching.value || isGroupsFetching.value)
+const isLoading = computed(() => !hasEverLoaded.value && isMethodsFetching.value && !fetchError.value)
 
 // ── Accounts (for GL selector) ────────────────────────────────────────────
 
@@ -484,9 +499,13 @@ useHead(() => ({
   title: group.value ? `${group.value.name} — Métodos de pago` : 'Métodos de pago - Warocol',
 }))
 
-registerProgressiveLoading(isRefreshing)
-onMounted(() => setRefreshHandler(refetchMethods))
-onUnmounted(() => clearRefreshHandler(refetchMethods))
+const refreshAll = async () => {
+  await Promise.all([refetchGroups(), refetchMethods()])
+}
+
+registerProgressiveLoading(isFetching)
+onMounted(() => setRefreshHandler(refreshAll))
+onUnmounted(() => clearRefreshHandler(refreshAll))
 
 // ── Toggle active ────────────────────────────────────────────────────────
 

--- a/pages/finanzas/metodos-pago/index.vue
+++ b/pages/finanzas/metodos-pago/index.vue
@@ -7,19 +7,18 @@
 
     <CommonsTheErrorState v-else-if="fetchError" />
 
-    <!-- Summary stats -->
-    <FinanzasMetricStrip
-      v-else-if="groups.length"
-      class="mb-4"
-      :items="[
-        { label: 'Efectivo',        value: String(cashGroup?.methodCount ?? 0) },
-        { label: 'Predeterminados', value: String(defaultGroups.length) },
-        { label: 'Personalizables', value: String(customGroups.length) },
-      ]"
-    />
+    <template v-else>
+      <!-- Summary stats -->
+      <FinanzasMetricStrip
+        class="mb-4"
+        :items="[
+          { label: 'Efectivo',        value: String(cashGroup?.methodCount ?? 0) },
+          { label: 'Predeterminados', value: String(defaultGroups.length) },
+          { label: 'Personalizables', value: String(customGroups.length) },
+        ]"
+      />
 
-    <UiResponsiveDataView
-      v-if="!isLoading && !fetchError"
+      <UiResponsiveDataView
       :columns="columns"
       :data="groups"
       empty-message="No hay grupos de pago configurados"
@@ -104,6 +103,7 @@
         </svg>
       </template>
     </UiResponsiveDataView>
+    </template>
 
   </div>
 </template>
@@ -155,10 +155,19 @@ const groups = computed<PaymentGroup[]>(() =>
 const cashGroup     = computed(() => groups.value.find(g => g.slug === 'efectivo'))
 const defaultGroups = computed(() => groups.value.filter(g => g.tenantId === null && g.slug !== 'efectivo'))
 const customGroups  = computed(() => groups.value.filter(g => g.tenantId !== null))
-const isLoading    = computed(() => !groupsData.value && !fetchError.value)
-const isRefreshing = computed(() => groupsAsyncStatus.value === 'loading' && groupsData.value != null)
 
-registerProgressiveLoading(isRefreshing)
+// First load: full-page loader + header matrix. Refetch: optimistic (content stays, matrix in header).
+const hasEverLoaded = ref(false)
+watch(() => groupsData.value, (v) => { if (v != null) hasEverLoaded.value = true })
+watch(() => currentTenant.value?.id, () => { hasEverLoaded.value = false })
+
+const isFetching = computed(() =>
+  !!currentTenant.value &&
+  (groupsStatus.value === 'pending' || groupsAsyncStatus.value === 'loading'),
+)
+const isLoading = computed(() => !hasEverLoaded.value && isFetching.value && !fetchError.value)
+
+registerProgressiveLoading(isFetching)
 onMounted(() => setRefreshHandler(refetch))
 onUnmounted(() => clearRefreshHandler(refetch))
 


### PR DESCRIPTION
## Summary

Fixes loading UX on `/finanzas/metodos-pago` and group detail: the dashboard header now shows `UiLoadingMatrix` during the **first** fetch (not only on refetch), while refetches keep table content visible (optimistic).

## Changes

- **`index.vue`**: `hasEverLoaded` + `isFetching` (Pinia Colada `pending` | `loading`); `registerProgressiveLoading(isFetching)`; full-page loader only on true first load; content wrapped in single `v-else` branch
- **`[groupId].vue`**: Same pattern for methods; progressive loading covers groups + methods queries; header refresh runs `refetchGroups` + `refetchMethods`

## Testing

- [ ] Hard refresh `/finanzas/metodos-pago` — matrix animates in header refresh button during load
- [ ] After data loads, click header refresh — table/strip stay visible, matrix only in header
- [ ] Open a payment group — same behavior on detail page
- [ ] Switch tenant — no stuck loader; first fetch for new tenant shows matrix again

Closes #703

Made with [Cursor](https://cursor.com)