### PR TITLE
feat(menu): dual-unit selectors on productos, recetas edit, modificadores

### DIFF
--- a/composables/useIngredientUnitOptions.ts
+++ b/composables/useIngredientUnitOptions.ts
@@ -5,7 +5,7 @@
  * `api_warocol.com/app/services/ingredient_purchase_units_service.py` — converts
  * recipe quantities in gr/ml/und/catalog keys (lt, kg, …) to the ingredient base unit.
  *
- * warocol.com#773
+ * warocol.com#773, #774
  */
 
 export interface IngredientForUnits {
@@ -56,6 +56,19 @@ export const UNIT_CATALOG: Record<string, UnitCatalogEntry> = {
 
 export function allUnitLabelOptions(): UnitOption[] {
   return Object.entries(UNIT_LABELS).map(([value, label]) => ({ value, label }))
+}
+
+/** Merge unit_weight fields from catalog when edit APIs only return id/name/unit. */
+export function mergeIngredientUnitFields<T extends Record<string, unknown>>(
+  partial: T,
+  catalogRow?: IngredientForUnits | null,
+): T & IngredientForUnits {
+  return {
+    ...partial,
+    unit: (partial.unit as string | undefined) ?? catalogRow?.unit,
+    unit_weight_gr: (partial.unit_weight_gr as number | null | undefined) ?? catalogRow?.unit_weight_gr ?? null,
+    unit_weight_unit: (partial.unit_weight_unit as string | null | undefined) ?? catalogRow?.unit_weight_unit ?? null,
+  }
 }
 
 export function isDualUnitIngredient(
@@ -177,6 +190,7 @@ export function useIngredientUnitOptions() {
     UNIT_LABELS,
     UNIT_CATALOG,
     allUnitLabelOptions,
+    mergeIngredientUnitFields,
     isDualUnitIngredient,
     defaultUnitForIngredient,
     formatCatalogOptionLabel,

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -633,6 +633,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
+import { useMenuIngredientsQuery } from '@/composables/queries/useMenuIngredients'
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
@@ -695,25 +696,25 @@ const { data: productsData, pending: loadingProducts } = useAsyncData(
   }
 )
 
+const { availableIngredients } = useMenuIngredientsQuery()
+
 // Ingredient cache and purchase units
 const ingredientCache = ref<Record<string, any>>({})
 const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 const loadingUnits = ref<Set<string>>(new Set())
 
-const unitLabels: Record<string, string> = {
-  g: 'Gramos (g)', kg: 'Kilogramos (kg)', ml: 'Mililitros (ml)',
-  l: 'Litros (l)', u: 'Unidades (u)', lb: 'Libras (lb)',
-  und: 'Unidades (und)', gr: 'Gramos (gr)',
-}
+const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient, mergeIngredientUnitFields } = useIngredientUnitOptions()
 
 function getIngredientUnitOptions(ingredientId: string | null) {
-  if (!ingredientId) return Object.entries(unitLabels).map(([value, label]) => ({ value, label }))
-  const ingredient = ingredientCache.value[ingredientId]
-  const baseUnit = ingredient?.unit || 'g'
-  const purchaseUnits = purchaseUnitsCache.value.get(ingredientId) || []
-  const unitSet = new Set<string>([baseUnit])
-  purchaseUnits.forEach((pu: any) => { if (pu.purchase_unit) unitSet.add(pu.purchase_unit) })
-  return Array.from(unitSet).map(u => ({ value: u, label: unitLabels[u] || u }))
+  return buildUnitOptions(ingredientId || '', {
+    ingredientCache: ingredientCache.value,
+    purchaseUnitsCache: purchaseUnitsCache.value,
+  })
+}
+
+function cacheIngredientForUnits(ing: any) {
+  const catalogRow = availableIngredients.value.find((i: any) => i.id === ing.id)
+  ingredientCache.value[ing.id] = mergeIngredientUnitFields(ing, catalogRow)
 }
 
 function getIngredientById(id: string) {
@@ -743,8 +744,8 @@ function selectIngredient(modifier: any, ing: any) {
   modifier.ingredient_id = ing.id
   modifier.name = ing.name
   modifier.ingredient_name = ing.name
-  modifier.ingredient_unit = ing.unit || 'g'
-  ingredientCache.value[ing.id] = ing
+  cacheIngredientForUnits(ing)
+  modifier.ingredient_unit = defaultUnitForIngredient(ingredientCache.value[ing.id])
   loadPurchaseUnits(ing.id)
 }
 
@@ -795,12 +796,12 @@ watch(groupData, (data) => {
       sort_order: group.sort_order,
       modifiers: group.modifiers.map((m: any) => {
         if (m.ingredient_id && m.ingredient) {
-          ingredientCache.value[m.ingredient_id] = {
+          cacheIngredientForUnits({
             id: m.ingredient_id,
             name: m.ingredient.name,
             unit: m.ingredient.unit,
-            costo_unitario: m.ingredient.costo_unitario
-          }
+            costo_unitario: m.ingredient.costo_unitario,
+          })
           loadPurchaseUnits(m.ingredient_id)
         }
         return {

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -780,20 +780,13 @@ const ingredientCache = ref<Record<string, any>>({})
 const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 const loadingUnits = ref<Set<string>>(new Set())
 
-const unitLabels: Record<string, string> = {
-  g: 'Gramos (g)', kg: 'Kilogramos (kg)', ml: 'Mililitros (ml)',
-  l: 'Litros (l)', u: 'Unidades (u)', lb: 'Libras (lb)',
-  und: 'Unidades (und)', gr: 'Gramos (gr)',
-}
+const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient } = useIngredientUnitOptions()
 
 function getIngredientUnitOptions(ingredientId: string | null) {
-  if (!ingredientId) return Object.entries(unitLabels).map(([value, label]) => ({ value, label }))
-  const ingredient = ingredientCache.value[ingredientId]
-  const baseUnit = ingredient?.unit || 'g'
-  const purchaseUnits = purchaseUnitsCache.value.get(ingredientId) || []
-  const unitSet = new Set<string>([baseUnit])
-  purchaseUnits.forEach((pu: any) => { if (pu.purchase_unit) unitSet.add(pu.purchase_unit) })
-  return Array.from(unitSet).map(u => ({ value: u, label: unitLabels[u] || u }))
+  return buildUnitOptions(ingredientId || '', {
+    ingredientCache: ingredientCache.value,
+    purchaseUnitsCache: purchaseUnitsCache.value,
+  })
 }
 
 function getIngredientById(id: string) {
@@ -822,8 +815,8 @@ async function loadPurchaseUnits(ingredientId: string) {
 function selectIngredient(modifier: any, ing: any) {
   modifier.ingredient_id = ing.id
   modifier.name = ing.name
-  modifier.ingredient_unit = ing.unit || 'g'
   ingredientCache.value[ing.id] = ing
+  modifier.ingredient_unit = defaultUnitForIngredient(ingredientCache.value[ing.id])
   loadPurchaseUnits(ing.id)
 }
 

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -776,20 +776,18 @@ const ingredientCache = ref<Record<string, any>>({})
 const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 const loadingUnits = ref<Set<string>>(new Set())
 
-const unitLabels: Record<string, string> = {
-  g: 'Gramos (g)', kg: 'Kilogramos (kg)', ml: 'Mililitros (ml)',
-  l: 'Litros (l)', u: 'Unidades (u)', lb: 'Libras (lb)',
-  und: 'Unidades (und)', gr: 'Gramos (gr)',
-}
+const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient, mergeIngredientUnitFields } = useIngredientUnitOptions()
 
 function getIngredientUnitOptions(ingredientId: string) {
-  if (!ingredientId) return Object.entries(unitLabels).map(([value, label]) => ({ value, label }))
-  const ingredient = ingredientCache.value[ingredientId]
-  const baseUnit = ingredient?.unit || 'g'
-  const purchaseUnits = purchaseUnitsCache.value.get(ingredientId) || []
-  const unitSet = new Set<string>([baseUnit])
-  purchaseUnits.forEach((pu: any) => { if (pu.purchase_unit) unitSet.add(pu.purchase_unit) })
-  return Array.from(unitSet).map(u => ({ value: u, label: unitLabels[u] || u }))
+  return buildUnitOptions(ingredientId, {
+    ingredientCache: ingredientCache.value,
+    purchaseUnitsCache: purchaseUnitsCache.value,
+  })
+}
+
+function cacheIngredientForUnits(ing: any) {
+  const catalogRow = ingredients.value.find((i: any) => i.id === ing.id)
+  ingredientCache.value[ing.id] = mergeIngredientUnitFields(ing, catalogRow)
 }
 
 async function loadPurchaseUnits(ingredientId: string) {
@@ -814,8 +812,8 @@ async function loadPurchaseUnits(ingredientId: string) {
 function selectIngredient(ing: any, index: number) {
   form.value.ingredients[index].ingredient_id = ing.id
   form.value.ingredients[index].ingredient_name = ing.name
-  form.value.ingredients[index].unit = ing.unit || 'g'
-  ingredientCache.value[ing.id] = ing
+  cacheIngredientForUnits(ing)
+  form.value.ingredients[index].unit = defaultUnitForIngredient(ingredientCache.value[ing.id])
   loadPurchaseUnits(ing.id)
   form.value.ingredients = [...form.value.ingredients]
 }
@@ -958,7 +956,7 @@ watch(productData, (data) => {
       ),
       ingredients: product.ingredients.map((ing: any) => {
         if (ing.ingredient_id) {
-          ingredientCache.value[ing.ingredient_id] = { id: ing.ingredient_id, name: ing.ingredient_name || '', unit: ing.unit }
+          cacheIngredientForUnits({ id: ing.ingredient_id, name: ing.ingredient_name || '', unit: ing.unit })
           loadPurchaseUnits(ing.ingredient_id)
         }
         return {

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -976,31 +976,19 @@ const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 // Tracks which ingredient IDs are currently fetching their purchase units
 const loadingUnits = ref<Set<string>>(new Set())
 
-const unitLabels: Record<string, string> = {
-  g: 'Gramos (g)',
-  gr: 'Gramos (gr)',
-  kg: 'Kilogramos (kg)',
-  ml: 'Mililitros (ml)',
-  l: 'Litros (l)',
-  u: 'Unidades (u)',
-  und: 'Unidades (und)',
-  lb: 'Libras (lb)',
-}
+const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient } = useIngredientUnitOptions()
 
 function getIngredientUnitOptions(ingredientId: string) {
-  if (!ingredientId) return Object.entries(unitLabels).map(([value, label]) => ({ value, label }))
-  const ingredient = ingredientCache.value[ingredientId]
-  const baseUnit = ingredient?.unit || 'g'
-  const purchaseUnits = purchaseUnitsCache.value.get(ingredientId) || []
-  const unitSet = new Set<string>([baseUnit])
-  purchaseUnits.forEach((pu: any) => { if (pu.purchase_unit) unitSet.add(pu.purchase_unit) })
-  return Array.from(unitSet).map(u => ({ value: u, label: unitLabels[u] || u }))
+  return buildUnitOptions(ingredientId, {
+    ingredientCache: ingredientCache.value,
+    purchaseUnitsCache: purchaseUnitsCache.value,
+  })
 }
 
 async function onIngredientChange(index: number, ingredientId: string) {
   if (!ingredientId) return
   const ingredient = ingredientCache.value[ingredientId]
-  form.value.ingredients[index].unit = ingredient?.unit || 'g'
+  form.value.ingredients[index].unit = defaultUnitForIngredient(ingredient)
   if (!purchaseUnitsCache.value.has(ingredientId)) {
     loadingUnits.value = new Set([...loadingUnits.value, ingredientId])
     try {

--- a/pages/menu/recetas/[id].vue
+++ b/pages/menu/recetas/[id].vue
@@ -258,6 +258,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
+import { useMenuIngredientsQuery } from '@/composables/queries/useMenuIngredients'
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
@@ -294,6 +295,8 @@ const { data: recipeData, pending: isLoading, error: fetchError, refresh } = use
 
 const isPageLoading = computed(() => isLoading.value)
 
+const { availableIngredients } = useMenuIngredientsQuery()
+
 // Ingredient cache: populated from API response on load or when user selects via UiIngredientSearchInput
 const ingredientCache = ref<Record<string, any>>({})
 
@@ -303,20 +306,18 @@ const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 // Tracks which ingredient IDs are currently fetching purchase units
 const loadingUnits = ref<Set<string>>(new Set())
 
-const unitLabels: Record<string, string> = {
-  g: 'Gramos (g)', kg: 'Kilogramos (kg)', ml: 'Mililitros (ml)',
-  l: 'Litros (l)', u: 'Unidades (u)', lb: 'Libras (lb)',
-  und: 'Unidades (und)', gr: 'Gramos (gr)',
-}
+const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient, mergeIngredientUnitFields } = useIngredientUnitOptions()
 
 function getIngredientUnitOptions(ingredientId: string) {
-  if (!ingredientId) return Object.entries(unitLabels).map(([value, label]) => ({ value, label }))
-  const ingredient = ingredientCache.value[ingredientId]
-  const baseUnit = ingredient?.unit || 'g'
-  const purchaseUnits = purchaseUnitsCache.value.get(ingredientId) || []
-  const unitSet = new Set<string>([baseUnit])
-  purchaseUnits.forEach((pu: any) => { if (pu.purchase_unit) unitSet.add(pu.purchase_unit) })
-  return Array.from(unitSet).map(u => ({ value: u, label: unitLabels[u] || u }))
+  return buildUnitOptions(ingredientId, {
+    ingredientCache: ingredientCache.value,
+    purchaseUnitsCache: purchaseUnitsCache.value,
+  })
+}
+
+function cacheIngredientForUnits(ing: any) {
+  const catalogRow = availableIngredients.value.find((i: any) => i.id === ing.id)
+  ingredientCache.value[ing.id] = mergeIngredientUnitFields(ing, catalogRow)
 }
 
 async function loadPurchaseUnits(ingredientId: string) {
@@ -341,8 +342,8 @@ async function loadPurchaseUnits(ingredientId: string) {
 function selectIngredient(ing: any, index: number) {
   form.value.ingredients[index].ingredient_id = ing.id
   form.value.ingredients[index].ingredient_name = ing.name
-  form.value.ingredients[index].unit = ing.unit || 'g'
-  ingredientCache.value[ing.id] = ing
+  cacheIngredientForUnits(ing)
+  form.value.ingredients[index].unit = defaultUnitForIngredient(ingredientCache.value[ing.id])
   loadPurchaseUnits(ing.id)
   form.value.ingredients = [...form.value.ingredients]
 }
@@ -391,7 +392,7 @@ watch(recipeData, (data) => {
       is_active: recipe.is_active,
       ingredients: recipe.ingredients.map((ing: any) => {
         if (ing.ingredient_id) {
-          ingredientCache.value[ing.ingredient_id] = { id: ing.ingredient_id, name: ing.ingredient_name || '', unit: ing.unit }
+          cacheIngredientForUnits({ id: ing.ingredient_id, name: ing.ingredient_name || '', unit: ing.unit })
           loadPurchaseUnits(ing.ingredient_id)
         }
         return {


### PR DESCRIPTION
## Summary
Wire `useIngredientUnitOptions` on five menu composition pages so resale `und` ingredients show `ml`/`gr` and catalog units (`lt`, `botella`, …). Edit pages enrich `ingredientCache` from the ingredient catalog so dual-unit options appear on load without re-selecting.

Depends on #773 (composable) — merge PR #777 first, then this PR.

## Stack
Nuxt 3

## Changes
- `composables/useIngredientUnitOptions.ts`: `mergeIngredientUnitFields` for edit-page cache enrichment
- `pages/menu/productos/crear.vue`, `productos/[id].vue`
- `pages/menu/recetas/[id].vue`
- `pages/menu/modificadores/crear.vue`, `modificadores/[id].vue`

## Testing
- Create product/recipe/modifier: select resale `und` (700 ml/und) → dropdown shows `ml`, `lt`, `botella`; default unit `ml`
- Edit existing row with `unit: ml` → options visible on load
- Save `quantity: 350`, `unit: ml` — persists (backend `resolve_recipe_quantity_to_base_unit` unchanged)

Closes #774

Made with [Cursor](https://cursor.com)