### PR TITLE
feat(pos): split checkout UI includes tip in amount due

### DIFF
--- a/docs/usuarios/pos.md
+++ b/docs/usuarios/pos.md
@@ -90,14 +90,15 @@ En mesas, la propina se envía al cerrar la sesión de la mesa.
 
 Cuando un cliente quiere pagar con varios métodos (ej: parte en efectivo y parte con tarjeta):
 
-1. Activa el toggle **Cobro parcial** en el checkout.
-2. Selecciona el método y escribe el monto del primer pago. Confirma.
-3. Repite para cada pago adicional hasta cubrir el total.
-4. Si te equivocaste en un pago ya registrado, toca el ícono de **papelera** para eliminarlo. Puedes opcionalmente escribir un motivo. Si el pago fue en efectivo, el sistema te advierte que debes devolverlo físicamente al cliente.
+1. Asigna el **mesero** y, si aplica, la **propina** (antes o después de activar cobro parcial).
+2. Activa el toggle **Cobro parcial** en el checkout.
+3. Selecciona el método y escribe el monto del primer pago. Confirma.
+4. Repite para cada pago adicional hasta cubrir **total de la orden + propina** (si hubo propina).
+5. Si te equivocaste en un pago ya registrado, toca el ícono de **papelera** para eliminarlo. Puedes opcionalmente escribir un motivo. Si el pago fue en efectivo, el sistema te advierte que debes devolverlo físicamente al cliente.
 
 Para pagos en efectivo, los presets de billetes (**$10K · $20K · $50K**) se suman acumulativamente al monto recibido, facilitando calcular el vuelto.
 
-> **Importante:** no se puede combinar cobro parcial con propinas. Si activas split, el selector de propina desaparece.
+La propina se calcula sobre el subtotal de la orden; el **saldo pendiente** del cobro parcial incluye orden + propina. Puedes cobrar la propina en cualquier pago parcial (no tiene que ir en el último).
 
 ---
 

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -410,9 +410,14 @@ watch(
 
 // Split payment state
 const splitMode = ref(false)
-// warocol.com#735 — propina solo tras elegir mesero (o mesero ya en carrito / sesión mesa)
+// warocol.com#735 + #737 — propina tras mesero; editable until first partial is posted
 const showCheckoutTipSelector = computed(
-  () => tipEnabled.value && !splitMode.value && !!posStore.cartServedByMemberId,
+  () => tipEnabled.value && !!posStore.cartServedByMemberId && splitPayments.value.length === 0,
+)
+const splitTipBody = computed(() =>
+  tipAmount.value > 0
+    ? { tip_amount: tipAmount.value, tip_source: tipSource.value }
+    : {},
 )
 const splitPayments = ref<Array<{ id: string; amount: number; payment_method: string; payment_method_name: string }>>([])
 const splitPaidTotal = ref(0)
@@ -422,7 +427,8 @@ const isVoidingPayment = ref<string | null>(null)
 const voidPaymentTarget = ref<{ id: string; amount: number; payment_method: string; payment_method_name: string } | null>(null)
 const voidPaymentReason = ref('')
 const voidPaymentError = ref('')
-const splitRemaining = computed(() => Math.max(0, discountedTotal.value - splitPaidTotal.value))
+const splitAmountDue = computed(() => discountedTotal.value + tipAmount.value)
+const splitRemaining = computed(() => Math.max(0, splitAmountDue.value - splitPaidTotal.value))
 const splitIsComplete = computed(() => splitRemaining.value <= 0.01)
 
 const onSplitAmountInput = (e: Event) => {
@@ -508,10 +514,11 @@ const addSplitPayment = async () => {
               ? { split_first_cash_received: Number(cashReceivedInput.value) }
               : {}),
             ...checkoutServedByBody.value,
+            ...splitTipBody.value,
           }
         }) as any
         paidTotal = response.data.paid_total ?? amountToCharge
-        remaining = response.data.remaining ?? (discountedTotal.value - amountToCharge)
+        remaining = response.data.remaining ?? (splitAmountDue.value - amountToCharge)
         isComplete = response.data.is_complete ?? false
         // Issue warocol.com#649 — real UUID from backend so the trash button can DELETE it.
         paymentId = response.data.payment_id
@@ -554,10 +561,11 @@ const addSplitPayment = async () => {
               ? { split_first_cash_received: Number(cashReceivedInput.value) }
               : {}),
             ...checkoutServedByBody.value,
+            ...splitTipBody.value,
           }
         }) as any
         paidTotal = response.data.paid_total ?? amountToCharge
-        remaining = response.data.remaining ?? (discountedTotal.value - amountToCharge)
+        remaining = response.data.remaining ?? (splitAmountDue.value - amountToCharge)
         isComplete = response.data.is_complete ?? false
         // Issue warocol.com#649 — backend always returns a real UUID; no fallback.
         paymentId = response.data.payment_id
@@ -609,7 +617,13 @@ const addSplitPayment = async () => {
         payment_method: selectedPaymentMethod.value,
         ...(discountEnabled.value && discountAmount.value > 0
           ? { discount_amount: discountAmount.value, subtotal: cartTotal.value }
-          : {})
+          : {}),
+        ...(tipAmount.value > 0
+          ? {
+              tip_amount: tipAmount.value,
+              charged_amount: splitAmountDue.value,
+            }
+          : {}),
       }
       cartItemsSnapshot.value = [...cartItems.value]
       receiptEmail.value = ''
@@ -2270,6 +2284,25 @@ onUnmounted(() => {
                     </svg>
                   </button>
                 </div>
+              </div>
+            </div>
+
+            <!-- warocol.com#737 — settlement total includes tip when selected -->
+            <div
+              v-if="tipAmount > 0"
+              class="rounded-lg border border-border bg-surface-secondary/60 px-3 py-2.5 space-y-1.5 text-sm"
+            >
+              <div class="flex items-center justify-between text-text-secondary">
+                <span>Total orden</span>
+                <span class="tabular-nums font-medium text-text-primary">{{ formatCurrency(discountedTotal) }}</span>
+              </div>
+              <div class="flex items-center justify-between text-text-secondary">
+                <span>Propina</span>
+                <span class="tabular-nums font-medium text-text-primary">{{ formatCurrency(tipAmount) }}</span>
+              </div>
+              <div class="flex items-center justify-between border-t border-border pt-1.5 font-semibold text-text-primary">
+                <span>Total a cobrar</span>
+                <span class="tabular-nums">{{ formatCurrency(splitAmountDue) }}</span>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
POS checkout: tip selector stays available with split mode until the first partial payment is posted. Split panel shows order total + tip breakdown; `splitAmountDue` / `splitRemaining` include tip; first split request sends `tip_amount` / `tip_source`.

## Changes
- `pages/pos/checkout.vue`: progressive tip with split; settlement UI; success modal charged amount includes tip
- `docs/usuarios/pos.md`: document split + tip compatibility

## Testing
Manual: select mesero → set tip % → enable cobro parcial → verify total a cobrar = orden + propina; post partials until saldo 0.

Closes #737

Requires API PR (deploy API first).

Made with [Cursor](https://cursor.com)