### PR TITLE
fix(menu): useProductMargins composable wrapper

### DIFF
--- a/composables/useProductMargins.ts
+++ b/composables/useProductMargins.ts
@@ -57,3 +57,13 @@ export function formatCostCell(
   if (value === null || value === undefined) return '—'
   return formatCurrency(Number(value))
 }
+
+/** Composable wrapper for auto-import in pages and components. */
+export function useProductMargins() {
+  return {
+    marginRealPct,
+    marginOperativoPct,
+    hasCostDrift,
+    formatCostCell,
+  }
+}

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -774,14 +774,14 @@ const formatCurrency = (value: number) => {
   }).format(value)
 }
 
-const formatCostCell = (value: unknown) => formatCostCellValue(value, formatCurrency)
-
 const {
   marginRealPct,
   marginOperativoPct,
   hasCostDrift,
   formatCostCell: formatCostCellValue,
 } = useProductMargins()
+
+const formatCostCell = (value: unknown) => formatCostCellValue(value, formatCurrency)
 
 // Backward compat alias
 const getMarginValue = marginRealPct


### PR DESCRIPTION
## Summary
- Add missing `useProductMargins()` wrapper in `composables/useProductMargins.ts`
- Fix declaration order in productos index (`formatCostCell` after destructuring)

## Testing
- Open `/menu/productos` — no ReferenceError on useProductMargins

Made with [Cursor](https://cursor.com)