### PR TITLE
feat(ventas): advanced filters on /ventas/productos (#763)

### DIFF
--- a/pages/ventas/productos.vue
+++ b/pages/ventas/productos.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { formatDistanceToNow } from 'date-fns'
 import { es } from 'date-fns/locale'
-import { format as fnsFormat, formatDistanceToNow } from 'date-fns'
 import MetricCard from '~/components/shared/MetricCard.vue'
 // @ts-ignore
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
@@ -13,41 +13,45 @@ const { currentTenant } = useTenantReactive()
 
 const lastUpdate = ref<Date>(new Date())
 
-// ── Filters ─────────────────────────────────────────────────────────────
-const dateRangeDates = ref<Date[] | null>(null)
+// Filters — AdvancedFiltersBar (#763)
+const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
+const { dateRangeDates, presetDates, formatDateRange, dateRange, clearDateRange } = useDateRangePresets()
+
 const categoryFilter = ref<string | null>(null)
 const sortFilter = ref<'qty_desc' | 'revenue_desc' | 'name_asc'>('qty_desc')
+const channelFilter = ref<'pos' | 'mesa' | 'online' | null>(null)
 
-const presetDates = ref([
-  { label: 'Hoy',           value: [new Date(), new Date()] },
-  { label: 'Ayer',          value: (() => { const d = new Date(); d.setDate(d.getDate() - 1); return [d, d] })() },
-  { label: 'Última semana', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 7); return d })(), new Date()] },
-  { label: 'Últimos 15 días', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 15); return d })(), new Date()] },
-  { label: 'Último mes',    value: [(() => { const d = new Date(); d.setDate(d.getDate() - 30); return d })(), new Date()] },
-  { label: 'Últimos 90 días', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 90); return d })(), new Date()] },
-])
+const performSearch = () => applySearch()
 
-const formatDateRange = (dates: Date[]) => {
-  if (!dates || !dates[0]) return ''
-  const from = fnsFormat(dates[0], 'dd/MM/yy', { locale: es })
-  if (!dates[1]) return from
-  return `${from} - ${fnsFormat(dates[1], 'dd/MM/yy', { locale: es })}`
-}
-
-const dateRange = computed(() => {
-  if (!dateRangeDates.value || dateRangeDates.value.length < 2) return { from: null, to: null }
-  const [from, to] = dateRangeDates.value
-  if (!from || !to) return { from: null, to: null }
-  return { from: fnsFormat(from, 'yyyy-MM-dd'), to: fnsFormat(to, 'yyyy-MM-dd') }
-})
-
-const hasFilters = computed(() => !!(dateRangeDates.value || categoryFilter.value || sortFilter.value !== 'qty_desc'))
+const hasActiveFilters = computed(
+  () =>
+    !!localSearchTerm.value
+    || !!appliedSearch.value
+    || !!dateRangeDates.value
+    || !!categoryFilter.value
+    || sortFilter.value !== 'qty_desc'
+    || !!channelFilter.value,
+)
 
 const clearFilters = () => {
-  dateRangeDates.value = null
+  clearSearch()
+  clearDateRange()
   categoryFilter.value = null
   sortFilter.value = 'qty_desc'
+  channelFilter.value = null
 }
+
+const emptyMessage = computed(() =>
+  hasActiveFilters.value
+    ? 'Ningún producto coincide con los filtros'
+    : 'No hay ventas en este período',
+)
+
+const emptySubMessage = computed(() =>
+  hasActiveFilters.value
+    ? 'Prueba ajustar o limpiar los filtros'
+    : 'Selecciona un rango de fechas o ajusta los filtros',
+)
 
 // ── Data ─────────────────────────────────────────────────────────────────
 type ProductRow = {
@@ -65,6 +69,8 @@ const { data: productsData, asyncStatus, error, refetch } = useQuery({
     to: dateRange.value.to,
     category_id: categoryFilter.value,
     sort: sortFilter.value,
+    search: appliedSearch.value || null,
+    channel: channelFilter.value,
   }],
   query: () => $fetch<{ success: boolean; data: ProductRow[]; totals: { quantity_sold: number; total_revenue: number } }>('/api/orders/products-sold', {
     params: {
@@ -72,7 +78,9 @@ const { data: productsData, asyncStatus, error, refetch } = useQuery({
       date_to: dateRange.value.to || undefined,
       category_id: categoryFilter.value || undefined,
       sort: sortFilter.value,
-    }
+      search: appliedSearch.value || undefined,
+      channel: channelFilter.value || undefined,
+    },
   }),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
@@ -86,7 +94,7 @@ const isRefreshing = computed(() => hasEverLoaded.value && asyncStatus.value ===
 const products = computed(() => productsData.value?.data ?? [])
 const totals = computed(() => productsData.value?.totals ?? { quantity_sold: 0, total_revenue: 0 })
 
-// Derive category list from unfiltered response (cache it so it persists when filter is active)
+// Derive category list from unfiltered response (cache when no category filter)
 const cachedCategories = ref<Array<{ id: string; name: string }>>([])
 watch(productsData, (data) => {
   if (data && !categoryFilter.value) {
@@ -101,10 +109,10 @@ watch(productsData, (data) => {
 
 // ── Table columns ────────────────────────────────────────────────────────
 const tableColumns = [
-  { key: 'product_name',  title: 'Producto',   sortable: false },
-  { key: 'category_name', title: 'Categoría',  sortable: false },
-  { key: 'quantity_sold', title: 'Vendidos',   sortable: false },
-  { key: 'total_revenue', title: 'Ingresos',   sortable: false },
+  { key: 'product_name', title: 'Producto', sortable: false },
+  { key: 'category_name', title: 'Categoría', sortable: false },
+  { key: 'quantity_sold', title: 'Vendidos', sortable: false },
+  { key: 'total_revenue', title: 'Ingresos', sortable: false },
 ]
 
 const formatCurrency = (value: number) =>
@@ -162,26 +170,18 @@ onUnmounted(() => {
       </div>
 
       <!-- Filters bar -->
-      <ClientOnly>
-        <div class="flex items-center gap-2 w-full overflow-x-auto scrollbar-hide">
-          <!-- Date picker -->
-          <VueDatePicker
-            v-model="dateRangeDates"
-            range
-            :preset-dates="presetDates"
-            :enable-time-picker="false"
-            :locale="es"
-            placeholder="Rango de fechas"
-            auto-apply
-            :teleport="true"
-            :max-date="new Date()"
-            :format="formatDateRange"
-            input-class-name="dp-custom-input"
-            menu-class-name="dp-custom-menu"
-            calendar-cell-class-name="dp-custom-cell"
-          />
-
-          <!-- Category filter -->
+      <UiAdvancedFiltersBar
+        v-model:search="localSearchTerm"
+        v-model:date-range="dateRangeDates"
+        search-placeholder="Buscar producto..."
+        :search-fields="[]"
+        :preset-dates="presetDates"
+        :format-date-range="formatDateRange"
+        :show-clear="hasActiveFilters"
+        @search="performSearch"
+        @clear="clearFilters"
+      >
+        <template #additional-filters>
           <select
             v-if="cachedCategories.length > 0"
             v-model="categoryFilter"
@@ -192,7 +192,6 @@ onUnmounted(() => {
             <option v-for="cat in cachedCategories" :key="cat.id" :value="cat.id">{{ cat.name }}</option>
           </select>
 
-          <!-- Sort -->
           <select
             v-model="sortFilter"
             aria-label="Ordenar por"
@@ -203,19 +202,18 @@ onUnmounted(() => {
             <option value="name_asc">Nombre A–Z</option>
           </select>
 
-          <!-- Clear -->
-          <button
-            v-if="hasFilters"
-            @click="clearFilters"
-            class="h-10 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-secondary hover:text-text-primary hover:border-primary transition-colors flex-shrink-0"
-            aria-label="Limpiar filtros"
+          <select
+            v-model="channelFilter"
+            aria-label="Filtrar por canal"
+            class="py-2 pl-3 pr-8 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer flex-shrink-0"
           >
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-      </ClientOnly>
+            <option :value="null">Canal</option>
+            <option value="pos">POS</option>
+            <option value="mesa">Mesa</option>
+            <option value="online">Online</option>
+          </select>
+        </template>
+      </UiAdvancedFiltersBar>
 
       <!-- Table loading (filter change, no cached data yet) -->
       <div v-if="isRefreshing && products.length === 0" class="flex items-center justify-center min-h-[200px]">
@@ -224,48 +222,48 @@ onUnmounted(() => {
 
       <!-- Table -->
       <HealthSemaphore v-else :is-unlocked="true" title="Productos más vendidos">
-      <UiResponsiveDataView
-        row-size="sm"
-        :columns="tableColumns"
-        :data="products"
-        empty-message="No hay ventas en este período"
-        empty-sub-message="Selecciona un rango de fechas o ajusta los filtros"
-        variant="default"
-      >
-        <!-- Mobile card -->
-        <template #card="{ item, index }">
-          <div
-            class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-surface-secondary"
-            :class="index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'"
-          >
-            <div class="flex-1 min-w-0">
-              <p class="text-sm font-bold text-text-primary">{{ item.product_name }}</p>
-              <p class="text-xs text-text-secondary mt-0.5">{{ item.category_name ?? 'Sin categoría' }}</p>
+        <UiResponsiveDataView
+          row-size="sm"
+          :columns="tableColumns"
+          :data="products"
+          :empty-message="emptyMessage"
+          :empty-sub-message="emptySubMessage"
+          variant="default"
+        >
+          <!-- Mobile card -->
+          <template #card="{ item, index }">
+            <div
+              class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-surface-secondary"
+              :class="index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'"
+            >
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-bold text-text-primary">{{ item.product_name }}</p>
+                <p class="text-xs text-text-secondary mt-0.5">{{ item.category_name ?? 'Sin categoría' }}</p>
+              </div>
+              <div class="flex flex-col items-end gap-0.5 flex-shrink-0">
+                <span class="text-sm font-bold text-primary tabular-nums">{{ formatCurrency(item.total_revenue) }}</span>
+                <span class="text-xs text-text-secondary">{{ item.quantity_sold }} uds.</span>
+              </div>
             </div>
-            <div class="flex flex-col items-end gap-0.5 flex-shrink-0">
-              <span class="text-sm font-bold text-primary tabular-nums">{{ formatCurrency(item.total_revenue) }}</span>
-              <span class="text-xs text-text-secondary">{{ item.quantity_sold }} uds.</span>
-            </div>
-          </div>
-        </template>
+          </template>
 
-        <!-- Desktop cells -->
-        <template #cell-product_name="{ value }">
-          <span class="text-sm font-bold text-text-primary">{{ value }}</span>
-        </template>
+          <!-- Desktop cells -->
+          <template #cell-product_name="{ value }">
+            <span class="text-sm font-bold text-text-primary">{{ value }}</span>
+          </template>
 
-        <template #cell-category_name="{ value }">
-          <span class="text-sm text-text-secondary">{{ value ?? 'Sin categoría' }}</span>
-        </template>
+          <template #cell-category_name="{ value }">
+            <span class="text-sm text-text-secondary">{{ value ?? 'Sin categoría' }}</span>
+          </template>
 
-        <template #cell-quantity_sold="{ value }">
-          <span class="text-sm font-medium text-text-primary tabular-nums">{{ value }}</span>
-        </template>
+          <template #cell-quantity_sold="{ value }">
+            <span class="text-sm font-medium text-text-primary tabular-nums">{{ value }}</span>
+          </template>
 
-        <template #cell-total_revenue="{ value }">
-          <span class="text-sm font-bold text-primary tabular-nums">{{ formatCurrency(value) }}</span>
-        </template>
-      </UiResponsiveDataView>
+          <template #cell-total_revenue="{ value }">
+            <span class="text-sm font-bold text-primary tabular-nums">{{ formatCurrency(value) }}</span>
+          </template>
+        </UiResponsiveDataView>
       </HealthSemaphore>
 
       <!-- Totals row -->
@@ -283,39 +281,3 @@ onUnmounted(() => {
     </template>
   </div>
 </template>
-
-<style>
-.dp-custom-input {
-  height: 40px !important;
-  border: 2px solid hsl(var(--border)) !important;
-  border-radius: 0.5rem !important;
-  background: hsl(var(--background)) !important;
-  font-size: 0.875rem !important;
-  color: hsl(var(--foreground)) !important;
-  padding-left: 0.75rem !important;
-  padding-right: 0.75rem !important;
-  min-width: 200px;
-}
-.dp-custom-input:focus {
-  outline: none !important;
-  border-color: hsl(var(--primary)) !important;
-  box-shadow: 0 0 0 2px hsl(var(--primary) / 0.2) !important;
-}
-.dp-custom-input::placeholder { color: hsl(var(--muted-foreground)) !important; }
-.dp__theme_light {
-  --dp-primary-color: hsl(var(--primary));
-  --dp-primary-text-color: hsl(var(--primary-foreground));
-  --dp-background-color: hsl(var(--card));
-  --dp-text-color: hsl(var(--foreground));
-  --dp-border-color: hsl(var(--border));
-  --dp-menu-border-color: hsl(var(--border));
-  --dp-hover-color: hsl(var(--accent));
-  --dp-hover-text-color: hsl(var(--foreground));
-  --dp-secondary-color: hsl(var(--muted));
-  --dp-border-color-hover: hsl(var(--primary));
-}
-.dp-custom-menu {
-  border-radius: 0.75rem !important;
-  box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1) !important;
-}
-</style>


### PR DESCRIPTION
## Summary
- Migrates `/ventas/productos` to `UiAdvancedFiltersBar` (parity with `/ventas/ordenes`)
- Adds product name search, keeps date/category/sort, adds channel filter
- Wires all filters to `GET /api/orders/products-sold` (requires API PR)

## Stack
Nuxt 3, Pinia Colada, UiAdvancedFiltersBar, useAppliedSearch, useDateRangePresets

## Changes
- `pages/ventas/productos.vue`: shared filter bar, dynamic empty states, removed duplicate datepicker CSS

## Testing
- [ ] Search + Enter filters by product name
- [ ] Date range + category + sort + channel work together
- [ ] Clear resets all filters; metric cards match API totals
- [ ] Deploy API PR first (search/channel params)

## Depends on
- #767 (AdvancedFiltersBar) — base branch
- api-warolabs PR for `products-sold` search/channel

Closes #763

Made with [Cursor](https://cursor.com)