### PR TITLE
fix(menu): remove En catálogo counter from reventa header

### DIFF
--- a/pages/menu/reventa/index.vue
+++ b/pages/menu/reventa/index.vue
@@ -90,10 +90,6 @@
                 <span class="hidden sm:inline">{{ editMode ? 'Ver catálogo' : 'Modo edición' }}</span>
                 <span class="sm:hidden">{{ editMode ? 'Ver' : 'Editar' }}</span>
               </button>
-              <div class="text-right flex-shrink-0">
-                <p class="text-xs text-text-secondary">En catálogo</p>
-                <p class="text-2xl font-bold text-primary tabular-nums">{{ activeProductsCount }}</p>
-              </div>
             </div>
           </template>
 
@@ -520,7 +516,6 @@ const {
   isLoading,
   isRefreshing,
   fetchError,
-  activeProductsCount,
   catalogHasChanges,
   canSubmit: catalogCanSubmit,
   isSubmittingBulk,


### PR DESCRIPTION
## Summary
Removes the \"En catálogo\" + count badge from the reventa page header. The column in the table remains.

## Testing
- [ ] Open `/menu/reventa` — header shows only Modo edición button, no counter

Made with [Cursor](https://cursor.com)