### PR TITLE
fix(pos): checkout tip flow — waiter first, percentages only on explicit selection

### DIFF
--- a/components/checkout/TipSelector.vue
+++ b/components/checkout/TipSelector.vue
@@ -75,10 +75,10 @@ const tipSource = computed<'preset' | 'custom' | 'none'>(() => {
   return activeMode.value.kind === 'preset' ? 'preset' : 'custom'
 })
 
-// Emit on every change
+// Emit on every change (immediate so parent v-model matches hydration/preselect)
 watch([tipAmount, tipSource], () => {
   emit('update:modelValue', { amount: tipAmount.value, source: tipSource.value })
-}, { immediate: false })
+}, { immediate: true })
 
 const formatCurrency = (value: number): string =>
   new Intl.NumberFormat('es-CO', {

--- a/docs/usuarios/pos.md
+++ b/docs/usuarios/pos.md
@@ -49,8 +49,8 @@ Haz clic en **Ir a checkout**. En la pantalla de checkout puedes ajustar:
 | Método de pago | Selecciona un grupo (ej: Tarjeta) o un método específico dentro del grupo. La lista la define el administrador. |
 | Puntos Waros | Si el cliente tiene puntos, puedes aplicarlos como descuento |
 | Descuento | Aplica un porcentaje o monto fijo sobre el subtotal |
-| Propina | Aparece solo si las propinas están activas. Ver [Propinas](#propinas) |
 | Mesero | Asigna el mesero responsable de la orden. Ver [Asignar mesero al cobrar](#asignar-mesero-al-cobrar) |
+| Propina | Aparece solo si las propinas están activas. Ver [Propinas](#propinas) |
 | Domicilio | Si la orden es para enviar, agrega dirección y valor de domicilio |
 | Cobro parcial | Permite dividir el pago en varios métodos. Ver [Cobro parcial](#cobro-parcial-split) |
 
@@ -58,31 +58,31 @@ Confirma el pago. WARO registra la orden, actualiza el inventario y muestra el r
 
 ---
 
-### Propinas
-
-Si el administrador activó las propinas en **Operaciones → Propinas**, aparece un selector durante el checkout.
-
-- El cajero ve **chips con los porcentajes preconfigurados** (por ejemplo 5% · 10% · 15%) y puede tocar uno para aplicarlo sobre el subtotal antes de impuestos.
-- También puede ingresar un **monto personalizado** en pesos.
-- El botón "Confirmar" cambia su etiqueta a **Confirmar — $X.XXX** mostrando el total cobrado (subtotal + propina).
-- La propina **no entra dentro de la base de impuestos**: se cobra encima del total.
-- Si el administrador activó la opción de pre-seleccionar un porcentaje, ese chip aparece marcado por defecto.
-
-> **Importante:** no se puede combinar propina con cobro parcial. Si activas el modo "cobro parcial", el selector de propina desaparece.
-
-En mesas, la propina se envía al cerrar la sesión de la mesa.
-
----
-
 ### Asignar mesero al cobrar
 
-Si las propinas están activas, aparece un selector de mesero en el checkout para atribuir la venta (y su propina) al miembro del equipo correspondiente.
+Si las propinas están activas, aparece primero un selector de mesero en el checkout para atribuir la venta (y su propina) al miembro del equipo correspondiente.
 
 - **Modo mesa:** el selector siempre aparece. Viene precargado con el mesero efectivo de la sesión (el último que tomó la orden), pero el cajero puede confirmarlo o cambiarlo antes de cobrar.
 - **Modo mostrador / barra:** el selector solo aparece si todavía no se asignó un mesero desde el chip del carrito.
 - Si las propinas están **desactivadas**, el selector no aparece y la venta no queda atribuida.
 
 El mesero asignado queda visible en el detalle de la orden en **Ventas** y alimenta las métricas del perfil del mesero en **Equipo → Miembros**.
+
+---
+
+### Propinas
+
+Si el administrador activó las propinas en **Operaciones → Propinas**, debajo del mesero aparece el selector de propina durante el checkout.
+
+- El cajero ve **chips con los porcentajes preconfigurados** (por ejemplo 5% · 10% · 15%) y debe tocar uno para aplicarlo sobre el subtotal antes de impuestos; si no elige ninguno, **no se cobra propina**.
+- También puede ingresar un **monto personalizado** en pesos o elegir **Sin propina**.
+- El botón "Confirmar" cambia su etiqueta a **Confirmar — $X.XXX** solo cuando hay propina seleccionada.
+- La propina **no entra dentro de la base de impuestos**: se cobra encima del total.
+- En el POS **nunca** se pre-selecciona un porcentaje automáticamente (la opción de pre-selección en Operaciones aplica solo a pedidos online).
+
+> **Importante:** no se puede combinar propina con cobro parcial. Si activas el modo "cobro parcial", el selector de propina desaparece.
+
+En mesas, la propina se envía al cerrar la sesión de la mesa.
 
 ---
 

--- a/pages/operaciones/propinas.vue
+++ b/pages/operaciones/propinas.vue
@@ -276,7 +276,7 @@ const saveConfig = async () => {
               Pre-seleccionar primer preset
             </p>
             <p class="text-xs mt-0.5 leading-snug text-text-secondary">
-              Recomendado: <strong>desactivado</strong>. La Ley 1935 establece que la propina es voluntaria — al no pre-seleccionar, el cliente la elige de forma consciente.
+              Recomendado: <strong>desactivado</strong>. La Ley 1935 establece que la propina es voluntaria. Solo aplica en <strong>pedidos online</strong>; en el POS el cajero siempre elige la propina de forma explícita.
             </p>
           </div>
           <label

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -175,7 +175,6 @@ const acceptsOnlineOrders = computed(() => settingsData.value?.data?.accepts_onl
 // warocol.com#639 — tipping config (gated by tenant; defaults keep selector hidden)
 const tipEnabled = computed(() => settingsData.value?.data?.tip_enabled === true)
 const tipPresets = computed<number[]>(() => settingsData.value?.data?.tip_default_percentages ?? [10])
-const tipPreselectIndex = computed<number | null>(() => settingsData.value?.data?.tip_preselect_index ?? null)
 const tipModel = ref<{ amount: number; source: 'preset' | 'custom' | 'none' }>({ amount: 0, source: 'none' })
 const tipAmount = computed(() => tipModel.value.amount)
 const tipSource = computed(() => tipModel.value.source)
@@ -1939,23 +1938,22 @@ onUnmounted(() => {
           </div>
         </div>
 
-        <!-- warocol.com#639 — Tip selector in the LEFT column (after Descuento, before Domicilio).
-             Hidden when tip_enabled=false or in split mode (backend rejects tip + split). -->
-        <CheckoutTipSelector
-          v-if="tipEnabled && !splitMode"
-          :enabled="tipEnabled"
-          :presets="tipPresets"
-          :preselect-index="tipPreselectIndex"
-          :subtotal="cartTotal"
-          v-model="tipModel"
-        />
-
-        <!-- warocol.com#663 — Waiter at checkout when session has no effective waiter -->
+        <!-- warocol.com#663 + #735 — Waiter first, then tip (opt-in; no tenant preselect on POS). -->
         <CheckoutWaiterSelector
           v-if="showCheckoutWaiterSelector"
           :members="tenantMembers"
           :model-value="posStore.cartServedByMemberId"
           @update:model-value="posStore.setCartServedBy"
+        />
+
+        <!-- warocol.com#639 — Tip selector after mesero; hidden in split mode (backend rejects tip + split). -->
+        <CheckoutTipSelector
+          v-if="tipEnabled && !splitMode"
+          :enabled="tipEnabled"
+          :presets="tipPresets"
+          :preselect-index="null"
+          :subtotal="cartTotal"
+          v-model="tipModel"
         />
 
         <!-- Section: Domicilio (mostrador or bar — never mesa) -->


### PR DESCRIPTION
## Summary
Reorders POS checkout so staff pick the waiter for tip credit before optional tip percentages. POS never auto-applies tenant preselect; online checkout keeps preselect behavior.

## Changes
- `pages/pos/checkout.vue`: waiter block above tip block; `:preselect-index="null"` on POS
- `components/checkout/TipSelector.vue`: `immediate: true` on v-model emit for sync
- `docs/usuarios/pos.md`: mesero before propina; opt-in wording
- `pages/operaciones/propinas.vue`: preselect copy scoped to online orders

## Testing
- [ ] POS checkout with `tip_enabled`: mesero appears above propina chips
- [ ] Confirm without selecting tip → no propina line, `tip_amount` not sent
- [ ] Select preset → Confirm shows total + propina
- [ ] Mesa: waiter still seeded from session
- [ ] Split mode: no tip UI (unchanged)
- [ ] Online checkout with preselect enabled: first chip still pre-selected

Closes #735

Made with [Cursor](https://cursor.com)