### PR TITLE
POS: print kitchen comandas after fire (#753)

### DIFF
--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -85,6 +85,18 @@
         :key="item.orderItemId"
         class="relative"
       >
+        <label
+          v-if="comandasEnabled && item.fulfillmentStatus === 'new'"
+          class="absolute top-2 left-2 z-10 flex items-center"
+        >
+          <input
+            type="checkbox"
+            class="h-4 w-4 rounded border-border text-primary focus:ring-primary/30"
+            :checked="selectedTabItemIds.includes(item.orderItemId)"
+            :aria-label="`Seleccionar ${item.productName} para enviar a cocina`"
+            @change="$emit('toggle-tab-selection', item.orderItemId)"
+          />
+        </label>
         <PosCartItem
           :item="{
             product: { id: item.orderItemId, name: item.productName, price: item.unitPrice, image: '🍽️', category: '' },
@@ -95,7 +107,10 @@
           }"
           :order-number="idx + 1"
           :show-fulfillment-status="comandasEnabled"
-          :class="pendingRemoveItemId === item.orderItemId ? 'opacity-40 pointer-events-none' : ''"
+          :class="[
+            pendingRemoveItemId === item.orderItemId ? 'opacity-40 pointer-events-none' : '',
+            comandasEnabled && item.fulfillmentStatus === 'new' ? 'pl-8' : '',
+          ]"
           @increment="$emit('increment-tab-item', item.orderItemId)"
           @decrement="$emit('decrement-tab-item', item.orderItemId)"
           @remove="$emit('remove-tab-item', item.orderItemId)"
@@ -218,6 +233,36 @@
         </div>
 
 
+        <!-- #753 — Fire / print comandas when KDS enabled -->
+        <template v-if="comandasEnabled">
+          <div class="grid grid-cols-2 gap-2">
+            <button
+              v-if="unfiredCount > 0"
+              type="button"
+              :disabled="isFiringToKitchen || isAddingToTab"
+              class="min-h-[44px] rounded-xl border border-primary/40 bg-primary/5 text-primary text-xs font-semibold flex items-center justify-center gap-1 hover:bg-primary/10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+              :aria-label="fireToKitchenLabel"
+              @click="$emit('fire-to-kitchen')"
+            >
+              <UiLoadingDots v-if="isFiringToKitchen" size="7px" />
+              <template v-else>{{ fireToKitchenLabel }}</template>
+            </button>
+            <button
+              type="button"
+              :disabled="!canPrintComandas"
+              class="min-h-[44px] rounded-xl border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+              :class="unfiredCount === 0 ? 'col-span-2' : ''"
+              aria-label="Imprimir comanda de cocina"
+              @click="$emit('print-comandas')"
+            >
+              <svg class="h-4 w-4 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18M6.72 13.829 6.34 18m10.94-4.171L17.66 18M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.75A2.25 2.25 0 0 1 5.25 7.5h13.5A2.25 2.25 0 0 1 21 9.75v6A2.25 2.25 0 0 1 18.75 18h-1.09M6.34 18h11.32" />
+              </svg>
+              Imprimir comanda
+            </button>
+          </div>
+        </template>
+
         <!-- Primary: Add to tab — full width -->
         <button
           type="button"
@@ -281,6 +326,8 @@ interface Props {
   comandasEnabled?: boolean
   unfiredCount?: number
   isFiringToKitchen?: boolean
+  canPrintComandas?: boolean
+  selectedTabItemIds?: string[]
   pendingRemoveItemId?: string | null
   // Issue #575 — per-order waiter attribution (bar + counter)
   showServedByChip?: boolean
@@ -302,11 +349,19 @@ interface Emits {
   (e: 'increment-tab-item', orderItemId: string): void
   (e: 'decrement-tab-item', orderItemId: string): void
   (e: 'fire-to-kitchen'): void
+  (e: 'print-comandas'): void
+  (e: 'toggle-tab-selection', orderItemId: string): void
   // Issue #575
   (e: 'update:served-by', memberId: string | null): void
 }
 
-const props = withDefaults(defineProps<Props>(), { mesaMode: false, isAddingToTab: false, isLoadingTabItems: false, isClearingTab: false, tabItems: () => [], tabTotal: 0, tabItemsLoading: () => new Set(), comandasEnabled: false, unfiredCount: 0, isFiringToKitchen: false, pendingRemoveItemId: null, showServedByChip: false, servedByMemberId: null, members: () => [] })
+const props = withDefaults(defineProps<Props>(), { mesaMode: false, isAddingToTab: false, isLoadingTabItems: false, isClearingTab: false, tabItems: () => [], tabTotal: 0, tabItemsLoading: () => new Set(), comandasEnabled: false, unfiredCount: 0, isFiringToKitchen: false, canPrintComandas: false, selectedTabItemIds: () => [], pendingRemoveItemId: null, showServedByChip: false, servedByMemberId: null, members: () => [] })
+
+const fireToKitchenLabel = computed(() => {
+  const n = props.selectedTabItemIds?.length ?? 0
+  if (n > 0) return `Enviar ${n} a cocina`
+  return 'Enviar a cocina'
+})
 const emit = defineEmits<Emits>()
 
 // Issue warocol.com#708 — mesa tab lines live outside posStore.cart; count both buckets.

--- a/components/pos/ComandaPrintTickets.vue
+++ b/components/pos/ComandaPrintTickets.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
+import { formatComandaPrintTime } from '~/composables/useComandaPrint'
+
+const props = defineProps<{
+  comandas: ComandaPrintPayload[]
+  businessName?: string
+}>()
+
+function formatModifiers(item: ComandaPrintPayload['items'][0]): string {
+  const mods = item.modifiers_snapshot
+  if (!mods?.length) return ''
+  return mods.map(m => m.name).join(', ')
+}
+</script>
+
+<template>
+  <div id="pos-comanda-print" aria-hidden="true">
+    <div
+      v-for="(c, idx) in comandas"
+      :key="c.id || `${c.comanda_number}-${idx}`"
+      class="comanda-ticket"
+    >
+      <div class="receipt-header">{{ businessName || 'WARO' }}</div>
+      <div class="receipt-row receipt-small">*** COMANDA COCINA ***</div>
+      <div class="receipt-row receipt-small">{{ formatComandaPrintTime(c.fired_at) }}</div>
+      <div v-if="c.table_display_name" class="receipt-row receipt-small">
+        {{ c.table_display_name }}
+      </div>
+      <div v-if="c.station_name" class="receipt-row receipt-small">
+        Estación: {{ c.station_name }}
+      </div>
+      <div class="receipt-row receipt-small">
+        Comanda #{{ c.comanda_number }}
+      </div>
+      <div class="receipt-divider">--------------------------------</div>
+      <div v-for="(item, i) in c.items" :key="i" class="receipt-item receipt-small">
+        <span>{{ item.quantity }}× {{ item.kitchen_name }}</span>
+      </div>
+      <template v-for="(item, i) in c.items" :key="`mod-${i}`">
+        <div v-if="formatModifiers(item)" class="receipt-row receipt-small" style="padding-left: 8px;">
+          ↳ {{ formatModifiers(item) }}
+        </div>
+        <div v-if="item.notes" class="receipt-row receipt-small" style="padding-left: 8px;">
+          Nota: {{ item.notes }}
+        </div>
+      </template>
+      <div class="receipt-divider">--------------------------------</div>
+      <div class="receipt-footer receipt-small">NO ES FACTURA — COCINA</div>
+    </div>
+  </div>
+</template>
+
+<style>
+#pos-comanda-print {
+  display: none;
+}
+
+.comanda-ticket {
+  margin-bottom: 4mm;
+}
+
+.comanda-ticket .receipt-header { font-size: 1.1em; font-weight: bold; text-align: center; margin-bottom: 4px; }
+.comanda-ticket .receipt-row { text-align: center; margin: 2px 0; }
+.comanda-ticket .receipt-divider { letter-spacing: 0; margin: 4px 0; text-align: center; }
+.comanda-ticket .receipt-item { margin: 2px 0; }
+.comanda-ticket .receipt-footer { text-align: center; margin-top: 6px; }
+.comanda-ticket .receipt-small { font-size: 0.9em; }
+
+@media print {
+  body.printing-comanda * { visibility: hidden; }
+  body.printing-comanda #pos-comanda-print,
+  body.printing-comanda #pos-comanda-print * { visibility: visible !important; }
+
+  body.printing-comanda #pos-receipt,
+  body.printing-comanda #pos-prefactura { display: none !important; }
+
+  #pos-comanda-print {
+    display: block !important;
+    position: absolute;
+    top: 0;
+    left: 0;
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 9pt;
+    line-height: 1.25;
+    width: 54mm;
+    color: #000;
+    background: #fff;
+    padding: 2mm;
+  }
+
+  .comanda-ticket {
+    page-break-after: always;
+  }
+
+  .comanda-ticket:last-child {
+    page-break-after: auto;
+  }
+
+  @page {
+    size: 58mm auto;
+    margin: 2mm;
+  }
+}
+</style>

--- a/composables/useComandaPrint.ts
+++ b/composables/useComandaPrint.ts
@@ -1,0 +1,88 @@
+/**
+ * Kitchen comanda ticket printing (#753) — browser print via hidden DOM + body class.
+ */
+
+export type ComandaPrintItem = {
+  kitchen_name: string
+  quantity: number
+  modifiers_snapshot?: Array<{ name: string; price?: number }> | null
+  notes?: string | null
+}
+
+export type ComandaPrintPayload = {
+  id?: string
+  comanda_number: number | string
+  station_name?: string | null
+  table_display_name?: string | null
+  fired_at?: string | null
+  items: ComandaPrintItem[]
+}
+
+export function formatComandaPrintTime(firedAt?: string | null): string {
+  if (!firedAt) {
+    return new Intl.DateTimeFormat('es-CO', {
+      dateStyle: 'short',
+      timeStyle: 'short',
+    }).format(new Date())
+  }
+  const d = new Date(firedAt)
+  if (Number.isNaN(d.getTime())) return firedAt
+  return new Intl.DateTimeFormat('es-CO', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(d)
+}
+
+export type FireTableResponse = {
+  success?: boolean
+  data?: { comandas?: unknown[]; fired_items_count?: number }
+  comandas?: unknown[]
+  fired_items_count?: number
+}
+
+/** API wraps fire payload in `data`; older paths may return flat fields. */
+export function parseFireTableResponse(raw: FireTableResponse): {
+  comandas: unknown[]
+  fired_items_count: number
+} {
+  return {
+    comandas: raw.data?.comandas ?? raw.comandas ?? [],
+    fired_items_count: raw.data?.fired_items_count ?? raw.fired_items_count ?? 0,
+  }
+}
+
+export function mapComandasForPrint(rawComandas: unknown[]): ComandaPrintPayload[] {
+  return (rawComandas as Record<string, unknown>[]).map((c) => ({
+    id: c.id != null ? String(c.id) : undefined,
+    comanda_number: (c.comanda_number as number | string) ?? '—',
+    station_name: (c.station_name as string) ?? null,
+    table_display_name: (c.table_display_name as string) ?? null,
+    fired_at: c.fired_at != null ? String(c.fired_at) : null,
+    items: ((c.items as Record<string, unknown>[]) ?? []).map((i) => ({
+      kitchen_name: String(i.kitchen_name ?? ''),
+      quantity: Number(i.quantity ?? 1),
+      modifiers_snapshot: i.modifiers_snapshot as ComandaPrintItem['modifiers_snapshot'],
+      notes: (i.notes as string) ?? null,
+    })),
+  }))
+}
+
+export function orderItemIdsFromComandas(rawComandas: unknown[]): Set<string> {
+  const ids = new Set<string>()
+  for (const c of rawComandas as Record<string, unknown>[]) {
+    for (const i of (c.items as Record<string, unknown>[]) ?? []) {
+      if (i.order_item_id != null) ids.add(String(i.order_item_id))
+    }
+  }
+  return ids
+}
+
+export function printComandaTickets(): void {
+  document.body.classList.add('printing-comanda')
+  const cleanup = () => {
+    document.body.classList.remove('printing-comanda')
+  }
+  window.addEventListener('afterprint', cleanup, { once: true })
+  setTimeout(cleanup, 4000)
+  window.print()
+}

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -5,6 +5,13 @@ import { $fetch } from 'ofetch'
 import type { CachedProduct, TabItem } from '~/stores/usePOSStore'
 import { usePOSStore } from '~/stores/usePOSStore'
 import { registerTableSessionRefresh } from '~/composables/useTableSessionSync'
+import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
+import {
+  mapComandasForPrint,
+  orderItemIdsFromComandas,
+  parseFireTableResponse,
+  printComandaTickets,
+} from '~/composables/useComandaPrint'
 
 definePageMeta({
   layout: 'dashboard',
@@ -236,6 +243,52 @@ const isFiringToKitchen = ref(false)
 const tabError = ref<string | null>(null)
 const tabSuccess = ref<string | null>(null)
 
+// #753 — kitchen ticket print after fire
+const lastFiredComandasRaw = ref<unknown[]>([])
+const comandasForPrint = ref<ComandaPrintPayload[]>([])
+const selectedTabItemIds = ref<string[]>([])
+const posBusinessName = computed(
+  () => settingsData.value?.data?.business_name
+    ?? settingsData.value?.data?.display_name
+    ?? 'WARO',
+)
+const canPrintComandas = computed(() => comandasForPrint.value.length > 0)
+
+function toggleTabItemSelection(orderItemId: string) {
+  const idx = selectedTabItemIds.value.indexOf(orderItemId)
+  if (idx >= 0) {
+    selectedTabItemIds.value = selectedTabItemIds.value.filter(id => id !== orderItemId)
+  } else {
+    selectedTabItemIds.value = [...selectedTabItemIds.value, orderItemId]
+  }
+}
+
+function applyFireResult(rawComandas: unknown[], firedCount: number) {
+  if (rawComandas.length > 0) {
+    lastFiredComandasRaw.value = rawComandas
+    comandasForPrint.value = mapComandasForPrint(rawComandas)
+  }
+  const firedIds = orderItemIdsFromComandas(rawComandas)
+  if (firedCount > 0 && posStore.activeTableSession) {
+    posStore.setTabItems(
+      storeTabItems.value.map((item: TabItem) => {
+        const shouldMarkSent = firedIds.size > 0
+          ? firedIds.has(item.orderItemId)
+          : item.fulfillmentStatus === 'new'
+        return shouldMarkSent
+          ? { ...item, fulfillmentStatus: 'sent' as const, sentAt: new Date().toISOString() }
+          : item
+      }),
+    )
+    selectedTabItemIds.value = []
+  }
+}
+
+function handlePrintComandas() {
+  if (!canPrintComandas.value) return
+  printComandaTickets()
+}
+
 // Issue warocol.com#708 — invalidate in-flight GET /current responses after tab mutations.
 let tableSessionFetchGen = 0
 const bumpTableSessionFetchGen = () => {
@@ -446,12 +499,13 @@ const addToTab = async () => {
     // Auto-fire to kitchen if comandas is enabled
     if (comandasEnabled.value) {
       try {
-        const result = await $fetch<{ fired_items_count: number; comandas: any[] }>(
-          `/api/tables/${posStore.activeTableSession.tableId}/fire`,
-          { method: 'POST' }
-        )
-        if (result.fired_items_count > 0) {
-          tabSuccess.value = `${result.fired_items_count} ${result.fired_items_count === 1 ? 'ítem enviado' : 'ítems enviados'} a cocina`
+        const raw = await $fetch(`/api/tables/${posStore.activeTableSession.tableId}/fire`, {
+          method: 'POST',
+        })
+        const { comandas, fired_items_count } = parseFireTableResponse(raw as any)
+        applyFireResult(comandas, fired_items_count)
+        if (fired_items_count > 0) {
+          tabSuccess.value = `${fired_items_count} ${fired_items_count === 1 ? 'ítem enviado' : 'ítems enviados'} a cocina`
           setTimeout(() => { tabSuccess.value = null }, 3000)
         }
       } catch {
@@ -483,23 +537,20 @@ const fireToKitchen = async () => {
   tabError.value = null
   tabSuccess.value = null
   try {
-    const result = await $fetch<{ fired_items_count: number; comandas: any[] }>(
-      `/api/tables/${posStore.activeTableSession.tableId}/fire`,
-      { method: 'POST' }
-    )
-    if (result.fired_items_count > 0) {
-      // Optimistically update local store: new → sent
-      posStore.setTabItems(
-        storeTabItems.value.map((item: TabItem) =>
-          item.fulfillmentStatus === 'new'
-            ? { ...item, fulfillmentStatus: 'sent', sentAt: new Date().toISOString() }
-            : item
-        )
-      )
-      tabSuccess.value = `${result.fired_items_count} ${result.fired_items_count === 1 ? 'ítem enviado' : 'ítems enviados'} a cocina`
+    const itemIds = selectedTabItemIds.value.length > 0 ? selectedTabItemIds.value : undefined
+    const raw = await $fetch(`/api/tables/${posStore.activeTableSession.tableId}/fire`, {
+      method: 'POST',
+      body: itemIds ? { item_ids: itemIds } : undefined,
+    })
+    const { comandas, fired_items_count } = parseFireTableResponse(raw as any)
+    if (fired_items_count > 0) {
+      applyFireResult(comandas, fired_items_count)
+      tabSuccess.value = `${fired_items_count} ${fired_items_count === 1 ? 'ítem enviado' : 'ítems enviados'} a cocina`
       setTimeout(() => { tabSuccess.value = null }, 3000)
     } else {
-      tabError.value = 'No hay ítems con estación configurada'
+      tabError.value = itemIds?.length
+        ? 'Los ítems seleccionados no tienen estación de cocina'
+        : 'No hay ítems con estación configurada'
       setTimeout(() => { tabError.value = null }, 3000)
     }
   } catch (e: any) {
@@ -1168,6 +1219,8 @@ onUnmounted(() => {
         :comandas-enabled="comandasEnabled"
         :unfired-count="unfiredCount"
         :is-firing-to-kitchen="isFiringToKitchen"
+        :can-print-comandas="canPrintComandas"
+        :selected-tab-item-ids="selectedTabItemIds"
         :pending-remove-item-id="pendingRemoveItemId"
         :show-served-by-chip="showServedByChip"
         :served-by-member-id="posStore.cartServedByMemberId"
@@ -1185,6 +1238,8 @@ onUnmounted(() => {
         @increment-tab-item="incrementTabItem"
         @decrement-tab-item="decrementTabItem"
         @fire-to-kitchen="fireToKitchen"
+        @print-comandas="handlePrintComandas"
+        @toggle-tab-selection="toggleTabItemSelection"
         @update:served-by="(id) => posStore.setCartServedBy(id)"
       />
       </div>
@@ -1346,6 +1401,12 @@ onUnmounted(() => {
     :table-session-id="posStore.activeTableSession?.tableId ?? null"
     :table-display-name="posStore.activeTableSession?.tableName ?? null"
     @success="refreshReadyComandasCount"
+  />
+
+  <PosComandaPrintTickets
+    v-if="comandasEnabled"
+    :comandas="comandasForPrint"
+    :business-name="posBusinessName"
   />
 
 </template>


### PR DESCRIPTION
## Summary
- Store `comandas` from fire response and print 58mm kitchen tickets in the browser.
- Checkboxes on unfired tab items + fire selected or all via `item_ids`.
- Buttons: **Enviar a cocina** and **Imprimir comanda** in mesa cart panel.

## Stack
Nuxt 3 / Vue 3

## Changes
- `composables/useComandaPrint.ts`: parse fire response, print helper
- `components/pos/ComandaPrintTickets.vue`: hidden print DOM + CSS
- `components/pos/CartPanel.vue`: selection UI + actions
- `pages/pos/index.vue`: wire fire/print state

## Testing
1. Enable comandas on tenant, open mesa session.
2. Add products with kitchen station → fire → print tickets.
3. Select subset of `new` tab items → partial fire → only those become `sent`.

Depends on API PR for `item_ids` body on `/tables/{id}/fire`.

Closes #753

Made with [Cursor](https://cursor.com)