### PR TITLE
docs(usuarios): Venta libre en POS — setup and usage

### DIFF
--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -102,6 +102,7 @@
             product: { id: item.orderItemId, name: item.productName, price: item.unitPrice, image: '🍽️', category: '' },
             modifiers: [],
             quantity: item.quantity,
+            notes: item.notes ?? undefined,
             fulfillmentStatus: item.fulfillmentStatus,
             sentAt: item.sentAt
           }"
@@ -348,6 +349,7 @@ interface TabItem {
   quantity: number
   unitPrice: number
   subtotal: number
+  notes?: string | null
   fulfillmentStatus?: string
   sentAt?: string | null
 }

--- a/components/pos/OpenSaleModal.vue
+++ b/components/pos/OpenSaleModal.vue
@@ -80,7 +80,7 @@
               :disabled="isSubmitting"
               class="flex-1 min-h-[44px] px-4 py-3 rounded-xl bg-primary text-primary-foreground font-semibold hover:opacity-90 active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {{ isSubmitting ? 'Agregando...' : 'Agregar al carrito' }}
+              {{ isSubmitting ? 'Agregando...' : confirmLabel }}
             </button>
           </div>
         </form>
@@ -92,10 +92,14 @@
 <script setup lang="ts">
 import { ref, watch, nextTick } from 'vue'
 
-const props = defineProps<{
-  modelValue: boolean
-  shellName?: string | null
-}>()
+const props = withDefaults(
+  defineProps<{
+    modelValue: boolean
+    shellName?: string | null
+    confirmLabel?: string
+  }>(),
+  { confirmLabel: 'Agregar al carrito' },
+)
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: boolean): void

--- a/composables/useOpenSale.ts
+++ b/composables/useOpenSale.ts
@@ -25,6 +25,9 @@ export function useOpenSale(options: {
     return true
   })
 
+  /** Real table session only (not bar) — warocol.com#797. */
+  const showOpenSaleOnMesa = computed(() => options.isMesaMode.value)
+
   const openSaleEnabled = computed(() => !!openSaleProduct.value)
 
   const openSaleDisabledReason = computed(() => {
@@ -70,12 +73,30 @@ export function useOpenSale(options: {
     }
   }
 
+  const buildOpenSaleTabItem = (amount: number, description?: string) => {
+    const shell = openSaleProduct.value
+    if (!shell) {
+      throw new Error('No hay producto de venta libre configurado')
+    }
+    const trimmed = description?.trim()
+    const notes = trimmed ? `VARIOS: ${trimmed}` : null
+    return {
+      product_id: shell.id,
+      quantity: 1,
+      unit_price: amount,
+      modifiers: [] as Array<{ id: string; name: string; price: number }>,
+      notes,
+    }
+  }
+
   return {
     openSaleProduct,
     showOpenSaleButton,
+    showOpenSaleOnMesa,
     openSaleEnabled,
     openSaleDisabledReason,
     validateOpenSaleAmount,
     buildOpenSaleCartLine,
+    buildOpenSaleTabItem,
   }
 }

--- a/docs/usuarios.md
+++ b/docs/usuarios.md
@@ -16,7 +16,7 @@ La documentación replica la estructura del menú lateral de la plataforma: tres
 
 | Módulo | Qué puedes hacer |
 |--------|------------------|
-| [POS](./usuarios/pos) | Procesar ventas en el punto de venta (mostrador, mesa, barra) |
+| [POS](./usuarios/pos) | Procesar ventas en el punto de venta (mostrador, mesa, barra); incluye [venta libre](./usuarios/pos-venta-libre) |
 | [Ventas](./usuarios/ventas) | Historial de órdenes, productos vendidos y propinas |
 | [Despacho](./usuarios/despacho) | Pedidos online (domicilios y recogida) y comandas de cocina |
 

--- a/docs/usuarios/operaciones.md
+++ b/docs/usuarios/operaciones.md
@@ -39,6 +39,8 @@ Registro de auditoría del POS: quién eliminó productos del tab o carrito, vac
 
 Ver [Bitácora de operaciones](./operaciones/bitacora) para la guía completa: qué se registra, qué no, filtros, políticas de motivo obligatorio en cocina y anulaciones de pago.
 
+Las líneas de [Venta libre en el POS](./pos-venta-libre) en mesa o barra aparecen como producto agregado o eliminado del tab; en mostrador, como línea o carrito vaciado.
+
 ---
 
 ## Turnos

--- a/docs/usuarios/pos-venta-libre.md
+++ b/docs/usuarios/pos-venta-libre.md
@@ -1,0 +1,148 @@
+# Venta libre en el POS
+
+**Venta libre** te permite cobrar un **monto en pesos** que no está fijado en el menú: servicios especiales, cargos varios, ajustes puntuales, etc. El cajero ingresa el valor en el momento; no hace falta crear un producto nuevo en el menú por cada venta.
+
+> Esta función requiere una versión de WARO con venta libre activa en tu negocio. Si no ves el botón **Venta libre** en el POS, contacta a soporte.
+
+---
+
+## ¿Cómo funciona?
+
+Tu negocio tiene **un solo producto contenedor** de venta libre (por ejemplo «Varios» o «Venta libre»). Cada vez que el cajero usa la función:
+
+1. Toca **Venta libre** en el panel del carrito.
+2. Escribe el **monto en COP** (obligatorio).
+3. Opcionalmente escribe una **descripción** (ej. «Servicio de meseros», «Empaque especial»).
+4. Confirma; el ítem se agrega con ese precio y sigue el flujo normal de cobro según el canal (mostrador, barra o mesa).
+
+No creas productos en el menú por cada monto distinto: reutilizas siempre el mismo producto contenedor.
+
+---
+
+## Configuración inicial (administrador)
+
+La activación la hace el equipo de **soporte WARO** o un administrador con acceso técnico. En el menú de productos **aún no hay un interruptor visible** para marcar un producto como venta libre.
+
+Requisitos del producto contenedor:
+
+| Aspecto | Recomendación |
+|---------|----------------|
+| **Cantidad** | Solo **uno** por negocio |
+| **Nombre** | Claro para el equipo, ej. «Varios» o «Venta libre» |
+| **Precio en menú** | Puede ser simbólico (ej. $1); en el POS el cajero define el monto real |
+| **Receta / ingredientes** | Sin receta ni ingredientes (no descuenta inventario por composición) |
+| **Modificadores** | No aplican en venta libre |
+| **Categoría fiscal** | La que corresponda a ese tipo de ingreso (estándar, licores o exento) |
+
+Si el producto contenedor no está configurado, el botón **Venta libre** aparece deshabilitado y el POS indica que falta configurar el producto de venta libre.
+
+---
+
+## Uso en mostrador
+
+Cuando el POS abre directamente en productos (módulo de mesas desactivado o modo mostrador):
+
+1. En el panel del carrito, toca **Venta libre**.
+2. Ingresa el monto y, si quieres, la descripción → **Agregar**.
+3. El ítem aparece en el carrito con el monto que ingresaste.
+4. Agrega más productos del menú si hace falta.
+5. Toca **Procesar Orden** y completa el [checkout](./pos) (pago, propina, cliente, etc.).
+
+La descripción opcional se muestra como nombre de la línea en el carrito. No puedes editar la línea como un producto de catálogo (no hay modificadores ni cambio de precio desde el detalle del producto).
+
+---
+
+## Uso en mesa
+
+Con el módulo de mesas activo, abre la **mesa** en el plano del salón:
+
+1. Toca **Venta libre** en el panel inferior.
+2. Ingresa monto y descripción opcional → **Agregar**.
+3. El ítem va **directo al tab de la mesa** (lista de consumo de esa sesión), no al carrito temporal de mostrador.
+4. Repite para más ítems del menú o más ventas libres.
+5. Cuando el cliente pida la cuenta, usa **Pedir cuenta** y cobra desde el [checkout de mesa](./pos#modo-mesas-plano-del-salón).
+
+> En mesa el flujo de venta libre **no es igual** al de mostrador: no pasa primero por «Procesar Orden» del carrito vacío; se suma al tab de la mesa.
+
+---
+
+## Uso en barra
+
+La **barra** se comporta como una sesión de mesa especial en el plano:
+
+1. Abre la barra como cualquier otra mesa/sesión.
+2. **Venta libre** agrega el ítem al **tab de la barra** (igual que en mesa).
+3. Si además tienes productos en el **carrito** de barra y comandas activas, puede aparecer **Procesar Orden** para enviar esos ítems a cocina antes de cobrar.
+4. Cierra con **Pedir cuenta** y checkout cuando corresponda.
+
+---
+
+## Después de cobrar
+
+| Dónde | Qué verás |
+|-------|-----------|
+| **Ventas → Órdenes** | Una línea con el producto contenedor y el **precio que ingresó el cajero** (o la descripción si la escribió) |
+| **Prefactura / recibo / correo** | Mismo desglose que el resto de la orden |
+| **Analítica** | Cuenta como venta del producto contenedor con ese monto |
+
+Si el producto contenedor no tiene receta, **no hay descuento de inventario** por esa línea (igual que otros productos sin composición).
+
+---
+
+## Bitácora de operaciones
+
+Las ventas libres en **mesa o barra** generan eventos como **Producto agregado al tab** o **Producto eliminado del tab** si alguien quita la línea del tab.
+
+En **mostrador** (o carrito de barra antes de sincronizar), aplican **Línea eliminada del carrito** o **Carrito vaciado** según la acción.
+
+No hay un tipo de evento distinto llamado «venta libre»: se audita igual que cualquier otro ítem. Ver [Bitácora de operaciones](./operaciones/bitacora).
+
+---
+
+## Comandas y cocina
+
+Si **Comandas & Cocina** está activo:
+
+- Al agregar venta libre al **tab de mesa o barra**, el ítem puede **enviarse a cocina** con el mismo comportamiento que un producto normal de esa estación.
+- Si escribiste **descripción**, puede aparecer en la comanda como nota (prefijo interno que ve cocina: varios / servicio especial).
+
+Si tu negocio no usa comandas en barra o mesa, la venta libre solo suma al total del tab.
+
+---
+
+## Qué no está soportado
+
+| Situación | Por qué |
+|-----------|---------|
+| Cobrar un monto **sin ninguna línea** en la orden | Siempre se usa el producto contenedor de venta libre |
+| **Modificadores** (tamaño, extras) en venta libre | No permitido en esta versión |
+| **Crear un producto nuevo en el menú** por cada monto | No es necesario: un solo producto contenedor + monto en el POS |
+| Ver en Bitácora acciones **anteriores al despliegue** | La bitácora no rellena historial pasado |
+| Cambiar el precio desde el editor de producto del carrito | La línea de venta libre no se edita como un plato de catálogo |
+
+---
+
+## Preguntas frecuentes
+
+**¿Tengo que crear un producto en el menú cada vez que cobro algo distinto?**
+No. Configuras **una vez** el producto contenedor de venta libre. El cajero solo ingresa el monto (y opcionalmente la descripción) en cada venta.
+
+**¿Puedo usar venta libre para propinas?**
+Puedes registrar un monto con descripción «Propina» si tu operación lo permite, pero las **propinas formales** del POS siguen el flujo de [Operaciones → Propinas](./operaciones) cuando están activas.
+
+**¿Por qué el botón está deshabilitado?**
+Falta el producto contenedor de venta libre en tu negocio. Contacta a soporte WARO para activarlo.
+
+**¿Afecta inventario?**
+Solo si el producto contenedor tiene receta o ingredientes asignados (no recomendado). Lo habitual es dejarlo sin composición.
+
+**¿Puedo tener dos productos de venta libre?**
+No. El sistema permite **un solo** producto contenedor por negocio.
+
+---
+
+## Ver también
+
+- [Procesar una venta en el POS](./pos)
+- [Bitácora de operaciones](./operaciones/bitacora)
+- [Operaciones](./operaciones)

--- a/docs/usuarios/pos.md
+++ b/docs/usuarios/pos.md
@@ -13,6 +13,8 @@ Ve a **POS** en el menú lateral.
 - Si el módulo de mesas está **desactivado**, verás directamente la pantalla de productos.
 - Si el módulo de mesas está **activo**, verás primero el plano del salón con todas las mesas configuradas.
 
+Para cobrar un **monto que no está en el menú** (servicios, cargos varios), usa [Venta libre](./pos-venta-libre).
+
 ---
 
 ## Modo mostrador (sin mesas)

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -379,6 +379,7 @@ function mapTabItemsFromApi(rows: any[]): TabItem[] {
     quantity: i.quantity,
     unitPrice: i.unitPrice,
     subtotal: i.subtotal,
+    notes: i.notes ?? null,
     fulfillmentStatus: i.fulfillmentStatus ?? 'new',
     sentAt: i.sentAt ?? null,
   }))

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -254,10 +254,12 @@ const openSaleModalRef = ref<{ clearSubmitting: () => void } | null>(null)
 const {
   openSaleProduct,
   showOpenSaleButton,
+  showOpenSaleOnMesa,
   openSaleEnabled,
   openSaleDisabledReason,
   validateOpenSaleAmount,
   buildOpenSaleCartLine,
+  buildOpenSaleTabItem,
 } = useOpenSale({
   settingsData,
   isMesaMode,
@@ -266,6 +268,10 @@ const {
 
 const showBarProcessOrder = computed(
   () => isKitchenServiceMode.value && !!posStore.activeTableSession?.isBar,
+)
+
+const showOpenSaleInPanel = computed(
+  () => showOpenSaleButton.value || showOpenSaleOnMesa.value,
 )
 const isAddingToTab = ref(false)
 const isLoadingTabItems = ref(false)
@@ -334,6 +340,7 @@ const mapTabItemsFromApi = (rows: any[]): TabItem[] =>
     quantity: i.quantity,
     unitPrice: i.unitPrice,
     subtotal: i.subtotal,
+    notes: i.notes ?? null,
     fulfillmentStatus: i.fulfillmentStatus ?? 'new',
     sentAt: i.sentAt ?? null,
   }))
@@ -834,16 +841,54 @@ const handleOpenSaleClick = () => {
   openSaleModalOpen.value = true
 }
 
+const addOpenSaleToTab = async (amount: number, description?: string) => {
+  if (!posStore.activeTableSession || isAddingToTab.value) return
+  bumpTableSessionFetchGen()
+  isAddingToTab.value = true
+  tabError.value = null
+  try {
+    const tabItem = buildOpenSaleTabItem(amount, description)
+    const addRes = await $fetch(`/api/tables/${posStore.activeTableSession.tableId}/tab/add`, {
+      method: 'POST',
+      body: { items: [tabItem] },
+    })
+    if (comandasEnabled.value) {
+      const { comandas, fired_items_count } = parseFireTableResponse(addRes as any)
+      if (comandas.length > 0 || fired_items_count > 0) {
+        applyFireResult(comandas, fired_items_count)
+        if (fired_items_count > 0) {
+          tabSuccess.value = `${fired_items_count} ${fired_items_count === 1 ? 'ítem enviado' : 'ítems enviados'} a cocina`
+          setTimeout(() => { tabSuccess.value = null }, 3000)
+        }
+      }
+    }
+    await refreshTableSession()
+  } catch (e: any) {
+    tabError.value = e?.data?.detail ?? e?.data?.message ?? `Error al agregar a la ${tableSingularLower.value}`
+    throw e
+  } finally {
+    isAddingToTab.value = false
+  }
+}
+
 const handleOpenSaleConfirm = async (payload: { amount: number; description?: string }) => {
   try {
     const amount = validateOpenSaleAmount(payload.amount)
+    if (isMesaMode.value) {
+      await addOpenSaleToTab(amount, payload.description)
+      openSaleModalOpen.value = false
+      toast.success(`Agregado a la ${tableSingularLower.value}`, { title: 'Venta libre' })
+      return
+    }
     const line = buildOpenSaleCartLine(amount, payload.description)
     await posStore.addToCart(line)
     openSaleModalOpen.value = false
     toast.success('Agregado al carrito', { title: 'Venta libre' })
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'No se pudo agregar la venta libre'
-    toast.error(message, { title: 'Venta libre' })
+    toast.error(typeof err === 'object' && err && 'data' in err
+      ? (err as any).data?.detail ?? message
+      : message, { title: 'Venta libre' })
     openSaleModalRef.value?.clearSubmitting()
   }
 }
@@ -1288,7 +1333,7 @@ onUnmounted(() => {
         :items="posStore.cart"
         :total="cartTotal"
         :mesa-mode="isKitchenServiceMode"
-        :show-open-sale="showOpenSaleButton"
+        :show-open-sale="showOpenSaleInPanel"
         :open-sale-enabled="openSaleEnabled"
         :open-sale-tooltip="openSaleDisabledReason"
         :show-bar-process-order="showBarProcessOrder"
@@ -1457,6 +1502,7 @@ onUnmounted(() => {
     ref="openSaleModalRef"
     v-model="openSaleModalOpen"
     :shell-name="openSaleProduct?.name"
+    :confirm-label="isMesaMode ? `Agregar a la ${tableSingularLower}` : 'Agregar al carrito'"
     @confirm="handleOpenSaleConfirm"
   />
 

--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -52,6 +52,7 @@ export interface TabItem {
     quantity: number
     unitPrice: number
     subtotal: number
+    notes?: string | null
     fulfillmentStatus: 'new' | 'sent' | 'preparing' | 'ready' | 'delivered' | 'cancelled'
     sentAt: string | null
 }


### PR DESCRIPTION
## Summary
Adds Spanish user documentation for **Venta libre** on POS: one-time setup (via soporte), flows for mostrador / mesa / barra, ventas, bitácora, comandas, limitations, and FAQ. No internal API paths or field names in user-facing text.

## Stack
Markdown docs (`docs/usuarios/`)

## Changes
- `docs/usuarios/pos-venta-libre.md`: new guide
- `docs/usuarios/pos.md`: link after “Cómo abrir el POS”
- `docs/usuarios/operaciones.md`: bitácora cross-reference
- `docs/usuarios.md`: POS index note

## Testing
- Open `/docs/usuarios/pos-venta-libre` in the app
- Follow links from `pos.md` and `operaciones.md`

Stacks on #802 (`gh-797-open-sale-mesa`). Merge after feature PRs land.

Closes #798

Made with [Cursor](https://cursor.com)