### PR TITLE
fix(menu): hydrate unit_weight fields in ingredient cache on edit pages

### DIFF
--- a/composables/useIngredientUnitOptions.ts
+++ b/composables/useIngredientUnitOptions.ts
@@ -5,7 +5,7 @@
  * `api_warocol.com/app/services/ingredient_purchase_units_service.py` — converts
  * recipe quantities in gr/ml/und/catalog keys (lt, kg, …) to the ingredient base unit.
  *
- * warocol.com#773, #774
+ * warocol.com#773, #774, #775
  */
 
 export interface IngredientForUnits {
@@ -68,6 +68,28 @@ export function mergeIngredientUnitFields<T extends Record<string, unknown>>(
     unit: (partial.unit as string | undefined) ?? catalogRow?.unit,
     unit_weight_gr: (partial.unit_weight_gr as number | null | undefined) ?? catalogRow?.unit_weight_gr ?? null,
     unit_weight_unit: (partial.unit_weight_unit as string | null | undefined) ?? catalogRow?.unit_weight_unit ?? null,
+  }
+}
+
+export interface IngredientCacheEntry {
+  id: string
+  name?: string
+  unit?: string
+  unit_weight_gr?: number | null
+  unit_weight_unit?: string | null
+}
+
+/** Re-merge composition rows with catalog once menu-ingredients query has loaded (#775). */
+export function rehydrateIngredientCaches(
+  entries: IngredientCacheEntry[],
+  catalog: Array<IngredientForUnits & { id: string }>,
+  cache: Record<string, unknown>,
+): void {
+  if (!entries.length || !catalog.length) return
+  const catalogById = new Map(catalog.map(row => [row.id, row]))
+  for (const entry of entries) {
+    if (!entry.id) continue
+    cache[entry.id] = mergeIngredientUnitFields(entry, catalogById.get(entry.id) ?? null)
   }
 }
 
@@ -191,6 +213,7 @@ export function useIngredientUnitOptions() {
     UNIT_CATALOG,
     allUnitLabelOptions,
     mergeIngredientUnitFields,
+    rehydrateIngredientCaches,
     isDualUnitIngredient,
     defaultUnitForIngredient,
     formatCatalogOptionLabel,

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -631,7 +631,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 import { useMenuIngredientsQuery } from '@/composables/queries/useMenuIngredients'
 
@@ -703,7 +703,7 @@ const ingredientCache = ref<Record<string, any>>({})
 const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 const loadingUnits = ref<Set<string>>(new Set())
 
-const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient, mergeIngredientUnitFields } = useIngredientUnitOptions()
+const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient, mergeIngredientUnitFields, rehydrateIngredientCaches } = useIngredientUnitOptions()
 
 function getIngredientUnitOptions(ingredientId: string | null) {
   return buildUnitOptions(ingredientId || '', {
@@ -715,6 +715,19 @@ function getIngredientUnitOptions(ingredientId: string | null) {
 function cacheIngredientForUnits(ing: any) {
   const catalogRow = availableIngredients.value.find((i: any) => i.id === ing.id)
   ingredientCache.value[ing.id] = mergeIngredientUnitFields(ing, catalogRow)
+}
+
+function rehydrateModifierIngredientCaches() {
+  if (!availableIngredients.value.length) return
+  const entries = form.value.modifiers
+    .filter(m => m.ingredient_id)
+    .map(m => ({
+      id: m.ingredient_id!,
+      name: m.ingredient_name || ingredientCache.value[m.ingredient_id!]?.name,
+      unit: ingredientCache.value[m.ingredient_id!]?.unit ?? m.ingredient_unit ?? undefined,
+      ...ingredientCache.value[m.ingredient_id!],
+    }))
+  rehydrateIngredientCaches(entries, availableIngredients.value, ingredientCache.value)
 }
 
 function getIngredientById(id: string) {
@@ -821,6 +834,12 @@ watch(groupData, (data) => {
     }
   }
 }, { immediate: true })
+
+watch(availableIngredients, (list) => {
+  if (list.length && form.value.modifiers.some(m => m.ingredient_id)) {
+    rehydrateModifierIngredientCaches()
+  }
+})
 
 // Methods
 function getProductName(productId: string) {

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -776,7 +776,7 @@ const ingredientCache = ref<Record<string, any>>({})
 const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 const loadingUnits = ref<Set<string>>(new Set())
 
-const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient, mergeIngredientUnitFields } = useIngredientUnitOptions()
+const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient, mergeIngredientUnitFields, rehydrateIngredientCaches } = useIngredientUnitOptions()
 
 function getIngredientUnitOptions(ingredientId: string) {
   return buildUnitOptions(ingredientId, {
@@ -788,6 +788,19 @@ function getIngredientUnitOptions(ingredientId: string) {
 function cacheIngredientForUnits(ing: any) {
   const catalogRow = ingredients.value.find((i: any) => i.id === ing.id)
   ingredientCache.value[ing.id] = mergeIngredientUnitFields(ing, catalogRow)
+}
+
+function rehydrateProductIngredientCaches() {
+  if (!ingredients.value.length) return
+  const entries = form.value.ingredients
+    .filter(ing => ing.ingredient_id)
+    .map(ing => ({
+      id: ing.ingredient_id,
+      name: ing.ingredient_name || ingredientCache.value[ing.ingredient_id]?.name,
+      unit: ing.unit,
+      ...ingredientCache.value[ing.ingredient_id],
+    }))
+  rehydrateIngredientCaches(entries, ingredients.value, ingredientCache.value)
 }
 
 async function loadPurchaseUnits(ingredientId: string) {
@@ -977,6 +990,12 @@ watch(productData, (data) => {
     selectedCategoryName.value = product.category_name || ''
   }
 }, { immediate: true })
+
+watch(ingredients, (list) => {
+  if (list.length && form.value.ingredients.some(ing => ing.ingredient_id)) {
+    rehydrateProductIngredientCaches()
+  }
+})
 
 // Read-only: station inherited from the product's category (returned by backend)
 const inheritedStation = computed(() => productData.value?.data?.station ?? null)

--- a/pages/menu/recetas/[id].vue
+++ b/pages/menu/recetas/[id].vue
@@ -306,7 +306,7 @@ const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 // Tracks which ingredient IDs are currently fetching purchase units
 const loadingUnits = ref<Set<string>>(new Set())
 
-const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient, mergeIngredientUnitFields } = useIngredientUnitOptions()
+const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient, mergeIngredientUnitFields, rehydrateIngredientCaches } = useIngredientUnitOptions()
 
 function getIngredientUnitOptions(ingredientId: string) {
   return buildUnitOptions(ingredientId, {
@@ -318,6 +318,19 @@ function getIngredientUnitOptions(ingredientId: string) {
 function cacheIngredientForUnits(ing: any) {
   const catalogRow = availableIngredients.value.find((i: any) => i.id === ing.id)
   ingredientCache.value[ing.id] = mergeIngredientUnitFields(ing, catalogRow)
+}
+
+function rehydrateRecipeIngredientCaches() {
+  if (!availableIngredients.value.length) return
+  const entries = form.value.ingredients
+    .filter(ing => ing.ingredient_id)
+    .map(ing => ({
+      id: ing.ingredient_id,
+      name: ing.ingredient_name || ingredientCache.value[ing.ingredient_id]?.name,
+      unit: ing.unit,
+      ...ingredientCache.value[ing.ingredient_id],
+    }))
+  rehydrateIngredientCaches(entries, availableIngredients.value, ingredientCache.value)
 }
 
 async function loadPurchaseUnits(ingredientId: string) {
@@ -407,6 +420,12 @@ watch(recipeData, (data) => {
     }
   }
 }, { immediate: true })
+
+watch(availableIngredients, (list) => {
+  if (list.length && form.value.ingredients.some(ing => ing.ingredient_id)) {
+    rehydrateRecipeIngredientCaches()
+  }
+})
 
 // Methods
 const addIngredient = () => {


### PR DESCRIPTION
## Summary
Fix catalog hydration race on edit pages: when `useMenuIngredientsQuery` finishes after the detail API, re-merge `unit_weight_gr` / `unit_weight_unit` into `ingredientCache` so dual-unit dropdown options appear on first load.

Depends on #774 (stacked). Merge order: #777 → #778 → this PR.

## Stack
Nuxt 3

## Changes
- `composables/useIngredientUnitOptions.ts`: `rehydrateIngredientCaches()`
- `pages/menu/productos/[id].vue`: `watch(ingredients)` re-hydrate
- `pages/menu/recetas/[id].vue`: `watch(availableIngredients)` re-hydrate
- `pages/menu/modificadores/[id].vue`: same

## Testing
- Edit product/recipe/modifier with saved `350 ml` on dual `und` ingredient → unit select lists `ml`, `lt`, `botella` without re-opening search
- Create flows unchanged

Closes #775

Made with [Cursor](https://cursor.com)