### PR TITLE
fix(operaciones): remove intro copy from Bitácora page

### DIFF
--- a/pages/operaciones/bitacora.vue
+++ b/pages/operaciones/bitacora.vue
@@ -136,11 +136,6 @@ const tableNameFor = (row: OperationEventRow) =>
     <CommonsTheErrorState v-else-if="fetchError" />
 
     <template v-else>
-      <p class="text-sm text-text-secondary leading-snug">
-        Registro de acciones en POS (mesas, barra y mostrador). Los eventos aparecen después de que el personal
-        use el sistema con la bitácora activa en producción.
-      </p>
-
       <UiAdvancedFiltersBar
         v-model:search="localSearchTerm"
         v-model:date-range="dateRangeDates"


### PR DESCRIPTION
## Summary
- Removes the introductory paragraph on `/operaciones/bitacora` about POS registration and production rollout.

## Test plan
- [ ] Open `/operaciones/bitacora` — filters and table render without the intro text
- [ ] Empty state and detail drawer still work


Made with [Cursor](https://cursor.com)