### PR TITLE
[#744] Product cost preview labeled as estimado

### DIFF
--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -153,7 +153,7 @@
 
               <div>
                 <label class="block text-sm font-medium text-text-secondary mb-2">
-                  Costo Calculado (desde receta)
+                  Costo estimado (previo al guardar)
                 </label>
                 <div class="relative">
                   <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
@@ -166,7 +166,7 @@
                   />
                 </div>
                 <p class="text-xs text-text-tertiary mt-1">
-                  Se calculará automáticamente desde los ingredientes
+                  Vista previa con precios configurados; el costo real se confirma al guardar
                 </p>
               </div>
             </div>
@@ -517,7 +517,7 @@
             </div>
 
             <div class="flex justify-between text-sm">
-              <span class="text-text-secondary">Costo:</span>
+              <span class="text-text-secondary">Costo estimado:</span>
               <span class="font-semibold text-text-primary">
                 {{ calculatedCost === null ? '—' : formatCurrency(calculatedCost) }}
               </span>

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -727,7 +727,7 @@
                     <span class="text-sm font-bold text-text-primary">{{ formatCurrency(form.price) }}</span>
                   </div>
                   <div class="flex justify-between items-center">
-                    <span class="text-sm text-text-secondary">Costo Calculado</span>
+                    <span class="text-sm text-text-secondary">Costo estimado</span>
                     <span class="text-sm font-semibold text-text-primary">
                       {{ calculatedCost === null ? '—' : formatCurrency(calculatedCost) }}
                     </span>
@@ -1042,7 +1042,7 @@ const calculatedCost = computed<number | null>(() => {
     const cached = ingredientCache.value[ing.ingredient_id]
     const ingredient = cached || availableIngredients.value.find((i: any) => i.id === ing.ingredient_id)
     if (!ingredient) return sum
-    return sum + (ing.quantity * (ingredient.price || 0))
+    return sum + (ing.quantity * Number(ingredient.costo_unitario || ingredient.price || 0))
   }, 0)
 
   return totalCost


### PR DESCRIPTION
## Summary
- Rename live preview label to **Costo estimado** (confirmed on save)
- Use `costo_unitario` fallback for direct recipe lines in crear.vue

Companion to api-warolabs PR for unified `costo_calculado`.

## Testing
- Manual: create/edit product — preview shows estimado; list matches after save

Closes #744

Made with [Cursor](https://cursor.com)