### PR TITLE
fix(pos): deleting venta libre tab line — always send DELETE body (#814)

### DIFF
--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -527,7 +527,7 @@ const executeRemoveTabItem = async (orderItemId: string, reason?: string) => {
   try {
     await $fetch(`/api/tables/${posStore.activeTableSession.tableId}/tab/items/${orderItemId}`, {
       method: 'DELETE',
-      body: reason ? { reason } : undefined,
+      body: { reason: reason ?? null },
     })
     pendingRemoveItemId.value = null
     removeTabReason.value = ''


### PR DESCRIPTION
## Summary
- `executeRemoveTabItem` always sends `body: { reason: reason ?? null }` on DELETE so unfired tab lines (venta libre without kitchen station) no longer hit FastAPI `Field required`.

## Stack
Nuxt 3 / POS

## Changes
- `pages/pos/index.vue`: unconditional JSON body on tab item DELETE

## Testing
- [ ] Mesa/barra: add venta libre → remove line → no validation error
- [ ] Fired line: motivo modal → delete with reason → still works

Closes #814

Made with [Cursor](https://cursor.com)