### PR TITLE
feat(pos): wire cart line remove to audit API

### DIFF
--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -117,6 +117,27 @@ export const usePOSStore = defineStore('pos', () => {
         })
     }
 
+    /** Bitácora channel for pos_cart audit (#784). */
+    const resolveCartChannel = (): 'mostrador' | 'barra' =>
+        activeTableSession.value?.isBar ? 'barra' : 'mostrador'
+
+    const buildCartAuditQuery = (): string => {
+        const params = new URLSearchParams({ channel: resolveCartChannel() })
+        if (cartServedByMemberId.value) {
+            params.set('actor_member_id', cartServedByMemberId.value)
+        }
+        return `?${params.toString()}`
+    }
+
+    const deleteSyncedCartLine = async (item: CartItem): Promise<boolean> => {
+        if (!cartId.value || !item.id || isSyncing.value) return false
+        const qs = buildCartAuditQuery()
+        await $fetch(`/api/pos/cart/${cartId.value}/items/${item.id}${qs}`, {
+            method: 'DELETE',
+        })
+        return true
+    }
+
     // Actions — local-only cart operations (no backend sync per item)
 
     const addToCart = async (item: Omit<CartItem, 'quantity'> & { quantity?: number }) => {
@@ -139,7 +160,18 @@ export const usePOSStore = defineStore('pos', () => {
     const removeFromCart = async (index: number) => {
         isDeleting.value = true
         try {
-            if (index >= 0 && index < cart.value.length) {
+            if (index < 0 || index >= cart.value.length) return
+            const item = cart.value[index]
+            const isSynced = Boolean(cartId.value && item.id && !isSyncing.value)
+            if (isSynced) {
+                try {
+                    await deleteSyncedCartLine(item)
+                    cart.value.splice(index, 1)
+                } catch {
+                    cart.value.splice(index, 1)
+                    invalidateSyncedCart()
+                }
+            } else {
                 cart.value.splice(index, 1)
                 invalidateSyncedCart()
             }
@@ -192,7 +224,9 @@ export const usePOSStore = defineStore('pos', () => {
         cartId.value = null
         if (oldCartId && !isSyncing.value) {
             try {
-                await $fetch(`/api/pos/cart/${oldCartId}`, { method: 'DELETE' })
+                await $fetch(`/api/pos/cart/${oldCartId}${buildCartAuditQuery()}`, {
+                    method: 'DELETE',
+                })
             } catch {
                 // Non-critical — local state already cleared
             }
@@ -354,7 +388,9 @@ export const usePOSStore = defineStore('pos', () => {
 
             if (cartId.value) {
                 try {
-                    await $fetch(`/api/pos/cart/${cartId.value}`, { method: 'DELETE' })
+                    await $fetch(`/api/pos/cart/${cartId.value}${buildCartAuditQuery()}`, {
+                        method: 'DELETE',
+                    })
                 } catch {
                     // Ignore delete failures for stale carts
                 }


### PR DESCRIPTION
## Summary
- `removeFromCart` calls `DELETE /api/pos/cart/{id}/items/{itemId}` when synced
- Keeps `cartId` after single-line remove (no invalidateSyncedCart on success)
- `clearCart` / `syncCartBatch` pass `channel` + optional `actor_member_id`

## Limitation
Unsynced local cart (no `cartId`) — no bitácora event until batch sync (option B).

Pairs with api-warolabs PR for #784.

Part of warocol.com#784

Made with [Cursor](https://cursor.com)