### PR TITLE
feat(pos): show tip on prefactura, printed receipt, and invoice (split + single pay)

### DIFF
--- a/docs/usuarios/pos.md
+++ b/docs/usuarios/pos.md
@@ -80,9 +80,7 @@ Si el administrador activó las propinas en **Operaciones → Propinas**, primer
 - La propina **no entra dentro de la base de impuestos**: se cobra encima del total.
 - En el POS **nunca** se pre-selecciona un porcentaje automáticamente (la opción de pre-selección en Operaciones aplica solo a pedidos online).
 
-> **Importante:** no se puede combinar propina con cobro parcial. Si activas el modo "cobro parcial", el selector de propina desaparece.
-
-En mesas, la propina se envía al cerrar la sesión de la mesa.
+En mesas, la propina se envía al cerrar la sesión de la mesa (o con el primer cobro parcial si usas split).
 
 ---
 
@@ -144,13 +142,20 @@ Dentro de una sesión de mesa, usa el botón **Cambiar mesa** en el carrito para
 - Si hubo propina, queda asociada a la orden y al mesero asignado
 - Aparece en el dashboard de analítica
 
-El modal de éxito muestra el desglose final: subtotal, descuento, **propina** (si aplica) y **Total cobrado** como línea destacada cuando hubo propina.
+El modal de éxito, la **tirilla impresa** y el **correo de recibo** muestran el mismo desglose: subtotal, descuento, **propina** (si aplica) y **Total cobrado** cuando hubo propina. La factura electrónica DIAN sigue reflejando solo el total de la orden (sin propina) hasta que se implemente #740.
 
 ---
 
 ## Recibos y comprobantes
 
 Cuando confirmas el pago aparece una pantalla de éxito con dos opciones para entregar el comprobante al cliente.
+
+### Imprimir prefactura (pre-cuenta)
+
+Antes de cobrar, usa **Imprimir prefactura** para que el cliente revise el consumo. No es factura electrónica (lleva el aviso *ESTA NO ES UNA FACTURA*).
+
+- Si hay **propina** seleccionada: muestra **Total orden**, **Propina** y **TOTAL A COBRAR** (orden + propina).
+- Si hay **cobro parcial** en curso: lista los pagos registrados y el **saldo pendiente** (incluye propina cuando aplica).
 
 ### Enviar recibo por correo
 
@@ -161,7 +166,8 @@ Haz clic en **Enviar** para que el sistema despache el recibo al instante. El re
 - Nombre del restaurante y datos de contacto
 - Número de orden
 - Productos comprados con cantidades y precios
-- Total y método de pago
+- Total de la orden, **propina** (si aplica) y **total cobrado**
+- Método de pago (o desglose de pagos si fue cobro parcial)
 
 El botón cambia a **Enviado** cuando el correo fue despachado correctamente.
 
@@ -195,4 +201,4 @@ Sí, si el administrador las activó en **Operaciones → Propinas**. Allí tamb
 Sí, con el ícono de papelera junto al pago. Puedes escribir un motivo opcional. Si el pago fue en efectivo, recuerda devolverlo físicamente al cliente.
 
 **¿Puedo combinar propina y cobro parcial?**
-No. Hay que elegir uno de los dos modos en cada venta.
+Sí. Elige mesero y propina primero; el saldo del cobro parcial incluye orden + propina. La propina queda fijada al registrar el primer pago parcial.

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1046,8 +1046,7 @@ watch(selectedPaymentMethod, () => {
 const isCashMethod = computed(() => selectedGroup.value?.slug === 'cash')
 const cashReceivedInput = ref<number>(0)
 
-// warocol.com#639 — single-payment cash flow must cover total + tip (split mode
-// disallows tips, enforced by the backend in api-warolabs#245).
+// warocol.com#639 — single-payment cash flow must cover total + tip (#737: split too).
 const cashAmountToCharge = computed(() =>
   splitMode.value ? splitAmountToCharge.value : finalChargedAmount.value
 )
@@ -1376,6 +1375,7 @@ const sendReceiptEmail = async () => {
         invoice_prefix: invoiceResult.value?.prefix ?? null,
         invoice_number: invoiceResult.value?.invoice_number ?? null,
         invoice_cufe: invoiceResult.value?.cufe ?? null,
+        tip_amount: orderResult.value.tip_amount ?? 0,
       }
     })
     emailSent.value = true
@@ -3196,10 +3196,41 @@ onUnmounted(() => {
       <span>Impuesto licores</span>
       <span>{{ formatCurrency(taxPreview.liquor_tax) }}</span>
     </div>
-    <div class="receipt-total">
+    <!-- warocol.com#739 — pre-bill totals include tip and split settlement when applicable -->
+    <template v-if="tipAmount > 0">
+      <div class="receipt-item">
+        <span>Total orden</span>
+        <span>{{ formatCurrency(discountedTotal) }}</span>
+      </div>
+      <div class="receipt-item">
+        <span>Propina</span>
+        <span>{{ formatCurrency(tipAmount) }}</span>
+      </div>
+      <div class="receipt-total">
+        <span>TOTAL A COBRAR</span>
+        <span>{{ formatCurrency(splitAmountDue) }}</span>
+      </div>
+    </template>
+    <div v-else class="receipt-total">
       <span>TOTAL</span>
       <span>{{ formatCurrency(discountedTotal) }}</span>
     </div>
+    <template v-if="splitPayments.length > 0">
+      <div class="receipt-divider">--------------------------------</div>
+      <div class="receipt-row receipt-small" style="font-weight:bold;">Pagos registrados</div>
+      <div
+        v-for="(p, idx) in splitPayments"
+        :key="p.id"
+        class="receipt-item receipt-small"
+      >
+        <span>#{{ idx + 1 }} · {{ p.payment_method_name }}</span>
+        <span>{{ formatCurrency(p.amount) }}</span>
+      </div>
+      <div class="receipt-item">
+        <span>{{ splitIsComplete ? 'Cobro completo' : 'Saldo pendiente' }}</span>
+        <span>{{ formatCurrency(splitRemaining) }}</span>
+      </div>
+    </template>
 
     <div v-if="isMesaMode && cartItems.some(i => i.fired === false)" class="receipt-row receipt-small" style="margin-top:6px;">
       * pendiente de enviar a cocina
@@ -3239,11 +3270,38 @@ onUnmounted(() => {
       <span>Descuento</span>
       <span>-{{ formatCurrency(orderResult.discount_amount) }}</span>
     </div>
-    <div class="receipt-total">
+    <!-- warocol.com#739 — printed receipt mirrors success modal + split payments -->
+    <template v-if="orderResult?.tip_amount && orderResult.tip_amount > 0">
+      <div class="receipt-item">
+        <span>Total orden</span>
+        <span>{{ formatCurrency(orderResult?.total_amount ?? 0) }}</span>
+      </div>
+      <div class="receipt-item">
+        <span>Propina</span>
+        <span>{{ formatCurrency(orderResult.tip_amount) }}</span>
+      </div>
+      <div class="receipt-total">
+        <span>TOTAL COBRADO</span>
+        <span>{{ formatCurrency(orderResult.charged_amount ?? (orderResult.total_amount + orderResult.tip_amount)) }}</span>
+      </div>
+    </template>
+    <div v-else class="receipt-total">
       <span>TOTAL</span>
       <span>{{ formatCurrency(orderResult?.total_amount ?? 0) }}</span>
     </div>
-    <div class="receipt-row">{{ getPaymentMethodLabel(orderResult?.payment_method ?? '') }}</div>
+    <template v-if="splitPayments.length > 0">
+      <div class="receipt-divider">--------------------------------</div>
+      <div class="receipt-row receipt-small" style="font-weight:bold;">Pagos</div>
+      <div
+        v-for="(p, idx) in splitPayments"
+        :key="p.id"
+        class="receipt-item receipt-small"
+      >
+        <span>#{{ idx + 1 }} · {{ p.payment_method_name }}</span>
+        <span>{{ formatCurrency(p.amount) }}</span>
+      </div>
+    </template>
+    <div v-else class="receipt-row">{{ getPaymentMethodLabel(orderResult?.payment_method ?? '') }}</div>
     <div class="receipt-divider">================================</div>
     <div class="receipt-footer">¡Gracias por tu compra!</div>
     <!-- DIAN invoice section on printed receipt -->


### PR DESCRIPTION
## Summary
Phase A of #739: surface tip and split payment state on prefactura (pre-bill), printed receipt, and receipt email. DIAN electronic invoice unchanged (tip still off-invoice; see #740).

## Changes
- `pages/pos/checkout.vue`:
  - `#pos-prefactura`: Total orden / Propina / TOTAL A COBRAR when tip selected; pagos registrados + saldo on split
  - `#pos-receipt`: same breakdown post-payment; list split payments when present
  - `sendReceiptEmail`: pass `tip_amount` (API template already supported)
- `docs/usuarios/pos.md`: prefactura section, receipt/email notes, FAQ split+tip

## Testing
Manual:
1. Checkout with mesero + 10% tip → Imprimir prefactura → verify three total lines
2. Complete sale → Imprimir comprobante → verify Propina + TOTAL COBRADO
3. Split + tip → prefactura shows partials and saldo; receipt lists Pagos
4. Send receipt email with tip → verify Propina in email body

Closes #739

Made with [Cursor](https://cursor.com)