### PR TITLE
fix(menu): reventa bulk catalog/availability persist

### DIFF
--- a/composables/useResaleIngredientCatalog.ts
+++ b/composables/useResaleIngredientCatalog.ts
@@ -200,40 +200,61 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
   )
   const fetchError = computed(() => ingredientsError.value || productsError.value)
 
+  function buildItemStateFromIngredient(
+    ingredient: ResaleIngredientItemState['ingredient'],
+    products: NonNullable<ResaleIngredientItemState['existingProduct']>[],
+  ): ResaleIngredientItemState {
+    const existingProduct = findProductForIngredient(products, ingredient)
+
+    const price = existingProduct ? Number(existingProduct.price) : 0
+    const isAvailable = existingProduct
+      ? normalizeCatalogBoolean(existingProduct.is_available)
+      : true
+    const costoPercibido =
+      existingProduct?.costo_percibido != null && existingProduct.costo_percibido !== ''
+        ? Number(existingProduct.costo_percibido)
+        : null
+    const categoryId = existingProduct?.category_id
+      ? String(existingProduct.category_id)
+      : ''
+
+    return {
+      ingredient,
+      existingProduct,
+      price,
+      costoPercibido,
+      categoryId,
+      isAvailable,
+      isActive: !!existingProduct,
+      isNew: false,
+      toDelete: false,
+      originalPrice: price,
+      originalAvailable: isAvailable,
+      originalCostoPercibido: costoPercibido,
+      originalCategoryId: categoryId,
+    }
+  }
+
   function buildItemsWithStatus() {
     const products = (existingProducts.value || []) as NonNullable<ResaleIngredientItemState['existingProduct']>[]
+    itemsWithStatus.value = (resaleIngredients.value as ResaleIngredientItemState['ingredient'][]).map(
+      ingredient => buildItemStateFromIngredient(ingredient, products),
+    )
+  }
 
-    itemsWithStatus.value = (resaleIngredients.value as ResaleIngredientItemState['ingredient'][]).map((ingredient) => {
-      const existingProduct = findProductForIngredient(products, ingredient)
+  function appendNewIngredientsFromServer() {
+    const products = (existingProducts.value || []) as NonNullable<ResaleIngredientItemState['existingProduct']>[]
+    const known = new Set(itemsWithStatus.value.map(i => i.ingredient.id))
+    const added: ResaleIngredientItemState[] = []
 
-      const price = existingProduct ? Number(existingProduct.price) : 0
-      const isAvailable = existingProduct
-        ? normalizeCatalogBoolean(existingProduct.is_available)
-        : true
-      const costoPercibido =
-        existingProduct?.costo_percibido != null && existingProduct.costo_percibido !== ''
-          ? Number(existingProduct.costo_percibido)
-          : null
-      const categoryId = existingProduct?.category_id
-        ? String(existingProduct.category_id)
-        : ''
+    for (const ingredient of resaleIngredients.value as ResaleIngredientItemState['ingredient'][]) {
+      if (known.has(ingredient.id)) continue
+      added.push(buildItemStateFromIngredient(ingredient, products))
+    }
 
-      return {
-        ingredient,
-        existingProduct,
-        price,
-        costoPercibido,
-        categoryId,
-        isAvailable,
-        isActive: !!existingProduct,
-        isNew: false,
-        toDelete: false,
-        originalPrice: price,
-        originalAvailable: isAvailable,
-        originalCostoPercibido: costoPercibido,
-        originalCategoryId: categoryId,
-      }
-    })
+    if (added.length > 0) {
+      itemsWithStatus.value = [...itemsWithStatus.value, ...added]
+    }
   }
 
   function mergeServerIntoLocalItems() {
@@ -326,11 +347,12 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
 
   function syncItemsFromServer() {
     if (!catalogReady.value) return
-    if (hasChanges.value) {
-      mergeServerIntoLocalItems()
-    } else {
+    if (itemsWithStatus.value.length === 0) {
       buildItemsWithStatus()
+      return
     }
+    mergeServerIntoLocalItems()
+    appendNewIngredientsFromServer()
   }
 
   watch([resaleIngredients, existingProducts, catalogReady], () => {
@@ -356,7 +378,25 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
     return raw != null && String(raw) !== '' ? String(raw) : null
   }
 
+  /** Precomputed map: resale ingredient id → server product id */
+  const ingredientToProductId = computed(() => {
+    const map = new Map<string, string>()
+    const products = (existingProducts.value || []) as ResaleProductRow[]
+    const ingredients = resaleIngredients.value as ResaleIngredientItemState['ingredient'][]
+
+    for (const ingredient of ingredients) {
+      const product = findProductForIngredient(products, ingredient)
+      const pid = productIdFromRow(product)
+      if (pid) map.set(normalizeEntityId(ingredient.id), pid)
+    }
+
+    return map
+  })
+
   function resolveProductIdForIngredient(ingredientId: string): string | null {
+    const mapped = ingredientToProductId.value.get(normalizeEntityId(ingredientId))
+    if (mapped) return mapped
+
     const item = itemsWithStatus.value.find(i => i.ingredient.id === ingredientId)
     const onItem = productIdFromRow(item?.existingProduct ?? null)
     if (onItem) return onItem
@@ -380,10 +420,11 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
     for (const ingredientId of ingredientIds) {
       linkExistingProductOnItem(ingredientId)
       const item = itemsWithStatus.value.find(i => i.ingredient.id === ingredientId)
+      const fromMap = ingredientToProductId.value.get(normalizeEntityId(ingredientId)) ?? null
       const fromItem = productIdFromRow(item?.existingProduct ?? null)
       const fromResolve = resolveProductIdForIngredient(ingredientId)
-      const productId = fromItem ?? fromResolve
-      debug.push({ ingredientId, fromItem, fromResolve })
+      const productId = fromMap ?? fromItem ?? fromResolve
+      debug.push({ ingredientId, fromMap, fromItem, fromResolve, productId })
       if (!productId || seen.has(productId)) continue
       seen.add(productId)
       ids.push(productId)
@@ -408,6 +449,41 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
     itemsWithStatus.value = [...itemsWithStatus.value]
   }
 
+  function commitBulkAvailabilityToItems(ingredientIds: string[], isAvailable: boolean) {
+    for (const ingredientId of ingredientIds) {
+      const item = itemsWithStatus.value.find(i => i.ingredient.id === ingredientId)
+      if (!item) continue
+      item.isAvailable = isAvailable
+      if (item.existingProduct) {
+        item.existingProduct.is_available = isAvailable
+      }
+    }
+    itemsWithStatus.value = [...itemsWithStatus.value]
+  }
+
+  function applyBulkCatalogToSelection(ingredientIds: string[], wantInCatalog: boolean) {
+    for (const ingredientId of ingredientIds) {
+      const item = itemsWithStatus.value.find(i => i.ingredient.id === ingredientId)
+      if (!item || isInCatalog(item) === wantInCatalog) continue
+
+      if (wantInCatalog) {
+        item.isActive = true
+        item.toDelete = false
+        if (!item.existingProduct) {
+          item.isNew = true
+          if (!item.categoryId) item.categoryId = defaultCategoryId.value
+        }
+      } else if (item.existingProduct) {
+        item.toDelete = true
+        item.isActive = false
+      } else {
+        item.isActive = false
+        item.isNew = false
+      }
+    }
+    itemsWithStatus.value = [...itemsWithStatus.value]
+  }
+
   function markBulkCategorySaved(ingredientIds: string[]) {
     for (const ingredientId of ingredientIds) {
       const item = itemsWithStatus.value.find(i => i.ingredient.id === ingredientId)
@@ -420,24 +496,23 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
 
   function linkExistingProductOnItem(ingredientId: string) {
     const item = itemsWithStatus.value.find(i => i.ingredient.id === ingredientId)
-    if (!item || item.existingProduct?.id) return
+    if (!item) return
+    if (productIdFromRow(item.existingProduct)) return
     const products = (existingProducts.value || []) as ResaleProductRow[]
     const product = findProductForIngredient(products, item.ingredient)
     if (product) item.existingProduct = product
   }
 
-  async function refreshProductLinksForBulk(ingredientIds: string[]) {
-    logReventaCatalog('catalog', 'bulk-refresh-products-start', {
+  /** Link from cache only — no refetch (refetch was wiping bulk catalog/availability toggles). */
+  function linkProductsForBulkFromCache(ingredientIds: string[]) {
+    logReventaCatalog('catalog', 'bulk-link-from-cache', {
       ingredientIds,
       productsInCache: (existingProducts.value as unknown[])?.length ?? 0,
     })
-    cache.invalidateQueries({ key: ['menu', 'products-resale', tenantId.value] })
-    await refetchProducts()
     for (const ingredientId of ingredientIds) {
       linkExistingProductOnItem(ingredientId)
     }
-    logReventaCatalog('catalog', 'bulk-refresh-products-done', {
-      productsInCache: (existingProducts.value as unknown[])?.length ?? 0,
+    logReventaCatalog('catalog', 'bulk-link-from-cache-done', {
       resolved: ingredientIds.map(id => ({
         ingredientId: id,
         productId: resolveProductIdForIngredient(id),
@@ -460,7 +535,7 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
       const categoryId = patchBody.category_id != null
         ? String(patchBody.category_id)
         : (item.categoryId || defaultCategoryId.value)
-      const price = Number(item.price)
+      const price = Number(item.price) || Number(item.existingProduct?.price) || 0
       if (!(price > 0 && categoryId)) continue
 
       const isAvailable = patchBody.is_available !== undefined
@@ -762,9 +837,11 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
     rollbackProductsResaleCache,
     resolveProductIdForIngredient,
     linkExistingProductOnItem,
-    refreshProductLinksForBulk,
+    linkProductsForBulkFromCache,
     collectProductIdsForBulkApply,
     commitBulkCategoryToItems,
+    commitBulkAvailabilityToItems,
+    applyBulkCatalogToSelection,
     markBulkCategorySaved,
     buildBulkCreateRequests,
     buildItemsWithStatus,

--- a/composables/useReventaCatalogDebugLog.ts
+++ b/composables/useReventaCatalogDebugLog.ts
@@ -19,15 +19,16 @@ export function logReventaCatalog(
   if (!isReventaCatalogDebugEnabled()) return
   console.log(`[reventa/${scope}]`, phase, payload ?? '')
 
-  if (scope === 'bulk') {
+  if (scope === 'bulk' || (scope === 'catalog' && phase === 'collect-bulk-product-ids')) {
     const summary = {
       phase,
       productIds: payload?.productIds ?? payload?.productIdsForPatch,
       hasApiPatch: payload?.hasApiPatch ?? payload?.hasApiPatchPreview,
       productsInCache: payload?.productsInCache,
       createCount: payload?.createCount,
+      debug: payload?.debug,
       selection: payload?.selection,
     }
-    console.warn(`[reventa/bulk] ${phase}`, JSON.stringify(summary))
+    console.warn(`[reventa/${scope}] ${phase}`, JSON.stringify(summary))
   }
 }

--- a/pages/menu/reventa/index.vue
+++ b/pages/menu/reventa/index.vue
@@ -96,6 +96,7 @@
           </template>
 
           <UiResponsiveDataView
+            :key="tableRefreshKey"
             :columns="productosTableColumns"
             :data="displayTableRows"
             :row-class="getRowClass"
@@ -458,7 +459,8 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, onUnmounted, watch } from 'vue'
+import { definePageMeta, useHead } from '#imports'
+import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
 import { useQueryCache } from '@pinia/colada'
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
@@ -513,6 +515,14 @@ const {
 const showBulkDeleteModal = ref(false)
 const bulkDeleteError = ref('')
 const bannerDismissed = ref(false)
+const tableRefreshKey = ref(0)
+
+function finalizeBulkUiAfterApply(categoryId: string) {
+  if (categoryId && categoryFilter.value && categoryFilter.value !== categoryId) {
+    categoryFilter.value = ''
+  }
+  tableRefreshKey.value += 1
+}
 
 const {
   categories,
@@ -536,9 +546,11 @@ const {
   rollbackProductsResaleCache,
   resolveProductIdForIngredient,
   linkExistingProductOnItem,
-  refreshProductLinksForBulk,
+  linkProductsForBulkFromCache,
   collectProductIdsForBulkApply,
   commitBulkCategoryToItems,
+  commitBulkAvailabilityToItems,
+  applyBulkCatalogToSelection,
   markBulkCategorySaved,
   buildBulkCreateRequests,
   buildItemsWithStatus,
@@ -800,12 +812,7 @@ const selectedProductIds = computed(() =>
 
 function applyBulkInCatalogToSelection() {
   if (bulkInCatalog.value === '') return
-  const wantInCatalog = bulkInCatalog.value === 'true'
-  for (const ingredientId of selectedIds.value) {
-    const item = findItemByIngredientId(ingredientId)
-    if (!item || isInCatalog(item) === wantInCatalog) continue
-    onToggleCatalog(item)
-  }
+  applyBulkCatalogToSelection(selectedIds.value, bulkInCatalog.value === 'true')
 }
 
 function applyBulkDraftToSelection() {
@@ -883,18 +890,25 @@ async function executeBulkCatalogApply() {
   try {
     applyBulkInCatalogToSelection()
     applyBulkDraftToSelection()
-    if (bulkCategoryId.value) {
-      commitBulkCategoryToItems(selectedIngredientIds, bulkCategoryId.value)
-    }
+    const appliedCategoryId = bulkCategoryId.value
+    const appliedAvailability = bulkAvailability.value
+    const appliedInCatalog = bulkInCatalog.value
 
     const body = buildBulkPatchBody()
     const hasApiPatch = Object.keys(body).length > 0
     let productIds = hasApiPatch ? collectProductIdsForBulkApply(selectedIngredientIds) : []
 
     if (hasApiPatch && productIds.length === 0) {
-      await refreshProductLinksForBulk(selectedIngredientIds)
+      linkProductsForBulkFromCache(selectedIngredientIds)
       productIds = collectProductIdsForBulkApply(selectedIngredientIds)
       logBulkApplyState('retry-resolve', { productIds, body })
+    }
+
+    if (appliedCategoryId) {
+      commitBulkCategoryToItems(selectedIngredientIds, appliedCategoryId)
+    }
+    if (appliedAvailability !== '') {
+      commitBulkAvailabilityToItems(selectedIngredientIds, appliedAvailability === 'true')
     }
 
     logBulkApplyState('post-apply', { hasApiPatch, productIds, body })
@@ -910,8 +924,9 @@ async function executeBulkCatalogApply() {
         logBulkApplyState('patch-done', { result, productIds })
         markBulkCategorySaved(selectedIngredientIds)
         await refetchCatalog()
-        if (bulkCategoryId.value) {
-          commitBulkCategoryToItems(selectedIngredientIds, bulkCategoryId.value)
+        if (appliedCategoryId) {
+          commitBulkCategoryToItems(selectedIngredientIds, appliedCategoryId)
+          finalizeBulkUiAfterApply(appliedCategoryId)
         }
         clearSelection()
         toastCatalogBulkResult(result, toast, {
@@ -934,8 +949,9 @@ async function executeBulkCatalogApply() {
         logBulkApplyState('create-done', { result })
         markBulkCategorySaved(selectedIngredientIds)
         await refetchCatalog()
-        if (bulkCategoryId.value) {
-          commitBulkCategoryToItems(selectedIngredientIds, bulkCategoryId.value)
+        if (appliedCategoryId) {
+          commitBulkCategoryToItems(selectedIngredientIds, appliedCategoryId)
+          finalizeBulkUiAfterApply(appliedCategoryId)
         }
         clearSelection()
         toastCatalogBulkResult(result, toast, {
@@ -947,20 +963,26 @@ async function executeBulkCatalogApply() {
       }
     }
 
-    if (bulkCategoryId.value) {
-      commitBulkCategoryToItems(selectedIngredientIds, bulkCategoryId.value)
+    if (appliedCategoryId) {
+      commitBulkCategoryToItems(selectedIngredientIds, appliedCategoryId)
+      finalizeBulkUiAfterApply(appliedCategoryId)
+    } else if (appliedAvailability !== '' || appliedInCatalog !== '') {
+      tableRefreshKey.value += 1
     }
-
-    clearSelection()
 
     if (hasApiPatch && productIds.length === 0) {
       toast.success(
-        'Categoría aplicada en la lista. Para guardar en servidor: precio > 0 y producto creado (Modo edición → Guardar).',
+        'Cambios aplicados en la lista. Para guardar en servidor: precio > 0 y producto creado (Modo edición → Guardar).',
         { title: 'Listo' },
       )
-    } else if (bulkInCatalog.value !== '') {
+    } else if (appliedInCatalog !== '') {
       toast.success(
         'En catálogo actualizado en la selección. Usa Modo edición y Guardar para persistir productos nuevos o eliminados.',
+        { title: 'Listo' },
+      )
+    } else if (appliedAvailability !== '') {
+      toast.success(
+        'Estado actualizado en la selección. Usa Modo edición y Guardar si el producto aún no está en el servidor.',
         { title: 'Listo' },
       )
     } else {
@@ -969,6 +991,8 @@ async function executeBulkCatalogApply() {
         { title: 'Listo' },
       )
     }
+
+    clearSelection()
   } catch (error: unknown) {
     rollbackProductsResaleCache(cacheSnapshot)
     const message = error instanceof Error ? error.message : 'Por favor intenta de nuevo.'


### PR DESCRIPTION
## Summary
- Fix bulk En catálogo and Estado flashing then reverting after apply.
- syncItemsFromServer merges instead of rebuilding when rows exist.
- Replace bulk refetch with cache-only product linking.
- Commit availability/catalog UI state; fix toasts after clearSelection.

## Test plan
- [ ] Bulk Estado / En catálogo on selected rows — toggles stay visible
- [ ] Bulk Categoría still updates column
- [ ] No regression on availability toggle refetch


Made with [Cursor](https://cursor.com)