### PR TITLE
feat(operaciones): toggle Venta libre en Personalizar (#805)

### DIFF
--- a/composables/useOpenSale.ts
+++ b/composables/useOpenSale.ts
@@ -6,10 +6,15 @@ export interface OpenSaleProduct {
   name: string
 }
 
+export interface OpenSaleSettings {
+  open_sale_enabled?: boolean
+  open_sale_product?: OpenSaleProduct | null
+}
+
 const MAX_OPEN_SALE_AMOUNT = 99_999_999
 
 export function useOpenSale(options: {
-  settingsData: Ref<{ success?: boolean; data?: { open_sale_product?: OpenSaleProduct | null } } | undefined>
+  settingsData: Ref<{ success?: boolean; data?: OpenSaleSettings } | undefined>
   isMesaMode: Ref<boolean> | ComputedRef<boolean>
   activeTableSession: Ref<ActiveTableSession | null>
 }) {
@@ -17,8 +22,19 @@ export function useOpenSale(options: {
     () => options.settingsData.value?.data?.open_sale_product ?? null,
   )
 
+  /** Master switch from Operaciones → Personalizar (#805). */
+  const openSaleFeatureOn = computed(
+    () => options.settingsData.value?.data?.open_sale_enabled === true,
+  )
+
+  /** Visible only when toggle ON and shell product is active. */
+  const openSaleVisible = computed(
+    () => openSaleFeatureOn.value && !!openSaleProduct.value,
+  )
+
   /** Counter, or bar session — excludes real mesa tab mode (#797). */
   const showOpenSaleButton = computed(() => {
+    if (!openSaleVisible.value) return false
     if (options.isMesaMode.value) {
       return !!options.activeTableSession.value?.isBar
     }
@@ -26,14 +42,13 @@ export function useOpenSale(options: {
   })
 
   /** Real table session only (not bar) — warocol.com#797. */
-  const showOpenSaleOnMesa = computed(() => options.isMesaMode.value)
+  const showOpenSaleOnMesa = computed(
+    () => openSaleVisible.value && options.isMesaMode.value,
+  )
 
-  const openSaleEnabled = computed(() => !!openSaleProduct.value)
+  const openSaleEnabled = computed(() => openSaleVisible.value)
 
-  const openSaleDisabledReason = computed(() => {
-    if (openSaleProduct.value) return null
-    return 'Configura un producto de venta libre en el menú (marca open_priced en un producto).'
-  })
+  const openSaleDisabledReason = computed(() => null)
 
   const validateOpenSaleAmount = (raw: string | number): number => {
     const amount = Math.round(Number(raw))
@@ -91,6 +106,7 @@ export function useOpenSale(options: {
 
   return {
     openSaleProduct,
+    openSaleFeatureOn,
     showOpenSaleButton,
     showOpenSaleOnMesa,
     openSaleEnabled,

--- a/docs/usuarios/pos-venta-libre.md
+++ b/docs/usuarios/pos-venta-libre.md
@@ -2,7 +2,7 @@
 
 **Venta libre** te permite cobrar un **monto en pesos** que no está fijado en el menú: servicios especiales, cargos varios, ajustes puntuales, etc. El cajero ingresa el valor en el momento; no hace falta crear un producto nuevo en el menú por cada venta.
 
-> Esta función requiere una versión de WARO con venta libre activa en tu negocio. Si no ves el botón **Venta libre** en el POS, contacta a soporte.
+> El botón **Venta libre** solo aparece en el POS cuando un administrador lo activa en **Operaciones → Personalizar**.
 
 ---
 
@@ -21,20 +21,23 @@ No creas productos en el menú por cada monto distinto: reutilizas siempre el mi
 
 ## Configuración inicial (administrador)
 
-La activación la hace el equipo de **soporte WARO** o un administrador con acceso técnico. En el menú de productos **aún no hay un interruptor visible** para marcar un producto como venta libre.
+1. Entra a **Operaciones → Personalizar** (requiere permiso de Operaciones).
+2. Activa el interruptor **Venta libre en POS**.
+3. WARO crea o reactiva automáticamente el producto contenedor (por defecto «Venta libre») en la primera categoría de tu menú.
 
-Requisitos del producto contenedor:
+**Requisito:** debe existir al menos **una categoría** en el menú. Si no hay categorías, la activación falla con un mensaje para que crees una categoría primero.
 
-| Aspecto | Recomendación |
+Con el interruptor **desactivado**, el botón **Venta libre no aparece** en el POS (los cajeros no lo ven).
+
+Detalles del producto contenedor (automático):
+
+| Aspecto | Comportamiento |
 |---------|----------------|
 | **Cantidad** | Solo **uno** por negocio |
-| **Nombre** | Claro para el equipo, ej. «Varios» o «Venta libre» |
-| **Precio en menú** | Puede ser simbólico (ej. $1); en el POS el cajero define el monto real |
-| **Receta / ingredientes** | Sin receta ni ingredientes (no descuenta inventario por composición) |
+| **Precio en menú** | Simbólico ($1); en el POS el cajero define el monto real |
+| **Receta / ingredientes** | Sin receta (no descuenta inventario por composición) |
 | **Modificadores** | No aplican en venta libre |
-| **Categoría fiscal** | La que corresponda a ese tipo de ingreso (estándar, licores o exento) |
-
-Si el producto contenedor no está configurado, el botón **Venta libre** aparece deshabilitado y el POS indica que falta configurar el producto de venta libre.
+| **Categoría fiscal** | Estándar (INC/IVA según tu configuración) |
 
 ---
 

--- a/pages/operaciones/personalizar.vue
+++ b/pages/operaciones/personalizar.vue
@@ -130,23 +130,25 @@ onMounted(() => {
   void migrateLocalStorageIfPresent()
 })
 
-// ── Toggle: auto-select Genérico at /pos/checkout open ──────────────────────
-const isToggling = ref(false)
+// ── Toggles (Operaciones → Personalizar) ────────────────────────────────────
+const isTogglingGeneric = ref(false)
+const isTogglingOpenSale = ref(false)
+
+const invalidateRestaurantContext = async () => {
+  await cache.invalidateQueries({ key: ['operaciones', 'restaurant-context'] })
+  await cache.invalidateQueries({ key: ['pos', 'restaurant-context'] })
+}
 
 const toggleAutoSelectGeneric = async () => {
-  if (!businessProfile.value || isToggling.value) return
-  isToggling.value = true
+  if (!businessProfile.value || isTogglingGeneric.value) return
+  isTogglingGeneric.value = true
   const newState = !businessProfile.value.auto_select_generic_enabled
   try {
     await $fetch('/api/operaciones/toggles/auto-select-generic', {
       method: 'PATCH',
       body: { enabled: newState },
     })
-    // Cross-audience invalidation: operaciones (this page + mesas/comandas)
-    // AND pos (read in /pos/index + /pos/checkout). The previous broad
-    // ['tenant'] invalidation no longer matches the audience-scoped keys.
-    await cache.invalidateQueries({ key: ['operaciones', 'restaurant-context'] })
-    await cache.invalidateQueries({ key: ['pos', 'restaurant-context'] })
+    await invalidateRestaurantContext()
     toast.success(
       newState
         ? 'El cobro abrirá con cliente Genérico ya seleccionado'
@@ -156,7 +158,31 @@ const toggleAutoSelectGeneric = async () => {
   } catch (error: any) {
     toast.error(error.data?.detail || 'Error al cambiar la configuración', { title: 'Error' })
   } finally {
-    isToggling.value = false
+    isTogglingGeneric.value = false
+  }
+}
+
+const toggleOpenSale = async () => {
+  if (!businessProfile.value || isTogglingOpenSale.value) return
+  isTogglingOpenSale.value = true
+  const newState = !businessProfile.value.open_sale_enabled
+  try {
+    await $fetch('/api/operaciones/toggles/open-sale', {
+      method: 'PATCH',
+      body: { enabled: newState },
+    })
+    await invalidateRestaurantContext()
+    toast.success(
+      newState
+        ? 'Venta libre visible en el POS para los cajeros'
+        : 'Venta libre oculta en el POS',
+      { title: newState ? 'Venta libre activada' : 'Venta libre desactivada' }
+    )
+  } catch (error: any) {
+    const detail = error?.data?.detail ?? error?.data?.message
+    toast.error(detail || 'Error al cambiar venta libre', { title: 'Error' })
+  } finally {
+    isTogglingOpenSale.value = false
   }
 }
 </script>
@@ -170,6 +196,39 @@ const toggleAutoSelectGeneric = async () => {
 
     <!-- Content -->
     <div v-else class="flex flex-col gap-3 md:gap-4">
+      <!-- ══════ VENTA LIBRE EN POS (#805) ══════ -->
+      <div
+        v-if="businessProfile"
+        class="flex items-center justify-between gap-4 rounded-xl border-2 border-border bg-surface px-4 py-3"
+      >
+        <div class="min-w-0">
+          <p class="text-sm font-semibold leading-snug text-text-primary">
+            {{ businessProfile.open_sale_enabled
+              ? 'Venta libre en POS activa'
+              : 'Venta libre en POS desactivada' }}
+          </p>
+          <p class="text-xs mt-0.5 leading-snug text-text-secondary">
+            Cuando está activa, los cajeros ven el botón Venta libre para cobrar montos que no están en el menú. Se crea un producto contenedor automáticamente.
+          </p>
+        </div>
+        <label
+          class="relative inline-flex items-center cursor-pointer flex-shrink-0"
+          :class="isTogglingOpenSale ? 'opacity-50 pointer-events-none' : ''"
+          :aria-label="businessProfile.open_sale_enabled
+            ? 'Desactivar venta libre en el POS'
+            : 'Activar venta libre en el POS'"
+        >
+          <input
+            type="checkbox"
+            class="sr-only peer"
+            :checked="!!businessProfile.open_sale_enabled"
+            :disabled="isTogglingOpenSale"
+            @change="toggleOpenSale"
+          />
+          <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+        </label>
+      </div>
+
       <!-- ══════ AUTO-SELECT GENÉRICO TOGGLE (Issue #529) ══════ -->
       <div
         v-if="businessProfile"
@@ -187,7 +246,7 @@ const toggleAutoSelectGeneric = async () => {
         </div>
         <label
           class="relative inline-flex items-center cursor-pointer flex-shrink-0"
-          :class="isToggling ? 'opacity-50 pointer-events-none' : ''"
+          :class="isTogglingGeneric ? 'opacity-50 pointer-events-none' : ''"
           :aria-label="businessProfile.auto_select_generic_enabled
             ? 'Desactivar pre-selección de cliente Genérico'
             : 'Activar pre-selección de cliente Genérico'"
@@ -196,7 +255,7 @@ const toggleAutoSelectGeneric = async () => {
             type="checkbox"
             class="sr-only peer"
             :checked="businessProfile.auto_select_generic_enabled"
-            :disabled="isToggling"
+            :disabled="isTogglingGeneric"
             @change="toggleAutoSelectGeneric"
           />
           <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />


### PR DESCRIPTION
## Summary
- Toggle **Venta libre en POS** on Operaciones → Personalizar
- POS button only visible when `open_sale_enabled` and shell product exist
- User docs updated for self-service activation

Requires API PR (migration + endpoint) deployed first.

## Testing
- Enable toggle in Personalizar → button appears in POS (mostrador/barra/mesa según modo)
- Disable toggle → button hidden

Closes #805

Made with [Cursor](https://cursor.com)