### PR TITLE
feat(front): /{tenant}/mesa/{token} menu and lightweight checkout

### DIFF
--- a/.cursor/rules/no-build-without-approval.mdc
+++ b/.cursor/rules/no-build-without-approval.mdc
@@ -1,0 +1,20 @@
+---
+description: Never run build/typecheck/lint scripts without explicit user authorization
+alwaysApply: true
+---
+
+# No builds without authorization
+
+Do **not** run build, compile, or heavy validation commands unless the user explicitly asks in that conversation turn.
+
+Forbidden without explicit approval:
+- `bun run build`, `npm run build`, `nuxt build`, `nuxi build`
+- `bun run lint`, `npm run lint`
+- `nuxi typecheck`, `tsc`, `vue-tsc`
+- Any long-running CI-like script used only to verify the project
+
+Allowed without asking (lightweight):
+- `git status`, `git diff`, `git log`
+- Targeted file reads, grep, small unit tests **only if the user requested tests**
+
+When verification is needed, ask first: *"¿Corro build/lint para verificar?"*

--- a/components/online/ProductDetailDrawer.vue
+++ b/components/online/ProductDetailDrawer.vue
@@ -63,13 +63,13 @@
           </template>
 
           <!-- Product disabled for online orders -->
-          <template v-else-if="productDetail && productDetail.is_available_online === false">
+          <template v-else-if="productDetail && isProductUnavailable">
             <div class="unavailable-banner unavailable-banner--offline">
               <div class="unavailable-icon-wrap unavailable-icon-wrap--offline">
                 <Icon name="heroicons:x-circle" class="unavailable-icon" aria-hidden="true" />
               </div>
-              <p class="unavailable-title">No disponible para domicilios</p>
-              <p class="unavailable-msg">Este producto no está disponible para pedidos en línea en este momento.</p>
+              <p class="unavailable-title">{{ unavailableTitle }}</p>
+              <p class="unavailable-msg">{{ unavailableMessage }}</p>
             </div>
           </template>
 
@@ -244,7 +244,7 @@
           <button
             v-else
             class="cta-btn"
-            :disabled="!isValid || cartStore.isLoading || isLoading || fetchError || productDetail?.is_available_online === false"
+            :disabled="!isValid || cartStore.isLoading || isLoading || fetchError || isProductUnavailable"
             @click="handleAddToCart"
           >
             <span v-if="cartStore.isLoading">Agregando...</span>
@@ -288,6 +288,7 @@ interface ProductDetail {
   preparation_time?: number
   image_url?: string
   is_available_online?: boolean
+  is_available_table_qr?: boolean
   modifier_groups: ModifierGroup[]
 }
 
@@ -296,20 +297,45 @@ interface WizardUnit {
   notes: string
 }
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   modelValue: boolean
   product: Record<string, any> | null
   tenantSlug: string
-}>()
+  channel?: 'online' | 'table-qr'
+  tableQrToken?: string
+}>(), {
+  channel: 'online',
+})
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: boolean): void
   (e: 'close'): void
 }>()
 
-const cartStore = useOnlineCartStore()
-
 const productDetail = ref<ProductDetail | null>(null)
+
+const onlineCartStore = useOnlineCartStore()
+const tableQrCartStore = useTableQrCartStore()
+const cartStore = computed(() =>
+  props.channel === 'table-qr' ? tableQrCartStore : onlineCartStore,
+)
+
+const isProductUnavailable = computed(() => {
+  if (!productDetail.value) return false
+  if (props.channel === 'table-qr') {
+    return productDetail.value.is_available_table_qr === false
+  }
+  return productDetail.value.is_available_online === false
+})
+
+const unavailableTitle = computed(() =>
+  props.channel === 'table-qr' ? 'No disponible en mesa (QR)' : 'No disponible para domicilios',
+)
+const unavailableMessage = computed(() =>
+  props.channel === 'table-qr'
+    ? 'Este producto no está disponible para pedido en mesa en este momento.'
+    : 'Este producto no está disponible para pedidos en línea en este momento.',
+)
 const isLoading = ref(false)
 const fetchError = ref(false)
 const selectedModifiers = ref<CartModifier[]>([])
@@ -395,9 +421,10 @@ watch(() => props.modelValue, async (val) => {
     wizardStep.value = 0
     wizardUnits.value = []
     try {
-      const res = await $fetch<{ data: ProductDetail }>(
-        `/api/public/restaurant/${props.tenantSlug}/product/${props.product.id}`
-      )
+      const url = props.channel === 'table-qr' && props.tableQrToken
+        ? `/api/public/table-qr/${props.tableQrToken}/product/${props.product.id}`
+        : `/api/public/restaurant/${props.tenantSlug}/product/${props.product.id}`
+      const res = await $fetch<{ data: ProductDetail }>(url)
       productDetail.value = res.data
       // Pre-select defaults
       for (const group of res.data.modifier_groups) {
@@ -542,12 +569,12 @@ async function handleAddToCart() {
   if (!props.product || !isValid.value) return
   try {
     if (wizardMode.value) {
-      await cartStore.addItemsBatch(
+      await cartStore.value.addItemsBatch(
         { id: props.product.id, name: props.product.name, price: props.product.price, has_modifiers: props.product.has_modifiers ?? true },
         wizardUnits.value.map(u => ({ modifiers: u.modifiers, notes: u.notes || undefined }))
       )
     } else {
-      await cartStore.addItem(
+      await cartStore.value.addItem(
         { id: props.product.id, name: props.product.name, price: props.product.price, has_modifiers: props.product.has_modifiers ?? true },
         quantity.value,
         [...selectedModifiers.value],

--- a/components/public/PublicMenu.vue
+++ b/components/public/PublicMenu.vue
@@ -100,6 +100,11 @@ const props = defineProps({
   acceptsOnlineOrders: {
     type: Boolean,
     default: true
+  },
+  /** When set, overrides acceptsOnlineOrders for add-to-cart gating (Table QR #713). */
+  orderingEnabled: {
+    type: Boolean,
+    default: undefined
   }
 })
 
@@ -107,9 +112,13 @@ const emit = defineEmits(['product-click'])
 
 const selectedCategory = ref('all')
 
-// Combined gate: orders are available only when restaurant is open AND accepts online orders.
-// Used to disable add-to-cart buttons in product cards.
-const ordersAvailable = computed(() => props.restaurantOpen && props.acceptsOnlineOrders)
+// Combined gate for add-to-cart. Table QR passes orderingEnabled explicitly.
+const ordersAvailable = computed(() => {
+  if (props.orderingEnabled !== undefined) {
+    return props.restaurantOpen && props.orderingEnabled
+  }
+  return props.restaurantOpen && props.acceptsOnlineOrders
+})
 
 // All categories including "Todos"
 const allCategories = computed(() => {

--- a/components/table-qr/TableQrCartBottomBar.vue
+++ b/components/table-qr/TableQrCartBottomBar.vue
@@ -1,0 +1,71 @@
+<template>
+  <Teleport to="body">
+    <Transition name="bar-slide">
+      <div v-if="cartStore.itemCount > 0 && orderingEnabled" class="cart-bottom-bar bg-white border-t border-border shadow-2xl">
+        <div class="max-w-7xl mx-auto px-4 py-3">
+          <div class="flex items-center justify-between gap-3">
+            <div class="flex items-center gap-3 min-w-0">
+              <div class="min-w-0">
+                <p class="font-bold text-foreground text-sm sm:text-base truncate">
+                  {{ cartStore.itemCount }} {{ cartStore.itemCount === 1 ? 'item' : 'items' }}
+                </p>
+                <p class="text-xs sm:text-sm text-muted-foreground">
+                  {{ cartStore.formattedSubtotal }}
+                </p>
+              </div>
+            </div>
+            <button
+              class="flex items-center gap-2 flex-shrink-0 min-h-[44px] py-2.5 px-4 sm:py-3 sm:px-6 bg-primary text-primary-foreground rounded-lg font-semibold text-sm sm:text-base transition-opacity hover:opacity-90 active:opacity-80"
+              @click="$emit('open-cart')"
+              aria-label="Ver carrito"
+            >
+              Ver carrito
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <line x1="5" y1="12" x2="19" y2="12" />
+                <polyline points="12 5 19 12 12 19" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { useTableQrCartStore } from '~/stores/table_qr_cart'
+
+withDefaults(defineProps<{
+  orderingEnabled?: boolean
+}>(), {
+  orderingEnabled: true,
+})
+
+defineEmits<{
+  (e: 'open-cart'): void
+}>()
+
+const cartStore = useTableQrCartStore()
+</script>
+
+<style scoped>
+.cart-bottom-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+.bar-slide-enter-active,
+.bar-slide-leave-active {
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.bar-slide-enter-from,
+.bar-slide-leave-to {
+  transform: translateY(100%);
+  opacity: 0;
+}
+</style>

--- a/components/table-qr/TableQrCartDrawer.vue
+++ b/components/table-qr/TableQrCartDrawer.vue
@@ -1,0 +1,113 @@
+<template>
+  <Teleport to="body">
+    <Transition name="fade">
+      <div v-if="modelValue" class="fixed inset-0 bg-foreground/50 backdrop-blur-sm z-[100]" @click="close" />
+    </Transition>
+    <Transition name="slide">
+      <aside v-if="modelValue" class="fixed top-0 right-0 bottom-0 w-full max-w-[480px] bg-background z-[101] flex flex-col shadow-2xl">
+        <header class="flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0">
+          <h2 class="text-base font-bold text-foreground m-0">Tu pedido</h2>
+          <button
+            class="w-10 h-10 flex items-center justify-center bg-muted rounded-lg"
+            aria-label="Cerrar carrito"
+            @click="close"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </header>
+
+        <div v-if="cartStore.isEmpty" class="flex-1 flex flex-col items-center justify-center px-6 text-center">
+          <div class="text-5xl mb-3 opacity-50">🛒</div>
+          <p class="text-sm text-muted-foreground">Agrega productos del menú</p>
+        </div>
+
+        <template v-else>
+          <div class="flex-1 overflow-y-auto min-h-0 py-1">
+            <CartItem
+              v-for="item in cartStore.items"
+              :key="item.id"
+              :item="item"
+              :loading="false"
+              :restaurant-closed="!restaurantOpen"
+              @update-quantity="(id, qty) => cartStore.updateItemQuantity(id, qty)"
+              @remove="(id) => cartStore.removeItem(id)"
+              @customize-add="handleCustomizeAdd(item)"
+            />
+          </div>
+          <div class="flex-shrink-0 border-t border-border p-4 space-y-3">
+            <div class="flex justify-between text-sm font-semibold">
+              <span>Subtotal ({{ cartStore.itemCount }} items)</span>
+              <span>{{ cartStore.formattedSubtotal }}</span>
+            </div>
+            <button
+              class="w-full py-3 bg-primary text-primary-foreground rounded-xl font-bold disabled:opacity-50"
+              :disabled="!restaurantOpen || !orderingEnabled"
+              @click="handleCheckout"
+            >
+              {{ restaurantOpen ? 'Continuar' : 'Restaurante cerrado' }}
+            </button>
+            <button
+              class="w-full py-2 text-sm text-destructive"
+              @click="cartStore.clearCart()"
+            >
+              Vaciar carrito
+            </button>
+          </div>
+        </template>
+      </aside>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import CartItem from '~/components/online/CartItem.vue'
+import { useTableQrCartStore } from '~/stores/table_qr_cart'
+
+const props = defineProps<{
+  modelValue: boolean
+  restaurantOpen?: boolean
+  orderingEnabled?: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'checkout'): void
+  (e: 'open-product', product: { id: string; name: string; price: number; has_modifiers: boolean }): void
+}>()
+
+const cartStore = useTableQrCartStore()
+
+const close = () => emit('update:modelValue', false)
+
+const handleCheckout = () => {
+  close()
+  emit('checkout')
+}
+
+const handleCustomizeAdd = (item: { product_id: string; product_name: string; unit_price: number }) => {
+  emit('open-product', {
+    id: item.product_id,
+    name: item.product_name,
+    price: item.unit_price,
+    has_modifiers: true,
+  })
+}
+
+onMounted(() => {
+  const onKeydown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape' && props.modelValue) close()
+  }
+  window.addEventListener('keydown', onKeydown)
+  onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+})
+</script>
+
+<style scoped>
+.fade-enter-active, .fade-leave-active { transition: opacity 0.3s ease; }
+.fade-enter-from, .fade-leave-to { opacity: 0; }
+.slide-enter-active, .slide-leave-active { transition: transform 0.3s ease; }
+.slide-enter-from, .slide-leave-to { transform: translateX(100%); }
+</style>

--- a/pages/[tenant]/mesa/[token].vue
+++ b/pages/[tenant]/mesa/[token].vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+import PublicMenu from '~/components/public/PublicMenu.vue'
+import ProductDetailDrawer from '~/components/online/ProductDetailDrawer.vue'
+import TableQrCartBottomBar from '~/components/table-qr/TableQrCartBottomBar.vue'
+import TableQrCartDrawer from '~/components/table-qr/TableQrCartDrawer.vue'
+import { useCityCatalog } from '~/composables/useCityCatalog'
+import { useTableQrCartStore } from '~/stores/table_qr_cart'
+
+definePageMeta({
+  layout: 'public-restaurant',
+})
+
+const route = useRoute()
+const router = useRouter()
+const tenantSlug = computed(() => String(route.params.tenant ?? ''))
+const token = computed(() => String(route.params.token ?? ''))
+
+const { isCitySlug } = useCityCatalog()
+const isCity = computed(() => isCitySlug(tenantSlug.value))
+
+const cartStore = useTableQrCartStore()
+watch(token, (t) => { if (t) cartStore.setToken(t) }, { immediate: true })
+
+interface ResolveData {
+  tenant_slug: string
+  display_name: string
+  table_name: string
+  is_currently_open: boolean
+}
+
+const { data: resolveData, status: resolveStatus, error: resolveError } = useQuery({
+  key: () => ['table-qr', token.value, 'resolve'],
+  query: () => $fetch<{ success: boolean; data: ResolveData }>(`/api/public/table-qr/${token.value}`),
+  enabled: () => !!token.value && !isCity.value,
+})
+
+const resolve = computed(() => (resolveData.value as { data?: ResolveData } | null)?.data ?? null)
+
+const slugMismatch = computed(
+  () => resolve.value && resolve.value.tenant_slug !== tenantSlug.value,
+)
+
+const { data: menuData, status: menuStatus, error: menuError } = useQuery({
+  key: () => ['table-qr', token.value, 'menu'],
+  query: () => $fetch<{ success: boolean; data: { categories: any[]; products: any[]; restaurant_name: string; table_name: string; is_currently_open: boolean } }>(
+    `/api/public/table-qr/${token.value}/menu`,
+  ),
+  enabled: () => !!token.value && !!resolve.value && !slugMismatch.value && !isCity.value,
+})
+
+const categories = computed(() => menuData.value?.data?.categories ?? [])
+const products = computed(() => menuData.value?.data?.products ?? [])
+const isOpen = computed(() => resolve.value?.is_currently_open ?? menuData.value?.data?.is_currently_open ?? false)
+const orderingEnabled = computed(() => !!resolve.value && !slugMismatch.value)
+
+const isLoading = computed(() => resolveStatus.value === 'pending' && !resolve.value)
+const loadError = computed(() => resolveError.value || menuError.value || slugMismatch.value)
+
+const isCartOpen = ref(false)
+const isProductDrawerOpen = ref(false)
+const selectedProduct = ref<Record<string, any> | null>(null)
+
+useSeoMeta({
+  title: () => resolve.value ? `${resolve.value.display_name} — Mesa ${resolve.value.table_name}` : 'Pedido en mesa',
+})
+
+const handleProductClick = (product: Record<string, any>) => {
+  selectedProduct.value = product
+  isProductDrawerOpen.value = true
+}
+
+const handleCheckout = () => {
+  if (!orderingEnabled.value || !isOpen.value || cartStore.isEmpty) return
+  router.push(`/${tenantSlug.value}/mesa/${token.value}/checkout`)
+}
+</script>
+
+<template>
+  <div v-if="isCity" class="min-h-screen flex items-center justify-center px-4">
+    <p class="text-text-secondary">Enlace no válido.</p>
+  </div>
+
+  <div v-else-if="isLoading" class="min-h-[50vh] flex items-center justify-center">
+    <CommonsTheCustomLoader size="large" />
+  </div>
+
+  <div v-else-if="loadError" class="min-h-[50vh] flex items-center justify-center px-4">
+    <div class="text-center max-w-md">
+      <div class="text-6xl mb-4">🔗</div>
+      <h1 class="text-2xl font-bold text-foreground mb-2">Enlace no disponible</h1>
+      <p class="text-muted-foreground mb-6">
+        <template v-if="slugMismatch">
+          Este código QR no corresponde a este restaurante.
+        </template>
+        <template v-else>
+          El enlace de mesa no existe, está desactivado o el restaurante está cerrado.
+        </template>
+      </p>
+      <NuxtLink to="/" class="text-primary font-semibold hover:underline">Volver al inicio</NuxtLink>
+    </div>
+  </div>
+
+  <div v-else-if="resolve" class="min-h-screen bg-gray-50 pb-24">
+    <div class="bg-card border-b border-border">
+      <div class="max-w-7xl mx-auto px-4 py-6">
+        <p class="text-xs font-semibold uppercase tracking-wide text-primary mb-1">Pedido en mesa</p>
+        <h1 class="text-2xl font-bold text-foreground">{{ resolve.display_name }}</h1>
+        <p class="text-text-secondary mt-1">
+          Mesa <span class="font-semibold text-foreground">{{ resolve.table_name }}</span>
+        </p>
+        <p
+          v-if="!isOpen"
+          class="mt-3 text-sm text-destructive font-medium"
+        >
+          El restaurante está cerrado. Puedes ver el menú pero no enviar pedidos.
+        </p>
+      </div>
+    </div>
+
+    <PublicMenu
+      :categories="categories"
+      :products="products"
+      :is-loading="menuStatus === 'pending'"
+      :restaurant-open="isOpen"
+      :accepts-online-orders="true"
+      :ordering-enabled="orderingEnabled && isOpen"
+      @product-click="handleProductClick"
+    />
+
+    <TableQrCartBottomBar
+      :ordering-enabled="orderingEnabled && isOpen"
+      @open-cart="isCartOpen = true"
+    />
+
+    <TableQrCartDrawer
+      v-model="isCartOpen"
+      :restaurant-open="isOpen"
+      :ordering-enabled="orderingEnabled"
+      @checkout="handleCheckout"
+      @open-product="(p) => { selectedProduct = p; isProductDrawerOpen = true }"
+    />
+
+    <ProductDetailDrawer
+      v-model="isProductDrawerOpen"
+      :product="selectedProduct"
+      :tenant-slug="tenantSlug"
+      channel="table-qr"
+      :table-qr-token="token"
+    />
+  </div>
+</template>

--- a/pages/[tenant]/mesa/[token]/checkout.vue
+++ b/pages/[tenant]/mesa/[token]/checkout.vue
@@ -1,0 +1,219 @@
+<script setup lang="ts">
+import CheckoutWizard from '~/components/online/CheckoutWizard.vue'
+import CartSummary from '~/components/online/CartSummary.vue'
+import type { PosPaymentGroup } from '~/utils/paymentDefaults'
+import { useTableQrCartStore } from '~/stores/table_qr_cart'
+
+definePageMeta({
+  layout: 'public-restaurant',
+})
+
+const route = useRoute()
+const router = useRouter()
+const tenantSlug = computed(() => String(route.params.tenant ?? ''))
+const token = computed(() => String(route.params.token ?? ''))
+
+const cartStore = useTableQrCartStore()
+
+const steps = [
+  { title: 'Tu pedido', short: 'Pedido' },
+  { title: 'Pago y envío', short: 'Confirmar' },
+]
+
+const currentStep = ref(0)
+const isSubmitting = ref(false)
+const checkoutError = ref('')
+const customerNotes = ref('')
+const submitted = ref(false)
+const successMessage = ref('')
+const successTableName = ref('')
+
+const paymentGroups = ref<PosPaymentGroup[]>([])
+const paymentSelection = ref<{ slug: string; id: string | null }>({ slug: '', id: null })
+const paymentError = ref('')
+
+const formatPrice = (price: number) =>
+  new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(price)
+
+onMounted(async () => {
+  if (cartStore.isEmpty) {
+    router.replace(`/${tenantSlug.value}/mesa/${token.value}`)
+    return
+  }
+  if (token.value) cartStore.setToken(token.value)
+
+  try {
+    const res = await $fetch<{ success: boolean; data: PosPaymentGroup[] }>(
+      `/api/public/table-qr/${token.value}/payment-methods`,
+    )
+    paymentGroups.value = res?.data ?? []
+    const first = paymentGroups.value.find(g => !g.triggersCartera)
+    if (first) paymentSelection.value = { slug: first.slug, id: null }
+  } catch {
+    paymentGroups.value = []
+  }
+})
+
+const canContinue = computed(() => {
+  if (currentStep.value === 0) return !cartStore.isEmpty
+  return !!paymentSelection.value.slug
+})
+
+const handleNext = () => {
+  if (currentStep.value < steps.length - 1) currentStep.value++
+}
+
+const handlePrev = () => {
+  if (currentStep.value > 0) currentStep.value--
+}
+
+const handleSubmit = async () => {
+  paymentError.value = ''
+  if (!paymentSelection.value.slug) {
+    paymentError.value = 'Selecciona un método de pago.'
+    return
+  }
+  const chosenGroup = paymentGroups.value.find(g => g.slug === paymentSelection.value.slug)
+  if (chosenGroup?.methods?.length && !paymentSelection.value.id) {
+    paymentError.value = `Elegí un método de ${chosenGroup.name}.`
+    return
+  }
+
+  isSubmitting.value = true
+  checkoutError.value = ''
+  try {
+    const res = await $fetch<{ success: boolean; data: { message: string; table_name: string } }>(
+      `/api/public/table-qr/${token.value}/requests`,
+      {
+        method: 'POST',
+        body: {
+          items: cartStore.buildSubmitItems(),
+          payment_method: paymentSelection.value.slug,
+          payment_method_id: paymentSelection.value.id,
+          customer_notes: customerNotes.value.trim() || undefined,
+        },
+      },
+    )
+    successMessage.value = res.data?.message ?? 'Pedido recibido — el restaurante lo confirmará.'
+    successTableName.value = res.data?.table_name ?? ''
+    cartStore.clearCart()
+    submitted.value = true
+  } catch (err: any) {
+    const detail = err?.data?.detail
+    checkoutError.value = typeof detail === 'string'
+      ? detail
+      : detail?.message ?? err?.message ?? 'No se pudo enviar el pedido. Intenta de nuevo.'
+  } finally {
+    isSubmitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="py-8 px-4 max-w-2xl mx-auto">
+    <div v-if="submitted" class="bg-card border border-border rounded-xl p-8 text-center shadow-sm">
+      <div class="w-16 h-16 rounded-full bg-success/15 flex items-center justify-center mx-auto mb-4">
+        <svg class="w-8 h-8 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+        </svg>
+      </div>
+      <h1 class="text-2xl font-bold text-foreground mb-2">Pedido recibido</h1>
+      <p class="text-muted-foreground mb-1">{{ successMessage }}</p>
+      <p v-if="successTableName" class="text-sm text-muted-foreground mb-6">Mesa {{ successTableName }}</p>
+      <NuxtLink
+        :to="`/${tenantSlug}/mesa/${token}`"
+        class="inline-flex items-center justify-center px-6 py-3 bg-primary text-primary-foreground rounded-lg font-semibold"
+      >
+        Volver al menú
+      </NuxtLink>
+    </div>
+
+    <CheckoutWizard
+      v-else
+      :steps="steps"
+      :current-step="currentStep"
+      :can-continue="canContinue"
+      :is-submitting="isSubmitting"
+      @next="handleNext"
+      @prev="handlePrev"
+      @submit="handleSubmit"
+    >
+      <template #back-action>
+        <NuxtLink
+          :to="`/${tenantSlug}/mesa/${token}`"
+          class="btn-secondary px-4 py-3 rounded-lg text-sm inline-flex items-center gap-1"
+        >
+          ← Menú
+        </NuxtLink>
+      </template>
+
+      <template #step-0>
+        <div class="space-y-4">
+          <h2 class="text-lg font-semibold text-foreground">Revisa tu pedido</h2>
+          <div class="rounded-xl border border-border divide-y divide-border overflow-hidden">
+            <div
+              v-for="item in cartStore.items"
+              :key="item.id"
+              class="flex items-start gap-3 px-4 py-3"
+            >
+              <span class="text-sm font-bold text-primary min-w-[2rem]">{{ item.quantity }}×</span>
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-medium">{{ item.product_name }}</p>
+                <p v-if="item.modifiers.length" class="text-xs text-muted-foreground mt-1">
+                  <span v-for="mod in item.modifiers" :key="mod.id">+ {{ mod.name }} </span>
+                </p>
+                <p v-if="item.notes" class="text-xs italic text-muted-foreground mt-1">{{ item.notes }}</p>
+              </div>
+              <p class="text-sm font-semibold">{{ formatPrice(item.total) }}</p>
+            </div>
+          </div>
+          <CartSummary
+            :subtotal="cartStore.subtotal"
+            :item-count="cartStore.itemCount"
+            order-type="dine-in"
+            :show-checkout-button="false"
+          />
+        </div>
+      </template>
+
+      <template #step-1>
+        <div class="space-y-5">
+          <h2 class="text-lg font-semibold text-foreground">Confirmar pedido</h2>
+          <p class="text-sm text-muted-foreground">
+            El restaurante revisará tu pedido antes de prepararlo.
+          </p>
+
+          <div class="rounded-xl border border-border bg-card p-4">
+            <p class="text-sm font-semibold mb-3">¿Cómo vas a pagar?</p>
+            <PaymentsPaymentMethodSelector
+              v-if="paymentGroups.length"
+              v-model="paymentSelection"
+              :groups="paymentGroups"
+              exclude-cartera
+              :disabled="isSubmitting"
+            />
+            <p v-else class="text-sm text-muted-foreground">Cargando métodos de pago…</p>
+            <p v-if="paymentError" class="mt-2 text-xs text-destructive">{{ paymentError }}</p>
+          </div>
+
+          <div>
+            <label for="customer-notes" class="text-sm font-medium text-foreground block mb-1">
+              Notas para el restaurante (opcional)
+            </label>
+            <textarea
+              id="customer-notes"
+              v-model="customerNotes"
+              rows="3"
+              class="w-full rounded-lg border border-border px-3 py-2 text-sm"
+              placeholder="Ej: sin cebolla, traer servilletas…"
+            />
+          </div>
+
+          <div v-if="checkoutError" class="p-3 rounded-lg bg-destructive/10 text-destructive text-sm">
+            {{ checkoutError }}
+          </div>
+        </div>
+      </template>
+    </CheckoutWizard>
+  </div>
+</template>

--- a/pages/[tenant]/mesa/[token]/checkout.vue
+++ b/pages/[tenant]/mesa/[token]/checkout.vue
@@ -17,7 +17,7 @@ const cartStore = useTableQrCartStore()
 
 const steps = [
   { title: 'Tu pedido', short: 'Pedido' },
-  { title: 'Pago y envío', short: 'Confirmar' },
+  { title: 'Pago y notas', short: 'Confirmar' },
 ]
 
 const currentStep = ref(0)

--- a/stores/table_qr_cart.ts
+++ b/stores/table_qr_cart.ts
@@ -1,0 +1,124 @@
+/**
+ * Client-only cart for Table QR ordering (warocol.com#713).
+ * Does not sync to /api/online/cart — items are submitted via POST /public/table-qr/{token}/requests.
+ */
+import { defineStore } from 'pinia'
+import type { CartItem, CartModifier } from '~/stores/online_cart'
+
+function modifiersKey(mods: CartModifier[]): string {
+  return JSON.stringify([...mods].sort((a, b) => a.id.localeCompare(b.id)))
+}
+
+function newItemId(): string {
+  return `tqr_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`
+}
+
+export const useTableQrCartStore = defineStore('tableQrCart', () => {
+  const token = ref<string | null>(null)
+  const items = ref<CartItem[]>([])
+  const isLoading = ref(false)
+
+  const itemCount = computed(() => items.value.reduce((sum, item) => sum + item.quantity, 0))
+  const subtotal = computed(() => items.value.reduce((sum, item) => sum + item.total, 0))
+  const isEmpty = computed(() => items.value.length === 0)
+  const formattedSubtotal = computed(() =>
+    new Intl.NumberFormat('es-CO', {
+      style: 'currency',
+      currency: 'COP',
+      minimumFractionDigits: 0,
+    }).format(subtotal.value),
+  )
+
+  function setToken(value: string) {
+    if (token.value && token.value !== value) {
+      items.value = []
+    }
+    token.value = value
+  }
+
+  function addItem(
+    product: { id: string; name: string; price: number; has_modifiers?: boolean },
+    quantity: number,
+    modifiers: CartModifier[] = [],
+    notes?: string,
+  ) {
+    const sortedModifiers = [...modifiers].sort((a, b) => a.id.localeCompare(b.id))
+    const modifiersTotal = modifiers.reduce((sum, mod) => sum + mod.price, 0)
+    const existingIndex = items.value.findIndex(
+      item => item.product_id === product.id && modifiersKey(item.modifiers) === modifiersKey(modifiers),
+    )
+    if (existingIndex >= 0) {
+      items.value[existingIndex].quantity += quantity
+      items.value[existingIndex].total =
+        (product.price + modifiersTotal) * items.value[existingIndex].quantity
+    } else {
+      items.value.push({
+        id: newItemId(),
+        product_id: product.id,
+        product_name: product.name,
+        quantity,
+        unit_price: product.price,
+        modifiers: sortedModifiers,
+        notes,
+        total: (product.price + modifiersTotal) * quantity,
+        has_modifiers: product.has_modifiers ?? false,
+      })
+    }
+  }
+
+  function addItemsBatch(
+    product: { id: string; name: string; price: number; has_modifiers?: boolean },
+    units: Array<{ modifiers: CartModifier[]; notes?: string }>,
+  ) {
+    for (const unit of units) {
+      addItem(product, 1, unit.modifiers, unit.notes)
+    }
+  }
+
+  function updateItemQuantity(itemId: string, quantity: number) {
+    const index = items.value.findIndex(item => item.id === itemId)
+    if (index < 0) return
+    if (quantity <= 0) {
+      items.value.splice(index, 1)
+      return
+    }
+    const item = items.value[index]
+    const modifiersTotal = item.modifiers.reduce((sum, mod) => sum + mod.price, 0)
+    item.quantity = quantity
+    item.total = (item.unit_price + modifiersTotal) * quantity
+  }
+
+  function removeItem(itemId: string) {
+    items.value = items.value.filter(item => item.id !== itemId)
+  }
+
+  function clearCart() {
+    items.value = []
+  }
+
+  function buildSubmitItems() {
+    return items.value.map(item => ({
+      product_id: item.product_id,
+      quantity: item.quantity,
+      modifiers: item.modifiers.map(mod => ({ id: mod.id })),
+      notes: item.notes || undefined,
+    }))
+  }
+
+  return {
+    token,
+    items,
+    isLoading,
+    itemCount,
+    subtotal,
+    isEmpty,
+    formattedSubtotal,
+    setToken,
+    addItem,
+    addItemsBatch,
+    updateItemQuantity,
+    removeItem,
+    clearCart,
+    buildSubmitItems,
+  }
+})


### PR DESCRIPTION
## Summary
Customer-facing Table QR flow: scan link → browse menu → lightweight checkout → pending request (staff confirms in #714).

Requires **api-warolabs#267** (or merged `/public/table-qr/*`) deployed before E2E works.

## Changes
- `pages/[tenant]/mesa/[token].vue` — resolve token, menu, cart UI
- `pages/[tenant]/mesa/[token]/checkout.vue` — 2-step wizard (review + payment/notes + submit)
- `stores/table_qr_cart.ts` — client-only cart (no online cart API)
- `components/table-qr/TableQrCartBottomBar.vue`, `TableQrCartDrawer.vue`
- `components/public/PublicMenu.vue` — optional `orderingEnabled` prop
- `components/online/ProductDetailDrawer.vue` — `channel="table-qr"` + table QR product endpoint

## Testing
- [ ] Deploy API with `/public/table-qr/*`
- [ ] Enable table QR module + product flags (#712)
- [ ] Open `/{slug}/mesa/{token}` on mobile — add items, checkout, submit
- [ ] Verify success copy: "Pedido recibido — el restaurante lo confirmará"
- [ ] Invalid/disabled token shows error state
- [ ] Slug mismatch shows error

Closes #713

Made with [Cursor](https://cursor.com)