### PR TITLE
docs: table QR ordering user guide

### DIFF
--- a/docs/usuarios/despacho.md
+++ b/docs/usuarios/despacho.md
@@ -1,14 +1,15 @@
 # Despacho
 
-El módulo de **Despacho** centraliza todos los pedidos online y, opcionalmente, el monitor de comandas para cocina.
+El módulo de **Despacho** centraliza pedidos online, la cola de **pedidos QR en mesa** pendientes de confirmación y, opcionalmente, el monitor de comandas para cocina.
 
 ## Cómo acceder
 
-Menú lateral → **Despacho**. La pantalla tiene dos pestañas:
+Menú lateral → **Despacho**. Según la configuración del negocio verás hasta tres pestañas:
 
 | Pestaña | Para qué |
 |---------|----------|
 | **Domicilios** | Pedidos online (domicilio, recogida y consumo en mesa) |
+| **Pedidos en mesa (QR)** | Pedidos enviados por QR de mesa, pendientes de aceptar o rechazar (requiere mesas + módulo QR activos) |
 | **Comandas** | Monitor en vivo de comandas de cocina (solo si el negocio tiene comandas activas) |
 
 ---
@@ -84,6 +85,35 @@ Al final del detalle se muestra la línea de tiempo con cada cambio de estado y 
 
 ---
 
+## Pedidos en mesa (QR)
+
+Cola de pedidos que los comensales envían desde el menú QR de cada mesa. Solo aparece si tienes **Gestión de mesas** y **Pedido por QR en mesa** activos en **Operaciones → Mesas**.
+
+Configuración del QR y enlaces por mesa: ver [Mesas](../operaciones/mesas#pedido-por-qr-en-mesa).
+
+### Vista general
+
+- Los pedidos se agrupan **por mesa** en el panel izquierdo.
+- Al seleccionar una mesa ves cada solicitud pendiente con ítems, notas y método de pago elegido por el cliente.
+- Por defecto **todos los pedidos de la mesa vienen seleccionados** (puedes desmarcar los que no quieras incluir).
+
+### Aceptar o rechazar
+
+| Acción | Efecto |
+|--------|--------|
+| **Aceptar** | Los ítems seleccionados se agregan al tab de esa mesa en el **POS**. Si hay comandas activas, se envían a cocina automáticamente. |
+| **Rechazar** | Descarta las solicitudes seleccionadas; no se agregan al POS. |
+
+Tras aceptar verás un mensaje de confirmación (incluye número de comanda si aplica).
+
+### Notificaciones
+
+Cuando llega un pedido QR nuevo, la campana de notificaciones muestra **Pedido QR — {nombre de mesa}**. Al tocarla entras a esta pestaña con la mesa ya filtrada.
+
+> **Diferencia con Domicilios:** los pedidos QR **no** usan el flujo Pendiente → Confirmado → Entregado de domicilios. Aquí solo existe la cola pendiente hasta que aceptas o rechazas.
+
+---
+
 ## Comandas
 
 Monitor en vivo para cocina. Solo aparece la pestaña si el negocio tiene **comandas activas** en su configuración.
@@ -136,3 +166,6 @@ Sí. Cuando se confirma un pedido de domicilio o se cobra una orden en mesa, el 
 
 **¿El monitor se actualiza solo?**
 Sí, tanto Domicilios como Comandas refrescan en tiempo real.
+
+**¿Dónde confirmo un pedido que mandó el cliente por QR?**
+En **Despacho → Pedidos en mesa (QR)**, no en Domicilios.

--- a/docs/usuarios/menu/crear-producto.md
+++ b/docs/usuarios/menu/crear-producto.md
@@ -41,8 +41,11 @@ El formulario tiene 3 pasos:
 | Tiempo de preparación | Cuántos minutos tarda en prepararse | No |
 | Disponible para venta | Si está activo en tu menú | — |
 | Disponible para domicilios | Si aparece en pedidos online (delivery / pickup) | — |
+| Pedido en mesa (QR) | Si aparece en el menú QR de las mesas | — |
 
 > Si desactivas "Disponible para venta", el producto no aparece en ningún menú hasta que lo actives de nuevo.
+>
+> **Pedido en mesa (QR)** es independiente de domicilios.
 
 ### Paso 2 — Recetas e ingredientes
 

--- a/docs/usuarios/menu/productos.md
+++ b/docs/usuarios/menu/productos.md
@@ -35,8 +35,11 @@ El formulario tiene 3 pasos:
 | Tiempo de preparación | Cuántos minutos tarda en prepararse | No |
 | Disponible para venta | Si está activo en tu menú | — |
 | Disponible para domicilios | Si aparece en pedidos online (delivery / pickup) | — |
+| Pedido en mesa (QR) | Si aparece en el menú QR de las mesas (solo si el módulo QR está activo en Operaciones) | — |
 
 > Si desactivas "Disponible para venta", el producto no aparece en ningún menú hasta que lo actives de nuevo.
+>
+> **Pedido en mesa (QR)** es independiente de domicilios: un producto puede estar en el QR de mesa sin estar en delivery, y viceversa.
 
 ### Paso 2 — Receta / Ingredientes
 
@@ -54,7 +57,10 @@ Revisa el resumen: nombre, categoría y estado. Si todo está bien, haz clic en 
 
 ## ¿El producto aparece en el menú online inmediatamente?
 
-Sí, siempre que tengas marcada la opción **Disponible para domicilios**. Si no la marcas, el producto existe en el sistema pero no es visible para tus clientes online.
+- **Domicilios / pedidos online:** sí, si está marcado **Disponible para domicilios**.
+- **QR en mesa:** sí, si está marcado **Pedido en mesa (QR)** y el negocio tiene el módulo QR activo en **Operaciones → Mesas**.
+
+Si no marcas ninguna de las dos, el producto existe en el sistema pero no es visible en esos canales.
 
 ---
 
@@ -71,3 +77,6 @@ No. Cada producto pertenece a una sola categoría. Si necesitas que aparezca en 
 
 **¿Cómo agrego una foto al producto?**
 Desde la pantalla de edición del producto, después de crearlo.
+
+**¿Por qué un producto no sale en el menú QR de la mesa?**
+Revisa **Pedido en mesa (QR)** en el producto y que el módulo esté activo en **Operaciones → Mesas**. Ver [Mesas](../../operaciones/mesas#pedido-por-qr-en-mesa).

--- a/docs/usuarios/operaciones.md
+++ b/docs/usuarios/operaciones.md
@@ -28,7 +28,7 @@ Pantalla en vivo para cocina: muestra las órdenes nuevas, en preparación y lis
 
 Aquí se activa/desactiva el módulo de mesas, se crean/editan/desactivan mesas, y se asigna la columna de mesero a las sesiones (si tu negocio tiene atribución de meseros activa).
 
-Ver [Mesas](./operaciones/mesas) para la guía completa: estados, crear/editar, reactivar mesas inactivas, etiqueta configurable (Mesa / Cubículo / Habitación / etc.).
+Ver [Mesas](./operaciones/mesas) para la guía completa: estados, crear/editar, reactivar mesas inactivas, **pedido por QR en mesa** (activar módulo, enlace por mesa, copiar/imprimir), etiqueta configurable (Mesa / Cubículo / Habitación / etc.).
 
 ---
 

--- a/docs/usuarios/operaciones/mesas.md
+++ b/docs/usuarios/operaciones/mesas.md
@@ -7,6 +7,7 @@ La gestión de mesas te permite organizar el salón de tu restaurante directamen
 Menú lateral → **Operaciones → Mesas**. Desde aquí puedes:
 
 - Activar o desactivar el módulo de mesas para el POS
+- Activar **pedido por QR en mesa** y gestionar el enlace QR de cada mesa
 - Ver el listado de mesas configuradas con su estado actual y, si aplica, el mesero asignado
 - Crear, editar, desactivar y reactivar mesas
 
@@ -72,6 +73,54 @@ Si tu negocio tiene activada la **atribución de meseros** (en **Operaciones →
 
 ---
 
+## Pedido por QR en mesa
+
+Permite que los comensales pidan desde su celular escaneando un código en la mesa. El pedido **no entra al POS ni a cocina** hasta que el personal lo **acepta** en **Despacho → Pedidos en mesa (QR)**.
+
+### Requisitos
+
+1. **Gestión de mesas** activa (toggle superior de esta página).
+2. **Pedido por QR en mesa** activo (segundo toggle en el bloque de módulos).
+3. Cada mesa con QR **activado** y enlace generado.
+4. Productos con **Pedido en mesa (QR)** marcado en **Menú → Productos** (independiente de domicilios).
+
+### Activar el módulo QR
+
+En el mismo bloque de módulos, debajo de **Gestión de mesas**, verás **Pedido por QR en mesa**.
+
+- **Activado** — puedes habilitar QR por mesa y los clientes pueden enviar pedidos pendientes de confirmación.
+- **Desactivado** — no se muestran controles QR en el listado ni en el panel de la mesa.
+
+### QR por mesa
+
+Con el módulo QR activo, cada mesa tiene controles para:
+
+| Acción | Para qué sirve |
+|--------|----------------|
+| Activar QR en esta mesa | Genera el enlace público de esa mesa |
+| **Copiar enlace** | Pegar en WhatsApp o donde compartas el menú |
+| **Descargar PNG** | Imagen del código QR para imprimir en la mesa |
+| **Regenerar enlace** | Invalida el QR anterior y crea uno nuevo (vuelve a imprimir si ya repartiste códigos) |
+
+El enlace tiene la forma `https://warocol.com/{tu-negocio}/mesa/{código}` y **permanece estable** hasta que uses **Regenerar enlace**.
+
+En escritorio también verás una columna **QR** en la tabla de mesas con accesos rápidos a copiar y descargar.
+
+### Qué hace el cliente
+
+1. Escanea el QR o abre el enlace.
+2. Ve el menú (solo productos marcados para QR).
+3. Arma el pedido, elige método de pago y envía.
+4. Ve un mensaje de confirmación: el restaurante revisará el pedido antes de prepararlo.
+
+### Qué hace el personal después
+
+Los pedidos pendientes aparecen en **Despacho → Pedidos en mesa (QR)**. Al **Aceptar**, los ítems se agregan al tab de esa mesa en el **POS** y, si tienes comandas activas, se envían a cocina. Ver [Despacho](../despacho#pedidos-en-mesa-qr).
+
+También puedes recibir una notificación en la campana; al tocarla irás directo a la cola de esa mesa.
+
+---
+
 ## Preguntas frecuentes
 
 **¿Dónde se toman los pedidos de las mesas?**
@@ -85,3 +134,15 @@ El toggle cambia la vista del POS, pero las sesiones abiertas no se cierran. Se 
 
 **¿Una mesa desactivada se pierde para siempre?**
 No. Queda en el listado de mesas inactivas y puedes reactivarla cuando quieras.
+
+**¿En qué se diferencia del pedido por QR de Domicilios?**
+En **Domicilios** el cliente pide por el canal online (envío, recogida o consumo en local) y el pedido sigue estados como Pendiente → Confirmado → En preparación. En **pedido QR en mesa** el cliente está físicamente en una mesa concreta, el menú es solo para esa mesa y el pedido queda **pendiente de aceptación** en **Despacho → Pedidos en mesa (QR)** hasta que el personal lo confirme.
+
+**¿Cambia la URL si vuelvo a abrir Operaciones → Mesas?**
+No. El enlace es estable mientras no uses **Regenerar enlace** en esa mesa.
+
+**¿Qué ve el cliente después de enviar el pedido?**
+Una pantalla de éxito indicando que el restaurante confirmará el pedido. Los ítems **no** aparecen en el POS ni se preparan hasta que alguien los **acepte** en Despacho.
+
+**¿Un producto no sale en el menú QR?**
+Revisa que tenga activo **Pedido en mesa (QR)** en **Menú → Productos** y que el módulo QR y el QR de esa mesa estén encendidos.

--- a/docs/usuarios/pos.md
+++ b/docs/usuarios/pos.md
@@ -120,6 +120,15 @@ El flujo es igual al modo mostrador: selecciona productos, ajusta el carrito e i
 
 Al cobrar, la sesión de la mesa se cierra y el POS regresa al plano del salón.
 
+### Pedidos aceptados desde QR
+
+Si el negocio usa **pedido por QR en mesa**, cuando el personal **acepta** un pedido en **Despacho → Pedidos en mesa (QR)**:
+
+- Los ítems aparecen en el tab de esa mesa (si ya tenías la mesa abierta, la lista se actualiza en unos segundos).
+- En **checkout**, el método de pago que eligió el cliente en el QR suele venir **preseleccionado**; el cajero puede cambiarlo antes de cobrar.
+
+Configuración del QR: [Operaciones → Mesas](./operaciones/mesas#pedido-por-qr-en-mesa).
+
 ### Cambiar de mesa
 
 Dentro de una sesión de mesa, usa el botón **Cambiar mesa** en el carrito para volver al plano del salón sin cerrar el pedido.


### PR DESCRIPTION
## Summary
Spanish operator documentation for table QR ordering (epic #710): setup in Operaciones, product visibility, Despacho queue, and POS after accept.

## Changes
- `docs/usuarios/operaciones/mesas.md` — QR module, per-table link/PNG, FAQ
- `docs/usuarios/despacho.md` — Pedidos en mesa (QR) tab
- `docs/usuarios/operaciones.md` — brief cross-link
- `docs/usuarios/menu/productos.md`, `crear-producto.md` — Pedido en mesa (QR) toggle
- `docs/usuarios/pos.md` — post-accept tab + payment prefill

## Testing
- Read docs at `/docs/usuarios/operaciones/mesas` after deploy
- Verify anchors and cross-links render

Docs describe UX from #711–#715; merge after or with those feature PRs.

Closes #716

Made with [Cursor](https://cursor.com)