### PR TITLE
fix(pos): prevent mesa tab items reappearing after delete (#708)

### DIFF
--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -5,7 +5,7 @@
       <div class="flex items-center justify-between">
         <h2 class="text-sm font-bold text-text-primary tracking-wide">Orden Actual</h2>
         <span class="px-2.5 py-0.5 text-xs rounded-full font-semibold bg-primary/10 text-primary border border-primary/20">
-          {{ items.length }} {{ items.length === 1 ? 'ítem' : 'ítems' }}
+          {{ displayItemCount }} {{ displayItemCount === 1 ? 'ítem' : 'ítems' }}
         </span>
       </div>
     </div>
@@ -306,8 +306,13 @@ interface Emits {
   (e: 'update:served-by', memberId: string | null): void
 }
 
-withDefaults(defineProps<Props>(), { mesaMode: false, isAddingToTab: false, isLoadingTabItems: false, isClearingTab: false, tabItems: () => [], tabTotal: 0, tabItemsLoading: () => new Set(), comandasEnabled: false, unfiredCount: 0, isFiringToKitchen: false, pendingRemoveItemId: null, showServedByChip: false, servedByMemberId: null, members: () => [] })
+const props = withDefaults(defineProps<Props>(), { mesaMode: false, isAddingToTab: false, isLoadingTabItems: false, isClearingTab: false, tabItems: () => [], tabTotal: 0, tabItemsLoading: () => new Set(), comandasEnabled: false, unfiredCount: 0, isFiringToKitchen: false, pendingRemoveItemId: null, showServedByChip: false, servedByMemberId: null, members: () => [] })
 const emit = defineEmits<Emits>()
+
+// Issue warocol.com#708 — mesa tab lines live outside posStore.cart; count both buckets.
+const displayItemCount = computed(() =>
+  props.mesaMode ? props.tabItems.length + props.items.length : props.items.length
+)
 
 // Issue #575 — handler for the served_by select
 const onServedByChange = (event: Event) => {

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -235,43 +235,72 @@ const isFiringToKitchen = ref(false)
 const tabError = ref<string | null>(null)
 const tabSuccess = ref<string | null>(null)
 
+// Issue warocol.com#708 — invalidate in-flight GET /current responses after tab mutations.
+let tableSessionFetchGen = 0
+const bumpTableSessionFetchGen = () => {
+  tableSessionFetchGen += 1
+  return tableSessionFetchGen
+}
+
+const mapTabItemsFromApi = (rows: any[]): TabItem[] =>
+  rows.map((i: any) => ({
+    orderItemId: i.id,
+    productName: i.productName,
+    quantity: i.quantity,
+    unitPrice: i.unitPrice,
+    subtotal: i.subtotal,
+    fulfillmentStatus: i.fulfillmentStatus ?? 'new',
+    sentAt: i.sentAt ?? null,
+  }))
+
+const applyTableSessionFromApi = (
+  data: { session?: any; tab_items?: any[] } | undefined,
+  fetchGen: number,
+  tableCtx?: { tableId: string; tableName: string; isBar?: boolean },
+) => {
+  if (fetchGen !== tableSessionFetchGen || !data?.session) return
+  const tableId = tableCtx?.tableId ?? posStore.activeTableSession?.tableId
+  if (!tableId) return
+  const s = data.session
+  posStore.setTableSession({
+    tableId,
+    sessionId: s.id,
+    tableName: tableCtx?.tableName ?? posStore.activeTableSession?.tableName ?? '',
+    runningTotal: s.running_total,
+    openedAt: s.opened_at,
+    isBar: tableCtx?.isBar ?? posStore.activeTableSession?.isBar ?? false,
+    attendedByMemberId: s.attended_by_member_id ?? null,
+    attendedByMemberName: s.attended_by_member_name ?? null,
+    effectiveWaiterMemberId: s.effective_waiter_member_id ?? null,
+    effectiveWaiterMemberName: s.effective_waiter_member_name ?? null,
+  })
+  posStore.setTabItems(mapTabItemsFromApi(data.tab_items ?? []))
+}
+
 // Handle enter-table event from floor plan component
 const handleEnterTable = async (ctx: { tableId: string; sessionId: string; tableName: string; isBar?: boolean; gotoCheckout?: boolean }) => {
   isEnteringTable.value = true
   posStore.clearAll()
+  posStore.setTableSession({
+    tableId: ctx.tableId,
+    sessionId: ctx.sessionId,
+    tableName: ctx.tableName,
+    runningTotal: 0,
+    openedAt: '',
+    isBar: ctx.isBar ?? false,
+  })
+  bumpTableSessionFetchGen()
   isLoadingTabItems.value = true
+  const fetchGen = tableSessionFetchGen
   try {
     const session = await $fetch<{ success: boolean; data: any }>(
       `/api/tables/${ctx.tableId}/current`
     )
-    if (session?.data?.session) {
-      const s = session.data.session
-      posStore.setTableSession({
-        tableId: ctx.tableId,
-        sessionId: s.id,
-        tableName: ctx.tableName,
-        runningTotal: s.running_total,
-        openedAt: s.opened_at,
-        isBar: ctx.isBar ?? false,
-        attendedByMemberId: s.attended_by_member_id ?? null,
-        attendedByMemberName: s.attended_by_member_name ?? null,
-        effectiveWaiterMemberId: s.effective_waiter_member_id ?? null,
-        effectiveWaiterMemberName: s.effective_waiter_member_name ?? null,
-      })
-      if (session.data.tab_items) {
-        posStore.setTabItems(
-          session.data.tab_items.map((i: any) => ({
-            orderItemId: i.id,
-            productName: i.productName,
-            quantity: i.quantity,
-            unitPrice: i.unitPrice,
-            subtotal: i.subtotal,
-            fulfillmentStatus: i.fulfillmentStatus ?? 'new',
-            sentAt: i.sentAt ?? null,
-          }))
-        )
-      }
-    }
+    applyTableSessionFromApi(session?.data, fetchGen, {
+      tableId: ctx.tableId,
+      tableName: ctx.tableName,
+      isBar: ctx.isBar ?? false,
+    })
   } catch {
     // Session may have closed — enter normal POS mode
   } finally {
@@ -289,38 +318,12 @@ const isRefreshingSession = ref(false)
 const refreshTableSession = async () => {
   if (!posStore.activeTableSession) return
   isRefreshingSession.value = true
+  const fetchGen = tableSessionFetchGen
   try {
     const session = await $fetch<{ success: boolean; data: any }>(
       `/api/tables/${posStore.activeTableSession.tableId}/current`
     )
-    if (session?.data?.session) {
-      const s = session.data.session
-      posStore.setTableSession({
-        tableId: posStore.activeTableSession.tableId,
-        sessionId: s.id,
-        tableName: posStore.activeTableSession.tableName,
-        runningTotal: s.running_total,
-        openedAt: s.opened_at,
-        isBar: posStore.activeTableSession.isBar,
-        attendedByMemberId: s.attended_by_member_id ?? null,
-        attendedByMemberName: s.attended_by_member_name ?? null,
-        effectiveWaiterMemberId: s.effective_waiter_member_id ?? null,
-        effectiveWaiterMemberName: s.effective_waiter_member_name ?? null,
-      })
-    }
-    if (session?.data?.tab_items) {
-      posStore.setTabItems(
-        session.data.tab_items.map((i: any) => ({
-          orderItemId: i.id,
-          productName: i.productName,
-          quantity: i.quantity,
-          unitPrice: i.unitPrice,
-          subtotal: i.subtotal,
-          fulfillmentStatus: i.fulfillmentStatus ?? 'new',
-          sentAt: i.sentAt ?? null,
-        }))
-      )
-    }
+    applyTableSessionFromApi(session?.data, fetchGen)
   } catch {
     // Non-critical — banner will just show stale data
   } finally {
@@ -329,6 +332,13 @@ const refreshTableSession = async () => {
 }
 
 const tabItemsLoading = ref<Set<string>>(new Set())
+
+const isTableSessionMutationActive = () =>
+  isAddingToTab.value
+  || isRefreshingSession.value
+  || isClearingTab.value
+  || tabItemsLoading.value.size > 0
+
 // ID of a tab item pending confirmation before removal (already fired to kitchen)
 const pendingRemoveItemId = ref<string | null>(null)
 
@@ -359,6 +369,9 @@ const cancelPendingRemove = () => {
 
 const executeRemoveTabItem = async (orderItemId: string) => {
   if (!posStore.activeTableSession) return
+  const previousTabItems = storeTabItems.value
+  bumpTableSessionFetchGen()
+  posStore.setTabItems(previousTabItems.filter((i: TabItem) => i.orderItemId !== orderItemId))
   tabItemsLoading.value = new Set([...tabItemsLoading.value, orderItemId])
   try {
     await $fetch(`/api/tables/${posStore.activeTableSession.tableId}/tab/items/${orderItemId}`, {
@@ -366,6 +379,8 @@ const executeRemoveTabItem = async (orderItemId: string) => {
     })
     await refreshTableSession()
   } catch (e: any) {
+    bumpTableSessionFetchGen()
+    posStore.setTabItems(previousTabItems)
     tabError.value = e?.data?.detail ?? 'Error al eliminar el producto'
   } finally {
     const next = new Set(tabItemsLoading.value)
@@ -376,6 +391,7 @@ const executeRemoveTabItem = async (orderItemId: string) => {
 
 const updateTabItemQuantity = async (orderItemId: string, quantity: number) => {
   if (!posStore.activeTableSession) return
+  bumpTableSessionFetchGen()
   tabItemsLoading.value = new Set([...tabItemsLoading.value, orderItemId])
   try {
     await $fetch(`/api/tables/${posStore.activeTableSession.tableId}/tab/items/${orderItemId}`, {
@@ -403,7 +419,8 @@ const decrementTabItem = (orderItemId: string) => {
 }
 
 const addToTab = async () => {
-  if (!posStore.activeTableSession || posStore.cart.length === 0) return
+  if (!posStore.activeTableSession || posStore.cart.length === 0 || isAddingToTab.value) return
+  bumpTableSessionFetchGen()
   isAddingToTab.value = true
   tabError.value = null
   try {
@@ -723,6 +740,7 @@ const duplicateCartItem = async (index: number) => {
 const clearCart = async () => {
   const session = posStore.activeTableSession
   if (session) {
+    bumpTableSessionFetchGen()
     isClearingTab.value = true
     try {
       await $fetch(`/api/tables/${session.tableId}/tab`, { method: 'DELETE' })
@@ -757,23 +775,13 @@ const startFulfillmentPolling = () => {
   if (fulfillmentPollInterval) return
   fulfillmentPollInterval = setInterval(async () => {
     if (!comandasEnabled.value || !posStore.activeTableSession) return
+    if (isTableSessionMutationActive()) return
+    const fetchGen = tableSessionFetchGen
     try {
       const session = await $fetch<{ success: boolean; data: any }>(
         `/api/tables/${posStore.activeTableSession.tableId}/current`
       )
-      if (session?.data?.tab_items) {
-        posStore.setTabItems(
-          session.data.tab_items.map((i: any) => ({
-            orderItemId: i.id,
-            productName: i.productName,
-            quantity: i.quantity,
-            unitPrice: i.unitPrice,
-            subtotal: i.subtotal,
-            fulfillmentStatus: i.fulfillmentStatus ?? 'new',
-            sentAt: i.sentAt ?? null,
-          }))
-        )
-      }
+      applyTableSessionFromApi(session?.data, fetchGen)
     } catch {
       // Non-critical — polling fails silently
     }


### PR DESCRIPTION
## Summary

Fixes intermittent “product reappears in cart” on mesa POS when comandas are enabled (Rebel Rebel report + video).

## Changes

- **`pages/pos/index.vue`**: Session fetch generation counter — stale `GET /current` (10s poll, header refresh) cannot overwrite state after add/delete/clear
- **`pages/pos/index.vue`**: `addToTab` mutex prevents double-tap duplicate `order_items`
- **`pages/pos/index.vue`**: Optimistic tab line removal on delete with revert on API error
- **`components/pos/CartPanel.vue`**: Order badge counts `tabItems + cart` in mesa mode (fixes “0 ítems” while lines visible)

## Test plan

- [ ] Mesa + comandas: add product → send to kitchen → delete → line stays gone (wait 10s / pull refresh)
- [ ] Double-tap “Agregar y enviar a cocina” → only one line created
- [ ] Badge count matches visible lines

Closes #708

Made with [Cursor](https://cursor.com)