### PR TITLE
feat(front): is_available_table_qr on products list and forms

### DIFF
--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -482,6 +482,23 @@
                 </div>
               </div>
 
+              <div class="flex items-start space-x-3">
+                <input
+                  v-model="form.is_available_table_qr"
+                  type="checkbox"
+                  id="is_available_table_qr"
+                  class="h-4 w-4 mt-0.5 text-primary focus:ring-primary border-border rounded"
+                />
+                <div>
+                  <label for="is_available_table_qr" class="text-sm font-medium text-text-primary block">
+                    Pedido en mesa (QR)
+                  </label>
+                  <p class="text-xs text-text-secondary mt-1">
+                    Independiente de domicilios. Solo aparece en el menú QR de la mesa.
+                  </p>
+                </div>
+              </div>
+
             </div>
           </div>
         </div>
@@ -844,6 +861,7 @@ const form = ref({
   controla_stock: true,
   is_available: true,
   is_available_online: true,
+  is_available_table_qr: false,
   is_combo: false,
   allow_modifiers: true,
   tax_category: 'standard' as 'standard' | 'liquor' | 'exempt',
@@ -873,6 +891,7 @@ watch(productData, (data) => {
       controla_stock: product.controla_stock,
       is_available: product.is_available,
       is_available_online: product.is_available_online ?? true,
+      is_available_table_qr: product.is_available_table_qr ?? false,
       is_combo: product.is_combo,
       allow_modifiers: product.allow_modifiers,
       tax_category: (product.tax_category || 'standard') as 'standard' | 'liquor' | 'exempt',

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -327,6 +327,18 @@
                   </div>
                 </label>
 
+                <label class="flex items-center gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    v-model="form.is_available_table_qr"
+                    class="w-5 h-5 text-primary border-border rounded focus:ring-primary"
+                  />
+                  <div>
+                    <span class="text-sm font-medium text-text-primary">Pedido en mesa (QR)</span>
+                    <p class="text-xs text-text-secondary mt-0.5">Independiente de domicilios. Solo aparece en el menú QR de la mesa.</p>
+                  </div>
+                </label>
+
                 <!-- REMOVED: Controlar stock - Now ALL products control inventory automatically -->
                 <!-- REMOVED: Es combo - Combos are now managed through product_base_recipes -->
               </div>
@@ -867,6 +879,7 @@ const form = ref({
   controla_stock: true,
   is_available: true,
   is_available_online: true,
+  is_available_table_qr: false,
   is_combo: false,
   allow_modifiers: true,
   tax_category: 'standard' as 'standard' | 'liquor' | 'exempt',

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -239,6 +239,39 @@
             </div>
           </template>
 
+          <template v-if="showTableQrColumn" #cell-is_available_table_qr="{ row }">
+            <div class="flex justify-center">
+              <button
+                @click="toggleTableQrAvailability(row)"
+                role="switch"
+                :aria-checked="row.is_available_table_qr"
+                :disabled="togglingTableQrIds.has(row.id)"
+                :aria-label="row.is_available_table_qr ? `Deshabilitar ${row.name} para QR en mesa` : `Habilitar ${row.name} para QR en mesa`"
+                :title="row.is_available_table_qr ? 'Deshabilitar para QR en mesa' : 'Habilitar para QR en mesa'"
+                class="relative inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-1"
+                :class="[
+                  row.is_available_table_qr ? 'bg-success' : 'bg-titan-300',
+                  togglingTableQrIds.has(row.id) ? 'cursor-wait opacity-70' : 'cursor-pointer'
+                ]"
+              >
+                <svg
+                  v-if="togglingTableQrIds.has(row.id)"
+                  class="animate-spin h-3.5 w-3.5 text-white"
+                  :class="row.is_available_table_qr ? 'translate-x-4' : 'translate-x-0.5'"
+                  fill="none" viewBox="0 0 24 24"
+                >
+                  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+                  <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                <span
+                  v-else
+                  class="inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform duration-200 ease-in-out"
+                  :class="row.is_available_table_qr ? 'translate-x-4' : 'translate-x-0.5'"
+                />
+              </button>
+            </div>
+          </template>
+
           <template #cell-actions="{ row }">
             <div class="flex justify-center space-x-2">
               <button
@@ -458,6 +491,10 @@ const visiblePages = computed(() => {
 // Tenant reactivity
 const { currentTenant, businessProfile } = useTenantReactive()
 
+const showTableQrColumn = computed(
+  () => !!(businessProfile.value?.tables_enabled && businessProfile.value?.table_qr_module_enabled)
+)
+
 // Fetch categories (static per tenant)
 const { data: categoriesData } = useQuery({
   key: () => ['menu', 'categories', currentTenant.value?.id],
@@ -635,6 +672,15 @@ const productosTableColumns = computed(() => {
       format: 'boolean',
       align: 'center'
     },
+    ...(showTableQrColumn.value
+      ? [{
+          key: 'is_available_table_qr',
+          title: 'QR mesa',
+          sortable: true,
+          format: 'boolean',
+          align: 'center'
+        }]
+      : []),
     {
       key: 'actions',
       title: 'Acciones',
@@ -701,6 +747,7 @@ const toTitleCase = (s: string) => s.toLowerCase().replace(/\b\w/g, c => c.toUpp
 // Inline toggle for online availability
 const toast = useToast()
 const togglingIds = ref<Set<string>>(new Set())
+const togglingTableQrIds = ref<Set<string>>(new Set())
 
 const toggleOnlineAvailability = async (product: any) => {
   if (togglingIds.value.has(product.id)) return
@@ -722,6 +769,29 @@ const toggleOnlineAvailability = async (product: any) => {
     toast.error('Error al actualizar. Intenta de nuevo.')
   } finally {
     togglingIds.value = new Set([...togglingIds.value].filter(id => id !== product.id))
+  }
+}
+
+const toggleTableQrAvailability = async (product: any) => {
+  if (togglingTableQrIds.value.has(product.id)) return
+  togglingTableQrIds.value = new Set([...togglingTableQrIds.value, product.id])
+
+  const newValue = !product.is_available_table_qr
+  product.is_available_table_qr = newValue
+  try {
+    await $fetch(`/api/menu/products/${product.id}`, {
+      method: 'PUT',
+      body: { is_available_table_qr: newValue }
+    })
+    toast.success(
+      newValue ? `${product.name} ahora aparece en el menú QR de mesa` : `${product.name} ocultado del menú QR de mesa`,
+      { duration: 3000 }
+    )
+  } catch {
+    product.is_available_table_qr = !newValue
+    toast.error('Error al actualizar. Intenta de nuevo.')
+  } finally {
+    togglingTableQrIds.value = new Set([...togglingTableQrIds.value].filter(id => id !== product.id))
   }
 }
 


### PR DESCRIPTION
## Summary
Adds table QR availability controls to the product catalog, mirroring the domicilios (`is_available_online`) pattern.

Requires api-warolabs PR merging first (product API must return/persist the field).

## Changes
- `pages/menu/productos/index.vue` — **QR mesa** column + inline toggle (when table QR module enabled)
- `pages/menu/productos/crear.vue` — checkbox, default `false`
- `pages/menu/productos/[id].vue` — checkbox on edit

## Testing
- [ ] Merge API PR, deploy API
- [ ] Enable table QR module on tenant
- [ ] Toggle product on list — only `is_available_table_qr` changes
- [ ] Create/edit product with checkbox
- [ ] Public table QR menu lists only flagged products

Closes #712

Made with [Cursor](https://cursor.com)