### PR TITLE
fix(menu): reventa bulk PATCH and debug logs

### DIFF
--- a/composables/useResaleIngredientCatalog.ts
+++ b/composables/useResaleIngredientCatalog.ts
@@ -6,6 +6,7 @@ import {
   runConcurrentRequests,
   type MenuSequentialRequest,
 } from '@/composables/useMenuCatalogBulkSave'
+import { logReventaCatalog } from '@/composables/useReventaCatalogDebugLog'
 import { useToast } from '@/composables/useToast'
 
 /** Normaliza is_available del API (boolean o string) para toggles de UI. */
@@ -100,6 +101,11 @@ async function fetchAllResaleProducts() {
   } while (merged.length < total)
 
   return { data: merged, total: merged.length }
+}
+
+type ProductsResaleCache = {
+  data: NonNullable<ResaleIngredientItemState['existingProduct']>[]
+  total: number
 }
 
 export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | null | undefined>) {
@@ -353,6 +359,48 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
     item.isAvailable = !item.isAvailable
   }
 
+  function productsResaleCacheKey() {
+    return ['menu', 'products-resale', tenantId.value] as const
+  }
+
+  function optimisticPatchProductsResale(
+    productIds: string[],
+    body: Record<string, string | boolean>,
+  ): ProductsResaleCache | undefined {
+    const snapshot = cache.getQueryData<ProductsResaleCache>(productsResaleCacheKey())
+    logReventaCatalog('catalog', 'optimistic-patch', {
+      productIds,
+      body,
+      cacheRows: snapshot?.data?.length ?? 0,
+    })
+    if (!snapshot?.data?.length) return snapshot
+
+    const ids = new Set(productIds)
+    cache.setQueryData(productsResaleCacheKey(), {
+      ...snapshot,
+      data: snapshot.data.map((p) => {
+        if (!ids.has(p.id)) return p
+        const next = { ...p }
+        if (body.category_id !== undefined) {
+          next.category_id = String(body.category_id)
+        }
+        if (body.is_available !== undefined) {
+          next.is_available = body.is_available
+        }
+        return next
+      }),
+    })
+    mergeServerIntoLocalItems()
+    return snapshot
+  }
+
+  function rollbackProductsResaleCache(snapshot: ProductsResaleCache | undefined) {
+    if (!snapshot) return
+    logReventaCatalog('catalog', 'optimistic-rollback', { cacheRows: snapshot.data?.length ?? 0 })
+    cache.setQueryData(productsResaleCacheKey(), snapshot)
+    mergeServerIntoLocalItems()
+  }
+
   async function toggleItemAvailabilityOptimistic(item: ResaleIngredientItemState) {
     if (!isInCatalog(item) || !item.existingProduct) {
       toggleItemAvailability(item)
@@ -368,16 +416,16 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
     item.originalAvailable = newValue
     togglingAvailabilityIds.value = new Set([...togglingAvailabilityIds.value, productId])
 
+    const snapshot = optimisticPatchProductsResale([productId], { is_available: newValue })
+
     try {
       await $fetch(`/api/menu/products/${productId}`, {
         method: 'PUT',
         body: { is_available: newValue },
       })
-      cache.invalidateQueries({ key: ['menu', 'products'] })
-      cache.invalidateQueries({ key: ['menu', 'products-resale'] })
-      await refetchProducts()
-      mergeServerIntoLocalItems()
+      await refetchCatalog()
     } catch {
+      rollbackProductsResaleCache(snapshot)
       item.isAvailable = previous
       item.originalAvailable = previous
       toast.error('Error al actualizar. Intenta de nuevo.', { title: 'Error' })
@@ -454,10 +502,16 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
   }
 
   async function refetchCatalog() {
+    logReventaCatalog('catalog', 'refetch-start', { tenantId: tenantId.value })
+    cache.invalidateQueries({ key: ['menu', 'products'] })
     cache.invalidateQueries({ key: ['menu', 'resale-ingredients', tenantId.value] })
     cache.invalidateQueries({ key: ['menu', 'products-resale', tenantId.value] })
     await Promise.all([refetchIngredients(), refetchProducts()])
     syncItemsFromServer()
+    logReventaCatalog('catalog', 'refetch-done', {
+      ingredients: (resaleIngredients.value as unknown[])?.length ?? 0,
+      products: (existingProducts.value as unknown[])?.length ?? 0,
+    })
   }
 
   async function saveChanges() {
@@ -518,6 +572,8 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
     discardChanges,
     saveChanges,
     refetchCatalog,
+    optimisticPatchProductsResale,
+    rollbackProductsResaleCache,
     buildItemsWithStatus,
   }
 }

--- a/composables/useReventaCatalogDebugLog.ts
+++ b/composables/useReventaCatalogDebugLog.ts
@@ -1,0 +1,21 @@
+/** Enable in prod/staging: localStorage.setItem('waro:reventa-catalog-debug', '1') */
+export const REVENTA_CATALOG_DEBUG_LS_KEY = 'waro:reventa-catalog-debug'
+
+export function isReventaCatalogDebugEnabled(): boolean {
+  if (import.meta.dev) return true
+  if (!import.meta.client) return false
+  try {
+    return localStorage.getItem(REVENTA_CATALOG_DEBUG_LS_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+export function logReventaCatalog(
+  scope: 'bulk' | 'catalog' | 'toggle',
+  phase: string,
+  payload?: Record<string, unknown>,
+) {
+  if (!isReventaCatalogDebugEnabled()) return
+  console.log(`[reventa/${scope}]`, phase, payload ?? '')
+}

--- a/pages/menu/reventa/index.vue
+++ b/pages/menu/reventa/index.vue
@@ -476,6 +476,7 @@ import {
   type ResaleIngredientTableRow,
 } from '@/composables/useResaleIngredientCatalog'
 import { useTenantReactive } from '@/composables/useTenantReactive'
+import { logReventaCatalog } from '@/composables/useReventaCatalogDebugLog'
 import { useToast } from '@/composables/useToast'
 
 definePageMeta({
@@ -531,6 +532,8 @@ const {
   toggleItemAvailabilityOptimistic,
   saveChanges,
   refetchCatalog,
+  optimisticPatchProductsResale,
+  rollbackProductsResaleCache,
   buildItemsWithStatus,
   itemsWithStatus,
 } = useResaleIngredientCatalog(currentTenant)
@@ -805,7 +808,7 @@ function applyBulkDraftToSelection() {
     if (bulkCategoryId.value) {
       item.categoryId = bulkCategoryId.value
     }
-    if (bulkAvailability.value !== '' && isInCatalog(item)) {
+    if (bulkAvailability.value !== '') {
       item.isAvailable = bulkAvailability.value === 'true'
     }
   }
@@ -820,18 +823,62 @@ function buildBulkPatchBody(): Record<string, string | boolean> {
   return body
 }
 
-function selectedProductIdsInCatalog() {
-  return selectedIds.value
-    .map(id => findItemByIngredientId(id))
-    .filter((item): item is ResaleIngredientItemState => !!item && isInCatalog(item) && !!item.existingProduct?.id)
-    .map(item => item.existingProduct!.id)
+/** Product ids on the server for selected rows (ingredient ids), regardless of toggle local. */
+function selectedProductIdsForBulkPatch() {
+  const seen = new Set<string>()
+  const ids: string[] = []
+  for (const ingredientId of selectedIds.value) {
+    const productId = findItemByIngredientId(ingredientId)?.existingProduct?.id
+    if (!productId || seen.has(productId)) continue
+    seen.add(productId)
+    ids.push(productId)
+  }
+  return ids
+}
+
+function bulkPatchSelectionDebug() {
+  return selectedIds.value.map((ingredientId) => {
+    const item = findItemByIngredientId(ingredientId)
+    return {
+      ingredientId,
+      inCatalog: item ? isInCatalog(item) : false,
+      productId: item?.existingProduct?.id ?? null,
+    }
+  })
+}
+
+function logBulkApplyState(phase: string, extra: Record<string, unknown> = {}) {
+  logReventaCatalog('bulk', phase, {
+    isSubmittingBulk: isSubmittingBulk.value,
+    isBulkBarSubmitting: isBulkBarSubmitting.value,
+    editMode: editMode.value,
+    selectedCount: selectedIds.value.length,
+    bulkCategoryId: bulkCategoryId.value,
+    bulkAvailability: bulkAvailability.value,
+    bulkInCatalog: bulkInCatalog.value,
+    ...extra,
+  })
 }
 
 async function executeBulkCatalogApply() {
   if (!canBulkApply.value || isBulkBarSubmitting.value) return
 
   isSubmittingBulk.value = true
+  logBulkApplyState('start')
   await nextTick()
+
+  const bodyPreview = buildBulkPatchBody()
+  const hasApiPatchPreview = Object.keys(bodyPreview).length > 0
+  const productIdsForPatch = hasApiPatchPreview ? selectedProductIdsForBulkPatch() : []
+
+  logBulkApplyState('pre-apply', {
+    hasApiPatchPreview,
+    productIdsForPatch,
+    body: bodyPreview,
+    selection: bulkPatchSelectionDebug(),
+  })
+
+  let cacheSnapshot: ReturnType<typeof optimisticPatchProductsResale> | undefined
 
   try {
     applyBulkInCatalogToSelection()
@@ -839,34 +886,54 @@ async function executeBulkCatalogApply() {
 
     const body = buildBulkPatchBody()
     const hasApiPatch = Object.keys(body).length > 0
-    const productIds = hasApiPatch ? selectedProductIdsInCatalog() : []
+    const productIds = hasApiPatch ? productIdsForPatch : []
+
+    logBulkApplyState('post-apply', { hasApiPatch, productIds, body })
 
     if (hasApiPatch && productIds.length > 0) {
-      const result = await runSequentialProductPatches(productIds, () => body)
-      cache.invalidateQueries({ key: ['menu', 'products'] })
-      await refetchCatalog()
-      clearSelection()
-      toastCatalogBulkResult(result, toast, {
-        title: 'Listo',
-        errorMessage: 'No se pudo actualizar ningún producto',
-      })
+      cacheSnapshot = optimisticPatchProductsResale(productIds, body)
+      try {
+        const result = await runSequentialProductPatches(productIds, () => body)
+        logBulkApplyState('patch-done', { result, productIds })
+        await refetchCatalog()
+        clearSelection()
+        toastCatalogBulkResult(result, toast, {
+          title: 'Listo',
+          errorMessage: 'No se pudo actualizar ningún producto',
+        })
+      } catch (error) {
+        rollbackProductsResaleCache(cacheSnapshot)
+        throw error
+      }
       return
     }
 
+    clearSelection()
+
     if (hasApiPatch && productIds.length === 0) {
       toast.success(
-        'Categoría o estado aplicados en la selección. Entra a Modo edición y Guardar para crear productos nuevos.',
+        'Categoría o estado guardados en la selección. Esos ítems aún no tienen producto en el servidor — usa Modo edición y Guardar para crearlos.',
+        { title: 'Listo' },
+      )
+    } else if (bulkInCatalog.value !== '') {
+      toast.success(
+        'En catálogo actualizado en la selección. Usa Modo edición y Guardar para persistir productos nuevos o eliminados.',
         { title: 'Listo' },
       )
     } else {
       toast.success(
-        'Cambios aplicados en la selección. Entra a Modo edición y Guardar para confirmar en el servidor.',
+        'Cambios aplicados en la selección.',
         { title: 'Listo' },
       )
     }
-    clearSelection()
+  } catch (error: unknown) {
+    rollbackProductsResaleCache(cacheSnapshot)
+    const message = error instanceof Error ? error.message : 'Por favor intenta de nuevo.'
+    toast.error(`No se pudo aplicar en lote: ${message}`, { title: 'Error' })
+    logBulkApplyState('error', { message })
   } finally {
     isSubmittingBulk.value = false
+    logBulkApplyState('end')
   }
 }
 


### PR DESCRIPTION
## Summary
- Bulk apply on `/menu/reventa` now sends `PUT /api/menu/products/:id` for every selected row that has `existingProduct`, not only rows with the catalog toggle on.
- Local-only bulk (e.g. En catálogo only) no longer refetches and wipes UI state.
- Pinia Colada optimistic cache + rollback on bulk/toggle; invalidate + refetch after successful PATCH.
- Debug logs: `[reventa/bulk]` and `[reventa/catalog]` in dev, or enable in prod with `localStorage.setItem('waro:reventa-catalog-debug', '1')`.

## Test plan
- [ ] Select resale rows with server product, set Categoría or Estado, Aplicar → Network shows PUT requests
- [ ] Console shows `pre-apply` with `productIdsForPatch` populated
- [ ] Select rows without product, bulk category → toast explains Modo edición, no PUT
- [ ] En catálogo only → local toggle, no refetch wipe


Made with [Cursor](https://cursor.com)