### PR TITLE
[Frontend] Menu productos: dual cost UI (real + perceived)

### DIFF
--- a/composables/useProductMargins.ts
+++ b/composables/useProductMargins.ts
@@ -1,0 +1,59 @@
+/**
+ * Dual product cost margins — real (costo_calculado) vs operativo (costo_percibido).
+ * Prefers API-computed fields from #745 when present.
+ */
+
+export type ProductCostFields = {
+  price?: number | string | null
+  costo_calculado?: number | string | null
+  costo_percibido?: number | string | null
+  margen_real_pct?: number | string | null
+  margen_operativo_pct?: number | string | null
+}
+
+export function toNum(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null
+  const n = Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+function marginPctFromCosts(price: number, cost: number): number | null {
+  if (price <= 0 || cost <= 0) return null
+  const margin = ((price - cost) / cost) * 100
+  return Number.isFinite(margin) ? margin : null
+}
+
+export function marginRealPct(product: ProductCostFields): number | null {
+  const fromApi = toNum(product.margen_real_pct)
+  if (fromApi !== null) return fromApi
+  const price = toNum(product.price)
+  const cost = toNum(product.costo_calculado)
+  if (price === null || cost === null) return null
+  return marginPctFromCosts(price, cost)
+}
+
+export function marginOperativoPct(product: ProductCostFields): number | null {
+  const fromApi = toNum(product.margen_operativo_pct)
+  if (fromApi !== null) return fromApi
+  const perceived = toNum(product.costo_percibido)
+  if (perceived === null) return null
+  const price = toNum(product.price)
+  if (price === null) return null
+  return marginPctFromCosts(price, perceived)
+}
+
+/** |real - perceived| / real > threshold when both costs are set. */
+export function hasCostDrift(product: ProductCostFields, threshold = 0.25): boolean {
+  const real = toNum(product.costo_calculado)
+  const perceived = toNum(product.costo_percibido)
+  if (real === null || perceived === null || real <= 0) return false
+  return Math.abs(real - perceived) / real > threshold
+}
+
+export function formatCostCell(
+  value: unknown,
+  formatCurrency: (n: number) => string,
+): string {
+  if (value === null || value === undefined) return '—'
+  return formatCurrency(Number(value))
+}

--- a/docs/usuarios/menu/productos.md
+++ b/docs/usuarios/menu/productos.md
@@ -32,6 +32,8 @@ El formulario tiene 3 pasos:
 | Descripción | Una descripción corta del plato | No |
 | Categoría | A qué grupo pertenece (Entradas, Platos fuertes, Bebidas...) | Sí |
 | Precio de venta | Precio en pesos colombianos | Sí |
+| Costo real (sistema) | Lo calcula WARO desde la receta y las compras de ingredientes (solo lectura) | — |
+| Mi costo del plato | Costo operativo que tú defines para márgenes y reportes; el sistema no lo sobrescribe | No |
 | Tiempo de preparación | Cuántos minutos tarda en prepararse | No |
 | Disponible para venta | Si está activo en tu menú | — |
 | Disponible para domicilios | Si aparece en pedidos online (delivery / pickup) | — |
@@ -52,6 +54,21 @@ Aquí vinculas el producto a una o más recetas base que ya creaste.
 ### Paso 3 — Revisión y confirmación
 
 Revisa el resumen: nombre, categoría y estado. Si todo está bien, haz clic en **Crear producto**.
+
+---
+
+## Costo real vs mi costo del plato
+
+WARO maneja dos costos por producto:
+
+| Concepto | Quién lo define | Para qué sirve |
+|----------|-----------------|----------------|
+| **Costo real (sistema)** | WARO, al guardar el producto con receta | Refleja ingredientes y precios de compra; se actualiza si cambian compras o receta |
+| **Mi costo del plato** | Tú, opcional | Tu referencia operativa (mano de obra, merma, proveedor distinto, etc.) |
+
+En el listado verás **Margen real** (precio vs costo del sistema) y **Margen operativo** (precio vs tu costo), cuando hayas definido "Mi costo".
+
+Si ambos costos difieren mucho, la fila se resalta en ámbar para que revises si conviene ajustar tu costo percibido o la receta.
 
 ---
 

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -151,37 +151,80 @@
                 </div>
               </div>
 
-              <div>
+              <div v-if="tracksInventory">
                 <label class="block text-sm font-medium text-text-secondary mb-2">
-                  Costo estimado (previo al guardar)
+                  Costo real (sistema)
                 </label>
                 <div class="relative">
                   <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
                   <input
-                    :value="calculatedCost === null ? '—' : formatCurrency(calculatedCost)"
+                    :value="displayRealCost === null ? '—' : formatCurrency(displayRealCost)"
                     type="text"
                     disabled
                     class="input-base w-full pl-8 pr-4 py-2 bg-surface-secondary cursor-not-allowed"
                     placeholder="0"
                   />
                 </div>
+                <p v-if="showRecipeCostPreview" class="text-xs text-status-warning mt-1">
+                  Vista previa con receta actual: {{ formatCurrency(calculatedCost!) }} (se confirma al guardar)
+                </p>
+                <p v-else class="text-xs text-text-tertiary mt-1">
+                  Calculado por el sistema desde receta y compras.
+                </p>
+              </div>
+
+              <div>
+                <label class="block text-sm font-medium text-text-primary mb-2">
+                  Mi costo del plato
+                </label>
+                <div class="relative">
+                  <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
+                  <input
+                    v-model.number="form.costo_percibido"
+                    type="number"
+                    min="0"
+                    step="100"
+                    class="input-base w-full pl-8 pr-4 py-2"
+                    placeholder="Opcional"
+                  />
+                </div>
                 <p class="text-xs text-text-tertiary mt-1">
-                  Vista previa con precios configurados; el costo real se confirma al guardar
+                  Costo operativo que tú defines; no lo cambia el sistema.
                 </p>
               </div>
             </div>
 
-            <!-- Margin Display -->
-            <div v-if="form.price > 0 && calculatedCost !== null && calculatedCost > 0" class="mt-4 p-4 bg-surface-secondary rounded-lg">
-              <div class="flex items-center justify-between">
-                <span class="text-sm font-medium text-text-primary">Margen:</span>
+            <!-- Dual margins -->
+            <div
+              v-if="form.price > 0 && (displayRealCost !== null || form.costo_percibido)"
+              class="mt-4 p-4 bg-surface-secondary rounded-lg space-y-3"
+            >
+              <div v-if="displayRealCost !== null && displayRealCost > 0" class="flex items-center justify-between">
+                <span class="text-sm font-medium text-text-primary">Margen real</span>
                 <div class="flex items-center gap-3">
-                  <span class="text-lg font-bold text-text-primary">
-                    {{ formatCurrency(form.price - calculatedCost) }}
+                  <span class="text-sm font-semibold text-text-primary">
+                    {{ marginRealValue === null ? '—' : formatCurrency(marginRealValue) }}
                   </span>
                   <UiStatusBadge
-                    :label="`${calculateMargin(form.price, calculatedCost) ?? 0}%`"
-                    :variant="(calculateMargin(form.price, calculatedCost) ?? 0) > 50 ? 'success' : 'warning'"
+                    v-if="marginRealPct(marginPreview) !== null"
+                    :label="`${marginRealPct(marginPreview)!.toFixed(1)}%`"
+                    :variant="(marginRealPct(marginPreview) ?? 0) > 50 ? 'success' : 'warning'"
+                  />
+                </div>
+              </div>
+              <div
+                v-if="form.costo_percibido != null && form.costo_percibido > 0"
+                class="flex items-center justify-between"
+              >
+                <span class="text-sm font-medium text-text-primary">Margen operativo</span>
+                <div class="flex items-center gap-3">
+                  <span class="text-sm font-semibold text-text-primary">
+                    {{ marginOperativoValue === null ? '—' : formatCurrency(marginOperativoValue) }}
+                  </span>
+                  <UiStatusBadge
+                    v-if="marginOperativoPct(marginPreview) !== null"
+                    :label="`${marginOperativoPct(marginPreview)!.toFixed(1)}%`"
+                    variant="secondary"
                   />
                 </div>
               </div>
@@ -517,16 +560,23 @@
             </div>
 
             <div class="flex justify-between text-sm">
-              <span class="text-text-secondary">Costo estimado:</span>
+              <span class="text-text-secondary">Costo real:</span>
               <span class="font-semibold text-text-primary">
-                {{ calculatedCost === null ? '—' : formatCurrency(calculatedCost) }}
+                {{ displayRealCost === null ? '—' : formatCurrency(displayRealCost) }}
+              </span>
+            </div>
+
+            <div class="flex justify-between text-sm">
+              <span class="text-text-secondary">Mi costo:</span>
+              <span class="font-semibold text-text-primary">
+                {{ form.costo_percibido != null && form.costo_percibido > 0 ? formatCurrency(form.costo_percibido) : '—' }}
               </span>
             </div>
 
             <div class="flex justify-between text-sm pt-3 border-t border-border">
-              <span class="text-text-secondary">Margen:</span>
+              <span class="text-text-secondary">Margen real:</span>
               <span class="font-semibold text-primary">
-                {{ calculatedCost === null ? '—' : formatCurrency(form.price - calculatedCost) }}
+                {{ marginRealValue === null ? '—' : formatCurrency(marginRealValue) }}
               </span>
             </div>
 
@@ -867,6 +917,7 @@ const form = ref({
   tax_category: 'standard' as 'standard' | 'liquor' | 'exempt',
   recipe_bases: [] as Array<{ recipe_base_id: string; quantity: number }>,
   ingredients: [] as Array<{ ingredient_id: string, ingredient_name: string, quantity: number, unit: string }>,
+  costo_percibido: null as number | null,
 })
 
 const isSubmitting = ref(false)
@@ -917,6 +968,7 @@ watch(productData, (data) => {
           unit: ing.unit
         }
       }),
+      costo_percibido: product.costo_percibido != null ? Number(product.costo_percibido) : null,
     }
     // Derive toggle from existing data — product without any recipe row → OFF
     tracksInventory.value = (
@@ -958,6 +1010,45 @@ const calculatedCost = computed<number | null>(() => {
   }, 0)
 
   return totalCost
+})
+
+const savedRealCost = computed<number | null>(() => {
+  const raw = productData.value?.data?.costo_calculado
+  if (raw === null || raw === undefined) return null
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : null
+})
+
+const displayRealCost = computed<number | null>(() => {
+  if (!tracksInventory.value) return null
+  if (savedRealCost.value !== null && savedRealCost.value > 0) return savedRealCost.value
+  return calculatedCost.value
+})
+
+const showRecipeCostPreview = computed(() => {
+  if (!tracksInventory.value || calculatedCost.value === null) return false
+  if (savedRealCost.value === null || savedRealCost.value <= 0) return calculatedCost.value > 0
+  return Math.abs(savedRealCost.value - calculatedCost.value) > 0.01
+})
+
+const { marginRealPct, marginOperativoPct } = useProductMargins()
+
+const marginPreview = computed(() => ({
+  price: form.value.price,
+  costo_calculado: displayRealCost.value,
+  costo_percibido: form.value.costo_percibido,
+}))
+
+const marginRealValue = computed<number | null>(() => {
+  const cost = displayRealCost.value
+  if (cost === null || cost <= 0) return null
+  return form.value.price - cost
+})
+
+const marginOperativoValue = computed<number | null>(() => {
+  const perceived = form.value.costo_percibido
+  if (perceived == null || perceived <= 0) return null
+  return form.value.price - perceived
 })
 
 // Methods
@@ -1048,6 +1139,7 @@ const handleSubmit = async () => {
       recipe_base_ids: cleanedRecipeBases.map(l => l.recipe_base_id),
       ingredients: tracksInventory.value ? form.value.ingredients : [],
       image_url: form.value.image_url || null,
+      costo_percibido: form.value.costo_percibido ?? null,
     }
     await $fetch(`/api/menu/products/${productId}`, {
       method: 'PUT',
@@ -1106,11 +1198,6 @@ const formatCurrency = (value: number) => {
     currency: 'COP',
     minimumFractionDigits: 0
   }).format(value)
-}
-
-const calculateMargin = (price: number, cost: number | null) => {
-  if (cost == null || cost <= 0) return null
-  return Math.round(((price - cost) / cost) * 100)
 }
 
 useHead({

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -304,6 +304,42 @@
                 </div>
               </div>
 
+              <!-- Costo real (preview) -->
+              <div v-if="tracksInventory">
+                <label class="block text-sm font-medium text-text-secondary mb-2">
+                  Costo real (sistema)
+                </label>
+                <div class="relative">
+                  <span class="absolute left-3 top-1/2 transform -translate-y-1/2 text-text-secondary">$</span>
+                  <input
+                    type="text"
+                    readonly
+                    :value="calculatedCost === null ? '—' : formatCurrency(calculatedCost)"
+                    class="w-full pl-8 pr-4 py-2 border border-border rounded-lg bg-surface-secondary text-text-primary cursor-not-allowed"
+                  />
+                </div>
+                <p class="text-xs text-text-tertiary mt-1">Estimado hasta guardar; se calcula desde la receta y compras.</p>
+              </div>
+
+              <!-- Mi costo del plato -->
+              <div>
+                <label class="block text-sm font-medium text-text-primary mb-2">
+                  Mi costo del plato
+                </label>
+                <div class="relative">
+                  <span class="absolute left-3 top-1/2 transform -translate-y-1/2 text-text-secondary">$</span>
+                  <input
+                    type="number"
+                    v-model.number="form.costo_percibido"
+                    placeholder="Opcional"
+                    min="0"
+                    step="100"
+                    class="w-full pl-8 pr-4 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-text-primary"
+                  />
+                </div>
+                <p class="text-xs text-text-tertiary mt-1">Costo operativo que tú defines; no lo cambia el sistema.</p>
+              </div>
+
               <!-- Checkboxes -->
               <div class="space-y-3">
                 <label class="flex items-center gap-3 cursor-pointer">
@@ -727,19 +763,29 @@
                     <span class="text-sm font-bold text-text-primary">{{ formatCurrency(form.price) }}</span>
                   </div>
                   <div class="flex justify-between items-center">
-                    <span class="text-sm text-text-secondary">Costo estimado</span>
+                    <span class="text-sm text-text-secondary">Costo real (estimado)</span>
                     <span class="text-sm font-semibold text-text-primary">
                       {{ calculatedCost === null ? '—' : formatCurrency(calculatedCost) }}
                     </span>
                   </div>
                   <div class="flex justify-between items-center">
-                    <span class="text-sm text-text-secondary">Margen</span>
-                    <span class="text-sm font-semibold text-crocus-600">{{ formatMarginPercent }}</span>
+                    <span class="text-sm text-text-secondary">Mi costo del plato</span>
+                    <span class="text-sm font-semibold text-text-primary">
+                      {{ form.costo_percibido != null && form.costo_percibido > 0 ? formatCurrency(form.costo_percibido) : '—' }}
+                    </span>
+                  </div>
+                  <div class="flex justify-between items-center">
+                    <span class="text-sm text-text-secondary">Margen real</span>
+                    <span class="text-sm font-semibold text-crocus-600">{{ formatMarginRealPercent }}</span>
+                  </div>
+                  <div class="flex justify-between items-center">
+                    <span class="text-sm text-text-secondary">Margen operativo</span>
+                    <span class="text-sm font-semibold text-crocus-600">{{ formatMarginOperativoPercent }}</span>
                   </div>
                   <div class="flex justify-between items-center pt-2 border-t border-border">
-                    <span class="text-sm font-semibold text-text-primary">Ganancia</span>
+                    <span class="text-sm font-semibold text-text-primary">Ganancia (real)</span>
                     <span class="text-base font-bold text-crocus-600">
-                      {{ marginValue === null ? '—' : formatCurrency(marginValue) }}
+                      {{ marginRealValue === null ? '—' : formatCurrency(marginRealValue) }}
                     </span>
                   </div>
                 </div>
@@ -889,6 +935,7 @@ const form = ref({
     unit: string
   }>,
   tenant_id: currentTenant.value?.id || '',
+  costo_percibido: null as number | null,
 })
 
 // Fetch categories
@@ -1048,16 +1095,27 @@ const calculatedCost = computed<number | null>(() => {
   return totalCost
 })
 
-const marginValue = computed<number | null>(() => {
+const { marginRealPct, marginOperativoPct } = useProductMargins()
+
+const marginPreview = computed(() => ({
+  price: form.value.price,
+  costo_calculado: calculatedCost.value,
+  costo_percibido: form.value.costo_percibido,
+}))
+
+const marginRealValue = computed<number | null>(() => {
   if (calculatedCost.value === null) return null
   return form.value.price - calculatedCost.value
 })
 
-const formatMarginPercent = computed(() => {
-  const cost = calculatedCost.value
-  if (!form.value.price || cost === null || cost <= 0) return '—'
-  const margin = ((form.value.price - cost) / cost * 100)
-  return `${margin.toFixed(1)}%`
+const formatMarginRealPercent = computed(() => {
+  const pct = marginRealPct(marginPreview.value)
+  return pct === null ? '—' : `${pct.toFixed(1)}%`
+})
+
+const formatMarginOperativoPercent = computed(() => {
+  const pct = marginOperativoPct(marginPreview.value)
+  return pct === null ? '—' : `${pct.toFixed(1)}%`
 })
 
 const canProceed = computed(() => {
@@ -1257,6 +1315,7 @@ async function submitProduct() {
       recipe_base_ids: cleanedRecipeBases.map(l => l.recipe_base_id),
       ingredients: tracksInventory.value ? form.value.ingredients : [],
       image_url: form.value.image_url || null,
+      costo_percibido: form.value.costo_percibido ?? null,
     }
 
     await $fetch('/api/menu/products', {

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -86,7 +86,11 @@
             <div
               class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-surface-secondary cursor-pointer"
               :class="[
-                costIssueProductIds?.has(item.id) ? 'bg-status-critical-bg' : (index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30')
+                costIssueProductIds?.has(item.id)
+                  ? 'bg-status-critical-bg'
+                  : costDriftProductIds?.has(item.id)
+                    ? 'bg-status-warning-bg/40'
+                    : (index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30')
               ]"
               @click="editProduct(item)"
             >
@@ -104,7 +108,13 @@
               </div>
               <div class="flex-1 min-w-0">
                 <span class="text-sm font-bold text-text-primary">{{ toTitleCase(item.name) }}</span>
-                <p class="text-xs text-text-secondary mt-0.5">{{ item.category_name || 'Sin categoría' }} · {{ formatCurrency(item.price) }}</p>
+                <p class="text-xs text-text-secondary mt-0.5">
+                  {{ item.category_name || 'Sin categoría' }} · {{ formatCurrency(item.price) }}
+                </p>
+                <p class="text-xs text-text-tertiary">
+                  Real: {{ formatCostCell(item.costo_calculado) }}
+                  · Mi costo: {{ formatCostCell(item.costo_percibido) }}
+                </p>
               </div>
               <div class="flex flex-col items-end gap-1.5 flex-shrink-0">
                 <span
@@ -115,11 +125,20 @@
                   {{ item.station.name }}
                 </span>
                 <UiStatusBadge
-                  v-if="getMarginValue(item) !== null"
-                  :value="getMarginValue(item)"
+                  v-if="marginRealPct(item) !== null"
+                  :value="marginRealPct(item)!"
                   format="percentage"
-                  :variant="(getMarginValue(item) ?? 0) >= 0 ? 'success' : 'secondary'"
+                  :variant="(marginRealPct(item) ?? 0) >= 0 ? 'success' : 'secondary'"
                   size="sm"
+                  title="Margen real"
+                />
+                <UiStatusBadge
+                  v-if="marginOperativoPct(item) !== null"
+                  :value="marginOperativoPct(item)!"
+                  format="percentage"
+                  variant="secondary"
+                  size="sm"
+                  title="Margen operativo"
                 />
                 <UiStatusBadge
                   :value="item.is_available ? 'Disponible' : 'No disponible'"
@@ -168,17 +187,36 @@
 
           <template #cell-costo_calculado="{ value }">
             <span class="text-sm text-text-primary">
-              {{ value === null || value === undefined ? '—' : formatCurrency(value) }}
+              {{ formatCostCell(value) }}
             </span>
           </template>
 
-          <template #cell-margen="{ row }">
+          <template #cell-costo_percibido="{ value }">
+            <span class="text-sm text-text-primary">
+              {{ formatCostCell(value) }}
+            </span>
+          </template>
+
+          <template #cell-margen_real="{ row }">
             <div class="flex justify-end">
               <UiStatusBadge
-                v-if="getMarginValue(row) !== null"
-                :value="getMarginValue(row)!"
+                v-if="marginRealPct(row) !== null"
+                :value="marginRealPct(row)!"
                 format="percentage"
-                :variant="getMarginValue(row)! >= 0 ? 'success' : 'secondary'"
+                :variant="(marginRealPct(row) ?? 0) >= 0 ? 'success' : 'secondary'"
+                size="sm"
+              />
+              <span v-else class="text-sm text-text-secondary">—</span>
+            </div>
+          </template>
+
+          <template #cell-margen_operativo="{ row }">
+            <div class="flex justify-end">
+              <UiStatusBadge
+                v-if="marginOperativoPct(row) !== null"
+                :value="marginOperativoPct(row)!"
+                format="percentage"
+                :variant="(marginOperativoPct(row) ?? 0) >= 0 ? 'success' : 'secondary'"
                 size="sm"
               />
               <span v-else class="text-sm text-text-secondary">—</span>
@@ -558,10 +596,19 @@ const costIssueProductIds = computed(() => {
 
 const costIssueCount = computed(() => costIssueProductIds.value.size)
 
+const costDriftProductIds = computed(() => {
+  const ids = new Set<string>()
+  for (const p of products.value) {
+    if (hasCostDrift(p)) ids.add(p.id)
+  }
+  return ids
+})
+
 const bannerDismissed = ref(false)
 
 const getRowClass = (row: any): string | undefined => {
   if (costIssueProductIds.value.has(row.id)) return 'bg-status-critical-bg'
+  if (costDriftProductIds.value.has(row.id)) return 'bg-status-warning-bg/40'
   return undefined
 }
 
@@ -643,14 +690,28 @@ const productosTableColumns = computed(() => {
     },
     {
       key: 'costo_calculado',
-      title: 'Costo',
+      title: 'Costo real',
       sortable: true,
       format: 'currency',
       align: 'right'
     },
     {
-      key: 'margen',
-      title: 'Margen',
+      key: 'costo_percibido',
+      title: 'Mi costo',
+      sortable: true,
+      format: 'currency',
+      align: 'right'
+    },
+    {
+      key: 'margen_real',
+      title: 'Margen real',
+      sortable: false,
+      format: 'text',
+      align: 'center'
+    },
+    {
+      key: 'margen_operativo',
+      title: 'Margen op.',
       sortable: false,
       format: 'text',
       align: 'center'
@@ -713,24 +774,17 @@ const formatCurrency = (value: number) => {
   }).format(value)
 }
 
-// Calculate and format margin
-const formatMargin = (product: any) => {
-  const price = Number(product.price) || 0
-  const cost = Number(product.costo_calculado) || 0
-  if (price <= 0 || cost <= 0) return '—'
-  const margin = ((price - cost) / cost) * 100
-  if (!isFinite(margin)) return '—'
-  return `${margin.toFixed(1)}%`
-}
+const formatCostCell = (value: unknown) => formatCostCellValue(value, formatCurrency)
 
-// Raw margin value for badge autoColor (null = no data)
-const getMarginValue = (product: any): number | null => {
-  const price = Number(product.price) || 0
-  const cost = Number(product.costo_calculado) || 0
-  if (price <= 0 || cost <= 0) return null
-  const margin = ((price - cost) / cost) * 100
-  return isFinite(margin) ? margin : null
-}
+const {
+  marginRealPct,
+  marginOperativoPct,
+  hasCostDrift,
+  formatCostCell: formatCostCellValue,
+} = useProductMargins()
+
+// Backward compat alias
+const getMarginValue = marginRealPct
 
 // True if the product has any recipe row (direct ingredients or recipe bases).
 // Null/zero costo_calculado is the proxy: the backend persists NULL when no recipe.

--- a/pages/menu/reventa/index.vue
+++ b/pages/menu/reventa/index.vue
@@ -52,14 +52,35 @@
           <template #card="{ item, index }">
             <div
               class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-surface-secondary"
-              :class="index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'"
+              :class="costDriftProductIds?.has(item.id)
+                ? 'bg-status-warning-bg/40'
+                : (index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30')"
             >
               <div class="flex-1 min-w-0">
                 <span class="text-sm font-bold text-text-primary">{{ item.name }}</span>
                 <p class="text-xs text-text-secondary mt-0.5">{{ item.category_name || 'Sin categoría' }} · {{ formatCurrency(item.price) }}</p>
+                <p class="text-xs text-text-tertiary">
+                  Real: {{ formatCostCell(item.costo_calculado) }}
+                  · Mi costo: {{ formatCostCell(item.costo_percibido) }}
+                </p>
               </div>
               <div class="flex flex-col items-end gap-1.5 flex-shrink-0">
-                <span class="text-sm font-semibold text-text-primary">{{ formatMargin(item) }}</span>
+                <UiStatusBadge
+                  v-if="marginRealPct(item) !== null"
+                  :value="marginRealPct(item)!"
+                  format="percentage"
+                  :variant="(marginRealPct(item) ?? 0) >= 0 ? 'success' : 'secondary'"
+                  size="sm"
+                  title="Margen real"
+                />
+                <UiStatusBadge
+                  v-if="marginOperativoPct(item) !== null"
+                  :value="marginOperativoPct(item)!"
+                  format="percentage"
+                  variant="secondary"
+                  size="sm"
+                  title="Margen operativo"
+                />
                 <UiStatusBadge
                   :value="item.is_available ? 'Disponible' : 'No disponible'"
                   format="text"
@@ -84,11 +105,37 @@
           </template>
 
           <template #cell-costo_calculado="{ value }">
-            <span class="text-sm text-text-primary">{{ formatCurrency(value) }}</span>
+            <span class="text-sm text-text-primary">{{ formatCostCell(value) }}</span>
           </template>
 
-          <template #cell-margen="{ row }">
-            <span class="text-sm text-text-secondary">{{ formatMargin(row) }}</span>
+          <template #cell-costo_percibido="{ value }">
+            <span class="text-sm text-text-primary">{{ formatCostCell(value) }}</span>
+          </template>
+
+          <template #cell-margen_real="{ row }">
+            <div class="flex justify-end">
+              <UiStatusBadge
+                v-if="marginRealPct(row) !== null"
+                :value="marginRealPct(row)!"
+                format="percentage"
+                :variant="(marginRealPct(row) ?? 0) >= 0 ? 'success' : 'secondary'"
+                size="sm"
+              />
+              <span v-else class="text-sm text-text-secondary">—</span>
+            </div>
+          </template>
+
+          <template #cell-margen_operativo="{ row }">
+            <div class="flex justify-end">
+              <UiStatusBadge
+                v-if="marginOperativoPct(row) !== null"
+                :value="marginOperativoPct(row)!"
+                format="percentage"
+                :variant="(marginOperativoPct(row) ?? 0) >= 0 ? 'success' : 'secondary'"
+                size="sm"
+              />
+              <span v-else class="text-sm text-text-secondary">—</span>
+            </div>
           </template>
 
           <template #cell-is_available="{ value }">
@@ -431,14 +478,28 @@ const productosTableColumns = [
   },
   {
     key: 'costo_calculado',
-    title: 'Costo',
+    title: 'Costo real',
     sortable: true,
     format: 'currency',
     align: 'right'
   },
   {
-    key: 'margen',
-    title: 'Margen',
+    key: 'costo_percibido',
+    title: 'Mi costo',
+    sortable: true,
+    format: 'currency',
+    align: 'right'
+  },
+  {
+    key: 'margen_real',
+    title: 'Margen real',
+    sortable: false,
+    format: 'text',
+    align: 'center'
+  },
+  {
+    key: 'margen_operativo',
+    title: 'Margen op.',
     sortable: false,
     format: 'text',
     align: 'center'
@@ -462,12 +523,22 @@ const formatCurrency = (value: number) => {
   }).format(value)
 }
 
-// Calculate and format margin
-const formatMargin = (product: any) => {
-  if (!product.price || !product.costo_calculado) return '--'
-  const margin = ((product.price - product.costo_calculado) / product.costo_calculado) * 100
-  return `${margin.toFixed(1)}%`
-}
+const {
+  marginRealPct,
+  marginOperativoPct,
+  hasCostDrift,
+  formatCostCell: formatCostCellValue,
+} = useProductMargins()
+
+const formatCostCell = (value: unknown) => formatCostCellValue(value, formatCurrency)
+
+const costDriftProductIds = computed(() => {
+  const ids = new Set<string>()
+  for (const p of sortedProducts.value) {
+    if (hasCostDrift(p)) ids.add(p.id)
+  }
+  return ids
+})
 
 </script>
 


### PR DESCRIPTION
## Summary
- Adds `useProductMargins` composable for real vs operativo margins and cost drift detection.
- Productos list, crear, edit, and reventa catalog show **Costo real**, **Mi costo**, **Margen real**, and **Margen op.** with amber row highlight when drift > 25%.
- User docs explain dual cost model.

## Stack
Nuxt 3 · Pinia Colada

## Changes
- `composables/useProductMargins.ts` — margin helpers + drift
- `pages/menu/productos/index.vue` — dual columns, mobile card, drift rows
- `pages/menu/productos/crear.vue` — perceived cost field + dual summary
- `pages/menu/productos/[id].vue` — Precios y Costos dual layout + save `costo_percibido`
- `pages/menu/reventa/index.vue` — mirror list columns
- `docs/usuarios/menu/productos.md` — real vs perceived section

## Testing
- [ ] With API #282 deployed: list shows both costs and margins
- [ ] Create/edit product with `costo_percibido`; persists after save
- [ ] Row highlights amber when real vs perceived differ > 25%
- [ ] Reventa list matches productos columns

**Depends on:** api-warolabs #282 (`costo_percibido` + margin fields). Stacks on #748 / `gh-744-unify-costo-calculado`.

Closes #746

Made with [Cursor](https://cursor.com)