### PR TITLE
feat(pos): Venta libre modal — mostrador and barra cart

### DIFF
--- a/components/pos/CartItem.vue
+++ b/components/pos/CartItem.vue
@@ -88,9 +88,9 @@
         </svg>
       </button>
 
-      <!-- Editar (oculto para reventa) -->
+      <!-- Editar (oculto para reventa y venta libre) -->
       <button
-        v-if="!item.is_resale"
+        v-if="!item.is_resale && !item.is_open_sale"
         class="min-w-[44px] min-h-[44px] flex items-center justify-center rounded bg-violet-50 border border-violet-300 text-violet-600 hover:bg-violet-100 theme-transition"
         aria-label="Editar ítem"
         @click.stop="$emit('edit')"
@@ -130,6 +130,7 @@ interface CartItem {
   quantity: number
   notes?: string
   is_resale?: boolean
+  is_open_sale?: boolean
   fulfillmentStatus?: 'new' | 'sent' | 'hold' | 'preparing' | 'ready' | 'delivered' | 'cancelled'
   sentAt?: string | null
 }

--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -171,6 +171,19 @@
       <!-- Actions — Standard POS mode -->
       <div v-if="!mesaMode" class="space-y-2">
         <button
+          v-if="showOpenSale"
+          type="button"
+          :disabled="!openSaleEnabled"
+          :title="openSaleTooltip ?? undefined"
+          class="w-full min-h-[44px] rounded-xl border border-dashed border-primary/50 text-primary text-sm font-semibold flex items-center justify-center gap-2 hover:bg-primary/5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+          @click="$emit('open-sale')"
+        >
+          <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" />
+          </svg>
+          Venta libre
+        </button>
+        <button
           type="button"
           :disabled="items.length === 0 || isDeleting"
           class="w-full h-12 rounded-xl bg-primary text-primary-foreground text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
@@ -200,6 +213,32 @@
 
       <!-- Actions — Mesa (tab) mode -->
       <div v-else class="space-y-2">
+        <button
+          v-if="showOpenSale"
+          type="button"
+          :disabled="!openSaleEnabled"
+          :title="openSaleTooltip ?? undefined"
+          class="w-full min-h-[44px] rounded-xl border border-dashed border-primary/50 text-primary text-sm font-semibold flex items-center justify-center gap-2 hover:bg-primary/5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+          @click="$emit('open-sale')"
+        >
+          <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" />
+          </svg>
+          Venta libre
+        </button>
+        <!-- Barra + items en carrito: cobrar sin pasar por tab (#796) -->
+        <button
+          v-if="showBarProcessOrder"
+          type="button"
+          :disabled="items.length === 0 || isDeleting"
+          class="w-full h-12 rounded-xl bg-primary text-primary-foreground text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
+          @click="$emit('process-order')"
+        >
+          <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+          </svg>
+          Procesar Orden
+        </button>
         <!-- 2-col grid: secondary actions (Liberar moved to the active-mesa banner) -->
         <div class="grid grid-cols-2 gap-2">
           <!-- Pedir cuenta -->
@@ -333,6 +372,10 @@ interface Props {
   showServedByChip?: boolean
   servedByMemberId?: string | null
   members?: Array<{ id: string; name: string; role: string }>
+  showOpenSale?: boolean
+  openSaleEnabled?: boolean
+  openSaleTooltip?: string | null
+  showBarProcessOrder?: boolean
 }
 
 interface Emits {
@@ -342,6 +385,7 @@ interface Emits {
   (e: 'decrement-item', index: number): void
   (e: 'duplicate-item', index: number): void
   (e: 'process-order'): void
+  (e: 'open-sale'): void
   (e: 'clear-cart'): void
   (e: 'add-to-tab'): void
   (e: 'request-bill'): void
@@ -355,7 +399,28 @@ interface Emits {
   (e: 'update:served-by', memberId: string | null): void
 }
 
-const props = withDefaults(defineProps<Props>(), { mesaMode: false, isAddingToTab: false, isLoadingTabItems: false, isClearingTab: false, tabItems: () => [], tabTotal: 0, tabItemsLoading: () => new Set(), comandasEnabled: false, unfiredCount: 0, isFiringToKitchen: false, canPrintComandas: false, selectedTabItemIds: () => [], pendingRemoveItemId: null, showServedByChip: false, servedByMemberId: null, members: () => [] })
+const props = withDefaults(defineProps<Props>(), {
+  mesaMode: false,
+  isAddingToTab: false,
+  isLoadingTabItems: false,
+  isClearingTab: false,
+  tabItems: () => [],
+  tabTotal: 0,
+  tabItemsLoading: () => new Set(),
+  comandasEnabled: false,
+  unfiredCount: 0,
+  isFiringToKitchen: false,
+  canPrintComandas: false,
+  selectedTabItemIds: () => [],
+  pendingRemoveItemId: null,
+  showServedByChip: false,
+  servedByMemberId: null,
+  members: () => [],
+  showOpenSale: false,
+  openSaleEnabled: false,
+  openSaleTooltip: null,
+  showBarProcessOrder: false,
+})
 
 const fireToKitchenLabel = computed(() => {
   const n = props.selectedTabItemIds?.length ?? 0

--- a/components/pos/OpenSaleModal.vue
+++ b/components/pos/OpenSaleModal.vue
@@ -1,0 +1,158 @@
+<template>
+  <Transition name="sheet">
+    <div
+      v-if="modelValue"
+      class="fixed inset-0 z-[60] flex items-end md:items-center justify-center md:p-4 bg-black/50"
+      @click.self="handleClose"
+    >
+      <div
+        class="bottom-sheet-panel bg-surface w-full md:max-w-md border border-border flex flex-col rounded-t-2xl md:rounded-2xl shadow-2xl"
+        @click.stop
+      >
+        <div class="flex justify-center pt-3 pb-1 md:hidden flex-shrink-0" aria-hidden="true">
+          <div class="w-10 h-1 rounded-full bg-border" />
+        </div>
+
+        <div class="p-5 border-b border-border flex items-center justify-between flex-shrink-0">
+          <div>
+            <h2 class="text-xl font-bold text-text-primary">Venta libre</h2>
+            <p class="text-sm text-text-secondary mt-0.5">
+              {{ shellName ? `Producto: ${shellName}` : 'Monto personalizado' }}
+            </p>
+          </div>
+          <button
+            type="button"
+            aria-label="Cerrar"
+            class="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-xl text-text-secondary hover:bg-surface-secondary hover:text-text-primary transition-colors"
+            @click="handleClose"
+          >
+            <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <form class="p-5 space-y-4" @submit.prevent="handleSubmit">
+          <div>
+            <label for="open-sale-amount" class="block text-sm font-medium text-text-primary mb-1.5">
+              Monto (COP) <span class="text-red-500">*</span>
+            </label>
+            <input
+              id="open-sale-amount"
+              ref="amountInputRef"
+              v-model="amountInput"
+              type="number"
+              inputmode="numeric"
+              min="1"
+              step="1"
+              required
+              placeholder="Ej. 25000"
+              class="w-full min-h-[44px] px-4 py-3 border-2 border-border rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary text-text-primary bg-background text-base tabular-nums"
+            />
+          </div>
+
+          <div>
+            <label for="open-sale-description" class="block text-sm font-medium text-text-primary mb-1.5">
+              Descripción <span class="text-text-tertiary font-normal">(opcional)</span>
+            </label>
+            <input
+              id="open-sale-description"
+              v-model="descriptionInput"
+              type="text"
+              maxlength="200"
+              placeholder="Ej. Servicio especial, propina externa..."
+              class="w-full min-h-[44px] px-4 py-3 border-2 border-border rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary text-text-primary bg-background text-base"
+            />
+          </div>
+
+          <p v-if="errorMessage" class="text-sm text-red-600" role="alert">{{ errorMessage }}</p>
+
+          <div class="flex gap-2 pt-1">
+            <button
+              type="button"
+              class="min-h-[44px] px-4 py-3 rounded-xl border border-border text-text-secondary font-medium hover:bg-surface-secondary transition-colors"
+              @click="handleClose"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              :disabled="isSubmitting"
+              class="flex-1 min-h-[44px] px-4 py-3 rounded-xl bg-primary text-primary-foreground font-semibold hover:opacity-90 active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {{ isSubmitting ? 'Agregando...' : 'Agregar al carrito' }}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, nextTick } from 'vue'
+
+const props = defineProps<{
+  modelValue: boolean
+  shellName?: string | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'confirm', payload: { amount: number; description?: string }): void
+}>()
+
+const amountInput = ref('')
+const descriptionInput = ref('')
+const errorMessage = ref<string | null>(null)
+const isSubmitting = ref(false)
+const amountInputRef = ref<HTMLInputElement | null>(null)
+
+const resetForm = () => {
+  amountInput.value = ''
+  descriptionInput.value = ''
+  errorMessage.value = null
+  isSubmitting.value = false
+}
+
+const handleClose = () => {
+  emit('update:modelValue', false)
+}
+
+watch(
+  () => props.modelValue,
+  (open) => {
+    if (open) {
+      resetForm()
+      nextTick(() => amountInputRef.value?.focus())
+    }
+  },
+)
+
+const handleSubmit = () => {
+  errorMessage.value = null
+  const amount = Number(amountInput.value)
+  if (!Number.isFinite(amount) || amount <= 0) {
+    errorMessage.value = 'Ingresa un monto mayor a cero'
+    return
+  }
+  isSubmitting.value = true
+  emit('confirm', {
+    amount: Math.round(amount),
+    description: descriptionInput.value.trim() || undefined,
+  })
+}
+
+defineExpose({ clearSubmitting: () => { isSubmitting.value = false } })
+</script>
+
+<style scoped>
+.sheet-enter-active,
+.sheet-leave-active {
+  transition: opacity 0.15s ease;
+}
+.sheet-enter-from,
+.sheet-leave-to {
+  opacity: 0;
+}
+</style>

--- a/composables/useOpenSale.ts
+++ b/composables/useOpenSale.ts
@@ -1,0 +1,81 @@
+import { computed, type ComputedRef, type Ref } from 'vue'
+import type { ActiveTableSession, CartItem } from '~/stores/usePOSStore'
+
+export interface OpenSaleProduct {
+  id: string
+  name: string
+}
+
+const MAX_OPEN_SALE_AMOUNT = 99_999_999
+
+export function useOpenSale(options: {
+  settingsData: Ref<{ success?: boolean; data?: { open_sale_product?: OpenSaleProduct | null } } | undefined>
+  isMesaMode: Ref<boolean> | ComputedRef<boolean>
+  activeTableSession: Ref<ActiveTableSession | null>
+}) {
+  const openSaleProduct = computed(
+    () => options.settingsData.value?.data?.open_sale_product ?? null,
+  )
+
+  /** Counter, or bar session — excludes real mesa tab mode (#797). */
+  const showOpenSaleButton = computed(() => {
+    if (options.isMesaMode.value) {
+      return !!options.activeTableSession.value?.isBar
+    }
+    return true
+  })
+
+  const openSaleEnabled = computed(() => !!openSaleProduct.value)
+
+  const openSaleDisabledReason = computed(() => {
+    if (openSaleProduct.value) return null
+    return 'Configura un producto de venta libre en el menú (marca open_priced en un producto).'
+  })
+
+  const validateOpenSaleAmount = (raw: string | number): number => {
+    const amount = Math.round(Number(raw))
+    if (!Number.isFinite(amount) || amount <= 0) {
+      throw new Error('Ingresa un monto mayor a cero')
+    }
+    if (amount > MAX_OPEN_SALE_AMOUNT) {
+      throw new Error('El monto es demasiado alto')
+    }
+    return amount
+  }
+
+  const buildOpenSaleCartLine = (
+    amount: number,
+    description?: string,
+  ): Omit<CartItem, 'quantity'> & { quantity: number } => {
+    const shell = openSaleProduct.value
+    if (!shell) {
+      throw new Error('No hay producto de venta libre configurado')
+    }
+    const trimmed = description?.trim()
+    const displayName = trimmed || shell.name
+    const notes = trimmed ? `VARIOS: ${trimmed}` : undefined
+
+    return {
+      product: {
+        id: shell.id,
+        name: displayName,
+        price: amount,
+        image: '💵',
+        category: 'Venta libre',
+      },
+      quantity: 1,
+      modifiers: [],
+      notes,
+      is_open_sale: true,
+    }
+  }
+
+  return {
+    openSaleProduct,
+    showOpenSaleButton,
+    openSaleEnabled,
+    openSaleDisabledReason,
+    validateOpenSaleAmount,
+    buildOpenSaleCartLine,
+  }
+}

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -4,6 +4,7 @@ import { storeToRefs } from 'pinia'
 import { $fetch } from 'ofetch'
 import type { CachedProduct, TabItem } from '~/stores/usePOSStore'
 import { usePOSStore } from '~/stores/usePOSStore'
+import { useOpenSale } from '~/composables/useOpenSale'
 import { registerTableSessionRefresh } from '~/composables/useTableSessionSync'
 import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
 import {
@@ -27,8 +28,9 @@ const tableSingularLower = computed(() => tableSingular.value.toLowerCase())
 const tablePluralLower = computed(() => tablePlural.value.toLowerCase())
 
 const router = useRouter()
+const toast = useToast()
 const posStore = usePOSStore()
-const { tabItems: storeTabItems, tabTotal: storeTabTotal } = storeToRefs(posStore)
+const { tabItems: storeTabItems, tabTotal: storeTabTotal, activeTableSession } = storeToRefs(posStore)
 
 // Clear session at setup time (before first render) so showFloorPlan is correct immediately.
 // If navigating from a POS sub-page (checkout, producto), posNavigation flag preserves the session.
@@ -245,6 +247,25 @@ const isKitchenServiceMode = computed(
 )
 const isMesaMode = computed(
   () => !!posStore.activeTableSession && !posStore.activeTableSession?.isBar,
+)
+
+const openSaleModalOpen = ref(false)
+const openSaleModalRef = ref<{ clearSubmitting: () => void } | null>(null)
+const {
+  openSaleProduct,
+  showOpenSaleButton,
+  openSaleEnabled,
+  openSaleDisabledReason,
+  validateOpenSaleAmount,
+  buildOpenSaleCartLine,
+} = useOpenSale({
+  settingsData,
+  isMesaMode,
+  activeTableSession,
+})
+
+const showBarProcessOrder = computed(
+  () => isKitchenServiceMode.value && !!posStore.activeTableSession?.isBar,
 )
 const isAddingToTab = ref(false)
 const isLoadingTabItems = ref(false)
@@ -799,9 +820,32 @@ const selectProduct = async (product: any) => {
 
 // Navigate to edit cart item
 const editCartItem = (cartIndex: number, productId: string) => {
-  // Mark that we're navigating within POS
+  const item = posStore.cart[cartIndex]
+  if (item?.is_open_sale) return
   sessionStorage.setItem('posNavigation', 'true')
   router.push(`/pos/producto/${productId}?edit=${cartIndex}`)
+}
+
+const handleOpenSaleClick = () => {
+  if (!openSaleEnabled.value) {
+    toast.warning(openSaleDisabledReason.value ?? 'Venta libre no disponible', { title: 'Venta libre' })
+    return
+  }
+  openSaleModalOpen.value = true
+}
+
+const handleOpenSaleConfirm = async (payload: { amount: number; description?: string }) => {
+  try {
+    const amount = validateOpenSaleAmount(payload.amount)
+    const line = buildOpenSaleCartLine(amount, payload.description)
+    await posStore.addToCart(line)
+    openSaleModalOpen.value = false
+    toast.success('Agregado al carrito', { title: 'Venta libre' })
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'No se pudo agregar la venta libre'
+    toast.error(message, { title: 'Venta libre' })
+    openSaleModalRef.value?.clearSubmitting()
+  }
 }
 
 const removeFromCart = async (index: number) => {
@@ -1244,6 +1288,10 @@ onUnmounted(() => {
         :items="posStore.cart"
         :total="cartTotal"
         :mesa-mode="isKitchenServiceMode"
+        :show-open-sale="showOpenSaleButton"
+        :open-sale-enabled="openSaleEnabled"
+        :open-sale-tooltip="openSaleDisabledReason"
+        :show-bar-process-order="showBarProcessOrder"
         :is-adding-to-tab="isAddingToTab"
         :is-loading-tab-items="isLoadingTabItems"
         :is-clearing-tab="isClearingTab"
@@ -1265,6 +1313,7 @@ onUnmounted(() => {
         @decrement-item="decrementCartItem"
         @duplicate-item="duplicateCartItem"
         @process-order="processOrder"
+        @open-sale="handleOpenSaleClick"
         @clear-cart="clearCart"
         @add-to-tab="addToTab"
         @request-bill="requestBill"
@@ -1403,6 +1452,13 @@ onUnmounted(() => {
       </div>
     </Transition>
   </Teleport>
+
+  <PosOpenSaleModal
+    ref="openSaleModalRef"
+    v-model="openSaleModalOpen"
+    :shell-name="openSaleProduct?.name"
+    @confirm="handleOpenSaleConfirm"
+  />
 
   <!-- Issue #537 — Expediter chip teleported into the dashboard header so it
        never overlaps content. Icon-only on mobile, icon + label on sm+.

--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -20,6 +20,8 @@ export interface CartItem {
     modifiers: CartModifier[]
     notes?: string
     is_resale?: boolean // Productos de reventa no permiten modificadores
+    /** Venta libre (#796): custom unit price; do not merge with catalog lines */
+    is_open_sale?: boolean
 }
 
 export interface Customer {
@@ -142,13 +144,23 @@ export const usePOSStore = defineStore('pos', () => {
 
     const addToCart = async (item: Omit<CartItem, 'quantity'> & { quantity?: number }) => {
         const quantity = item.quantity || 1
-        // Merge with existing item if same product + same modifiers + same notes
-        const existingIndex = cart.value.findIndex(c =>
-            c.product.id === item.product.id &&
-            c.notes === (item.notes ?? undefined) &&
-            c.modifiers.length === (item.modifiers?.length ?? 0) &&
-            c.modifiers.every((m, i) => m.id === item.modifiers?.[i]?.id)
-        )
+        const existingIndex = cart.value.findIndex((c) => {
+            if (item.is_open_sale || c.is_open_sale) {
+                return (
+                    !!item.is_open_sale &&
+                    !!c.is_open_sale &&
+                    c.product.id === item.product.id &&
+                    Number(c.product.price) === Number(item.product.price) &&
+                    c.notes === (item.notes ?? undefined)
+                )
+            }
+            return (
+                c.product.id === item.product.id &&
+                c.notes === (item.notes ?? undefined) &&
+                c.modifiers.length === (item.modifiers?.length ?? 0) &&
+                c.modifiers.every((m, i) => m.id === item.modifiers?.[i]?.id)
+            )
+        })
         if (existingIndex !== -1) {
             cart.value[existingIndex].quantity += quantity
         } else {
@@ -200,7 +212,8 @@ export const usePOSStore = defineStore('pos', () => {
                 product: { ...originalItem.product },
                 modifiers: [...originalItem.modifiers],
                 notes: originalItem.notes,
-                is_resale: originalItem.is_resale
+                is_resale: originalItem.is_resale,
+                is_open_sale: originalItem.is_open_sale,
             })
         }
     }


### PR DESCRIPTION
## Summary
- Adds **Venta libre** button on counter and bar cart panels (hidden on real mesa tab mode).
- Modal for COP amount + optional description → cart line with custom `product.price`.
- `is_open_sale` prevents incorrect merge with catalog lines; edit disabled on open-sale lines.
- Bar + comandas: **Procesar Orden** shown when cart has items (direct checkout path).

## Stack
Nuxt 3 · Pinia · `/api/pos/restaurant-context` (`open_sale_product` from #795)

## Changes
- `composables/useOpenSale.ts` — visibility, validation, line builder
- `components/pos/OpenSaleModal.vue` — mobile-friendly sheet modal
- `components/pos/CartPanel.vue` — buttons + bar checkout
- `stores/usePOSStore.ts` — `is_open_sale` merge rules
- `pages/pos/index.vue` — wiring

## Testing
1. Merge/deploy API #795 and mark one product `open_priced=true`.
2. POS mostrador: Venta libre → monto → Procesar orden → checkout total matches.
3. Barra session: same; verify `table_session_id` on complete.
4. Without shell product: button disabled + tooltip.

Closes #796

Made with [Cursor](https://cursor.com)