### PR TITLE
fix(menu): reventa bulk list category update

### DIFF
--- a/composables/useResaleIngredientCatalog.ts
+++ b/composables/useResaleIngredientCatalog.ts
@@ -273,6 +273,12 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
       if (item.categoryId === item.originalCategoryId) {
         item.categoryId = serverCategoryId
         item.originalCategoryId = serverCategoryId
+      } else if (item.existingProduct && item.categoryId) {
+        item.existingProduct.category_id = item.categoryId
+        const cat = (categories.value as { id: string, name: string }[]).find(
+          c => c.id === item.categoryId,
+        )
+        if (cat) item.existingProduct.category_name = cat.name
       }
 
       if (!item.isNew && !item.toDelete) {
@@ -344,9 +350,16 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
     return resaleCategory?.id ?? (categories.value as { id: string }[])[0]?.id ?? ''
   })
 
+  function productIdFromRow(product: ResaleProductRow | null | undefined): string | null {
+    if (!product) return null
+    const raw = product.id ?? (product as { product_id?: string }).product_id
+    return raw != null && String(raw) !== '' ? String(raw) : null
+  }
+
   function resolveProductIdForIngredient(ingredientId: string): string | null {
     const item = itemsWithStatus.value.find(i => i.ingredient.id === ingredientId)
-    if (item?.existingProduct?.id) return String(item.existingProduct.id)
+    const onItem = productIdFromRow(item?.existingProduct ?? null)
+    if (onItem) return onItem
 
     const ingredient = item?.ingredient
       ?? (resaleIngredients.value as ResaleIngredientItemState['ingredient'][]).find(
@@ -356,7 +369,53 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
 
     const products = (existingProducts.value || []) as ResaleProductRow[]
     const product = findProductForIngredient(products, ingredient)
-    return product?.id ? String(product.id) : null
+    return productIdFromRow(product)
+  }
+
+  function collectProductIdsForBulkApply(ingredientIds: string[]) {
+    const seen = new Set<string>()
+    const ids: string[] = []
+    const debug: { ingredientId: string, fromItem: string | null, fromResolve: string | null }[] = []
+
+    for (const ingredientId of ingredientIds) {
+      linkExistingProductOnItem(ingredientId)
+      const item = itemsWithStatus.value.find(i => i.ingredient.id === ingredientId)
+      const fromItem = productIdFromRow(item?.existingProduct ?? null)
+      const fromResolve = resolveProductIdForIngredient(ingredientId)
+      const productId = fromItem ?? fromResolve
+      debug.push({ ingredientId, fromItem, fromResolve })
+      if (!productId || seen.has(productId)) continue
+      seen.add(productId)
+      ids.push(productId)
+    }
+
+    logReventaCatalog('catalog', 'collect-bulk-product-ids', { ids, debug })
+    return ids
+  }
+
+  function commitBulkCategoryToItems(ingredientIds: string[], categoryId: string) {
+    if (!categoryId) return
+    const cat = (categories.value as { id: string, name: string }[]).find(c => c.id === categoryId)
+    for (const ingredientId of ingredientIds) {
+      const item = itemsWithStatus.value.find(i => i.ingredient.id === ingredientId)
+      if (!item) continue
+      item.categoryId = categoryId
+      if (item.existingProduct) {
+        item.existingProduct.category_id = categoryId
+        if (cat) item.existingProduct.category_name = cat.name
+      }
+    }
+    itemsWithStatus.value = [...itemsWithStatus.value]
+  }
+
+  function markBulkCategorySaved(ingredientIds: string[]) {
+    for (const ingredientId of ingredientIds) {
+      const item = itemsWithStatus.value.find(i => i.ingredient.id === ingredientId)
+      if (!item) continue
+      item.originalCategoryId = item.categoryId
+      item.originalAvailable = item.isAvailable
+      item.originalPrice = item.price
+    }
   }
 
   function linkExistingProductOnItem(ingredientId: string) {
@@ -438,7 +497,8 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
   function itemToTableRow(item: ResaleIngredientItemState): ResaleIngredientTableRow {
     const p = item.existingProduct
     const cats = categories.value as { id: string, name: string }[]
-    const cat = cats.find(c => c.id === item.categoryId)
+    const effectiveCategoryId = item.categoryId || (p?.category_id ? String(p.category_id) : '')
+    const cat = cats.find(c => c.id === effectiveCategoryId)
     return {
       id: item.ingredient.id,
       _item: item,
@@ -703,6 +763,9 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
     resolveProductIdForIngredient,
     linkExistingProductOnItem,
     refreshProductLinksForBulk,
+    collectProductIdsForBulkApply,
+    commitBulkCategoryToItems,
+    markBulkCategorySaved,
     buildBulkCreateRequests,
     buildItemsWithStatus,
   }

--- a/pages/menu/reventa/index.vue
+++ b/pages/menu/reventa/index.vue
@@ -537,6 +537,9 @@ const {
   resolveProductIdForIngredient,
   linkExistingProductOnItem,
   refreshProductLinksForBulk,
+  collectProductIdsForBulkApply,
+  commitBulkCategoryToItems,
+  markBulkCategorySaved,
   buildBulkCreateRequests,
   buildItemsWithStatus,
   itemsWithStatus,
@@ -827,17 +830,8 @@ function buildBulkPatchBody(): Record<string, string | boolean> {
   return body
 }
 
-/** Product ids on server for selected ingredient rows (recipe link or name match). */
 function selectedProductIdsForBulkPatch() {
-  const seen = new Set<string>()
-  const ids: string[] = []
-  for (const ingredientId of selectedIds.value) {
-    const productId = resolveProductIdForIngredient(ingredientId)
-    if (!productId || seen.has(productId)) continue
-    seen.add(productId)
-    ids.push(productId)
-  }
-  return ids
+  return collectProductIdsForBulkApply(selectedIds.value)
 }
 
 function bulkPatchSelectionDebug() {
@@ -889,14 +883,17 @@ async function executeBulkCatalogApply() {
   try {
     applyBulkInCatalogToSelection()
     applyBulkDraftToSelection()
+    if (bulkCategoryId.value) {
+      commitBulkCategoryToItems(selectedIngredientIds, bulkCategoryId.value)
+    }
 
     const body = buildBulkPatchBody()
     const hasApiPatch = Object.keys(body).length > 0
-    let productIds = hasApiPatch ? selectedProductIdsForBulkPatch() : []
+    let productIds = hasApiPatch ? collectProductIdsForBulkApply(selectedIngredientIds) : []
 
     if (hasApiPatch && productIds.length === 0) {
       await refreshProductLinksForBulk(selectedIngredientIds)
-      productIds = selectedProductIdsForBulkPatch()
+      productIds = collectProductIdsForBulkApply(selectedIngredientIds)
       logBulkApplyState('retry-resolve', { productIds, body })
     }
 
@@ -911,7 +908,11 @@ async function executeBulkCatalogApply() {
       try {
         const result = await runSequentialProductPatches(productIds, () => body)
         logBulkApplyState('patch-done', { result, productIds })
+        markBulkCategorySaved(selectedIngredientIds)
         await refetchCatalog()
+        if (bulkCategoryId.value) {
+          commitBulkCategoryToItems(selectedIngredientIds, bulkCategoryId.value)
+        }
         clearSelection()
         toastCatalogBulkResult(result, toast, {
           title: 'Listo',
@@ -931,7 +932,11 @@ async function executeBulkCatalogApply() {
         logBulkApplyState('will-create', { createCount: createRequests.length, body })
         const result = await runSequentialRequests(createRequests)
         logBulkApplyState('create-done', { result })
+        markBulkCategorySaved(selectedIngredientIds)
         await refetchCatalog()
+        if (bulkCategoryId.value) {
+          commitBulkCategoryToItems(selectedIngredientIds, bulkCategoryId.value)
+        }
         clearSelection()
         toastCatalogBulkResult(result, toast, {
           title: 'Listo',
@@ -942,11 +947,15 @@ async function executeBulkCatalogApply() {
       }
     }
 
+    if (bulkCategoryId.value) {
+      commitBulkCategoryToItems(selectedIngredientIds, bulkCategoryId.value)
+    }
+
     clearSelection()
 
     if (hasApiPatch && productIds.length === 0) {
       toast.success(
-        'Categoría o estado guardados en la selección. Falta precio > 0 o producto en servidor — usa Modo edición y Guardar.',
+        'Categoría aplicada en la lista. Para guardar en servidor: precio > 0 y producto creado (Modo edición → Guardar).',
         { title: 'Listo' },
       )
     } else if (bulkInCatalog.value !== '') {


### PR DESCRIPTION
## Summary
- Fix list not showing bulk category (prefer item.categoryId over stale product category_name).
- Robust product id collection with collect-bulk-product-ids debug log.
- Commit category to UI after apply; mark originals after successful PATCH/POST.

## Test plan
- [ ] Bulk categoría → column updates immediately
- [ ] Console: collect-bulk-product-ids with non-empty ids → will-patch
- [ ] Network PUT when products exist


Made with [Cursor](https://cursor.com)