### PR TITLE
feat(front): show QR-sourced tab items and payment intent in POS

### DIFF
--- a/composables/useTableSessionSync.ts
+++ b/composables/useTableSessionSync.ts
@@ -1,0 +1,65 @@
+import { usePOSStore } from '~/stores/usePOSStore'
+
+export interface TableQrPaymentIntent {
+  payment_method: string
+  payment_method_id?: string | null
+}
+
+type TableSessionRefreshHandler = (tableId: string) => void | Promise<void>
+
+let refreshHandler: TableSessionRefreshHandler | null = null
+let mutationActiveChecker: (() => boolean) | null = null
+
+function paymentIntentKey(tableId: string) {
+  return `tableQrPaymentIntent:${tableId}`
+}
+
+/** POS index registers its refreshTableSession here (warocol.com#715). */
+export function registerTableSessionRefresh(
+  handler: TableSessionRefreshHandler,
+  options?: { isMutationActive?: () => boolean },
+) {
+  refreshHandler = handler
+  mutationActiveChecker = options?.isMutationActive ?? null
+
+  onScopeDispose(() => {
+    if (refreshHandler === handler) {
+      refreshHandler = null
+      mutationActiveChecker = null
+    }
+  })
+}
+
+export function storeTableQrPaymentIntent(tableId: string, intent: TableQrPaymentIntent) {
+  if (!import.meta.client || !intent.payment_method) return
+  sessionStorage.setItem(paymentIntentKey(tableId), JSON.stringify(intent))
+}
+
+/** Read payment intent set by Despacho after QR accept (does not clear). */
+export function readTableQrPaymentIntent(tableId: string): TableQrPaymentIntent | null {
+  if (!import.meta.client) return null
+  const raw = sessionStorage.getItem(paymentIntentKey(tableId))
+  if (!raw) return null
+  try {
+    return JSON.parse(raw) as TableQrPaymentIntent
+  } catch {
+    return null
+  }
+}
+
+export function clearTableQrPaymentIntent(tableId: string) {
+  if (!import.meta.client) return
+  sessionStorage.removeItem(paymentIntentKey(tableId))
+}
+
+/** Invalidate table session cache and refresh POS tab if that mesa is open. */
+export async function notifyTableSessionUpdated(tableId: string) {
+  const cache = useQueryCache()
+  await cache.invalidateQueries({ key: ['tables', tableId, 'current'] })
+  await cache.invalidateQueries({ key: ['tables'] })
+
+  const posStore = usePOSStore()
+  if (posStore.activeTableSession?.tableId !== tableId) return
+  if (mutationActiveChecker?.()) return
+  await refreshHandler?.(tableId)
+}

--- a/pages/despacho/en-mesa/index.vue
+++ b/pages/despacho/en-mesa/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useTenantReactive } from '@/composables/useTenantReactive'
+import { notifyTableSessionUpdated, storeTableQrPaymentIntent } from '~/composables/useTableSessionSync'
 
 definePageMeta({ layout: 'dashboard' })
 
@@ -103,7 +104,15 @@ async function acceptSelected() {
   if (!selectedIds.value.length) return
   isBulkWorking.value = true
   try {
-    const res = await $fetch<{ success: boolean; data: { order_number?: number } }>(
+    const res = await $fetch<{
+      success: boolean
+      data: {
+        order_number?: number
+        table_id?: string
+        payment_method?: string | null
+        payment_method_id?: string | null
+      }
+    }>(
       '/api/table-qr-requests/bulk-accept',
       { method: 'POST', body: { request_ids: selectedIds.value } },
     )
@@ -113,6 +122,16 @@ async function acceptSelected() {
         : 'Pedidos aceptados',
       { title: 'Listo' },
     )
+    const tableId = res.data?.table_id ?? activeTableId.value
+    if (tableId && res.data?.payment_method) {
+      storeTableQrPaymentIntent(tableId, {
+        payment_method: res.data.payment_method,
+        payment_method_id: res.data.payment_method_id ?? null,
+      })
+    }
+    if (tableId) {
+      await notifyTableSessionUpdated(tableId)
+    }
     selectedIds.value = []
     await refetchPending()
     invalidateAfterAction()

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -4,7 +4,8 @@ import { storeToRefs } from 'pinia'
 import { $fetch } from 'ofetch'
 import { useQuery } from '@pinia/colada'
 import QRCode from 'qrcode'
-import { usePOSStore } from '~/stores/usePOSStore'
+import { usePOSStore, type TabItem } from '~/stores/usePOSStore'
+import { clearTableQrPaymentIntent, readTableQrPaymentIntent } from '~/composables/useTableSessionSync'
 import { useAddressStore, type AddressCreate } from '~/stores/address'
 import { PAYMENT_DEFAULTS, type PosPaymentGroup, type PosPaymentMethod } from '~/utils/paymentDefaults'
 import DeliveryAddressPicker from '~/components/pos/checkout/DeliveryAddressPicker.vue'
@@ -333,6 +334,76 @@ const taxPreview = computed<TaxPreview | null>(() => {
 
 // Tax preview is auto-recomputed via useQuery (mesaCurrentData / posTaxPreviewData)
 // — discount/cart changes invalidate the query keys, no manual debounce needed.
+
+// warocol.com#715 — QR accept payment intent + tab sync on checkout
+const paymentPrefillSeeded = ref(false)
+
+function mapTabItemsFromApi(rows: any[]): TabItem[] {
+  return rows.map((i: any) => ({
+    orderItemId: i.id,
+    productName: i.productName,
+    quantity: i.quantity,
+    unitPrice: i.unitPrice,
+    subtotal: i.subtotal,
+    fulfillmentStatus: i.fulfillmentStatus ?? 'new',
+    sentAt: i.sentAt ?? null,
+  }))
+}
+
+function seedPaymentFromTableQr() {
+  if (paymentPrefillSeeded.value || !isMesaMode.value || !posPaymentGroups.value.length) return
+
+  const tableId = posStore.activeTableSession?.tableId
+  if (!tableId) return
+
+  const intent = readTableQrPaymentIntent(tableId)
+  if (intent?.payment_method) {
+    const group = posPaymentGroups.value.find(g => g.slug === intent.payment_method)
+    if (group) {
+      selectedPaymentMethod.value = intent.payment_method
+      if (
+        intent.payment_method_id
+        && group.methods?.some(m => m.id === intent.payment_method_id)
+      ) {
+        selectedPaymentMethodId.value = intent.payment_method_id
+      }
+      clearTableQrPaymentIntent(tableId)
+      paymentPrefillSeeded.value = true
+      return
+    }
+  }
+
+  const orders = mesaCurrentData.value?.data?.orders as Array<{
+    status?: string
+    payment_method?: string
+  }> | undefined
+  const pending = orders?.find(o => o.status === 'pending' && o.payment_method)
+  if (pending?.payment_method) {
+    const group = posPaymentGroups.value.find(g => g.slug === pending.payment_method)
+    if (group) {
+      selectedPaymentMethod.value = pending.payment_method
+      paymentPrefillSeeded.value = true
+    }
+  }
+}
+
+watch(
+  [
+    () => posPaymentGroups.value.length,
+    () => mesaCurrentData.value?.data?.orders,
+    () => posStore.activeTableSession?.tableId,
+  ],
+  seedPaymentFromTableQr,
+  { immediate: true },
+)
+
+watch(
+  () => mesaCurrentData.value?.data?.tab_items,
+  (rows) => {
+    if (!isMesaMode.value || !rows?.length) return
+    posStore.setTabItems(mapTabItemsFromApi(rows))
+  },
+)
 
 // Split payment state
 const splitMode = ref(false)

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -4,6 +4,7 @@ import { storeToRefs } from 'pinia'
 import { $fetch } from 'ofetch'
 import type { CachedProduct, TabItem } from '~/stores/usePOSStore'
 import { usePOSStore } from '~/stores/usePOSStore'
+import { registerTableSessionRefresh } from '~/composables/useTableSessionSync'
 
 definePageMeta({
   layout: 'dashboard',
@@ -338,6 +339,11 @@ const isTableSessionMutationActive = () =>
   || isRefreshingSession.value
   || isClearingTab.value
   || tabItemsLoading.value.size > 0
+
+registerTableSessionRefresh(
+  () => refreshTableSession(),
+  { isMutationActive: isTableSessionMutationActive },
+)
 
 // ID of a tab item pending confirmation before removal (already fired to kitchen)
 const pendingRemoveItemId = ref<string | null>(null)
@@ -768,6 +774,35 @@ const processOrder = async () => {
   router.push('/pos/checkout')
 }
 
+// ── Table session sync (QR accept / cross-device updates, warocol.com#715) ───
+const SESSION_SYNC_MS = 15_000
+let sessionSyncInterval: ReturnType<typeof setInterval> | null = null
+
+const startSessionSyncPolling = () => {
+  if (sessionSyncInterval) return
+  sessionSyncInterval = setInterval(async () => {
+    if (!posStore.activeTableSession) return
+    if (isTableSessionMutationActive()) return
+    await refreshTableSession()
+  }, SESSION_SYNC_MS)
+}
+
+const stopSessionSyncPolling = () => {
+  if (sessionSyncInterval) {
+    clearInterval(sessionSyncInterval)
+    sessionSyncInterval = null
+  }
+}
+
+watch(
+  () => !!posStore.activeTableSession,
+  (active) => {
+    if (active) startSessionSyncPolling()
+    else stopSessionSyncPolling()
+  },
+  { immediate: true },
+)
+
 // ── Fulfillment status polling ───────────────────────────────────────────────
 let fulfillmentPollInterval: ReturnType<typeof setInterval> | null = null
 
@@ -845,6 +880,7 @@ onMounted(async () => {
 
 onUnmounted(() => {
   setRefreshHandler(undefined)
+  stopSessionSyncPolling()
   stopFulfillmentPolling()
   if (readyCountInterval) clearInterval(readyCountInterval)
 })


### PR DESCRIPTION
## Summary
Syncs POS mesa tab and checkout payment method after staff accepts table QR orders in Despacho.

## Changes
- `composables/useTableSessionSync.ts`: cross-page refresh registry, payment intent in sessionStorage, cache invalidation
- `pages/pos/index.vue`: register refresh handler; 15s session poll while mesa is open
- `pages/despacho/en-mesa/index.vue`: after bulk accept, notify POS + store payment intent
- `pages/pos/checkout.vue`: prefill payment method (intent + pending order slug); sync tab_items to store

## Testing
- Open mesa in POS, accept QR orders from Despacho on another device → tab updates within ~15s or immediately via notify
- Go to checkout → customer QR payment method preselected (editable)
- Re-enter mesa after accept → items visible (existing flow)

Stacks on #720 (Despacho #714). Depends on api-warolabs table QR accept (#268).

Closes #715

Made with [Cursor](https://cursor.com)