### PR TITLE
docs(operaciones): Bitácora de operaciones user guide

### DIFF
--- a/composables/useOperationEvents.ts
+++ b/composables/useOperationEvents.ts
@@ -1,0 +1,104 @@
+/** POS operation audit log helpers (warocol.com#787). */
+
+export type OperationEventRow = {
+  id: string
+  created_at: string
+  domain: string
+  channel: string
+  action: string
+  actor_user_id: string | null
+  actor_user_name: string | null
+  actor_member_id: string | null
+  actor_member_name: string | null
+  table_id: string | null
+  table_session_id: string | null
+  pos_cart_id: string | null
+  order_id: string | null
+  order_item_id: string | null
+  comanda_item_id: string | null
+  payload: Record<string, unknown>
+  reason: string | null
+}
+
+export type OperationEventsListResponse = {
+  success: boolean
+  data: OperationEventRow[]
+  pagination: {
+    total: number
+    limit: number
+    offset: number
+    has_more: boolean
+  }
+}
+
+export const OPERATION_EVENT_ACTIONS = [
+  'tab_item_added',
+  'tab_item_removed',
+  'tab_item_qty_changed',
+  'tab_cleared',
+  'cart_line_removed',
+  'cart_cleared',
+  'payment_voided',
+  'comanda_line_cancelled',
+] as const
+
+export const ACTION_LABELS: Record<string, string> = {
+  tab_item_added: 'Producto agregado al tab',
+  tab_item_removed: 'Producto eliminado del tab',
+  tab_item_qty_changed: 'Cantidad modificada',
+  tab_cleared: 'Tab vaciado',
+  cart_line_removed: 'Línea eliminada del carrito',
+  cart_cleared: 'Carrito vaciado',
+  payment_voided: 'Pago anulado',
+  comanda_line_cancelled: 'Línea de comanda cancelada',
+}
+
+export const CHANNEL_LABELS: Record<string, string> = {
+  mesa: 'Mesa',
+  barra: 'Barra',
+  mostrador: 'Mostrador',
+}
+
+export function formatOperationEventActor(row: OperationEventRow): string {
+  if (row.actor_user_name) return row.actor_user_name
+  if (row.actor_member_name) return row.actor_member_name
+  if (row.actor_user_id) return row.actor_user_id.slice(0, 8)
+  return 'Sistema'
+}
+
+export function formatOperationEventSummary(
+  action: string,
+  payload: Record<string, unknown>,
+  formatCurrency: (n: number) => string,
+): string {
+  const product = payload.product_name as string | undefined
+  const qty = payload.quantity as number | undefined
+
+  if (product && qty != null) {
+    return `${product} × ${qty}`
+  }
+  if (product) return product
+
+  if (action === 'payment_voided') {
+    const method = payload.payment_method as string | undefined
+    const amount = payload.amount as number | undefined
+    if (method && amount != null) return `${method} · ${formatCurrency(amount)}`
+    if (amount != null) return formatCurrency(amount)
+  }
+
+  if (action === 'tab_cleared' || action === 'cart_cleared') {
+    const count = payload.items_count as number | undefined
+    if (count != null) return `${count} línea${count === 1 ? '' : 's'}`
+  }
+
+  if (payload.order_number != null) {
+    return `Orden #${payload.order_number}`
+  }
+
+  return '—'
+}
+
+export function formatOperationEventTableName(payload: Record<string, unknown>): string | null {
+  const name = payload.table_name as string | undefined
+  return name?.trim() || null
+}

--- a/docs/usuarios/operaciones.md
+++ b/docs/usuarios/operaciones.md
@@ -4,12 +4,13 @@ El módulo de Operaciones agrupa la configuración del día a día del restauran
 
 ## Cómo acceder
 
-Menú lateral → **Operaciones**. La pantalla tiene cinco pestañas:
+Menú lateral → **Operaciones**. La pantalla tiene seis pestañas:
 
 | Pestaña | Para qué |
 |---------|----------|
 | **Comandas & Cocina** | Vista en tiempo real de los pedidos para el área de producción |
 | **Mesas** | Plano del salón y configuración de mesas (la etiqueta cambia si tu tenant usa "Habitaciones", "Salones", etc.) |
+| **Bitácora** | Auditoría de acciones en POS (eliminaciones, anulaciones de pago, etc.) |
 | **Turnos** | Plantillas de horario reutilizables para arqueos por plantilla (Mañana, Tarde, Noche…) |
 | **Personalizar** | Renombrar módulos, mostrar/ocultar secciones según el tipo de negocio |
 | **Propinas** | Activar propinas, definir porcentajes sugeridos |
@@ -29,6 +30,14 @@ Pantalla en vivo para cocina: muestra las órdenes nuevas, en preparación y lis
 Aquí se activa/desactiva el módulo de mesas, se crean/editan/desactivan mesas, y se asigna la columna de mesero a las sesiones (si tu negocio tiene atribución de meseros activa).
 
 Ver [Mesas](./operaciones/mesas) para la guía completa: estados, crear/editar, reactivar mesas inactivas, **pedido por QR en mesa** (activar módulo, enlace por mesa, copiar/imprimir), etiqueta configurable (Mesa / Cubículo / Habitación / etc.).
+
+---
+
+## Bitácora
+
+Registro de auditoría del POS: quién eliminó productos del tab o carrito, vació tabs, anuló pagos parciales y con qué motivo. Pensado para dueños, administradores y supervisores.
+
+Ver [Bitácora de operaciones](./operaciones/bitacora) para la guía completa: qué se registra, qué no, filtros, políticas de motivo obligatorio en cocina y anulaciones de pago.
 
 ---
 

--- a/docs/usuarios/operaciones/bitacora.md
+++ b/docs/usuarios/operaciones/bitacora.md
@@ -1,0 +1,115 @@
+# Bitácora de operaciones
+
+La **Bitácora de operaciones** es el registro de auditoría del POS: quién hizo qué, en qué canal (mesa, barra o mostrador), cuándo y —cuando aplica— con qué motivo. Sirve para que dueños, administradores y supervisores revisen eliminaciones de productos, vaciados de tab o carrito y anulaciones de pagos parciales.
+
+## Cómo acceder
+
+Menú lateral → **Operaciones → Bitácora**.
+
+Verás un listado paginado de eventos. Arriba puedes filtrar por fechas, canal, tipo de acción y buscar por nombre de producto. Haz clic en una fila para ver el detalle técnico del evento (útil para soporte).
+
+> **Permisos:** solo usuarios con acceso al módulo **Operaciones** pueden abrir la Bitácora (típicamente dueño, administrador y supervisor). El personal de caja sin ese módulo no verá la pestaña ni podrá consultar el historial.
+
+---
+
+## Qué registra la Bitácora (POS)
+
+Cada fila es un evento automático generado cuando el equipo usa el POS después de que la función está activa en tu negocio.
+
+| Acción en la Bitácora | Qué significa |
+|----------------------|-----------------|
+| **Producto agregado al tab** | Se añadió un ítem al tab de una mesa o barra |
+| **Producto eliminado del tab** | Se quitó un ítem del tab (mesa/barra) |
+| **Cantidad modificada** | Se cambió la cantidad de un ítem en el tab |
+| **Tab vaciado** | Se vació el tab de una sesión de mesa o barra |
+| **Línea eliminada del carrito** | Se eliminó un producto del carrito en mostrador o barra |
+| **Carrito vaciado** | Se vació el carrito completo |
+| **Pago anulado** | Se anuló un pago parcial ya registrado en el checkout |
+
+En cada evento verás, entre otros datos:
+
+- **Cuándo** — fecha y hora
+- **Usuario** — quién realizó la acción en el sistema
+- **Canal** — Mesa, Barra o Mostrador
+- **Resumen** — producto y cantidad, o datos del pago anulado
+- **Mesa** — nombre de la mesa cuando aplica
+- **Motivo** — texto capturado en el POS (ver políticas abajo)
+- **Orden** — enlace a la venta cuando existe
+
+---
+
+## Qué no registra
+
+| Situación | Por qué no aparece |
+|-----------|-------------------|
+| Productos en el carrito **antes de enviarlos al tab** o antes de que el carrito quede sincronizado con el servidor | Solo se auditan acciones que llegan al servidor |
+| Acciones **anteriores al despliegue** de la bitácora en tu negocio | El registro es desde la activación en producción, no rellena el pasado |
+| Anulación de una **venta completa** desde Ventas → Órdenes | Es otro flujo; no es lo mismo que anular un pago parcial en checkout |
+| Cambios de precio, descuentos o configuración del menú | Fuera del alcance del MVP de POS |
+
+Si el listado está vacío justo después de activar la función, es normal: los eventos aparecen cuando el personal empiece a operar con la versión que incluye la bitácora.
+
+---
+
+## Cómo filtrar
+
+| Filtro | Para qué sirve |
+|--------|----------------|
+| **Rango de fechas** | Acota el período (calendario con atajos como Hoy, Última semana, etc.) |
+| **Canal** | Solo Mesa, solo Barra, solo Mostrador, o todos |
+| **Acción** | Un tipo concreto (ej. solo “Pago anulado” o “Producto eliminado del tab”) |
+| **Buscar producto** | Texto libre sobre el resumen (nombre del producto en el payload) |
+
+Usa **Limpiar** para quitar todos los filtros. La lista se actualiza al cambiar filtros o al usar el botón de actualizar del encabezado del panel.
+
+---
+
+## Políticas de motivo
+
+### Producto ya enviado a cocina (mesa o barra)
+
+Si las **comandas** están activas y el producto **ya salió a cocina** (ya no está en estado “nuevo”), al eliminarlo del tab el POS pide un **motivo obligatorio** antes de confirmar. Ese texto queda guardado en la columna **Motivo** de la Bitácora y cocina sigue viendo la línea anulada en el KDS.
+
+Si el producto **aún no se envió a cocina**, puedes eliminarlo sin escribir motivo.
+
+### Anulación de un pago parcial
+
+En el **checkout**, al quitar un pago ya registrado (ícono de papelera en cobro parcial), puedes escribir un motivo opcional. Si lo dejas en blanco, el sistema registra **“Sin motivo”** en la Bitácora.
+
+> Si el pago era en **efectivo**, el POS te recuerda devolver el dinero físicamente al cliente antes de confirmar. Ver [Cobro parcial](../pos#cobro-parcial-split) en la guía del POS.
+
+---
+
+## Detalle de un evento
+
+Haz clic en cualquier fila (o tarjeta en celular) para abrir el detalle. Ahí verás el **motivo** completo, el enlace a la **orden** si existe, y el **payload** en formato técnico (JSON) con todos los datos que guardó el sistema — útil si soporte necesita investigar un caso.
+
+---
+
+## Relación con otras pantallas
+
+| Necesitas… | Ve a… |
+|------------|--------|
+| Configurar mesas, comandas o propinas | [Operaciones](../operaciones) |
+| Cómo se elimina un pago o un producto en POS | [Procesar una venta en el POS](../pos) |
+| Historial de ventas y anulación de orden completa | [Ventas](../ventas) |
+| Números de facturación DIAN descartados | [Facturación — Bitácora de números quemados](../facturacion#bitácora-de-números-quemados) (es un registro distinto) |
+
+---
+
+## Preguntas frecuentes — Bitácora
+
+**¿La Bitácora reemplaza las cámaras o el arqueo de caja?**
+No. Es un registro de acciones sensibles en POS, no un video ni un cierre de caja.
+
+**¿El cajero puede ver qué motivo puso el gerente?**
+Solo si su rol tiene acceso a **Operaciones**. La mayoría de cajeros no ven la Bitácora.
+
+**¿Puedo exportar a Excel?**
+En el MVP no hay exportación desde la pantalla; usa filtros y paginación para revisar por período.
+
+**¿Por qué no veo eventos de ayer si ya usábamos WARO?**
+El registro comenzó cuando tu negocio quedó con la versión que incluye bitácora; no reconstruye el historial anterior.
+
+**¿Eliminar un producto del carrito en mostrador siempre queda registrado?**
+Sí, cuando el carrito está sincronizado con el servidor. Cambios solo en el carrito local, antes de que el sistema los guarde, no generan evento.

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -907,6 +907,16 @@ const getPageConfig = () => {
       breadcrumbPage: undefined,
       backButton: undefined
     }
+  } else if (path === '/operaciones/bitacora' || path === '/operaciones/bitacora/') {
+    return {
+      pageTitle: 'Bitácora de operaciones',
+      pageSubtitle: 'Auditoría de acciones en POS — mesas, barra y mostrador',
+      searchPlaceholder: undefined,
+      activePage: 'operaciones' as const,
+      showBreadcrumb: false,
+      breadcrumbPage: undefined,
+      backButton: undefined
+    }
   } else if (path === '/operaciones/turnos' || path === '/operaciones/turnos/') {
     return {
       pageTitle: 'Turnos',

--- a/pages/operaciones.vue
+++ b/pages/operaciones.vue
@@ -17,6 +17,7 @@ definePageMeta({
 const navigationItems = computed(() => [
   { to: '/operaciones/comandas', label: 'Comandas & Cocina' },
   { to: '/operaciones/mesas', label: plural.value },
+  { to: '/operaciones/bitacora', label: 'Bitácora' },
   { to: '/operaciones/turnos', label: 'Turnos' },
   { to: '/operaciones/personalizar', label: 'Personalizar' },
   { to: '/operaciones/propinas', label: 'Propinas' },

--- a/pages/operaciones/bitacora.vue
+++ b/pages/operaciones/bitacora.vue
@@ -1,0 +1,402 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { es } from 'date-fns/locale'
+import { ClipboardDocumentListIcon, XMarkIcon } from '@heroicons/vue/24/outline'
+import type { Column } from '~/components/ui/ResponsiveDataView.vue'
+import {
+  type OperationEventRow,
+  ACTION_LABELS,
+  CHANNEL_LABELS,
+  OPERATION_EVENT_ACTIONS,
+  formatOperationEventActor,
+  formatOperationEventSummary,
+  formatOperationEventTableName,
+} from '~/composables/useOperationEvents'
+import { filterSelectClass } from '~/composables/useFilterSelectClass'
+import { useFormatters } from '~/composables/useFormatters'
+
+definePageMeta({ layout: 'dashboard', module: 'operaciones' })
+useHead({ title: 'Bitácora de operaciones — WaRo' })
+
+const PAGE_SIZE = 50
+const { currentTenant } = useTenantReactive()
+const { formatDateTime, formatCurrency } = useFormatters()
+const { dateRangeDates, presetDates, formatDateRange, dateRange, clearDateRange } = useDateRangePresets()
+const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
+const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
+
+const channelFilter = ref<string | null>(null)
+const actionFilter = ref<string | null>(null)
+const currentPage = ref(1)
+const detailOpen = ref(false)
+const selectedEvent = ref<OperationEventRow | null>(null)
+
+const hasActiveFilters = computed(
+  () =>
+    !!appliedSearch.value
+    || !!dateRangeDates.value
+    || !!channelFilter.value
+    || !!actionFilter.value,
+)
+
+watch([dateRange, channelFilter, actionFilter, appliedSearch], () => {
+  currentPage.value = 1
+})
+
+const queryParams = computed(() => ({
+  domain: 'pos',
+  limit: PAGE_SIZE,
+  offset: (currentPage.value - 1) * PAGE_SIZE,
+  date_from: dateRange.value.from ?? undefined,
+  date_to: dateRange.value.to ?? undefined,
+  channel: channelFilter.value ?? undefined,
+  action: actionFilter.value ?? undefined,
+  q: appliedSearch.value || undefined,
+}))
+
+const {
+  data: eventsData,
+  status: eventsStatus,
+  asyncStatus: eventsAsyncStatus,
+  error: fetchError,
+  refetch,
+} = useQuery({
+  key: () => ['operaciones', 'operation-events', currentTenant.value?.id, queryParams.value],
+  query: () => $fetch<import('~/composables/useOperationEvents').OperationEventsListResponse>(
+    '/api/operaciones/operation-events',
+    { params: queryParams.value },
+  ),
+  enabled: () => !!currentTenant.value,
+  staleTime: 30_000,
+})
+
+const events = computed(() => eventsData.value?.data ?? [])
+const totalCount = computed(() => eventsData.value?.pagination?.total ?? 0)
+const totalPages = computed(() => Math.max(1, Math.ceil(totalCount.value / PAGE_SIZE)))
+const isLoading = computed(() => eventsStatus.value === 'pending' && !eventsData.value)
+const isRefreshing = computed(() => eventsAsyncStatus.value === 'loading' && !!eventsData.value)
+
+registerProgressiveLoading(isRefreshing)
+onMounted(() => setRefreshHandler(refetch))
+onUnmounted(() => clearRefreshHandler())
+
+const goToPage = (page: number) => {
+  if (page >= 1 && page <= totalPages.value) currentPage.value = page
+}
+
+const clearFilters = () => {
+  clearSearch()
+  clearDateRange()
+  channelFilter.value = null
+  actionFilter.value = null
+  currentPage.value = 1
+}
+
+const openDetail = (row: OperationEventRow) => {
+  selectedEvent.value = row
+  detailOpen.value = true
+}
+
+const closeDetail = () => {
+  detailOpen.value = false
+  selectedEvent.value = null
+}
+
+const detailPayloadJson = computed(() => {
+  if (!selectedEvent.value?.payload) return '{}'
+  return JSON.stringify(selectedEvent.value.payload, null, 2)
+})
+
+const columns = computed<Column[]>(() => [
+  { key: 'created_at', title: 'Cuándo', sortable: false },
+  { key: 'actor', title: 'Usuario', sortable: false },
+  { key: 'channel', title: 'Canal', sortable: false },
+  { key: 'action', title: 'Acción', sortable: false },
+  { key: 'summary', title: 'Resumen', sortable: false },
+  { key: 'table_name', title: 'Mesa', sortable: false },
+  { key: 'reason', title: 'Motivo', sortable: false },
+  { key: 'links', title: '', sortable: false, align: 'right' },
+])
+
+const actionLabel = (action: string) => ACTION_LABELS[action] ?? action
+const channelLabel = (channel: string) => CHANNEL_LABELS[channel] ?? channel
+
+const summaryFor = (row: OperationEventRow) =>
+  formatOperationEventSummary(row.action, row.payload ?? {}, formatCurrency)
+
+const tableNameFor = (row: OperationEventRow) =>
+  formatOperationEventTableName(row.payload ?? {})
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div v-if="isLoading" class="flex items-center justify-center min-h-[300px]">
+      <CommonsTheCustomLoader size="large" />
+    </div>
+
+    <CommonsTheErrorState v-else-if="fetchError" />
+
+    <template v-else>
+      <p class="text-sm text-text-secondary leading-snug">
+        Registro de acciones en POS (mesas, barra y mostrador). Los eventos aparecen después de que el personal
+        use el sistema con la bitácora activa en producción.
+      </p>
+
+      <!-- Filters -->
+      <div class="flex flex-wrap items-center gap-2">
+        <VueDatePicker
+          v-model="dateRangeDates"
+          range
+          :preset-dates="presetDates"
+          :enable-time-picker="false"
+          :locale="es"
+          placeholder="Rango de fechas"
+          auto-apply
+          :teleport="true"
+          :max-date="new Date()"
+          :format="formatDateRange"
+          input-class-name="dp-custom-input"
+          menu-class-name="dp-custom-menu"
+          calendar-cell-class-name="dp-custom-cell"
+        />
+
+        <select
+          v-model="channelFilter"
+          :class="filterSelectClass"
+          aria-label="Filtrar por canal"
+        >
+          <option :value="null">Todos los canales</option>
+          <option value="mesa">{{ CHANNEL_LABELS.mesa }}</option>
+          <option value="barra">{{ CHANNEL_LABELS.barra }}</option>
+          <option value="mostrador">{{ CHANNEL_LABELS.mostrador }}</option>
+        </select>
+
+        <select
+          v-model="actionFilter"
+          :class="filterSelectClass"
+          aria-label="Filtrar por acción"
+        >
+          <option :value="null">Todas las acciones</option>
+          <option v-for="a in OPERATION_EVENT_ACTIONS" :key="a" :value="a">
+            {{ ACTION_LABELS[a] }}
+          </option>
+        </select>
+
+        <input
+          v-model="localSearchTerm"
+          type="search"
+          placeholder="Buscar producto…"
+          class="h-10 min-w-[140px] flex-1 max-w-xs px-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+          aria-label="Buscar en resumen"
+          @keydown.enter="applySearch"
+        />
+
+        <button
+          type="button"
+          class="h-10 px-4 rounded-lg border-2 border-border bg-background text-sm font-medium text-text-primary hover:border-primary transition-colors"
+          @click="applySearch"
+        >
+          Buscar
+        </button>
+
+        <button
+          v-if="hasActiveFilters"
+          type="button"
+          class="h-10 px-3 rounded-lg border-2 border-border text-sm text-text-secondary hover:text-text-primary transition-colors"
+          @click="clearFilters"
+        >
+          Limpiar
+        </button>
+
+        <span class="text-sm text-text-secondary ml-auto tabular-nums">
+          {{ totalCount }} {{ totalCount === 1 ? 'evento' : 'eventos' }}
+        </span>
+      </div>
+
+      <!-- Empty -->
+      <div
+        v-if="events.length === 0"
+        class="text-center py-16 space-y-3 bg-surface border-2 border-border rounded-xl"
+      >
+        <ClipboardDocumentListIcon class="w-12 h-12 mx-auto text-text-tertiary" aria-hidden="true" />
+        <p class="text-text-primary font-medium">Sin eventos en este período</p>
+        <p class="text-sm text-text-tertiary max-w-md mx-auto px-4">
+          La bitácora registra eliminaciones de tab, anulaciones de pago y cambios en carrito.
+          Si acabas de activar la función, los eventos aparecerán cuando el equipo use POS.
+        </p>
+      </div>
+
+      <!-- List -->
+      <UiResponsiveDataView
+        v-else
+        :columns="columns"
+        :data="events"
+        row-key="id"
+        row-size="sm"
+        @row-click="openDetail"
+      >
+        <template #cell-created_at="{ value }">
+          <span class="text-sm text-text-secondary whitespace-nowrap">{{ formatDateTime(value) }}</span>
+        </template>
+
+        <template #cell-actor="{ row }">
+          <span class="text-sm text-text-primary">{{ formatOperationEventActor(row) }}</span>
+        </template>
+
+        <template #cell-channel="{ value }">
+          <span class="text-xs font-medium text-text-secondary">{{ channelLabel(value) }}</span>
+        </template>
+
+        <template #cell-action="{ value }">
+          <span class="text-sm text-text-primary">{{ actionLabel(value) }}</span>
+        </template>
+
+        <template #cell-summary="{ row }">
+          <span class="text-sm text-text-primary">{{ summaryFor(row) }}</span>
+        </template>
+
+        <template #cell-table_name="{ row }">
+          <span class="text-sm text-text-secondary">{{ tableNameFor(row) ?? '—' }}</span>
+        </template>
+
+        <template #cell-reason="{ value }">
+          <span class="text-sm text-text-secondary line-clamp-2">{{ value || '—' }}</span>
+        </template>
+
+        <template #cell-links="{ row }">
+          <NuxtLink
+            v-if="row.order_id"
+            :to="`/ventas/${row.order_id}`"
+            class="text-xs text-primary hover:underline"
+            @click.stop
+          >
+            Orden
+          </NuxtLink>
+          <span v-else class="text-xs text-text-tertiary">—</span>
+        </template>
+
+        <template #card="{ item: row }">
+          <button
+            type="button"
+            class="w-full text-left py-3 px-3 border-b border-border hover:bg-surface-secondary transition-colors"
+            @click="openDetail(row)"
+          >
+            <div class="flex items-start justify-between gap-2">
+              <span class="text-sm font-semibold text-text-primary">{{ actionLabel(row.action) }}</span>
+              <span class="text-xs text-text-tertiary flex-shrink-0">{{ formatDateTime(row.created_at) }}</span>
+            </div>
+            <p class="text-sm text-text-primary mt-0.5">{{ summaryFor(row) }}</p>
+            <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-1 text-xs text-text-secondary">
+              <span>{{ formatOperationEventActor(row) }}</span>
+              <span>·</span>
+              <span>{{ channelLabel(row.channel) }}</span>
+              <template v-if="tableNameFor(row)">
+                <span>·</span>
+                <span>{{ tableNameFor(row) }}</span>
+              </template>
+            </div>
+            <p v-if="row.reason" class="text-xs text-text-tertiary mt-1 line-clamp-2">
+              {{ row.reason }}
+            </p>
+          </button>
+        </template>
+      </UiResponsiveDataView>
+
+      <!-- Pagination -->
+      <div v-if="events.length > 0 && totalPages > 1" class="flex items-center justify-between pt-2">
+        <button
+          type="button"
+          :disabled="currentPage === 1"
+          class="min-h-[36px] px-3 py-1.5 text-sm font-medium rounded-lg border border-border bg-surface text-text-primary hover:bg-surface-secondary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          @click="goToPage(currentPage - 1)"
+        >
+          Anterior
+        </button>
+        <span class="text-sm text-text-secondary tabular-nums">
+          Página {{ currentPage }} de {{ totalPages }}
+        </span>
+        <button
+          type="button"
+          :disabled="currentPage === totalPages"
+          class="min-h-[36px] px-3 py-1.5 text-sm font-medium rounded-lg border border-border bg-surface text-text-primary hover:bg-surface-secondary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          @click="goToPage(currentPage + 1)"
+        >
+          Siguiente
+        </button>
+      </div>
+    </template>
+  </div>
+
+  <!-- Detail modal -->
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-150"
+      enter-from-class="opacity-0"
+      leave-active-class="transition-opacity duration-150"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="detailOpen && selectedEvent"
+        class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 bg-black/50"
+        @click.self="closeDetail"
+      >
+        <div
+          class="w-full sm:max-w-lg max-h-[90vh] overflow-hidden bg-surface rounded-t-2xl sm:rounded-2xl shadow-2xl border border-border flex flex-col"
+          role="dialog"
+          aria-labelledby="event-detail-title"
+        >
+          <div class="flex items-start justify-between gap-3 px-5 pt-5 pb-3 border-b border-border">
+            <div class="min-w-0">
+              <h3 id="event-detail-title" class="text-base font-bold text-text-primary">
+                {{ actionLabel(selectedEvent.action) }}
+              </h3>
+              <p class="text-xs text-text-secondary mt-0.5">
+                {{ formatDateTime(selectedEvent.created_at) }} · {{ channelLabel(selectedEvent.channel) }}
+              </p>
+            </div>
+            <button
+              type="button"
+              class="min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg hover:bg-surface-secondary"
+              aria-label="Cerrar"
+              @click="closeDetail"
+            >
+              <XMarkIcon class="w-5 h-5 text-text-secondary" />
+            </button>
+          </div>
+
+          <div class="px-5 py-4 overflow-y-auto space-y-3 text-sm">
+            <div>
+              <p class="text-xs font-medium text-text-tertiary uppercase tracking-wide">Usuario</p>
+              <p class="text-text-primary">{{ formatOperationEventActor(selectedEvent) }}</p>
+            </div>
+            <div v-if="selectedEvent.reason">
+              <p class="text-xs font-medium text-text-tertiary uppercase tracking-wide">Motivo</p>
+              <p class="text-text-primary">{{ selectedEvent.reason }}</p>
+            </div>
+            <div v-if="selectedEvent.order_id">
+              <p class="text-xs font-medium text-text-tertiary uppercase tracking-wide">Orden</p>
+              <NuxtLink :to="`/ventas/${selectedEvent.order_id}`" class="text-primary hover:underline">
+                {{ selectedEvent.order_id }}
+              </NuxtLink>
+            </div>
+            <div>
+              <p class="text-xs font-medium text-text-tertiary uppercase tracking-wide mb-1">Payload</p>
+              <pre class="text-xs bg-surface-secondary border border-border rounded-lg p-3 overflow-x-auto text-text-primary">{{ detailPayloadJson }}</pre>
+            </div>
+          </div>
+
+          <div class="px-5 pb-5 pt-2 border-t border-border">
+            <button
+              type="button"
+              class="w-full min-h-[44px] rounded-xl bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 transition-colors"
+              @click="closeDetail"
+            >
+              Cerrar
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -400,6 +400,8 @@ registerTableSessionRefresh(
 
 // ID of a tab item pending confirmation before removal (already fired to kitchen)
 const pendingRemoveItemId = ref<string | null>(null)
+const removeTabReason = ref('')
+const removeTabError = ref('')
 
 const removeTabItem = (orderItemId: string) => {
   if (!posStore.activeTableSession) return
@@ -409,6 +411,8 @@ const removeTabItem = (orderItemId: string) => {
     const isFired = item && item.fulfillmentStatus && item.fulfillmentStatus !== 'new'
     if (isFired) {
       pendingRemoveItemId.value = orderItemId
+      removeTabReason.value = ''
+      removeTabError.value = ''
       return
     }
   }
@@ -417,16 +421,21 @@ const removeTabItem = (orderItemId: string) => {
 
 const confirmRemoveTabItem = () => {
   if (!pendingRemoveItemId.value) return
-  const id = pendingRemoveItemId.value
-  pendingRemoveItemId.value = null
-  executeRemoveTabItem(id)
+  if (!removeTabReason.value.trim()) {
+    removeTabError.value = 'Indica el motivo de eliminación'
+    return
+  }
+  removeTabError.value = ''
+  executeRemoveTabItem(pendingRemoveItemId.value, removeTabReason.value.trim())
 }
 
 const cancelPendingRemove = () => {
   pendingRemoveItemId.value = null
+  removeTabReason.value = ''
+  removeTabError.value = ''
 }
 
-const executeRemoveTabItem = async (orderItemId: string) => {
+const executeRemoveTabItem = async (orderItemId: string, reason?: string) => {
   if (!posStore.activeTableSession) return
   const previousTabItems = storeTabItems.value
   bumpTableSessionFetchGen()
@@ -435,12 +444,24 @@ const executeRemoveTabItem = async (orderItemId: string) => {
   try {
     await $fetch(`/api/tables/${posStore.activeTableSession.tableId}/tab/items/${orderItemId}`, {
       method: 'DELETE',
+      body: reason ? { reason } : undefined,
     })
+    pendingRemoveItemId.value = null
+    removeTabReason.value = ''
+    removeTabError.value = ''
     await refreshTableSession()
   } catch (e: any) {
     bumpTableSessionFetchGen()
     posStore.setTabItems(previousTabItems)
-    tabError.value = e?.data?.detail ?? 'Error al eliminar el producto'
+    const beMessage = e?.data?.message
+      ?? (typeof e?.data?.detail === 'string' ? e.data.detail : null)
+      ?? e?.data?.detail
+    const errText = beMessage ?? 'Error al eliminar el producto'
+    if (reason) {
+      removeTabError.value = errText
+    } else {
+      tabError.value = errText
+    }
   } finally {
     const next = new Set(tabItemsLoading.value)
     next.delete(orderItemId)
@@ -1328,6 +1349,19 @@ onUnmounted(() => {
                 </p>
               </div>
             </div>
+            <label for="remove-tab-reason" class="block text-xs font-medium text-text-secondary uppercase tracking-wide mt-4 mb-1.5">
+              Motivo de eliminación <span class="text-destructive">*</span>
+            </label>
+            <textarea
+              id="remove-tab-reason"
+              v-model="removeTabReason"
+              rows="2"
+              placeholder="Ej: cliente cambió de opinión"
+              class="w-full px-3 py-2 bg-surface-secondary border border-border rounded-lg text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+            />
+            <p v-if="removeTabError" class="mt-2 text-sm text-destructive">
+              {{ removeTabError }}
+            </p>
           </div>
           <!-- Actions -->
           <div class="px-5 pb-5 flex gap-2">
@@ -1340,7 +1374,8 @@ onUnmounted(() => {
             </button>
             <button
               type="button"
-              class="flex-1 h-11 rounded-xl bg-destructive text-white text-sm font-semibold hover:bg-destructive/90 active:scale-95 transition-all"
+              :disabled="!removeTabReason.trim()"
+              class="flex-1 h-11 rounded-xl bg-destructive text-white text-sm font-semibold hover:bg-destructive/90 active:scale-95 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
               @click="confirmRemoveTabItem"
             >
               Sí, eliminar

--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -117,6 +117,27 @@ export const usePOSStore = defineStore('pos', () => {
         })
     }
 
+    /** Bitácora channel for pos_cart audit (#784). */
+    const resolveCartChannel = (): 'mostrador' | 'barra' =>
+        activeTableSession.value?.isBar ? 'barra' : 'mostrador'
+
+    const buildCartAuditQuery = (): string => {
+        const params = new URLSearchParams({ channel: resolveCartChannel() })
+        if (cartServedByMemberId.value) {
+            params.set('actor_member_id', cartServedByMemberId.value)
+        }
+        return `?${params.toString()}`
+    }
+
+    const deleteSyncedCartLine = async (item: CartItem): Promise<boolean> => {
+        if (!cartId.value || !item.id || isSyncing.value) return false
+        const qs = buildCartAuditQuery()
+        await $fetch(`/api/pos/cart/${cartId.value}/items/${item.id}${qs}`, {
+            method: 'DELETE',
+        })
+        return true
+    }
+
     // Actions — local-only cart operations (no backend sync per item)
 
     const addToCart = async (item: Omit<CartItem, 'quantity'> & { quantity?: number }) => {
@@ -139,7 +160,18 @@ export const usePOSStore = defineStore('pos', () => {
     const removeFromCart = async (index: number) => {
         isDeleting.value = true
         try {
-            if (index >= 0 && index < cart.value.length) {
+            if (index < 0 || index >= cart.value.length) return
+            const item = cart.value[index]
+            const isSynced = Boolean(cartId.value && item.id && !isSyncing.value)
+            if (isSynced) {
+                try {
+                    await deleteSyncedCartLine(item)
+                    cart.value.splice(index, 1)
+                } catch {
+                    cart.value.splice(index, 1)
+                    invalidateSyncedCart()
+                }
+            } else {
                 cart.value.splice(index, 1)
                 invalidateSyncedCart()
             }
@@ -192,7 +224,9 @@ export const usePOSStore = defineStore('pos', () => {
         cartId.value = null
         if (oldCartId && !isSyncing.value) {
             try {
-                await $fetch(`/api/pos/cart/${oldCartId}`, { method: 'DELETE' })
+                await $fetch(`/api/pos/cart/${oldCartId}${buildCartAuditQuery()}`, {
+                    method: 'DELETE',
+                })
             } catch {
                 // Non-critical — local state already cleared
             }
@@ -354,7 +388,9 @@ export const usePOSStore = defineStore('pos', () => {
 
             if (cartId.value) {
                 try {
-                    await $fetch(`/api/pos/cart/${cartId.value}`, { method: 'DELETE' })
+                    await $fetch(`/api/pos/cart/${cartId.value}${buildCartAuditQuery()}`, {
+                        method: 'DELETE',
+                    })
                 } catch {
                     // Ignore delete failures for stale carts
                 }


### PR DESCRIPTION
## Summary
Spanish user guide for the POS operation audit log (Bitácora) and index link from Operaciones.

## Changes
- `docs/usuarios/operaciones/bitacora.md` — new guide (access, what is logged, filters, motivo policies, FAQ)
- `docs/usuarios/operaciones.md` — six tabs + Bitácora section

## Testing
- Open `/docs/usuarios/operaciones/bitacora` in dev
- Verify link from `/docs/usuarios/operaciones`

Closes #788

Made with [Cursor](https://cursor.com)