### PR TITLE
feat(front): mesas page — QR toggle, copy link, QR preview

### DIFF
--- a/components/mesas/MesaPanel.vue
+++ b/components/mesas/MesaPanel.vue
@@ -116,6 +116,15 @@
             </p>
           </div>
 
+          <!-- Table QR (warocol.com#711) -->
+          <MesasTableQrControls
+            v-if="isEdit && tableQrModuleEnabled && table"
+            :table="table"
+            variant="panel"
+            show-regenerate
+            @updated="(data) => emit('qr-updated', data)"
+          />
+
           <!-- Error general -->
           <p v-if="errors.general" class="text-sm text-destructive bg-destructive/10 rounded-lg px-3 py-2">
             {{ errors.general }}
@@ -163,17 +172,20 @@ interface Props {
   table?: any // null/undefined = create mode, object = edit mode
   members?: Member[]
   waiterAttributionEnabled?: boolean
+  tableQrModuleEnabled?: boolean
 }
 
 interface Emits {
   (e: 'update:modelValue', v: boolean): void
   (e: 'saved', table: any): void
+  (e: 'qr-updated', table: Record<string, unknown>): void
 }
 
 const props = withDefaults(defineProps<Props>(), {
   table: null,
   members: () => [],
   waiterAttributionEnabled: false,
+  tableQrModuleEnabled: false,
 })
 const emit = defineEmits<Emits>()
 

--- a/components/mesas/TableQrControls.vue
+++ b/components/mesas/TableQrControls.vue
@@ -1,0 +1,206 @@
+<script setup lang="ts">
+/**
+ * Per-table QR toggle, copy link, download PNG (warocol.com#711).
+ */
+const props = withDefaults(defineProps<{
+  table: {
+    id: string
+    name: string
+    qr_enabled?: boolean
+    qr_public_token?: string | null
+  }
+  variant?: 'compact' | 'panel'
+  showRegenerate?: boolean
+}>(), {
+  variant: 'compact',
+  showRegenerate: false,
+})
+
+const emit = defineEmits<{
+  updated: [table: Record<string, unknown>]
+}>()
+
+const toast = useToast()
+const { buildTableQrUrl, copyTableQrLink, downloadTableQrPng } = useTableQrLink()
+
+const isToggling = ref(false)
+const isRegenerating = ref(false)
+const showRegenerateConfirm = ref(false)
+
+const publicUrl = computed(() => buildTableQrUrl(props.table.qr_public_token))
+const hasToken = computed(() => !!props.table.qr_public_token)
+
+const toggleQr = async () => {
+  if (isToggling.value) return
+  isToggling.value = true
+  const newEnabled = !props.table.qr_enabled
+  try {
+    const res = await $fetch<{ success: boolean; data: Record<string, unknown> }>(
+      `/api/tables/${props.table.id}/qr`,
+      { method: 'PATCH', body: { enabled: newEnabled } },
+    )
+    emit('updated', res.data)
+    toast.success(
+      newEnabled ? 'QR activado para esta mesa' : 'QR desactivado',
+      { title: newEnabled ? 'Activado' : 'Desactivado' },
+    )
+  } catch (err: any) {
+    toast.error(err?.data?.detail || 'Error al cambiar el QR', { title: 'Error' })
+  } finally {
+    isToggling.value = false
+  }
+}
+
+const regenerateToken = async () => {
+  if (isRegenerating.value) return
+  isRegenerating.value = true
+  try {
+    const res = await $fetch<{ success: boolean; data: Record<string, unknown> }>(
+      `/api/tables/${props.table.id}/qr-token/regenerate`,
+      { method: 'POST' },
+    )
+    emit('updated', res.data)
+    showRegenerateConfirm.value = false
+    toast.success('Enlace actualizado — imprime el QR de nuevo', { title: 'Token regenerado' })
+  } catch (err: any) {
+    toast.error(err?.data?.detail || 'No se pudo regenerar el enlace', { title: 'Error' })
+  } finally {
+    isRegenerating.value = false
+  }
+}
+</script>
+
+<template>
+  <div
+    v-if="variant === 'panel'"
+    class="rounded-xl border border-border bg-surface-secondary/40 p-4 space-y-3"
+  >
+    <div class="flex items-center justify-between gap-3">
+      <div>
+        <p class="text-sm font-semibold text-text-primary">Pedido por QR</p>
+        <p class="text-xs text-text-secondary mt-0.5 leading-snug">
+          El enlace es estable hasta que regeneres el token.
+        </p>
+      </div>
+      <label
+        class="relative inline-flex items-center cursor-pointer flex-shrink-0"
+        :class="isToggling ? 'opacity-50 pointer-events-none' : ''"
+      >
+        <input
+          type="checkbox"
+          class="sr-only peer"
+          :checked="!!table.qr_enabled"
+          :disabled="isToggling"
+          @change="toggleQr"
+        >
+        <div
+          class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full"
+        />
+      </label>
+    </div>
+
+    <div v-if="table.qr_enabled && hasToken" class="space-y-2">
+      <label class="text-xs font-medium text-text-secondary">Enlace público</label>
+      <input
+        type="text"
+        readonly
+        :value="publicUrl || ''"
+        class="h-9 w-full rounded-lg border border-border bg-background px-3 text-xs text-text-secondary font-mono"
+      >
+      <div class="flex flex-wrap gap-2">
+        <button
+          type="button"
+          class="h-9 px-3 rounded-lg border border-border text-xs font-semibold text-text-secondary hover:bg-surface transition-colors"
+          @click="copyTableQrLink(table.qr_public_token)"
+        >
+          Copiar enlace
+        </button>
+        <button
+          type="button"
+          class="h-9 px-3 rounded-lg border border-border text-xs font-semibold text-text-secondary hover:bg-surface transition-colors"
+          @click="downloadTableQrPng(table.qr_public_token, table.name)"
+        >
+          Descargar PNG
+        </button>
+        <button
+          v-if="showRegenerate && !showRegenerateConfirm"
+          type="button"
+          class="h-9 px-3 rounded-lg border border-amber-200 text-xs font-semibold text-amber-700 hover:bg-amber-50 dark:border-amber-800 dark:text-amber-300 dark:hover:bg-amber-950/30 transition-colors"
+          @click="showRegenerateConfirm = true"
+        >
+          Regenerar enlace
+        </button>
+      </div>
+      <div
+        v-if="showRegenerate && showRegenerateConfirm"
+        class="rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-800/40 dark:bg-amber-950/20"
+      >
+        <p class="text-xs text-amber-800 dark:text-amber-300 leading-relaxed">
+          Los QR impresos dejarán de funcionar. ¿Continuar?
+        </p>
+        <div class="flex gap-2 mt-2">
+          <button
+            type="button"
+            class="h-8 px-3 rounded-lg text-xs font-semibold border border-border"
+            @click="showRegenerateConfirm = false"
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            :disabled="isRegenerating"
+            class="h-8 px-3 rounded-lg text-xs font-bold bg-amber-500 text-white disabled:opacity-50"
+            @click="regenerateToken"
+          >
+            {{ isRegenerating ? 'Regenerando…' : 'Sí, regenerar' }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <p v-else-if="table.qr_enabled && !hasToken" class="text-xs text-text-tertiary">
+      Generando enlace… guarda de nuevo si no aparece.
+    </p>
+  </div>
+
+  <div v-else class="flex flex-wrap items-center gap-1.5">
+    <label
+      class="relative inline-flex items-center cursor-pointer flex-shrink-0"
+      :class="isToggling ? 'opacity-50 pointer-events-none' : ''"
+      :title="table.qr_enabled ? 'Desactivar QR' : 'Activar QR'"
+    >
+      <input
+        type="checkbox"
+        class="sr-only peer"
+        :checked="!!table.qr_enabled"
+        :disabled="isToggling"
+        @change="toggleQr"
+      >
+      <div
+        class="w-8 h-5 bg-border rounded-full peer peer-checked:bg-primary after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-3"
+      />
+    </label>
+    <button
+      type="button"
+      :disabled="!hasToken"
+      class="flex items-center justify-center h-8 w-8 rounded-lg text-text-secondary hover:bg-surface-secondary disabled:opacity-30 disabled:cursor-not-allowed"
+      title="Copiar enlace"
+      @click="copyTableQrLink(table.qr_public_token)"
+    >
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+      </svg>
+    </button>
+    <button
+      type="button"
+      :disabled="!hasToken"
+      class="flex items-center justify-center h-8 w-8 rounded-lg text-text-secondary hover:bg-surface-secondary disabled:opacity-30 disabled:cursor-not-allowed"
+      title="Descargar QR"
+      @click="downloadTableQrPng(table.qr_public_token, table.name)"
+    >
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+      </svg>
+    </button>
+  </div>
+</template>

--- a/composables/useTableQrLink.ts
+++ b/composables/useTableQrLink.ts
@@ -1,0 +1,67 @@
+import QRCode from 'qrcode'
+
+/**
+ * Table QR public link helpers (warocol.com#711).
+ * Token must come from the API — never derived in the browser.
+ */
+export function useTableQrLink() {
+  const config = useRuntimeConfig()
+  const { currentTenant } = useTenantReactive()
+  const toast = useToast()
+
+  const buildTableQrUrl = (token: string | null | undefined): string | null => {
+    const slug = currentTenant.value?.slug
+    if (!token || !slug) return null
+    const base = String(config.public.siteUrl || 'https://warocol.com').replace(/\/$/, '')
+    return `${base}/${slug}/mesa/${token}`
+  }
+
+  const copyTableQrLink = async (token: string | null | undefined) => {
+    const url = buildTableQrUrl(token)
+    if (!url) {
+      toast.error('Activa el QR de la mesa primero', { title: 'Sin enlace' })
+      return
+    }
+    try {
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(url)
+      } else {
+        const textArea = document.createElement('textarea')
+        textArea.value = url
+        textArea.style.position = 'fixed'
+        textArea.style.opacity = '0'
+        document.body.appendChild(textArea)
+        textArea.select()
+        document.execCommand('copy')
+        document.body.removeChild(textArea)
+      }
+      toast.success('Enlace copiado al portapapeles', { title: 'Copiado' })
+    } catch {
+      toast.error('No se pudo copiar el enlace', { title: 'Error' })
+    }
+  }
+
+  const downloadTableQrPng = async (
+    token: string | null | undefined,
+    tableName: string,
+  ) => {
+    const url = buildTableQrUrl(token)
+    if (!url) {
+      toast.error('Activa el QR de la mesa primero', { title: 'Sin enlace' })
+      return
+    }
+    try {
+      const dataUrl = await QRCode.toDataURL(url, { width: 512, margin: 2 })
+      const anchor = document.createElement('a')
+      const safeName = tableName.replace(/[^\w\s-]/g, '').trim().replace(/\s+/g, '-') || 'mesa'
+      anchor.href = dataUrl
+      anchor.download = `qr-${safeName}.png`
+      anchor.click()
+      toast.success('Imagen QR descargada', { title: 'Listo' })
+    } catch {
+      toast.error('No se pudo generar el código QR', { title: 'Error' })
+    }
+  }
+
+  return { buildTableQrUrl, copyTableQrLink, downloadTableQrPng }
+}

--- a/pages/operaciones/mesas.vue
+++ b/pages/operaciones/mesas.vue
@@ -90,6 +90,9 @@ const tableColumns = computed(() => {
   if (businessProfile.value?.waiter_attribution_enabled) {
     cols.push({ key: 'mesero', title: 'Mesero' })
   }
+  if (businessProfile.value?.tables_enabled && businessProfile.value?.table_qr_module_enabled) {
+    cols.push({ key: 'qr', title: 'QR' })
+  }
   cols.push({ key: 'status', title: 'Estado' })
   cols.push({ key: 'actions', title: '' })
   return cols
@@ -105,6 +108,13 @@ const openPanel = (table: any = null) => {
 }
 
 const onSaved = () => { refetch() }
+
+const onTableQrUpdated = (data: Record<string, unknown>) => {
+  if (panelTable.value?.id === data.id) {
+    panelTable.value = { ...panelTable.value, ...data }
+  }
+  refetch()
+}
 
 // ── Deactivate modal ────────────────────────────────────────────────────────
 const deactivateModalOpen = ref(false)
@@ -260,6 +270,32 @@ const toggleWaiterAttribution = async () => {
   }
 }
 
+// ── Toggle Table QR module (warocol.com#711) ───────────────────────────────
+const isTogglingTableQrModule = ref(false)
+const toggleTableQrModule = async () => {
+  if (!businessProfile.value || isTogglingTableQrModule.value) return
+  isTogglingTableQrModule.value = true
+  const newState = !businessProfile.value.table_qr_module_enabled
+  try {
+    await $fetch('/api/operaciones/toggles/table-qr', {
+      method: 'PATCH',
+      body: { enabled: newState },
+    })
+    await invalidateContextCaches()
+    await cache.invalidateQueries({ key: ['tables'] })
+    toast.success(
+      newState
+        ? 'Los clientes pueden pedir por QR en la mesa (con confirmación del personal)'
+        : 'Pedido por QR en mesa desactivado',
+      { title: newState ? 'Módulo activado' : 'Módulo desactivado' },
+    )
+  } catch (error: any) {
+    toast.error(error.data?.detail || 'Error al cambiar el módulo QR', { title: 'Error' })
+  } finally {
+    isTogglingTableQrModule.value = false
+  }
+}
+
 // Members embedded in the operaciones aggregator (no Module.EQUIPO required).
 // Used by MesaPanel to render the "Mesero por defecto" picker.
 const tenantMembers = computed<Array<{ id: string; name: string; role: string }>>(() =>
@@ -346,6 +382,32 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
             <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
           </label>
         </div>
+
+        <!-- Table QR module (warocol.com#711) -->
+        <div v-if="businessProfile.tables_enabled" class="flex items-center justify-between gap-4 px-4 py-3">
+          <div class="min-w-0">
+            <p class="text-sm font-semibold leading-snug text-text-primary">
+              Pedido por QR en mesa
+            </p>
+            <p class="text-xs mt-0.5 leading-snug text-text-secondary">
+              Enlace estático por {{ singularLower }} para que el comensal pida desde el celular.
+            </p>
+          </div>
+          <label
+            class="relative inline-flex items-center cursor-pointer flex-shrink-0"
+            :class="isTogglingTableQrModule ? 'opacity-50 pointer-events-none' : ''"
+            :aria-label="businessProfile.table_qr_module_enabled ? 'Desactivar pedido por QR' : 'Activar pedido por QR'"
+          >
+            <input
+              type="checkbox"
+              class="sr-only peer"
+              :checked="!!businessProfile.table_qr_module_enabled"
+              @change="toggleTableQrModule"
+              :disabled="isTogglingTableQrModule"
+            >
+            <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+          </label>
+        </div>
       </div>
 
       <!-- Filters -->
@@ -395,6 +457,16 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
                 >
                   Mesero: {{ item.assigned_member_name || 'sin asignar' }}
                 </p>
+                <div
+                  v-if="businessProfile?.tables_enabled && businessProfile?.table_qr_module_enabled"
+                  class="mt-2"
+                >
+                  <MesasTableQrControls
+                    :table="item"
+                    variant="compact"
+                    @updated="onTableQrUpdated"
+                  />
+                </div>
               </div>
               <div class="flex items-center gap-2 flex-shrink-0">
                 <UiStatusBadge :variant="badgeVariant(item.status)" size="sm">
@@ -439,6 +511,15 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
             >
               Sin asignar
             </span>
+          </template>
+
+          <!-- Desktop: QR -->
+          <template #cell-qr="{ row }">
+            <MesasTableQrControls
+              :table="row"
+              variant="compact"
+              @updated="onTableQrUpdated"
+            />
           </template>
 
           <!-- Desktop: status -->
@@ -547,7 +628,9 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
       :table="panelTable"
       :members="tenantMembers"
       :waiter-attribution-enabled="!!businessProfile?.waiter_attribution_enabled"
+      :table-qr-module-enabled="!!businessProfile?.tables_enabled && !!businessProfile?.table_qr_module_enabled"
       @saved="onSaved"
+      @qr-updated="onTableQrUpdated"
     />
 
     <!-- ══════ DEACTIVATE MODAL ══════ -->


### PR DESCRIPTION
## Summary
Operaciones UI for Table QR ordering (epic #710): enable module and per-table QR links for staff to copy or download as PNG.

## Changes
- `composables/useTableQrLink.ts`: build public URL, copy, download PNG
- `components/mesas/TableQrControls.vue`: toggle, copy, download, regenerate
- `pages/operaciones/mesas.vue`: module toggle + QR column + mobile controls
- `components/mesas/MesaPanel.vue`: full QR section on edit

## Testing
- Enable “Pedido por QR en mesa” on `/operaciones/mesas` (requires API #266 deployed)
- Toggle QR on a table → copy link → download PNG → scan opens `/{slug}/mesa/{token}`
- Regenerate token in panel invalidates old QR

Depends on api-warolabs #266+ merged/deployed.

Closes #711

Made with [Cursor](https://cursor.com)