### PR TITLE
fix(menu): reventa bulk create — recipe unit and optional quantity UI

### DIFF
--- a/docs/usuarios/menu.md
+++ b/docs/usuarios/menu.md
@@ -190,6 +190,8 @@ Ve a **Menú → Reventa → Gestionar**.
 3. **Disponibilidad** — activa o desactiva cada ítem con el toggle
 4. Presiona **Guardar Cambios**
 
+Cada producto creado desde esta pantalla usa **1 unidad** (`und`) del ingrediente en receta — es decir, al vender una unidad del producto se descuenta una unidad del ingrediente en inventario. Para cantidades fraccionadas (por ejemplo vender medio envase en mililitros), configura la receta desde **Menú → Productos** (edición individual).
+
 ### Estados de cada ítem
 
 | Badge | Significado |

--- a/pages/menu/reventa/crear.vue
+++ b/pages/menu/reventa/crear.vue
@@ -332,6 +332,20 @@ const canSubmit = computed(() => {
   return activeItems.every(item => item.price > 0)
 })
 
+/** Resale ingredients use base unit `und` (backend ALLOWED_UNITS / is_resale rule). */
+function resaleRecipeUnit(ingredient: { unit?: string }): string {
+  const u = ingredient?.unit || 'und'
+  return u === 'u' ? 'und' : u
+}
+
+function resaleRecipeRow(ingredient: { id: string, unit?: string }, quantity = 1) {
+  return {
+    ingredient_id: ingredient.id,
+    quantity,
+    unit: resaleRecipeUnit(ingredient),
+  }
+}
+
 // Get default category
 const defaultCategoryId = computed(() => {
   const resaleCategory = categories.value.find((c: any) =>
@@ -429,11 +443,7 @@ async function saveChanges() {
             is_combo: false,
             allow_modifiers: false,
             recipe_base_ids: [],
-            ingredients: [{
-              ingredient_id: item.ingredient.id,
-              quantity: 1,
-              unit: 'u'
-            }],
+            ingredients: [resaleRecipeRow(item.ingredient)],
             tenant_id: currentTenant.value?.id || ''
           }
         })
@@ -447,12 +457,18 @@ async function saveChanges() {
     // Update existing products
     for (const item of toUpdate.value) {
       try {
+        const existingRecipe = item.existingProduct?.ingredients?.[0]
+        const body: Record<string, unknown> = {
+          price: item.price,
+          is_available: item.isAvailable,
+        }
+        // Normalize legacy recipe unit `u` → `und` when user saves from Gestionar
+        if (existingRecipe?.unit === 'u' && item.ingredient?.id) {
+          body.ingredients = [resaleRecipeRow(item.ingredient, Number(existingRecipe.quantity) || 1)]
+        }
         await $fetch(`/api/menu/products/${item.existingProduct.id}`, {
           method: 'PUT',
-          body: {
-            price: item.price,
-            is_available: item.isAvailable
-          }
+          body,
         })
         results.updated++
       } catch (error) {


### PR DESCRIPTION
## Summary
Bulk reventa product creation now persists recipe `unit: und` (not legacy `u`). Saving an existing resale product with legacy `u` in `product_recipes` normalizes the row via PUT. Docs clarify 1 `und` per item from Gestionar.

Stacked on epic #772 branch chain (#773–#775).

## Stack
Nuxt 3

## Changes
- `pages/menu/reventa/crear.vue`: `resaleRecipeUnit` / `resaleRecipeRow`; create + legacy update fix
- `docs/usuarios/menu.md`: reventa section note on 1 und vs fractional via Productos edit

## Testing
- Gestionar → create new resale product → POST body `unit: und`
- Existing product with `unit: u` → edit price → save → recipe normalized
- POS: sell 1 unit → inventory deducts 1

Closes #776

Made with [Cursor](https://cursor.com)