### PR TITLE
fix(pos): enable Imprimir comanda after tab/add (#753)

### DIFF
--- a/composables/useComandaPrint.ts
+++ b/composables/useComandaPrint.ts
@@ -40,19 +40,23 @@ export type FireTableResponse = {
   fired_items_count?: number
 }
 
-/** API wraps fire payload in `data`; older paths may return flat fields. */
+/** API wraps fire payload in `data`; tab/add and /fire share the same fields. */
 export function parseFireTableResponse(raw: FireTableResponse): {
   comandas: unknown[]
   fired_items_count: number
 } {
+  const data = raw.data as Record<string, unknown> | undefined
+  const comandas = data?.comandas ?? raw.comandas
+  const fired = data?.fired_items_count ?? raw.fired_items_count
   return {
-    comandas: raw.data?.comandas ?? raw.comandas ?? [],
-    fired_items_count: raw.data?.fired_items_count ?? raw.fired_items_count ?? 0,
+    comandas: Array.isArray(comandas) ? comandas : [],
+    fired_items_count: typeof fired === 'number' ? fired : Number(fired ?? 0),
   }
 }
 
 export function mapComandasForPrint(rawComandas: unknown[]): ComandaPrintPayload[] {
-  return (rawComandas as Record<string, unknown>[]).map((c) => ({
+  return (rawComandas as Record<string, unknown>[])
+    .map((c) => ({
     id: c.id != null ? String(c.id) : undefined,
     comanda_number: (c.comanda_number as number | string) ?? '—',
     station_name: (c.station_name as string) ?? null,
@@ -65,6 +69,7 @@ export function mapComandasForPrint(rawComandas: unknown[]): ComandaPrintPayload
       notes: (i.notes as string) ?? null,
     })),
   }))
+    .filter(c => c.items.length > 0)
 }
 
 export function orderItemIdsFromComandas(rawComandas: unknown[]): Set<string> {

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -490,26 +490,21 @@ const addToTab = async () => {
       modifiers: item.modifiers.map((m) => ({ id: m.id, name: m.name, price: m.price })),
       notes: item.notes ?? null,
     }))
-    await $fetch(`/api/tables/${posStore.activeTableSession.tableId}/tab/add`, {
+    const addRes = await $fetch(`/api/tables/${posStore.activeTableSession.tableId}/tab/add`, {
       method: 'POST',
       body: { items },
     })
     // Clear cart — items committed to tab
     await posStore.clearCart()
-    // Auto-fire to kitchen if comandas is enabled
+    // tab/add already auto-fires when comandas enabled; use its payload for print (#753)
     if (comandasEnabled.value) {
-      try {
-        const raw = await $fetch(`/api/tables/${posStore.activeTableSession.tableId}/fire`, {
-          method: 'POST',
-        })
-        const { comandas, fired_items_count } = parseFireTableResponse(raw as any)
+      const { comandas, fired_items_count } = parseFireTableResponse(addRes as any)
+      if (comandas.length > 0 || fired_items_count > 0) {
         applyFireResult(comandas, fired_items_count)
         if (fired_items_count > 0) {
           tabSuccess.value = `${fired_items_count} ${fired_items_count === 1 ? 'ítem enviado' : 'ítems enviados'} a cocina`
           setTimeout(() => { tabSuccess.value = null }, 3000)
         }
-      } catch {
-        // Fire failure is non-critical — items are still on the tab
       }
     }
     // Refresh session + tab items


### PR DESCRIPTION
Use comandas from tab/add response; remove duplicate POST /fire that returned empty.

Requires API fix PR.

Fixes #753

Made with [Cursor](https://cursor.com)