### PR TITLE
fix(pos): quitar Enviar a cocina; checkboxes solo para reimprimir (#812)

### DIFF
--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -86,14 +86,14 @@
         class="relative"
       >
         <label
-          v-if="showFireToKitchen && item.fulfillmentStatus === 'new'"
+          v-if="showPrintItemSelection && printableOrderItemIds.includes(item.orderItemId)"
           class="absolute top-2 left-2 z-10 flex items-center"
         >
           <input
             type="checkbox"
             class="h-4 w-4 rounded border-border text-primary focus:ring-primary/30"
             :checked="selectedTabItemIds.includes(item.orderItemId)"
-            :aria-label="`Seleccionar ${item.productName} para enviar a cocina`"
+            :aria-label="`Seleccionar ${item.productName} para reimprimir comanda`"
             @change="$emit('toggle-tab-selection', item.orderItemId)"
           />
         </label>
@@ -110,7 +110,7 @@
           :show-fulfillment-status="comandasEnabled"
           :class="[
             pendingRemoveItemId === item.orderItemId ? 'opacity-40 pointer-events-none' : '',
-            showFireToKitchen && item.fulfillmentStatus === 'new' ? 'pl-8' : '',
+            showPrintItemSelection && printableOrderItemIds.includes(item.orderItemId) ? 'pl-8' : '',
           ]"
           @increment="$emit('increment-tab-item', item.orderItemId)"
           @decrement="$emit('decrement-tab-item', item.orderItemId)"
@@ -308,35 +308,19 @@
         </div>
 
 
-        <!-- #753 — Fire / print comandas when KDS enabled -->
-        <template v-if="comandasEnabled">
-          <div class="grid grid-cols-2 gap-2">
-            <button
-              v-if="showFireToKitchen"
-              type="button"
-              :disabled="isFiringToKitchen || isAddingToTab"
-              class="min-h-[44px] rounded-xl border border-primary/40 bg-primary/5 text-primary text-xs font-semibold flex items-center justify-center gap-1 hover:bg-primary/10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
-              :aria-label="fireToKitchenLabel"
-              @click="$emit('fire-to-kitchen')"
-            >
-              <UiLoadingDots v-if="isFiringToKitchen" size="7px" />
-              <template v-else>{{ fireToKitchenLabel }}</template>
-            </button>
-            <button
-              type="button"
-              :disabled="!canPrintComandas"
-              class="min-h-[44px] rounded-xl border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
-              :class="!showFireToKitchen ? 'col-span-2' : ''"
-              aria-label="Imprimir comanda de cocina"
-              @click="$emit('print-comandas')"
-            >
-              <svg class="h-4 w-4 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18M6.72 13.829 6.34 18m10.94-4.171L17.66 18M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.75A2.25 2.25 0 0 1 5.25 7.5h13.5A2.25 2.25 0 0 1 21 9.75v6A2.25 2.25 0 0 1 18.75 18h-1.09M6.34 18h11.32" />
-              </svg>
-              Imprimir comanda
-            </button>
-          </div>
-        </template>
+        <!-- #753 / #812 — Re-print kitchen tickets (fire is via Agregar y enviar only) -->
+        <button
+          v-if="comandasEnabled && canPrintComandas"
+          type="button"
+          class="w-full min-h-[44px] rounded-xl border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
+          :aria-label="printComandaLabel"
+          @click="$emit('print-comandas')"
+        >
+          <svg class="h-4 w-4 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18M6.72 13.829 6.34 18m10.94-4.171L17.66 18M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.75A2.25 2.25 0 0 1 5.25 7.5h13.5A2.25 2.25 0 0 1 21 9.75v6A2.25 2.25 0 0 1 18.75 18h-1.09M6.34 18h11.32" />
+          </svg>
+          {{ printComandaLabel }}
+        </button>
 
         <!-- Primary: Add to tab — full width -->
         <button
@@ -402,8 +386,8 @@ interface Props {
   tabItemsLoading?: Set<string>
   comandasEnabled?: boolean
   unfiredCount?: number
-  showFireToKitchen?: boolean
-  isFiringToKitchen?: boolean
+  showPrintItemSelection?: boolean
+  printableOrderItemIds?: string[]
   canPrintComandas?: boolean
   selectedTabItemIds?: string[]
   pendingRemoveItemId?: string | null
@@ -433,7 +417,6 @@ interface Emits {
   (e: 'remove-tab-item', orderItemId: string): void
   (e: 'increment-tab-item', orderItemId: string): void
   (e: 'decrement-tab-item', orderItemId: string): void
-  (e: 'fire-to-kitchen'): void
   (e: 'print-comandas'): void
   (e: 'toggle-tab-selection', orderItemId: string): void
   // Issue #575
@@ -450,8 +433,8 @@ const props = withDefaults(defineProps<Props>(), {
   tabItemsLoading: () => new Set(),
   comandasEnabled: false,
   unfiredCount: 0,
-  showFireToKitchen: false,
-  isFiringToKitchen: false,
+  showPrintItemSelection: false,
+  printableOrderItemIds: () => [],
   canPrintComandas: false,
   selectedTabItemIds: () => [],
   pendingRemoveItemId: null,
@@ -476,10 +459,10 @@ const openSaleButtonClass = computed(() => [
     : 'border-dashed border-border text-text-tertiary hover:bg-surface-secondary hover:text-text-secondary',
 ])
 
-const fireToKitchenLabel = computed(() => {
+const printComandaLabel = computed(() => {
   const n = props.selectedTabItemIds?.length ?? 0
-  if (n > 0) return `Enviar ${n} a cocina`
-  return 'Enviar a cocina'
+  if (n > 0) return `Imprimir comanda (${n})`
+  return 'Imprimir comanda'
 })
 const emit = defineEmits<Emits>()
 

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -235,7 +235,7 @@ const isMesaMode = computed(
 )
 
 // ── Unfired counts — tab vs cart (#807) ───────────────────────────────────
-// Banner uses tab + cart; manual fire only when cart is empty (tab/add auto-fires).
+// Banner uses tab + cart; kitchen send is only via Agregar y enviar (tab/add auto-fires).
 const tabUnfiredCount = computed(() => {
   if (!isKitchenServiceMode.value) return 0
   return storeTabItems.value.filter((i: TabItem) => i.fulfillmentStatus === 'new').length
@@ -251,14 +251,6 @@ const unfiredCount = computed(() => {
   }
   return 0
 })
-
-const showFireToKitchen = computed(
-  () =>
-    comandasEnabled.value
-    && isKitchenServiceMode.value
-    && tabUnfiredCount.value > 0
-    && posStore.cart.length === 0,
-)
 
 const openSaleModalOpen = ref(false)
 const openSaleModalRef = ref<{ clearSubmitting: () => void } | null>(null)
@@ -299,7 +291,6 @@ const showOpenSaleInPanel = computed(
 const isAddingToTab = ref(false)
 const isLoadingTabItems = ref(false)
 const isClearingTab = ref(false)
-const isFiringToKitchen = ref(false)
 const tabError = ref<string | null>(null)
 const tabSuccess = ref<string | null>(null)
 
@@ -313,6 +304,37 @@ const posBusinessName = computed(
     ?? 'WARO',
 )
 const canPrintComandas = computed(() => comandasForPrint.value.length > 0)
+
+/** Tab lines from the last fire batch — checkboxes select tickets to re-print (#812). */
+const printableOrderItemIds = computed(
+  () => orderItemIdsFromComandas(lastFiredComandasRaw.value),
+)
+
+const showPrintItemSelection = computed(
+  () =>
+    comandasEnabled.value
+    && isKitchenServiceMode.value
+    && canPrintComandas.value
+    && printableOrderItemIds.value.size > 0,
+)
+
+const comandasForPrintDisplay = computed(() => {
+  const sel = selectedTabItemIds.value
+  const raw = lastFiredComandasRaw.value
+  if (!Array.isArray(raw) || sel.length === 0) {
+    return comandasForPrint.value
+  }
+  const selSet = new Set(sel)
+  const filteredRaw = (raw as Record<string, unknown>[])
+    .map((c) => {
+      const items = ((c.items as Record<string, unknown>[]) ?? []).filter(
+        (i) => i.order_item_id != null && selSet.has(String(i.order_item_id)),
+      )
+      return { ...c, items }
+    })
+    .filter((c) => ((c.items as unknown[]) ?? []).length > 0)
+  return mapComandasForPrint(filteredRaw)
+})
 
 function toggleTabItemSelection(orderItemId: string) {
   const idx = selectedTabItemIds.value.indexOf(orderItemId)
@@ -345,7 +367,7 @@ function applyFireResult(rawComandas: unknown[], firedCount: number) {
 }
 
 function handlePrintComandas() {
-  if (!canPrintComandas.value) return
+  if (!comandasForPrintDisplay.value.length) return
   printComandaTickets()
 }
 
@@ -606,36 +628,6 @@ const requestBill = () => {
 
 const cache = useQueryCache()
 
-
-// ── Fire to kitchen ─────────────────────────────────────────────────────────
-const fireToKitchen = async () => {
-  if (!posStore.activeTableSession || !comandasEnabled.value) return
-  isFiringToKitchen.value = true
-  tabError.value = null
-  tabSuccess.value = null
-  try {
-    const itemIds = selectedTabItemIds.value.length > 0 ? selectedTabItemIds.value : undefined
-    const raw = await $fetch(`/api/tables/${posStore.activeTableSession.tableId}/fire`, {
-      method: 'POST',
-      body: itemIds ? { item_ids: itemIds } : undefined,
-    })
-    const { comandas, fired_items_count } = parseFireTableResponse(raw as any)
-    if (fired_items_count > 0) {
-      applyFireResult(comandas, fired_items_count)
-      tabSuccess.value = `${fired_items_count} ${fired_items_count === 1 ? 'ítem enviado' : 'ítems enviados'} a cocina`
-      setTimeout(() => { tabSuccess.value = null }, 3000)
-    } else {
-      tabError.value = itemIds?.length
-        ? 'Los ítems seleccionados no tienen estación de cocina'
-        : 'No hay ítems con estación configurada'
-      setTimeout(() => { tabError.value = null }, 3000)
-    }
-  } catch (e: any) {
-    tabError.value = e?.data?.detail ?? 'Error al enviar a cocina'
-  } finally {
-    isFiringToKitchen.value = false
-  }
-}
 
 // ── Move table ─────────────────────────────────────────────────────────────
 const moveTableSource = ref<{ tableId: string; sessionId: string; tableName: string } | null>(null)
@@ -1370,8 +1362,8 @@ onUnmounted(() => {
         :tab-items-loading="tabItemsLoading"
         :comandas-enabled="comandasEnabled"
         :unfired-count="unfiredCount"
-        :show-fire-to-kitchen="showFireToKitchen"
-        :is-firing-to-kitchen="isFiringToKitchen"
+        :show-print-item-selection="showPrintItemSelection"
+        :printable-order-item-ids="[...printableOrderItemIds]"
         :can-print-comandas="canPrintComandas"
         :selected-tab-item-ids="selectedTabItemIds"
         :pending-remove-item-id="pendingRemoveItemId"
@@ -1391,7 +1383,6 @@ onUnmounted(() => {
         @remove-tab-item="removeTabItem"
         @increment-tab-item="incrementTabItem"
         @decrement-tab-item="decrementTabItem"
-        @fire-to-kitchen="fireToKitchen"
         @print-comandas="handlePrintComandas"
         @toggle-tab-selection="toggleTabItemSelection"
         @update:served-by="(id) => posStore.setCartServedBy(id)"
@@ -1581,7 +1572,7 @@ onUnmounted(() => {
 
   <PosComandaPrintTickets
     v-if="comandasEnabled"
-    :comandas="comandasForPrint"
+    :comandas="comandasForPrintDisplay"
     :business-name="posBusinessName"
   />
 


### PR DESCRIPTION
## Summary
- Removes **Enviar a cocina** entirely from mesa/barra+comandas — kitchen fire only via **Agregar y enviar a cocina** (`tab/add` auto-fire).
- Repurposes tab line checkboxes to filter **re-print** of the last fired comanda batch.
- Single **Imprimir comanda** button; label shows count when lines are selected.

Closes #812

## Test plan
- [ ] Mesa con comandas: agregar ítems → **Agregar y enviar** → no aparece Enviar a cocina
- [ ] Tras enviar, checkboxes en líneas de la comanda → **Imprimir comanda (N)** filtra tickets
- [ ] Sin selección, **Imprimir comanda** imprime todo el último batch


Made with [Cursor](https://cursor.com)