### PR TITLE
fix(menu): reventa bulk refetch + create fallback

### DIFF
--- a/composables/useResaleIngredientCatalog.ts
+++ b/composables/useResaleIngredientCatalog.ts
@@ -73,13 +73,24 @@ function normalizeEntityId(id: unknown): string {
   return String(id ?? '').trim().toLowerCase()
 }
 
-/** Match resale product by recipe ingredient_id, then by exact name (legacy rows without recipe). */
+function normalizeResaleName(name: string): string {
+  return (name ?? '')
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{M}/gu, '')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/** Match resale product by recipe ingredient_id, then by normalized name. */
 function findProductForIngredient(
   products: ResaleProductRow[],
   ingredient: { id: string, name: string },
 ): ResaleProductRow | null {
   const ingId = normalizeEntityId(ingredient.id)
-  const ingName = (ingredient.name ?? '').trim().toLowerCase()
+  const ingName = normalizeResaleName(ingredient.name)
   let nameFallback: ResaleProductRow | null = null
 
   for (const p of products) {
@@ -87,7 +98,8 @@ function findProductForIngredient(
     if (p.ingredients?.some(ing => normalizeEntityId(ing.ingredient_id) === ingId)) {
       return p
     }
-    if (ingName && (p.name ?? '').trim().toLowerCase() === ingName && !nameFallback) {
+    const productName = normalizeResaleName(p.name ?? '')
+    if (ingName && productName && productName === ingName && !nameFallback) {
       nameFallback = p
     }
   }
@@ -109,8 +121,8 @@ async function fetchAllResaleProducts() {
         query: {
           page,
           limit,
-          is_resale: true,
-          include_ingredients: true,
+          is_resale: 'true',
+          include_ingredients: 'true',
         },
       },
     )
@@ -353,6 +365,74 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
     const products = (existingProducts.value || []) as ResaleProductRow[]
     const product = findProductForIngredient(products, item.ingredient)
     if (product) item.existingProduct = product
+  }
+
+  async function refreshProductLinksForBulk(ingredientIds: string[]) {
+    logReventaCatalog('catalog', 'bulk-refresh-products-start', {
+      ingredientIds,
+      productsInCache: (existingProducts.value as unknown[])?.length ?? 0,
+    })
+    cache.invalidateQueries({ key: ['menu', 'products-resale', tenantId.value] })
+    await refetchProducts()
+    for (const ingredientId of ingredientIds) {
+      linkExistingProductOnItem(ingredientId)
+    }
+    logReventaCatalog('catalog', 'bulk-refresh-products-done', {
+      productsInCache: (existingProducts.value as unknown[])?.length ?? 0,
+      resolved: ingredientIds.map(id => ({
+        ingredientId: id,
+        productId: resolveProductIdForIngredient(id),
+      })),
+    })
+  }
+
+  function buildBulkCreateRequests(
+    ingredientIds: string[],
+    patchBody: Record<string, string | boolean>,
+  ): MenuSequentialRequest[] {
+    const requests: MenuSequentialRequest[] = []
+
+    for (const ingredientId of ingredientIds) {
+      if (resolveProductIdForIngredient(ingredientId)) continue
+
+      const item = itemsWithStatus.value.find(i => i.ingredient.id === ingredientId)
+      if (!item || !isInCatalog(item)) continue
+
+      const categoryId = patchBody.category_id != null
+        ? String(patchBody.category_id)
+        : (item.categoryId || defaultCategoryId.value)
+      const price = Number(item.price)
+      if (!(price > 0 && categoryId)) continue
+
+      const isAvailable = patchBody.is_available !== undefined
+        ? patchBody.is_available === true || patchBody.is_available === 'true'
+        : item.isAvailable
+
+      requests.push({
+        key: `bulk-create-${ingredientId}`,
+        run: () =>
+          $fetch('/api/menu/products', {
+            method: 'POST',
+            body: {
+              name: item.ingredient.name,
+              description: '',
+              price,
+              category_id: categoryId,
+              costo_percibido: item.costoPercibido,
+              is_available: isAvailable,
+              is_resale: true,
+              controla_stock: true,
+              is_combo: false,
+              allow_modifiers: false,
+              recipe_base_ids: [],
+              ingredients: [resaleRecipeRow(item.ingredient)],
+              tenant_id: currentTenant.value?.id || '',
+            },
+          }).then(() => undefined),
+      })
+    }
+
+    return requests
   }
 
   function itemToTableRow(item: ResaleIngredientItemState): ResaleIngredientTableRow {
@@ -622,6 +702,8 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
     rollbackProductsResaleCache,
     resolveProductIdForIngredient,
     linkExistingProductOnItem,
+    refreshProductLinksForBulk,
+    buildBulkCreateRequests,
     buildItemsWithStatus,
   }
 }

--- a/composables/useReventaCatalogDebugLog.ts
+++ b/composables/useReventaCatalogDebugLog.ts
@@ -18,4 +18,16 @@ export function logReventaCatalog(
 ) {
   if (!isReventaCatalogDebugEnabled()) return
   console.log(`[reventa/${scope}]`, phase, payload ?? '')
+
+  if (scope === 'bulk') {
+    const summary = {
+      phase,
+      productIds: payload?.productIds ?? payload?.productIdsForPatch,
+      hasApiPatch: payload?.hasApiPatch ?? payload?.hasApiPatchPreview,
+      productsInCache: payload?.productsInCache,
+      createCount: payload?.createCount,
+      selection: payload?.selection,
+    }
+    console.warn(`[reventa/bulk] ${phase}`, JSON.stringify(summary))
+  }
 }

--- a/pages/menu/reventa/index.vue
+++ b/pages/menu/reventa/index.vue
@@ -536,6 +536,8 @@ const {
   rollbackProductsResaleCache,
   resolveProductIdForIngredient,
   linkExistingProductOnItem,
+  refreshProductLinksForBulk,
+  buildBulkCreateRequests,
   buildItemsWithStatus,
   itemsWithStatus,
 } = useResaleIngredientCatalog(currentTenant)
@@ -871,13 +873,13 @@ async function executeBulkCatalogApply() {
   logBulkApplyState('start')
   await nextTick()
 
+  const selectedIngredientIds = [...selectedIds.value]
   const bodyPreview = buildBulkPatchBody()
   const hasApiPatchPreview = Object.keys(bodyPreview).length > 0
-  const productIdsForPatch = hasApiPatchPreview ? selectedProductIdsForBulkPatch() : []
 
   logBulkApplyState('pre-apply', {
     hasApiPatchPreview,
-    productIdsForPatch,
+    productIdsForPatch: hasApiPatchPreview ? selectedProductIdsForBulkPatch() : [],
     body: bodyPreview,
     selection: bulkPatchSelectionDebug(),
   })
@@ -890,12 +892,18 @@ async function executeBulkCatalogApply() {
 
     const body = buildBulkPatchBody()
     const hasApiPatch = Object.keys(body).length > 0
-    const productIds = hasApiPatch ? productIdsForPatch : []
+    let productIds = hasApiPatch ? selectedProductIdsForBulkPatch() : []
+
+    if (hasApiPatch && productIds.length === 0) {
+      await refreshProductLinksForBulk(selectedIngredientIds)
+      productIds = selectedProductIdsForBulkPatch()
+      logBulkApplyState('retry-resolve', { productIds, body })
+    }
 
     logBulkApplyState('post-apply', { hasApiPatch, productIds, body })
 
     if (hasApiPatch && productIds.length > 0) {
-      for (const ingredientId of selectedIds.value) {
+      for (const ingredientId of selectedIngredientIds) {
         linkExistingProductOnItem(ingredientId)
       }
       logBulkApplyState('will-patch', { productIds, body })
@@ -916,11 +924,29 @@ async function executeBulkCatalogApply() {
       return
     }
 
+    if (hasApiPatch) {
+      const createRequests = buildBulkCreateRequests(selectedIngredientIds, body)
+      logBulkApplyState('create-check', { createCount: createRequests.length, body })
+      if (createRequests.length > 0) {
+        logBulkApplyState('will-create', { createCount: createRequests.length, body })
+        const result = await runSequentialRequests(createRequests)
+        logBulkApplyState('create-done', { result })
+        await refetchCatalog()
+        clearSelection()
+        toastCatalogBulkResult(result, toast, {
+          title: 'Listo',
+          successLabel: 'Productos creados/actualizados',
+          errorMessage: 'No se pudo crear ningún producto en el servidor',
+        })
+        return
+      }
+    }
+
     clearSelection()
 
     if (hasApiPatch && productIds.length === 0) {
       toast.success(
-        'Categoría o estado guardados en la selección. Esos ítems aún no tienen producto en el servidor — usa Modo edición y Guardar para crearlos.',
+        'Categoría o estado guardados en la selección. Falta precio > 0 o producto en servidor — usa Modo edición y Guardar.',
         { title: 'Listo' },
       )
     } else if (bulkInCatalog.value !== '') {


### PR DESCRIPTION
## Summary
- Refetch products and re-resolve IDs before bulk PATCH when the first pass finds none.
- POST create for in-catalog rows with price > 0 when no server product exists.
- Normalized name matching and explicit `console.warn` JSON for bulk debug.

## Test plan
- [ ] Bulk categoría on linked rows → PUT in Network
- [ ] Bulk on new catalog rows with price → POST in Network
- [ ] Console shows `retry-resolve`, `will-patch` or `will-create`


Made with [Cursor](https://cursor.com)