### PR TITLE
feat(despacho): notification sound for table QR requests (parity with online orders)

### DIFF
--- a/components/DashboardBottomNav.vue
+++ b/components/DashboardBottomNav.vue
@@ -36,7 +36,7 @@
 
         <!-- Notificaciones -->
         <button
-          @click="showNotificationsModal = true"
+          @click="openNotificationsModal"
           aria-label="Ver notificaciones"
           class="relative w-10 h-10 flex items-center justify-center rounded-full transition-all duration-200 hover:bg-titan-100"
         >
@@ -123,6 +123,19 @@
 
     <!-- Notifications Modal -->
     <UiBottomSheetModal v-model="showNotificationsModal" title="Notificaciones" max-height="lg">
+      <div class="flex items-center justify-between px-4 py-2 border-b border-titan-100">
+        <span class="text-xs text-titan-600">Sonido de alertas</span>
+        <button
+          type="button"
+          @click="handleToggleDespachoSound"
+          :aria-label="despachoSoundEnabled ? 'Silenciar alertas sonoras' : 'Activar alertas sonoras'"
+          class="w-8 h-8 flex items-center justify-center rounded-full hover:bg-titan-100 transition-colors"
+          :class="despachoSoundEnabled ? 'text-ebony-800' : 'text-titan-400'"
+        >
+          <SpeakerWaveIcon v-if="despachoSoundEnabled" class="w-4 h-4" aria-hidden="true" />
+          <SpeakerXMarkIcon v-else class="w-4 h-4" aria-hidden="true" />
+        </button>
+      </div>
       <!-- Empty state -->
       <div v-if="notifications.length === 0" class="flex flex-col items-center justify-center py-10 px-4 gap-2">
         <BellIcon class="w-8 h-8 text-muted-foreground/40" aria-hidden="true" />
@@ -132,9 +145,7 @@
       <ul v-else class="divide-y divide-titan-100">
         <li v-for="notification in notifications" :key="notification.id">
           <NuxtLink
-            :to="notification.payload?.order_id
-              ? `/despacho/domicilios/${notification.payload.order_id}`
-              : '/despacho/domicilios'"
+            :to="notificationDespachoPath(notification)"
             @click="handleMarkAsRead(notification.id); showNotificationsModal = false"
             class="flex items-start gap-3 px-4 py-3 hover:bg-titan-50 transition-colors"
             :class="!notification.read_at ? 'bg-crocus-50/40' : ''"
@@ -144,7 +155,7 @@
             </div>
             <div class="flex-1 min-w-0">
               <p class="text-sm font-semibold text-ebony-800 leading-snug">
-                Nuevo pedido #{{ notification.payload?.order_number ?? '—' }}
+                {{ notificationDespachoTitle(notification) }}
               </p>
               <p class="text-xs text-titan-500 mt-0.5">{{ formatRelativeTime(notification.created_at) }}</p>
             </div>
@@ -217,6 +228,8 @@ import {
   Bars3Icon,
   BellAlertIcon,
   BellIcon,
+  SpeakerWaveIcon,
+  SpeakerXMarkIcon,
   BuildingStorefrontIcon,
   ChartBarIcon,
   CheckCircleIcon,
@@ -236,6 +249,8 @@ import {
 import { computed, ref } from 'vue'
 import type { FunctionalComponent } from 'vue'
 import { useLayoutActions } from '../composables/useLayoutActions'
+import { notificationDespachoPath, notificationDespachoTitle } from '~/composables/useNotificationDespachoLink'
+import { useDespachoNotificationAudio } from '~/composables/useDespachoNotificationAudio'
 import type { Module } from '~/stores/access'
 
 type ActivePage =
@@ -309,9 +324,24 @@ const showNotificationsModal = ref(false)
 
 // Notifications
 const { notifications, markAsRead } = useNotifications()
+const {
+  enabled: despachoSoundEnabled,
+  toggleEnabled: toggleDespachoSound,
+  unlockFromGesture: unlockDespachoSound,
+} = useDespachoNotificationAudio()
 
 const handleMarkAsRead = async (id: string) => {
   await markAsRead(id)
+}
+
+const openNotificationsModal = () => {
+  unlockDespachoSound()
+  showNotificationsModal.value = true
+}
+
+const handleToggleDespachoSound = () => {
+  unlockDespachoSound()
+  toggleDespachoSound()
 }
 
 const formatRelativeTime = (dateStr: string): string => {

--- a/components/notifications/MobileOrderToast.vue
+++ b/components/notifications/MobileOrderToast.vue
@@ -105,6 +105,7 @@ import { ref, watch, onMounted } from 'vue'
 import { ShoppingBagIcon, XMarkIcon } from '@heroicons/vue/24/outline'
 import { useNotifications, type Notification } from '~/composables/useNotifications'
 import { notificationDespachoPath, notificationDespachoTitle } from '~/composables/useNotificationDespachoLink'
+import { useDespachoNotificationAudio } from '~/composables/useDespachoNotificationAudio'
 
 interface MobileToast {
   id: number
@@ -116,6 +117,7 @@ const MAX_TOASTS = 3
 const DISMISS_AFTER_MS = 8000
 
 const { notifications, isTenantResetting } = useNotifications()
+const { playChime, prefetchBuffer } = useDespachoNotificationAudio()
 const toasts = ref<MobileToast[]>([])
 let toastIdCounter = 0
 let baselineCount = 0
@@ -142,6 +144,7 @@ const addToast = (notification: Notification) => {
 }
 
 onMounted(() => {
+  prefetchBuffer()
   // Set baseline so we don't toast notifications that already existed on load
   baselineCount = notifications.value.length
 
@@ -150,7 +153,8 @@ onMounted(() => {
     (newLen, oldLen) => {
       if (isTenantResetting.value) return // skip post-reset repopulation — not genuine new arrivals
       if (newLen > oldLen) {
-        // One or more new notifications arrived — toast the newest ones
+        // One chime per arrival burst (not per toast in the loop)
+        playChime()
         const newNotifications = notifications.value.slice(0, newLen - oldLen)
         for (const n of newNotifications) {
           addToast(n)

--- a/components/notifications/NotificationBell.vue
+++ b/components/notifications/NotificationBell.vue
@@ -40,15 +40,28 @@
         aria-label="Panel de notificaciones"
       >
         <!-- Header -->
-        <div class="flex items-center justify-between px-4 py-3 border-b border-border">
+        <div class="flex items-center justify-between px-4 py-3 border-b border-border gap-2">
           <h2 class="text-sm font-semibold text-text-primary">Notificaciones</h2>
-          <button
-            v-if="notifications.length > 0"
-            @click="handleMarkAllRead"
-            class="text-xs text-primary hover:text-primary/80 font-medium transition-colors"
-          >
-            Marcar todo como leído
-          </button>
+          <div class="flex items-center gap-1">
+            <button
+              type="button"
+              @click="handleToggleSound"
+              :title="soundEnabled ? 'Silenciar alertas sonoras' : 'Activar alertas sonoras'"
+              :aria-label="soundEnabled ? 'Silenciar alertas sonoras' : 'Activar alertas sonoras'"
+              class="w-8 h-8 flex items-center justify-center rounded-full hover:bg-surface-secondary transition-colors"
+              :class="soundEnabled ? 'text-text-primary' : 'text-muted-foreground'"
+            >
+              <SpeakerWaveIcon v-if="soundEnabled" class="w-4 h-4" aria-hidden="true" />
+              <SpeakerXMarkIcon v-else class="w-4 h-4" aria-hidden="true" />
+            </button>
+            <button
+              v-if="notifications.length > 0"
+              @click="handleMarkAllRead"
+              class="text-xs text-primary hover:text-primary/80 font-medium transition-colors whitespace-nowrap"
+            >
+              Marcar todo como leído
+            </button>
+          </div>
         </div>
 
         <!-- Loading state -->
@@ -104,19 +117,28 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
-import { BellIcon, BellAlertIcon, ShoppingBagIcon } from '@heroicons/vue/24/outline'
+import { BellIcon, BellAlertIcon, ShoppingBagIcon, SpeakerWaveIcon, SpeakerXMarkIcon } from '@heroicons/vue/24/outline'
 import { useNotifications } from '~/composables/useNotifications'
 import { notificationDespachoPath, notificationDespachoTitle } from '~/composables/useNotificationDespachoLink'
+import { useDespachoNotificationAudio } from '~/composables/useDespachoNotificationAudio'
 
 const { notifications, unreadCount, init, markAsRead, markAllRead } = useNotifications()
+const { enabled: soundEnabled, toggleEnabled, unlockFromGesture, prefetchBuffer } = useDespachoNotificationAudio()
 
 const isOpen = ref(false)
 const isLoading = ref(false)
 const containerRef = ref<HTMLElement | null>(null)
 const triggerRef = ref<HTMLButtonElement | null>(null)
 
+const handleToggleSound = (event: MouseEvent) => {
+  event.stopPropagation()
+  unlockFromGesture()
+  toggleEnabled()
+}
+
 const toggle = async (event: MouseEvent) => {
   triggerRef.value = event.currentTarget as HTMLButtonElement
+  unlockFromGesture()
   if (isOpen.value) {
     close()
     return
@@ -163,8 +185,10 @@ const handleClickOutside = (event: MouseEvent) => {
 
 onMounted(() => {
   document.addEventListener('click', handleClickOutside)
-  // Start SSE connection eagerly (no-op if already connected)
-  if (process.client) init()
+  if (process.client) {
+    prefetchBuffer()
+    init()
+  }
 })
 
 onUnmounted(() => {

--- a/composables/useDespachoNotificationAudio.ts
+++ b/composables/useDespachoNotificationAudio.ts
@@ -1,0 +1,95 @@
+/**
+ * Despacho staff notification chime — issue #732.
+ *
+ * Plays when new notifications arrive (domicilio + mesa QR).
+ * Uses the same asset as KDS but a separate localStorage flag so
+ * muting comandas does not silence despacho alerts.
+ */
+import { readonly } from 'vue'
+
+const STORAGE_KEY = 'despacho_notification_sound_enabled'
+const SOUND_URL = '/sounds/kds-new-order.wav'
+
+let _audioCtx: AudioContext | null = null
+let _audioBuffer: AudioBuffer | null = null
+let _prefetchStarted = false
+
+const getEnabledFromStorage = (): boolean => {
+  if (typeof window === 'undefined') return true
+  return localStorage.getItem(STORAGE_KEY) !== 'false'
+}
+
+const prefetchBuffer = async () => {
+  if (typeof window === 'undefined') return
+  if (_prefetchStarted && _audioBuffer) return
+  _prefetchStarted = true
+  try {
+    if (!_audioCtx) _audioCtx = new AudioContext()
+    if (!_audioBuffer) {
+      const res = await fetch(SOUND_URL)
+      if (!res.ok) return
+      const raw = await res.arrayBuffer()
+      _audioBuffer = await _audioCtx.decodeAudioData(raw)
+    }
+  } catch {
+    /* network / decode — fail silently */
+  }
+}
+
+export const useDespachoNotificationAudio = () => {
+  const enabled = useState<boolean>('despacho-notification-sound-enabled', getEnabledFromStorage)
+
+  const setEnabled = (value: boolean) => {
+    enabled.value = value
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(STORAGE_KEY, value ? 'true' : 'false')
+    }
+    if (value && _audioCtx?.state === 'suspended') {
+      _audioCtx.resume().catch(() => {})
+    }
+  }
+
+  const toggleEnabled = () => setEnabled(!enabled.value)
+
+  /** Call inside a user gesture (bell click) to unlock AudioContext for autoplay. */
+  const unlockFromGesture = () => {
+    if (typeof window === 'undefined') return
+    try {
+      if (!_audioCtx) _audioCtx = new AudioContext()
+      if (_audioCtx.state === 'suspended') {
+        _audioCtx.resume().catch(() => {})
+      }
+      if (!_audioBuffer) prefetchBuffer()
+    } catch {
+      /* fail silently */
+    }
+  }
+
+  const playChime = async () => {
+    if (!enabled.value) return
+    try {
+      if (!_audioBuffer) await prefetchBuffer()
+      if (!_audioCtx || !_audioBuffer) return
+      if (_audioCtx.state === 'suspended') await _audioCtx.resume()
+      if (_audioCtx.state !== 'running') return
+      const src = _audioCtx.createBufferSource()
+      src.buffer = _audioBuffer
+      const gain = _audioCtx.createGain()
+      gain.gain.value = 0.7
+      src.connect(gain)
+      gain.connect(_audioCtx.destination)
+      src.start()
+    } catch {
+      /* autoplay blocked — fail silently */
+    }
+  }
+
+  return {
+    enabled: readonly(enabled),
+    setEnabled,
+    toggleEnabled,
+    unlockFromGesture,
+    playChime,
+    prefetchBuffer,
+  }
+}

--- a/composables/useNotifications.ts
+++ b/composables/useNotifications.ts
@@ -50,7 +50,7 @@ export const useNotifications = () => {
     eventSource.onmessage = async (event) => {
       if (!event.data || event.data.startsWith(':')) return // ignore heartbeat comments
       // Invalidate cache — Pinia Colada refetches automatically
-      // Sound + toast are handled by MobileOrderToast.vue via its length watcher
+      // Toast + chime are handled by MobileOrderToast.vue via its length watcher
       await _queryCache?.invalidateQueries({ key: ['notifications'] })
     }
 

--- a/docs/usuarios/despacho.md
+++ b/docs/usuarios/despacho.md
@@ -128,6 +128,8 @@ Tras aceptar verás un mensaje de confirmación (incluye número de comanda si a
 
 ### Notificaciones
 
+Cuando llega un pedido nuevo (domicilio o QR en mesa), la campana muestra el aviso y suena un **tono corto** (mismo estilo que cocina). Puedes silenciarlo con el icono de volumen en el panel de notificaciones (campana en escritorio o modal en móvil).
+
 Cuando llega un pedido QR nuevo, la campana muestra **Pedido QR — {nombre de mesa}**.
 
 | Al tocar la notificación | Destino |


### PR DESCRIPTION
## Summary

Adds a short chime when new staff notifications arrive (domicilio + mesa QR), with mute toggle in the notification bell (desktop) and bottom-nav modal (mobile). Reuses `/sounds/kds-new-order.wav` with a separate `despacho_notification_sound_enabled` localStorage key.

Also fixes mobile bottom-nav notification links to use `notificationDespachoPath` / `notificationDespachoTitle` for `table_qr_request`.

## Changes

- `composables/useDespachoNotificationAudio.ts` — AudioContext + buffer prefetch, play, mute, gesture unlock
- `components/notifications/MobileOrderToast.vue` — one chime per SSE burst before toasts
- `components/notifications/NotificationBell.vue` — volume toggle + unlock on bell open
- `components/DashboardBottomNav.vue` — sound toggle + en-mesa routing fix
- `composables/useNotifications.ts` — comment fix
- `docs/usuarios/despacho.md` — document sound + mute

## Testing

- [ ] Submit online order → chime + toast (sound on)
- [ ] Submit mesa QR order → chime + toast
- [ ] Toggle mute in bell → no chime on next notification
- [ ] Open bell once → unlocks audio for session
- [ ] Tenant switch → no chime on repopulated list
- [ ] Mobile bottom nav → QR notification links to en-mesa detail

Closes #732

Made with [Cursor](https://cursor.com)