### PR TITLE
feat(menu): extract useIngredientUnitOptions composable

### DIFF
--- a/composables/useIngredientUnitOptions.ts
+++ b/composables/useIngredientUnitOptions.ts
@@ -1,0 +1,189 @@
+/**
+ * Ingredient unit options for recipe/composition UIs (dual-unit und → gr/ml + catalog).
+ *
+ * Backend mirror: `resolve_recipe_quantity_to_base_unit` in
+ * `api_warocol.com/app/services/ingredient_purchase_units_service.py` — converts
+ * recipe quantities in gr/ml/und/catalog keys (lt, kg, …) to the ingredient base unit.
+ *
+ * warocol.com#773
+ */
+
+export interface IngredientForUnits {
+  unit?: string
+  unit_weight_gr?: number | null
+  unit_weight_unit?: string | null
+}
+
+export interface UnitOption {
+  value: string
+  label: string
+}
+
+export interface UnitCatalogEntry {
+  label: string
+  factor: number
+  base: 'gr' | 'ml'
+}
+
+export interface PurchaseUnitForOptions {
+  purchase_unit?: string
+  purchase_unit_label?: string
+  conversion_factor?: number
+}
+
+/** Display labels for base and weight units in recipe selectors. */
+export const UNIT_LABELS: Record<string, string> = {
+  g: 'Gramos (g)',
+  gr: 'Gramos (gr)',
+  kg: 'Kilogramos (kg)',
+  ml: 'Mililitros (ml)',
+  l: 'Litros (l)',
+  u: 'Unidades (u)',
+  und: 'Unidades (und)',
+  lb: 'Libras (lb)',
+}
+
+/** Standard catalog matching backend PURCHASE_UNIT_CATALOG / _CATALOG_TO_BASE. */
+export const UNIT_CATALOG: Record<string, UnitCatalogEntry> = {
+  kg: { label: 'Kilogramo', factor: 1000, base: 'gr' },
+  libra: { label: 'Libra', factor: 500, base: 'gr' },
+  arroba: { label: 'Arroba', factor: 12500, base: 'gr' },
+  bulto_25kg: { label: 'Bulto (25 kg)', factor: 25000, base: 'gr' },
+  lt: { label: 'Litro', factor: 1000, base: 'ml' },
+  botella: { label: 'Botella', factor: 750, base: 'ml' },
+  galon: { label: 'Galón', factor: 3785, base: 'ml' },
+}
+
+export function allUnitLabelOptions(): UnitOption[] {
+  return Object.entries(UNIT_LABELS).map(([value, label]) => ({ value, label }))
+}
+
+export function isDualUnitIngredient(
+  ingredient: IngredientForUnits | null | undefined,
+): boolean {
+  if (!ingredient) return false
+  const baseUnit = ingredient.unit || 'g'
+  return !!(
+    ingredient.unit_weight_gr
+    && ingredient.unit_weight_gr > 0
+    && ingredient.unit_weight_unit
+    && ingredient.unit_weight_unit !== baseUnit
+  )
+}
+
+/** Default recipe unit: prefers unit_weight_unit when dual-unit. */
+export function defaultUnitForIngredient(
+  ingredient: IngredientForUnits | null | undefined,
+): string {
+  if (
+    ingredient?.unit_weight_gr
+    && ingredient.unit_weight_gr > 0
+    && ingredient.unit_weight_unit
+    && ingredient.unit_weight_unit !== ingredient.unit
+  ) {
+    return ingredient.unit_weight_unit
+  }
+  return ingredient?.unit || 'g'
+}
+
+export function formatCatalogOptionLabel(
+  entry: Pick<UnitCatalogEntry, 'label' | 'factor'>,
+  weightUnit: string,
+): string {
+  return `${entry.label} · ${entry.factor.toLocaleString('es-CO')} ${weightUnit}`
+}
+
+export function formatPurchaseUnitOptionLabel(
+  purchaseUnitLabel: string,
+  conversionFactor: number,
+  baseUnit: string,
+): string {
+  return `${purchaseUnitLabel} · ${Number(conversionFactor).toLocaleString('es-CO')} ${baseUnit}`
+}
+
+/** Catalog keys (kg, lt, …) for a dual-unit weight base (gr | ml). */
+export function buildDualUnitCatalogOptions(weightUnit: string): UnitOption[] {
+  return Object.entries(UNIT_CATALOG)
+    .filter(([, entry]) => entry.base === weightUnit)
+    .map(([key, entry]) => ({
+      value: key,
+      label: formatCatalogOptionLabel(entry, weightUnit),
+    }))
+}
+
+/** Same as buildDualUnitCatalogOptions but includes conversion_factor (compras-directas). */
+export function buildDualUnitCatalogOptionsWithMeta(weightUnit: string): Array<UnitOption & { conversion_factor: number }> {
+  return Object.entries(UNIT_CATALOG)
+    .filter(([, entry]) => entry.base === weightUnit)
+    .map(([key, entry]) => ({
+      value: key,
+      label: formatCatalogOptionLabel(entry, weightUnit),
+      conversion_factor: entry.factor,
+    }))
+}
+
+/**
+ * Recipe/composition unit dropdown options ({ value, label }).
+ * When ingredient is missing but an id was provided, uses base unit fallback `g`.
+ */
+export function buildRecipeUnitOptions(params: {
+  ingredient?: IngredientForUnits | null
+  purchaseUnits?: PurchaseUnitForOptions[]
+}): UnitOption[] {
+  const { ingredient, purchaseUnits = [] } = params
+  const baseUnit = ingredient?.unit || 'g'
+
+  const options: UnitOption[] = [
+    { value: baseUnit, label: UNIT_LABELS[baseUnit] || baseUnit },
+  ]
+
+  const weightUnit = ingredient?.unit_weight_unit
+  if (isDualUnitIngredient(ingredient) && weightUnit) {
+    options.push({ value: weightUnit, label: UNIT_LABELS[weightUnit] || weightUnit })
+    options.push(...buildDualUnitCatalogOptions(weightUnit))
+  }
+
+  purchaseUnits.forEach((pu) => {
+    if (pu.purchase_unit && !options.find(o => o.value === pu.purchase_unit)) {
+      options.push({
+        value: pu.purchase_unit,
+        label: formatPurchaseUnitOptionLabel(
+          pu.purchase_unit_label || pu.purchase_unit,
+          Number(pu.conversion_factor) || 0,
+          baseUnit,
+        ),
+      })
+    }
+  })
+
+  return options
+}
+
+export function useIngredientUnitOptions() {
+  function getIngredientUnitOptions(
+    ingredientId: string,
+    caches: {
+      ingredientCache: Record<string, IngredientForUnits>
+      purchaseUnitsCache: Map<string, PurchaseUnitForOptions[]>
+    },
+  ): UnitOption[] {
+    if (!ingredientId) return allUnitLabelOptions()
+    const ingredient = caches.ingredientCache[ingredientId]
+    const purchaseUnits = caches.purchaseUnitsCache.get(ingredientId) || []
+    return buildRecipeUnitOptions({ ingredient, purchaseUnits })
+  }
+
+  return {
+    UNIT_LABELS,
+    UNIT_CATALOG,
+    allUnitLabelOptions,
+    isDualUnitIngredient,
+    defaultUnitForIngredient,
+    formatCatalogOptionLabel,
+    formatPurchaseUnitOptionLabel,
+    buildDualUnitCatalogOptions,
+    buildDualUnitCatalogOptionsWithMeta,
+    buildRecipeUnitOptions,
+    getIngredientUnitOptions,
+  }
+}

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -1413,16 +1413,10 @@ const itemsByType = computed(() => ({
 const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 const loadingUnitsFor = ref<Set<string>>(new Set())
 
-// Standard catalog matching backend PURCHASE_UNIT_CATALOG
-const UNIT_CATALOG: Record<string, { label: string; factor: number; base: 'gr' | 'ml' }> = {
-  kg:         { label: 'Kilogramo',     factor: 1000,  base: 'gr' },
-  libra:      { label: 'Libra',         factor: 500,   base: 'gr' },
-  arroba:     { label: 'Arroba',        factor: 12500, base: 'gr' },
-  bulto_25kg: { label: 'Bulto (25 kg)', factor: 25000, base: 'gr' },
-  lt:         { label: 'Litro',         factor: 1000,  base: 'ml' },
-  botella:    { label: 'Botella',       factor: 750,   base: 'ml' },
-  galon:      { label: 'Galón',         factor: 3785,  base: 'ml' },
-}
+const {
+  isDualUnitIngredient,
+  buildDualUnitCatalogOptionsWithMeta,
+} = useIngredientUnitOptions()
 
 // Loading state
 const isLoadingData = computed(() => loadingSuppliers.value)
@@ -1498,21 +1492,17 @@ const getPurchaseUnitOptions = (ingredientId: string) => {
     options.push({ value: baseUnit, label: baseUnit, conversion_factor: 1, is_default: units.length === 0 && pendingUnits.length === 0 })
   }
 
-  // For dual und ingredients: show gr/ml raw unit + catalog options for that unit type
-  const isDual = ingredient?.unit_weight_gr > 0 && ingredient?.unit_weight_unit && ingredient.unit_weight_unit !== baseUnit
   const weightUnit = ingredient?.unit_weight_unit as string | undefined
-  if (isDual && weightUnit) {
+  if (isDualUnitIngredient(ingredient) && weightUnit) {
     options.push({ value: weightUnit, label: weightUnit, conversion_factor: 1, is_default: false })
-    Object.entries(UNIT_CATALOG)
-      .filter(([, entry]) => entry.base === weightUnit)
-      .forEach(([key, entry]) => {
-        options.push({
-          value: key,
-          label: `${entry.label} · ${entry.factor.toLocaleString('es-CO')} ${weightUnit}`,
-          conversion_factor: entry.factor,
-          is_default: false,
-        })
+    buildDualUnitCatalogOptionsWithMeta(weightUnit).forEach((entry) => {
+      options.push({
+        value: entry.value,
+        label: entry.label,
+        conversion_factor: entry.conversion_factor,
+        is_default: false,
       })
+    })
   }
 
   const serverOptions = units.map((u: any) => ({

--- a/pages/menu/recetas/crear.vue
+++ b/pages/menu/recetas/crear.vue
@@ -564,76 +564,19 @@ const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 // Tracks which ingredient IDs are currently fetching their purchase units
 const loadingUnits = ref<Set<string>>(new Set())
 
-const unitLabels: Record<string, string> = {
-  g: 'Gramos (g)',
-  gr: 'Gramos (gr)',
-  kg: 'Kilogramos (kg)',
-  ml: 'Mililitros (ml)',
-  l: 'Litros (l)',
-  u: 'Unidades (u)',
-  und: 'Unidades (und)',
-  lb: 'Libras (lb)',
-}
-
-// Standard catalog matching backend PURCHASE_UNIT_CATALOG
-const UNIT_CATALOG: Record<string, { label: string; factor: number; base: 'gr' | 'ml' }> = {
-  kg:         { label: 'Kilogramo',    factor: 1000,  base: 'gr' },
-  libra:      { label: 'Libra',        factor: 500,   base: 'gr' },
-  arroba:     { label: 'Arroba',       factor: 12500, base: 'gr' },
-  bulto_25kg: { label: 'Bulto (25 kg)',factor: 25000, base: 'gr' },
-  lt:         { label: 'Litro',        factor: 1000,  base: 'ml' },
-  botella:    { label: 'Botella',      factor: 750,   base: 'ml' },
-  galon:      { label: 'Galón',        factor: 3785,  base: 'ml' },
-}
+const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient } = useIngredientUnitOptions()
 
 function getIngredientUnitOptions(ingredientId: string) {
-  if (!ingredientId) return Object.entries(unitLabels).map(([value, label]) => ({ value, label }))
-  const ingredient = ingredientCache.value[ingredientId]
-  const baseUnit = ingredient?.unit || 'g'
-  const purchaseUnits = purchaseUnitsCache.value.get(ingredientId) || []
-
-  const options: { value: string; label: string }[] = [
-    { value: baseUnit, label: unitLabels[baseUnit] || baseUnit }
-  ]
-
-  const isDual = ingredient?.unit_weight_gr > 0 && ingredient?.unit_weight_unit && ingredient.unit_weight_unit !== baseUnit
-  const weightUnit = ingredient?.unit_weight_unit as string | undefined
-
-  // For dual und ingredients: show gr/ml raw unit + catalog options for that unit type
-  if (isDual && weightUnit) {
-    options.push({ value: weightUnit, label: unitLabels[weightUnit] || weightUnit })
-    // Add catalog entries compatible with unit_weight_unit (e.g. lt, botella, galon for ml)
-    Object.entries(UNIT_CATALOG)
-      .filter(([, entry]) => entry.base === weightUnit)
-      .forEach(([key, entry]) => {
-        options.push({
-          value: key,
-          label: `${entry.label} · ${entry.factor.toLocaleString('es-CO')} ${weightUnit}`,
-        })
-      })
-  }
-
-  // Purchase units with proper labels and conversion info
-  purchaseUnits.forEach((pu: any) => {
-    if (pu.purchase_unit && !options.find(o => o.value === pu.purchase_unit)) {
-      options.push({
-        value: pu.purchase_unit,
-        label: `${pu.purchase_unit_label} · ${Number(pu.conversion_factor).toLocaleString('es-CO')} ${baseUnit}`,
-      })
-    }
+  return buildUnitOptions(ingredientId, {
+    ingredientCache: ingredientCache.value,
+    purchaseUnitsCache: purchaseUnitsCache.value,
   })
-
-  return options
 }
 
 async function onIngredientChange(index: number, ingredientId: string) {
   if (!ingredientId) return
   const ingredient = ingredientCache.value[ingredientId]
-  // For dual-unit und ingredients, default to unit_weight_unit (gr/ml) for recipe use
-  const defaultUnit = (ingredient?.unit_weight_gr > 0 && ingredient?.unit_weight_unit && ingredient.unit_weight_unit !== ingredient?.unit)
-    ? ingredient.unit_weight_unit
-    : ingredient?.unit || 'g'
-  form.value.ingredients[index].unit = defaultUnit
+  form.value.ingredients[index].unit = defaultUnitForIngredient(ingredient)
   if (!purchaseUnitsCache.value.has(ingredientId)) {
     loadingUnits.value = new Set([...loadingUnits.value, ingredientId])
     try {


### PR DESCRIPTION
## Summary
Extract shared dual-unit ingredient option logic into `composables/useIngredientUnitOptions.ts`. Refactor `recetas/crear.vue` to use the composable with no behavior change. Deduplicate `UNIT_CATALOG` and dual-unit catalog branch in `compras-directas/crear.vue` while keeping label-based purchase unit values.

## Stack
Nuxt 3 (composables + pages)

## Changes
- `composables/useIngredientUnitOptions.ts`: `UNIT_LABELS`, `UNIT_CATALOG`, pure helpers (`isDualUnitIngredient`, `defaultUnitForIngredient`, `buildRecipeUnitOptions`, …), JSDoc → backend `resolve_recipe_quantity_to_base_unit`
- `pages/menu/recetas/crear.vue`: uses composable for options + default unit; keeps page-level fetch cache
- `pages/abastecimiento/compras-directas/crear.vue`: imports shared dual-unit catalog helpers

## Testing
- Manual on `/menu/recetas/crear`: empty ingredient id → full label list; dual `und` ingredient → und + gr/ml + catalog + purchase units; default unit on select = `unit_weight_unit`
- Manual on `/abastecimiento/compras-directas/crear`: dual-unit options unchanged; purchase dropdown still uses `purchase_unit_label` values

Closes #773

Made with [Cursor](https://cursor.com)