### PR TITLE
fix(pos): quitar Enviar a cocina redundante cuando tab/add ya dispara fire

### DIFF
--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -86,7 +86,7 @@
         class="relative"
       >
         <label
-          v-if="comandasEnabled && item.fulfillmentStatus === 'new'"
+          v-if="showFireToKitchen && item.fulfillmentStatus === 'new'"
           class="absolute top-2 left-2 z-10 flex items-center"
         >
           <input
@@ -110,7 +110,7 @@
           :show-fulfillment-status="comandasEnabled"
           :class="[
             pendingRemoveItemId === item.orderItemId ? 'opacity-40 pointer-events-none' : '',
-            comandasEnabled && item.fulfillmentStatus === 'new' ? 'pl-8' : '',
+            showFireToKitchen && item.fulfillmentStatus === 'new' ? 'pl-8' : '',
           ]"
           @increment="$emit('increment-tab-item', item.orderItemId)"
           @decrement="$emit('decrement-tab-item', item.orderItemId)"
@@ -277,7 +277,7 @@
         <template v-if="comandasEnabled">
           <div class="grid grid-cols-2 gap-2">
             <button
-              v-if="unfiredCount > 0"
+              v-if="showFireToKitchen"
               type="button"
               :disabled="isFiringToKitchen || isAddingToTab"
               class="min-h-[44px] rounded-xl border border-primary/40 bg-primary/5 text-primary text-xs font-semibold flex items-center justify-center gap-1 hover:bg-primary/10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
@@ -291,7 +291,7 @@
               type="button"
               :disabled="!canPrintComandas"
               class="min-h-[44px] rounded-xl border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
-              :class="unfiredCount === 0 ? 'col-span-2' : ''"
+              :class="!showFireToKitchen ? 'col-span-2' : ''"
               aria-label="Imprimir comanda de cocina"
               @click="$emit('print-comandas')"
             >
@@ -366,6 +366,7 @@ interface Props {
   tabItemsLoading?: Set<string>
   comandasEnabled?: boolean
   unfiredCount?: number
+  showFireToKitchen?: boolean
   isFiringToKitchen?: boolean
   canPrintComandas?: boolean
   selectedTabItemIds?: string[]
@@ -411,6 +412,7 @@ const props = withDefaults(defineProps<Props>(), {
   tabItemsLoading: () => new Set(),
   comandasEnabled: false,
   unfiredCount: 0,
+  showFireToKitchen: false,
   isFiringToKitchen: false,
   canPrintComandas: false,
   selectedTabItemIds: () => [],

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -223,21 +223,6 @@ watch(
   { immediate: true },
 )
 
-// ── Unfired items count — items in the tab not yet sent to the KDS ──────────
-// In counter mode (no mesa session), all cart items are "new" — none have been fired yet.
-// In mesa mode, count tab items with fulfillmentStatus === 'new'.
-const unfiredCount = computed(() => {
-  if (!comandasEnabled.value) return 0
-  if (!posStore.activeTableSession) {
-    return posStore.cart.length
-  }
-  if (isKitchenServiceMode.value) {
-    const tabUnfired = storeTabItems.value.filter((i: TabItem) => i.fulfillmentStatus === 'new').length
-    return tabUnfired + posStore.cart.length
-  }
-  return 0
-})
-
 // ── Kitchen service mode (mesa + barra with comandas) ─────────────────────
 // Bar without comandas stays cart-only (“venta directa”). #799
 const isKitchenServiceMode = computed(
@@ -247,6 +232,32 @@ const isKitchenServiceMode = computed(
 )
 const isMesaMode = computed(
   () => !!posStore.activeTableSession && !posStore.activeTableSession?.isBar,
+)
+
+// ── Unfired counts — tab vs cart (#807) ───────────────────────────────────
+// Banner uses tab + cart; manual fire only when cart is empty (tab/add auto-fires).
+const tabUnfiredCount = computed(() => {
+  if (!isKitchenServiceMode.value) return 0
+  return storeTabItems.value.filter((i: TabItem) => i.fulfillmentStatus === 'new').length
+})
+
+const unfiredCount = computed(() => {
+  if (!comandasEnabled.value) return 0
+  if (!posStore.activeTableSession) {
+    return posStore.cart.length
+  }
+  if (isKitchenServiceMode.value) {
+    return tabUnfiredCount.value + posStore.cart.length
+  }
+  return 0
+})
+
+const showFireToKitchen = computed(
+  () =>
+    comandasEnabled.value
+    && isKitchenServiceMode.value
+    && tabUnfiredCount.value > 0
+    && posStore.cart.length === 0,
 )
 
 const openSaleModalOpen = ref(false)
@@ -1345,6 +1356,7 @@ onUnmounted(() => {
         :tab-items-loading="tabItemsLoading"
         :comandas-enabled="comandasEnabled"
         :unfired-count="unfiredCount"
+        :show-fire-to-kitchen="showFireToKitchen"
         :is-firing-to-kitchen="isFiringToKitchen"
         :can-print-comandas="canPrintComandas"
         :selected-tab-item-ids="selectedTabItemIds"


### PR DESCRIPTION
## Summary
- Split `tabUnfiredCount` from cart items in POS mesa/barra+comandas mode
- Show **Enviar a cocina** only when the cart is empty and tab lines are still `new` (edge: no station / failed auto-fire)
- With items in the cart, cashiers only see **Agregar y enviar a cocina** (tab/add auto-fires)

## Stack
Nuxt 3 / Vue (frontend only)

## Changes
- `pages/pos/index.vue`: `tabUnfiredCount`, `showFireToKitchen`, pass prop to panel
- `components/pos/CartPanel.vue`: gate fire button and tab checkboxes on `showFireToKitchen`

## Testing
- [ ] Mesa + comandas: add products to cart → only Agregar y enviar (no Enviar)
- [ ] Empty cart + tab lines `new` → Enviar a cocina visible
- [ ] Barra sin comandas → mostrador footer unchanged
- [ ] After tab/add → Imprimir comanda still available
- [ ] Product without kitchen station on tab → manual Enviar when cart empty

Closes #807

Made with [Cursor](https://cursor.com)