### PR TITLE
chore(ui): migrate SharedFiltersBar P0 pages (#765)

### DIFF
--- a/composables/useFilterSelectClass.ts
+++ b/composables/useFilterSelectClass.ts
@@ -1,0 +1,3 @@
+/** Shared Tailwind classes for filter bar `<select>` controls. */
+export const filterSelectClass =
+  'py-2 pl-3 pr-8 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer flex-shrink-0'

--- a/composables/usePurchaseDateFilter.ts
+++ b/composables/usePurchaseDateFilter.ts
@@ -1,0 +1,26 @@
+import { ref } from 'vue'
+
+/** Enum values for GET purchases `date_filter` (matches legacy FiltersBar + API). */
+export const purchaseDateFilterOptions = [
+  { label: 'Período', value: '' },
+  { label: 'Hoy', value: 'today' },
+  { label: 'Ayer', value: 'yesterday' },
+  { label: 'Semana pasada', value: 'last_week' },
+  { label: 'Últimos 15 días', value: '15_days' },
+  { label: 'Último mes', value: '1_month' },
+  { label: 'Últimos 3 meses', value: '3_months' },
+] as const
+
+export function usePurchaseDateFilter() {
+  const dateFilter = ref('')
+
+  const clearPurchaseDateFilter = () => {
+    dateFilter.value = ''
+  }
+
+  return {
+    dateFilter,
+    purchaseDateFilterOptions,
+    clearPurchaseDateFilter,
+  }
+}

--- a/pages/abastecimiento/compras-directas/index.vue
+++ b/pages/abastecimiento/compras-directas/index.vue
@@ -12,21 +12,46 @@
     <div v-else class="flex flex-col gap-3 md:gap-4">
 
       <!-- Filters Bar -->
-      <SharedFiltersBar
+      <UiAdvancedFiltersBar
         v-model:search="localSearchTerm"
-        v-model:supplier-filter="proveedorFilter"
-        v-model:status-filter="statusFilter"
-        v-model:date-filter="dateFilter"
-        :suppliers="suppliers"
-        :status-options="statusOptions"
-        status-label="Estado"
-        status-placeholder="Todos los estados"
-        show-supplier-filter
-        show-status-filter
-        show-date-filter
+        search-placeholder="Buscar compras directas..."
+        :search-fields="[]"
+        :show-date-range="false"
+        :show-clear="hasActiveFilters"
         @search="performSearch"
-        @clear-filters="clearFilters"
-      />
+        @clear="clearFilters"
+      >
+        <template #additional-filters>
+          <select
+            v-model="proveedorFilter"
+            :class="filterSelectClass"
+            aria-label="Filtrar por proveedor"
+            @change="currentPage = 1"
+          >
+            <option value="">Proveedor</option>
+            <option v-for="s in suppliers" :key="s.id" :value="s.id">{{ s.name }}</option>
+          </select>
+
+          <select
+            v-model="statusFilter"
+            :class="filterSelectClass"
+            aria-label="Filtrar por estado"
+            @change="currentPage = 1"
+          >
+            <option value="">Estado</option>
+            <option v-for="opt in statusOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+          </select>
+
+          <select
+            v-model="dateFilter"
+            :class="filterSelectClass"
+            aria-label="Filtrar por período"
+            @change="currentPage = 1"
+          >
+            <option v-for="opt in purchaseDateFilterOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+          </select>
+        </template>
+      </UiAdvancedFiltersBar>
 
       <!-- Responsive Data View -->
       <HealthSemaphore :is-unlocked="true" title="Compras Directas">
@@ -214,10 +239,10 @@ const { quota, warningLevel, scansRemaining } = useScanQuotaQuery()
 // State
 const currentPage = ref(1)
 const itemsPerPage = ref(20)
-const localSearchTerm = ref('')
+const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
 const proveedorFilter = ref('')
 const statusFilter = ref('')
-const dateFilter = ref('')
+const { dateFilter, purchaseDateFilterOptions, clearPurchaseDateFilter } = usePurchaseDateFilter()
 const sortField = ref('purchase_date')
 const sortDirection = ref<'asc' | 'desc'>('desc')
 
@@ -228,7 +253,7 @@ const { data: purchasesResponse, asyncStatus: queryAsyncStatus, error: fetchErro
   key: () => ['suppliers', 'direct-purchases', currentTenant.value?.id ?? null, {
     page: currentPage.value,
     limit: itemsPerPage.value,
-    search: localSearchTerm.value || null,
+    search: appliedSearch.value || null,
     status: statusFilter.value || null,
     supplier_id: proveedorFilter.value || null,
     date_filter: dateFilter.value || null,
@@ -239,8 +264,8 @@ const { data: purchasesResponse, asyncStatus: queryAsyncStatus, error: fetchErro
       limit: itemsPerPage.value,
     }
 
-    if (localSearchTerm.value) {
-      params.search = localSearchTerm.value
+    if (appliedSearch.value) {
+      params.search = appliedSearch.value
     }
     if (statusFilter.value) {
       params.status = statusFilter.value
@@ -270,10 +295,7 @@ const { data: suppliersResponse } = useQuery({
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })
-const suppliers = computed(() => (suppliersResponse.value?.data || []).map((s: any) => ({
-  value: s.id,
-  label: s.name
-})))
+const suppliers = computed(() => suppliersResponse.value?.data || [])
 
 // Status options
 const statusOptions = [
@@ -356,15 +378,22 @@ const handleSort = (field: string) => {
   }
 }
 
-const performSearch = () => {
-  currentPage.value = 1
-}
+const hasActiveFilters = computed(
+  () =>
+    !!localSearchTerm.value
+    || !!appliedSearch.value
+    || !!proveedorFilter.value
+    || !!statusFilter.value
+    || !!dateFilter.value,
+)
+
+const performSearch = () => applySearch(() => { currentPage.value = 1 })
 
 const clearFilters = () => {
-  localSearchTerm.value = ''
+  clearSearch()
   proveedorFilter.value = ''
   statusFilter.value = ''
-  dateFilter.value = ''
+  clearPurchaseDateFilter()
   currentPage.value = 1
 }
 

--- a/pages/abastecimiento/compras.vue
+++ b/pages/abastecimiento/compras.vue
@@ -11,23 +11,47 @@
     <!-- Main Content -->
     <div v-else class="flex flex-col gap-3 md:gap-4">
       <!-- Filters Bar -->
-      <SharedFiltersBar
+      <UiAdvancedFiltersBar
         v-model:search="localSearchTerm"
         v-model:search-field="apiSearchField"
-        v-model:supplier-filter="proveedorFilter"
-        v-model:status-filter="statusFilter"
-        v-model:date-filter="dateFilter"
         :search-fields="searchFields"
-        :suppliers="suppliers"
-        :status-options="purchaseStatusOptions"
-        status-label="Estado"
-        status-placeholder="Todos los estados"
-        show-supplier-filter
-        show-status-filter
-        show-date-filter
+        search-placeholder="Buscar órdenes de compra..."
+        :show-date-range="false"
+        :show-clear="hasActiveFilters"
         @search="performSearch"
-        @clear-filters="clearFilters"
-      />
+        @clear="clearFilters"
+      >
+        <template #additional-filters>
+          <select
+            v-model="proveedorFilter"
+            :class="filterSelectClass"
+            aria-label="Filtrar por proveedor"
+            @change="currentPage = 1"
+          >
+            <option value="">Proveedor</option>
+            <option v-for="s in suppliers" :key="s.id" :value="s.id">{{ s.name }}</option>
+          </select>
+
+          <select
+            v-model="statusFilter"
+            :class="filterSelectClass"
+            aria-label="Filtrar por estado"
+            @change="currentPage = 1"
+          >
+            <option value="">Estado</option>
+            <option v-for="opt in purchaseStatusOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+          </select>
+
+          <select
+            v-model="dateFilter"
+            :class="filterSelectClass"
+            aria-label="Filtrar por período"
+            @change="currentPage = 1"
+          >
+            <option v-for="opt in purchaseDateFilterOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+          </select>
+        </template>
+      </UiAdvancedFiltersBar>
 
       <!-- Responsive Data View (Mobile Cards + Desktop Table) -->
       <HealthSemaphore :is-unlocked="true" title="Órdenes de Compra">
@@ -220,13 +244,12 @@ import {
   ArrowPathIcon
 } from '@heroicons/vue/24/outline'
 
-// Reactive state
-const localSearchTerm = ref('')
-const apiSearchTerm = ref('')
+// Filters — AdvancedFiltersBar (#765)
+const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
 const apiSearchField = ref('purchase_number')
 const proveedorFilter = ref('')
 const statusFilter = ref('')
-const dateFilter = ref('')
+const { dateFilter, purchaseDateFilterOptions, clearPurchaseDateFilter } = usePurchaseDateFilter()
 const showCreateModal = ref(false)
 const currentPage = ref(1)
 const itemsPerPage = ref(20) // 20 filas por página
@@ -250,20 +273,27 @@ const purchaseStatusOptions = [
   { label: 'Cancelada', value: 'cancelled' }
 ]
 
-const performSearch = () => {
-  apiSearchTerm.value = localSearchTerm.value
-  currentPage.value = 1
-}
+const performSearch = () => applySearch(() => { currentPage.value = 1 })
+
+const hasActiveFilters = computed(
+  () =>
+    !!localSearchTerm.value
+    || !!appliedSearch.value
+    || !!proveedorFilter.value
+    || !!statusFilter.value
+    || !!dateFilter.value,
+)
 
 // Sorting state
 const sortField = ref('')
 const sortDirection = ref('asc')
 
-// Clear all filters
 const clearFilters = () => {
+  clearSearch()
   proveedorFilter.value = ''
   statusFilter.value = ''
-  dateFilter.value = ''
+  clearPurchaseDateFilter()
+  currentPage.value = 1
 }
 
 // Pagination
@@ -318,7 +348,7 @@ const { data: purchasesData, status: queryStatus, asyncStatus: purchasesAsyncSta
   key: () => ['suppliers', 'purchases', currentTenant.value?.id, {
     page: currentPage.value,
     limit: itemsPerPage.value,
-    search: apiSearchTerm.value || null,
+    search: appliedSearch.value || null,
     searchField: apiSearchField.value,
     status: statusFilter.value || null,
     supplier: proveedorFilter.value || null,
@@ -329,8 +359,8 @@ const { data: purchasesData, status: queryStatus, asyncStatus: purchasesAsyncSta
       page: currentPage.value,
       limit: itemsPerPage.value,
     }
-    if (apiSearchTerm.value) {
-      params.search = apiSearchTerm.value
+    if (appliedSearch.value) {
+      params.search = appliedSearch.value
       params.search_field = apiSearchField.value
     }
     if (statusFilter.value) params.status = statusFilter.value

--- a/pages/inventario/movimientos.vue
+++ b/pages/inventario/movimientos.vue
@@ -8,42 +8,42 @@
     <!-- Main Content -->
     <div v-else class="flex flex-col gap-3 md:gap-4">
       <!-- Filters Bar -->
-      <SharedFiltersBar
-        v-model:search="searchQuery"
-        v-model:date-filter="dateFilter"
-        search-label="Buscar"
+      <UiAdvancedFiltersBar
+        v-model:search="localSearchTerm"
+        v-model:date-range="dateRangeDates"
         search-placeholder="Buscar por ingrediente o referencia..."
-        show-date-filter
-        @search="handleSearch"
-        @clear-filters="clearFilters"
+        :search-fields="[]"
+        :preset-dates="presetDates"
+        :format-date-range="formatDateRange"
+        :show-clear="hasActiveFilters"
+        @search="performSearch"
+        @clear="clearFilters"
       >
         <template #additional-filters>
-          <!-- Ingredient Filter -->
           <select
             v-model="ingredientFilter"
-            class="px-4 py-2 border border-border rounded-lg bg-surface text-text-primary focus:outline-none focus:ring-2 focus:ring-ring"
-            @change="applyFilters"
+            :class="filterSelectClass"
+            aria-label="Filtrar por ingrediente"
           >
-            <option value="">Todos los ingredientes</option>
+            <option value="">Ingrediente</option>
             <option v-for="ingredient in ingredients" :key="ingredient.id" :value="ingredient.id">
               {{ ingredient.name }}
             </option>
           </select>
 
-          <!-- Movement Type Filter -->
           <select
             v-model="movementTypeFilter"
-            class="px-4 py-2 border border-border rounded-lg bg-surface text-text-primary focus:outline-none focus:ring-2 focus:ring-ring"
-            @change="applyFilters"
+            :class="filterSelectClass"
+            aria-label="Filtrar por tipo de movimiento"
           >
-            <option value="">Todos los tipos</option>
+            <option value="">Tipo</option>
             <option value="purchase">Compras</option>
             <option value="consumption">Consumo</option>
             <option value="adjustment">Ajustes</option>
             <option value="loss">Pérdidas</option>
           </select>
         </template>
-      </SharedFiltersBar>
+      </UiAdvancedFiltersBar>
 
       <!-- Responsive Data View -->
       <HealthSemaphore :is-unlocked="true" title="Movimientos de Inventario">
@@ -139,7 +139,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, inject, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { INGREDIENTS_FETCH_LIMIT } from '@/composables/useMenuIngredients'
 import { useFormatters } from '~/composables/useFormatters'
 // @ts-ignore
@@ -150,11 +150,22 @@ useHead({ title: 'Movimientos de Inventario' })
 // Tenant reactivity
 const { currentTenant } = useTenantReactive()
 
-// State
-const searchQuery = ref('')
+// Filters — AdvancedFiltersBar (#765)
+const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
+const { dateRangeDates, presetDates, formatDateRange, dateRange, clearDateRange } = useDateRangePresets()
 const ingredientFilter = ref('')
 const movementTypeFilter = ref('')
-const dateFilter = ref('')
+
+const hasActiveFilters = computed(
+  () =>
+    !!localSearchTerm.value
+    || !!appliedSearch.value
+    || !!dateRangeDates.value
+    || !!ingredientFilter.value
+    || !!movementTypeFilter.value,
+)
+
+const performSearch = () => applySearch()
 
 // Sorting state
 const sortField = ref('')
@@ -176,14 +187,9 @@ const ingredients = computed(() => {
   })).sort((a: any, b: any) => a.name.localeCompare(b.name))
 })
 
-// Compute date params from filter string
 const dateParts = computed(() => {
-  if (!dateFilter.value) return {}
-  if (dateFilter.value.includes(' to ')) {
-    const [start, end] = dateFilter.value.split(' to ')
-    return { start_date: start, end_date: end }
-  }
-  return { start_date: dateFilter.value, end_date: dateFilter.value }
+  if (!dateRange.value.from || !dateRange.value.to) return {}
+  return { start_date: dateRange.value.from, end_date: dateRange.value.to }
 })
 
 // Load movements data from API — reactive to tenant + filters
@@ -191,7 +197,8 @@ const { data: movementsData, status: queryStatus, asyncStatus: queryAsyncStatus,
   key: () => ['inventory', 'movements', currentTenant.value?.id, {
     type: movementTypeFilter.value || null,
     ingredient: ingredientFilter.value || null,
-    date: dateFilter.value || null,
+    from: dateRange.value.from,
+    to: dateRange.value.to,
   }],
   query: () => $fetch('/api/inventory/movements', {
     params: {
@@ -212,10 +219,11 @@ const isRefreshing = computed(() => queryAsyncStatus.value === 'loading' && move
 const movements = computed(() => movementsData.value?.data || [])
 
 const filteredMovements = computed(() => {
-  return movements.value.filter(movement => {
-    const matchesSearch = movement.ingredient_name.toLowerCase().includes(searchQuery.value.toLowerCase()) ||
-                         (movement.reference_number && movement.reference_number.toLowerCase().includes(searchQuery.value.toLowerCase()))
-    return matchesSearch
+  const q = appliedSearch.value.toLowerCase()
+  if (!q) return movements.value
+  return movements.value.filter((movement) => {
+    return movement.ingredient_name.toLowerCase().includes(q)
+      || (movement.reference_number && movement.reference_number.toLowerCase().includes(q))
   })
 })
 
@@ -252,20 +260,11 @@ const handleSort = (field) => {
   }
 }
 
-// Handle search
-const handleSearch = () => {
-  // Search is handled by computed filteredMovements
-}
-
-// Apply filters — reactive key triggers refetch automatically
-const applyFilters = () => {}
-
-// Clear filters
 const clearFilters = () => {
-  searchQuery.value = ''
+  clearSearch()
+  clearDateRange()
   ingredientFilter.value = ''
   movementTypeFilter.value = ''
-  dateFilter.value = ''
 }
 
 // Table columns configuration

--- a/pages/pagos/index.vue
+++ b/pages/pagos/index.vue
@@ -9,18 +9,35 @@
     <!-- Content -->
     <div v-else class="space-y-6">
       <!-- Filters Bar -->
-      <SharedFiltersBar
+      <UiAdvancedFiltersBar
         v-model:search="localSearchTerm"
         v-model:search-field="apiSearchField"
-        v-model:supplier-filter="selectedSupplierFilter"
-        v-model:date-filter="selectedDateFilter"
         :search-fields="searchFields"
-        :suppliers="suppliers"
-        show-supplier-filter
-        show-date-filter
+        search-placeholder="Buscar órdenes..."
+        :show-date-range="false"
+        :show-clear="hasActiveFilters"
         @search="performSearch"
-        @clear-filters="clearFilters"
-      />
+        @clear="clearFilters"
+      >
+        <template #additional-filters>
+          <select
+            v-model="selectedSupplierFilter"
+            :class="filterSelectClass"
+            aria-label="Filtrar por proveedor"
+          >
+            <option value="">Proveedor</option>
+            <option v-for="s in suppliers" :key="s.id" :value="s.id">{{ s.name }}</option>
+          </select>
+
+          <select
+            v-model="selectedDateFilter"
+            :class="filterSelectClass"
+            aria-label="Filtrar por período"
+          >
+            <option v-for="opt in purchaseDateFilterOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
+          </select>
+        </template>
+      </UiAdvancedFiltersBar>
 
       <!-- Pending Payments -->
       <div class="bg-surface rounded-lg">
@@ -184,13 +201,15 @@ const selectedPurchases = ref<any[]>([])
 const route = useRoute()
 const highlightId = ref<string | null>(null)
 
-// Filter state - Initialize from query params
-const localSearchTerm = ref((route.query.search as string) || '')
-const apiSearchTerm = ref((route.query.search as string) || '')
+// Filter state — AdvancedFiltersBar (#765); init from query params
+const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
+appliedSearch.value = (route.query.search as string) || ''
+localSearchTerm.value = appliedSearch.value
 const apiSearchField = ref((route.query.search_field as string) || 'purchase_number')
 const selectedSupplierFilter = ref((route.query.supplier_id as string) || '')
 const selectedStatusFilter = ref((route.query.payment_status as string) || '')
-const selectedDateFilter = ref((route.query.date_filter as string) || '')
+const { dateFilter: selectedDateFilter, purchaseDateFilterOptions, clearPurchaseDateFilter } = usePurchaseDateFilter()
+selectedDateFilter.value = (route.query.date_filter as string) || ''
 
 // Sorting state
 const sortField = ref('')
@@ -208,9 +227,15 @@ const statusOptions = [
   { label: 'Vence esta semana', value: 'due_this_week' }
 ]
 
-const performSearch = () => {
-  apiSearchTerm.value = localSearchTerm.value
-}
+const hasActiveFilters = computed(
+  () =>
+    !!localSearchTerm.value
+    || !!appliedSearch.value
+    || !!selectedSupplierFilter.value
+    || !!selectedDateFilter.value,
+)
+
+const performSearch = () => applySearch()
 
 // Set highlight ID from query params
 if (route.query.highlight) {
@@ -233,7 +258,7 @@ const suppliers = computed(() => (suppliersData.value as any)?.data || [])
 // Fetch all purchases with reactive filters
 const { data: purchasesData, status: queryStatus, asyncStatus: queryAsyncStatus, refetch } = useQuery({
   key: () => ['suppliers', 'purchases-payments', currentTenant.value?.id, {
-    search: apiSearchTerm.value || null,
+    search: appliedSearch.value || null,
     searchField: apiSearchField.value,
     supplier: selectedSupplierFilter.value || null,
     status: selectedStatusFilter.value || null,
@@ -242,7 +267,7 @@ const { data: purchasesData, status: queryStatus, asyncStatus: queryAsyncStatus,
   query: () => $fetch('/api/suppliers/purchases', {
     params: {
       limit: 250,
-      search: apiSearchTerm.value || undefined,
+      search: appliedSearch.value || undefined,
       search_field: apiSearchField.value || undefined,
       supplier_id: selectedSupplierFilter.value || undefined,
       payment_status: selectedStatusFilter.value || undefined,
@@ -496,10 +521,9 @@ function handleSort(field: string) {
 
 // Filter functions
 function clearFilters() {
-  localSearchTerm.value = ''
-  apiSearchTerm.value = ''
+  clearSearch()
   selectedSupplierFilter.value = ''
   selectedStatusFilter.value = ''
-  selectedDateFilter.value = ''
+  clearPurchaseDateFilter()
 }
 </script>


### PR DESCRIPTION
## Summary
PR 1 of #765 — migrates high-traffic pages from `SharedFiltersBar` to `UiAdvancedFiltersBar`.

## Changes
- `composables/usePurchaseDateFilter.ts` — shared `date_filter` enum options for purchases API
- `composables/useFilterSelectClass.ts` — consistent select styling
- `pages/abastecimiento/compras.vue` — search + supplier + status + period
- `pages/abastecimiento/compras-directas/index.vue` — same pattern; fix supplier option ids
- `pages/pagos/index.vue` — search + supplier + period
- `pages/inventario/movimientos.vue` — **fix** date filter: VueDatePicker presets → ISO `start_date`/`end_date`

## Testing
- [ ] Compras / compras-directas: enum period filters still work (`date_filter`)
- [ ] Pagos: search + supplier + period; clear resets all
- [ ] Movimientos: date range filters API correctly; search client-side on Enter

## Remaining (#765 PR 2/3)
stock, ajustes, proveedores, menu pages, mesas, mis-pedidos (~11 pages)

Depends on #767 (AdvancedFiltersBar base).

Part of #765

Made with [Cursor](https://cursor.com)