### PR TITLE
feat(pos): Venta libre on mesa tab

### DIFF
--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -102,6 +102,7 @@
             product: { id: item.orderItemId, name: item.productName, price: item.unitPrice, image: '🍽️', category: '' },
             modifiers: [],
             quantity: item.quantity,
+            notes: item.notes ?? undefined,
             fulfillmentStatus: item.fulfillmentStatus,
             sentAt: item.sentAt
           }"
@@ -348,6 +349,7 @@ interface TabItem {
   quantity: number
   unitPrice: number
   subtotal: number
+  notes?: string | null
   fulfillmentStatus?: string
   sentAt?: string | null
 }

--- a/components/pos/OpenSaleModal.vue
+++ b/components/pos/OpenSaleModal.vue
@@ -80,7 +80,7 @@
               :disabled="isSubmitting"
               class="flex-1 min-h-[44px] px-4 py-3 rounded-xl bg-primary text-primary-foreground font-semibold hover:opacity-90 active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {{ isSubmitting ? 'Agregando...' : 'Agregar al carrito' }}
+              {{ isSubmitting ? 'Agregando...' : confirmLabel }}
             </button>
           </div>
         </form>
@@ -92,10 +92,14 @@
 <script setup lang="ts">
 import { ref, watch, nextTick } from 'vue'
 
-const props = defineProps<{
-  modelValue: boolean
-  shellName?: string | null
-}>()
+const props = withDefaults(
+  defineProps<{
+    modelValue: boolean
+    shellName?: string | null
+    confirmLabel?: string
+  }>(),
+  { confirmLabel: 'Agregar al carrito' },
+)
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: boolean): void

--- a/composables/useOpenSale.ts
+++ b/composables/useOpenSale.ts
@@ -25,6 +25,9 @@ export function useOpenSale(options: {
     return true
   })
 
+  /** Real table session only (not bar) — warocol.com#797. */
+  const showOpenSaleOnMesa = computed(() => options.isMesaMode.value)
+
   const openSaleEnabled = computed(() => !!openSaleProduct.value)
 
   const openSaleDisabledReason = computed(() => {
@@ -70,12 +73,30 @@ export function useOpenSale(options: {
     }
   }
 
+  const buildOpenSaleTabItem = (amount: number, description?: string) => {
+    const shell = openSaleProduct.value
+    if (!shell) {
+      throw new Error('No hay producto de venta libre configurado')
+    }
+    const trimmed = description?.trim()
+    const notes = trimmed ? `VARIOS: ${trimmed}` : null
+    return {
+      product_id: shell.id,
+      quantity: 1,
+      unit_price: amount,
+      modifiers: [] as Array<{ id: string; name: string; price: number }>,
+      notes,
+    }
+  }
+
   return {
     openSaleProduct,
     showOpenSaleButton,
+    showOpenSaleOnMesa,
     openSaleEnabled,
     openSaleDisabledReason,
     validateOpenSaleAmount,
     buildOpenSaleCartLine,
+    buildOpenSaleTabItem,
   }
 }

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -379,6 +379,7 @@ function mapTabItemsFromApi(rows: any[]): TabItem[] {
     quantity: i.quantity,
     unitPrice: i.unitPrice,
     subtotal: i.subtotal,
+    notes: i.notes ?? null,
     fulfillmentStatus: i.fulfillmentStatus ?? 'new',
     sentAt: i.sentAt ?? null,
   }))

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -254,10 +254,12 @@ const openSaleModalRef = ref<{ clearSubmitting: () => void } | null>(null)
 const {
   openSaleProduct,
   showOpenSaleButton,
+  showOpenSaleOnMesa,
   openSaleEnabled,
   openSaleDisabledReason,
   validateOpenSaleAmount,
   buildOpenSaleCartLine,
+  buildOpenSaleTabItem,
 } = useOpenSale({
   settingsData,
   isMesaMode,
@@ -266,6 +268,10 @@ const {
 
 const showBarProcessOrder = computed(
   () => isKitchenServiceMode.value && !!posStore.activeTableSession?.isBar,
+)
+
+const showOpenSaleInPanel = computed(
+  () => showOpenSaleButton.value || showOpenSaleOnMesa.value,
 )
 const isAddingToTab = ref(false)
 const isLoadingTabItems = ref(false)
@@ -334,6 +340,7 @@ const mapTabItemsFromApi = (rows: any[]): TabItem[] =>
     quantity: i.quantity,
     unitPrice: i.unitPrice,
     subtotal: i.subtotal,
+    notes: i.notes ?? null,
     fulfillmentStatus: i.fulfillmentStatus ?? 'new',
     sentAt: i.sentAt ?? null,
   }))
@@ -834,16 +841,54 @@ const handleOpenSaleClick = () => {
   openSaleModalOpen.value = true
 }
 
+const addOpenSaleToTab = async (amount: number, description?: string) => {
+  if (!posStore.activeTableSession || isAddingToTab.value) return
+  bumpTableSessionFetchGen()
+  isAddingToTab.value = true
+  tabError.value = null
+  try {
+    const tabItem = buildOpenSaleTabItem(amount, description)
+    const addRes = await $fetch(`/api/tables/${posStore.activeTableSession.tableId}/tab/add`, {
+      method: 'POST',
+      body: { items: [tabItem] },
+    })
+    if (comandasEnabled.value) {
+      const { comandas, fired_items_count } = parseFireTableResponse(addRes as any)
+      if (comandas.length > 0 || fired_items_count > 0) {
+        applyFireResult(comandas, fired_items_count)
+        if (fired_items_count > 0) {
+          tabSuccess.value = `${fired_items_count} ${fired_items_count === 1 ? 'ítem enviado' : 'ítems enviados'} a cocina`
+          setTimeout(() => { tabSuccess.value = null }, 3000)
+        }
+      }
+    }
+    await refreshTableSession()
+  } catch (e: any) {
+    tabError.value = e?.data?.detail ?? e?.data?.message ?? `Error al agregar a la ${tableSingularLower.value}`
+    throw e
+  } finally {
+    isAddingToTab.value = false
+  }
+}
+
 const handleOpenSaleConfirm = async (payload: { amount: number; description?: string }) => {
   try {
     const amount = validateOpenSaleAmount(payload.amount)
+    if (isMesaMode.value) {
+      await addOpenSaleToTab(amount, payload.description)
+      openSaleModalOpen.value = false
+      toast.success(`Agregado a la ${tableSingularLower.value}`, { title: 'Venta libre' })
+      return
+    }
     const line = buildOpenSaleCartLine(amount, payload.description)
     await posStore.addToCart(line)
     openSaleModalOpen.value = false
     toast.success('Agregado al carrito', { title: 'Venta libre' })
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'No se pudo agregar la venta libre'
-    toast.error(message, { title: 'Venta libre' })
+    toast.error(typeof err === 'object' && err && 'data' in err
+      ? (err as any).data?.detail ?? message
+      : message, { title: 'Venta libre' })
     openSaleModalRef.value?.clearSubmitting()
   }
 }
@@ -1288,7 +1333,7 @@ onUnmounted(() => {
         :items="posStore.cart"
         :total="cartTotal"
         :mesa-mode="isKitchenServiceMode"
-        :show-open-sale="showOpenSaleButton"
+        :show-open-sale="showOpenSaleInPanel"
         :open-sale-enabled="openSaleEnabled"
         :open-sale-tooltip="openSaleDisabledReason"
         :show-bar-process-order="showBarProcessOrder"
@@ -1457,6 +1502,7 @@ onUnmounted(() => {
     ref="openSaleModalRef"
     v-model="openSaleModalOpen"
     :shell-name="openSaleProduct?.name"
+    :confirm-label="isMesaMode ? `Agregar a la ${tableSingularLower}` : 'Agregar al carrito'"
     @confirm="handleOpenSaleConfirm"
   />
 

--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -52,6 +52,7 @@ export interface TabItem {
     quantity: number
     unitPrice: number
     subtotal: number
+    notes?: string | null
     fulfillmentStatus: 'new' | 'sent' | 'preparing' | 'ready' | 'delivered' | 'cancelled'
     sentAt: string | null
 }


### PR DESCRIPTION
## Summary
- Mesa-only venta libre: modal → direct `POST /tab/add` (no cart staging).
- `showOpenSaleOnMesa` + `addOpenSaleToTab` + branched confirm handler.
- Tab lines show `notes` when API returns them.

## Stack
Nuxt 3 · depends on #801 (#796)

## Changes
- `composables/useOpenSale.ts`: `showOpenSaleOnMesa`, `buildOpenSaleTabItem`
- `pages/pos/index.vue`: `addOpenSaleToTab`, mesa confirm path
- `components/pos/OpenSaleModal.vue`: dynamic confirm label
- `components/pos/CartPanel.vue`, `stores/usePOSStore.ts`, `checkout.vue`: tab `notes`

## API companion
api-warolabs `gh-795-open-priced-api` @ e8e2cc0 adds `notes` to `GET /tables/{id}/current` tab_items.

## Testing
1. Merge #801 first (or test on this stack).
2. Open mesa session → Venta libre → monto → appears on tab with note.
3. Pedir cuenta → total includes amount.

Closes #797

Made with [Cursor](https://cursor.com)