### PR TITLE
fix(menu): reventa bulk estado and en catálogo persist to server

### DIFF
--- a/composables/useResaleIngredientCatalog.ts
+++ b/composables/useResaleIngredientCatalog.ts
@@ -84,27 +84,52 @@ function normalizeResaleName(name: string): string {
     .trim()
 }
 
-/** Match resale product by recipe ingredient_id, then by normalized name. */
+function recipeIngredientIdFromRow(ing: {
+  ingredient_id?: string
+  ingredientId?: string
+  id?: string
+}): string | null {
+  const raw = ing.ingredient_id ?? ing.ingredientId ?? ing.id
+  return raw != null && String(raw) !== '' ? normalizeEntityId(raw) : null
+}
+
+function namesLooselyMatch(ingredientName: string, productName: string): boolean {
+  const a = normalizeResaleName(ingredientName)
+  const b = normalizeResaleName(productName)
+  if (!a || !b) return false
+  if (a === b) return true
+  if (a.length >= 4 && b.includes(a)) return true
+  if (b.length >= 4 && a.includes(b)) return true
+  const tokens = a.split(' ').filter(t => t.length > 2)
+  return tokens.length > 0 && tokens.every(t => b.includes(t))
+}
+
+/** Match resale product by recipe ingredient_id, then by normalized / loose name. */
 function findProductForIngredient(
   products: ResaleProductRow[],
   ingredient: { id: string, name: string },
 ): ResaleProductRow | null {
   const ingId = normalizeEntityId(ingredient.id)
-  const ingName = normalizeResaleName(ingredient.name)
+  const ingName = ingredient.name ?? ''
   let nameFallback: ResaleProductRow | null = null
+  let looseFallback: ResaleProductRow | null = null
 
   for (const p of products) {
     if (!p?.id) continue
-    if (p.ingredients?.some(ing => normalizeEntityId(ing.ingredient_id) === ingId)) {
+    if (p.ingredients?.some(ing => recipeIngredientIdFromRow(ing) === ingId)) {
       return p
     }
-    const productName = normalizeResaleName(p.name ?? '')
-    if (ingName && productName && productName === ingName && !nameFallback) {
-      nameFallback = p
+    const productName = p.name ?? ''
+    if (ingName && namesLooselyMatch(ingName, productName)) {
+      if (normalizeResaleName(ingName) === normalizeResaleName(productName)) {
+        nameFallback = p
+      } else if (!looseFallback) {
+        looseFallback = p
+      }
     }
   }
 
-  return nameFallback
+  return nameFallback ?? looseFallback
 }
 
 /** GET /menu/products caps limit at 250 — paginate to load full resale mapping. */
@@ -205,8 +230,9 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
     products: NonNullable<ResaleIngredientItemState['existingProduct']>[],
   ): ResaleIngredientItemState {
     const existingProduct = findProductForIngredient(products, ingredient)
+    const listPrice = Number((ingredient as { price?: number }).price) || 0
 
-    const price = existingProduct ? Number(existingProduct.price) : 0
+    const price = existingProduct ? Number(existingProduct.price) : (listPrice > 0 ? listPrice : 0)
     const isAvailable = existingProduct
       ? normalizeCatalogBoolean(existingProduct.is_available)
       : true
@@ -412,10 +438,64 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
     return productIdFromRow(product)
   }
 
-  function collectProductIdsForBulkApply(ingredientIds: string[]) {
+  function mergeProductIntoResaleCache(product: ResaleProductRow) {
+    const pid = productIdFromRow(product)
+    if (!pid) return
+    const key = productsResaleCacheKey()
+    const snapshot = cache.getQueryData<ProductsResaleCache>(key)
+    if (!snapshot?.data?.some(p => productIdFromRow(p) === pid)) {
+      cache.setQueryData(key, {
+        data: [...(snapshot?.data ?? []), product],
+        total: (snapshot?.total ?? snapshot?.data?.length ?? 0) + 1,
+      })
+    }
+    mergeServerIntoLocalItems()
+  }
+
+  async function searchProductIdForIngredient(
+    ingredient: ResaleIngredientItemState['ingredient'],
+  ): Promise<string | null> {
+    const name = (ingredient.name ?? '').trim()
+    if (!name) return null
+
+    try {
+      const res = await $fetch<{ data?: ResaleProductRow[], total?: number }>(
+        '/api/menu/products',
+        {
+          query: {
+            search: name,
+            is_resale: 'true',
+            include_ingredients: 'true',
+            limit: 10,
+          },
+        },
+      )
+      const chunk = res?.data ?? []
+      const matched = findProductForIngredient(chunk, ingredient)
+      const pid = productIdFromRow(matched)
+      if (pid && matched) {
+        mergeProductIntoResaleCache(matched)
+        linkExistingProductOnItem(ingredient.id)
+        return pid
+      }
+    } catch {
+      return null
+    }
+    return null
+  }
+
+  async function collectProductIdsForBulkApply(ingredientIds: string[]) {
     const seen = new Set<string>()
     const ids: string[] = []
-    const debug: { ingredientId: string, fromItem: string | null, fromResolve: string | null }[] = []
+    const debug: {
+      ingredientId: string
+      ingredientName: string | null
+      fromMap: string | null
+      fromItem: string | null
+      fromResolve: string | null
+      fromSearch: string | null
+      productId: string | null
+    }[] = []
 
     for (const ingredientId of ingredientIds) {
       linkExistingProductOnItem(ingredientId)
@@ -423,14 +503,39 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
       const fromMap = ingredientToProductId.value.get(normalizeEntityId(ingredientId)) ?? null
       const fromItem = productIdFromRow(item?.existingProduct ?? null)
       const fromResolve = resolveProductIdForIngredient(ingredientId)
-      const productId = fromMap ?? fromItem ?? fromResolve
-      debug.push({ ingredientId, fromMap, fromItem, fromResolve, productId })
+      let productId = fromMap ?? fromItem ?? fromResolve
+      let fromSearch: string | null = null
+
+      if (!productId && item?.ingredient) {
+        fromSearch = await searchProductIdForIngredient(item.ingredient)
+        productId = fromSearch
+      }
+
+      debug.push({
+        ingredientId,
+        ingredientName: item?.ingredient.name ?? null,
+        fromMap,
+        fromItem,
+        fromResolve,
+        fromSearch,
+        productId,
+      })
       if (!productId || seen.has(productId)) continue
       seen.add(productId)
       ids.push(productId)
     }
 
-    logReventaCatalog('catalog', 'collect-bulk-product-ids', { ids, debug })
+    const products = (existingProducts.value || []) as ResaleProductRow[]
+    logReventaCatalog('catalog', 'collect-bulk-product-ids', {
+      ids,
+      debug,
+      mapSize: ingredientToProductId.value.size,
+      productsInCache: products.map(p => ({
+        id: productIdFromRow(p),
+        name: p.name,
+        recipeIds: (p.ingredients ?? []).map(ing => recipeIngredientIdFromRow(ing)).filter(Boolean),
+      })),
+    })
     return ids
   }
 
@@ -484,14 +589,32 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
     itemsWithStatus.value = [...itemsWithStatus.value]
   }
 
-  function markBulkCategorySaved(ingredientIds: string[]) {
+  function markBulkFieldsSaved(ingredientIds: string[]) {
     for (const ingredientId of ingredientIds) {
       const item = itemsWithStatus.value.find(i => i.ingredient.id === ingredientId)
       if (!item) continue
       item.originalCategoryId = item.categoryId
       item.originalAvailable = item.isAvailable
       item.originalPrice = item.price
+      item.isNew = false
+      item.toDelete = false
     }
+    itemsWithStatus.value = [...itemsWithStatus.value]
+  }
+
+  /** @deprecated alias — use markBulkFieldsSaved */
+  const markBulkCategorySaved = markBulkFieldsSaved
+
+  function selectionNeedsPriceForCreate(ingredientIds: string[]): string[] {
+    const names: string[] = []
+    const idSet = new Set(ingredientIds)
+    for (const item of itemsWithStatus.value) {
+      if (!idSet.has(item.ingredient.id) || !item.isNew || !isInCatalog(item)) continue
+      if (!(Number(item.price) > 0) || !item.categoryId) {
+        names.push(item.ingredient.name)
+      }
+    }
+    return names
   }
 
   function linkExistingProductOnItem(ingredientId: string) {
@@ -535,7 +658,8 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
       const categoryId = patchBody.category_id != null
         ? String(patchBody.category_id)
         : (item.categoryId || defaultCategoryId.value)
-      const price = Number(item.price) || Number(item.existingProduct?.price) || 0
+      const listPrice = Number((item.ingredient as { price?: number }).price) || 0
+      const price = Number(item.price) || Number(item.existingProduct?.price) || listPrice || 0
       if (!(price > 0 && categoryId)) continue
 
       const isAvailable = patchBody.is_available !== undefined
@@ -700,12 +824,16 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
     buildItemsWithStatus()
   }
 
-  function buildResaleSaveRequests(): {
+  function buildResaleSaveRequests(ingredientIds?: string[]): {
     creates: MenuSequentialRequest[]
     updates: MenuSequentialRequest[]
     deletes: MenuSequentialRequest[]
   } {
-    const creates: MenuSequentialRequest[] = toCreate.value.map(item => ({
+    const idSet = ingredientIds ? new Set(ingredientIds) : null
+    const inScope = (item: ResaleIngredientItemState) =>
+      !idSet || idSet.has(item.ingredient.id)
+
+    const creates: MenuSequentialRequest[] = toCreate.value.filter(inScope).map(item => ({
       key: `create-${item.ingredient.id}`,
       run: () =>
         $fetch('/api/menu/products', {
@@ -728,7 +856,7 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
         }).then(() => undefined),
     }))
 
-    const updates: MenuSequentialRequest[] = toUpdate.value.map((item) => {
+    const updates: MenuSequentialRequest[] = toUpdate.value.filter(inScope).map((item) => {
       const existingRecipe = item.existingProduct?.ingredients?.[0]
       const body: Record<string, unknown> = {
         price: item.price,
@@ -749,7 +877,7 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
       }
     })
 
-    const deletes: MenuSequentialRequest[] = toDeleteList.value.map(item => ({
+    const deletes: MenuSequentialRequest[] = toDeleteList.value.filter(inScope).map(item => ({
       key: `delete-${item.existingProduct!.id}`,
       run: () =>
         $fetch(`/api/menu/products/${item.existingProduct!.id}`, {
@@ -758,6 +886,49 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
     }))
 
     return { creates, updates, deletes }
+  }
+
+  async function saveBulkCatalogSelection(ingredientIds: string[]) {
+    const blockedNames = selectionNeedsPriceForCreate(ingredientIds)
+    if (blockedNames.length > 0) {
+      return {
+        ok: 0,
+        fail: 0,
+        blocked: true as const,
+        message: `Precio > 0 y categoría requeridos: ${blockedNames.slice(0, 3).join(', ')}${blockedNames.length > 3 ? '…' : ''}`,
+      }
+    }
+
+    const { creates, updates, deletes } = buildResaleSaveRequests(ingredientIds)
+    const total = creates.length + updates.length + deletes.length
+    if (total === 0) {
+      return { ok: 0, fail: 0, empty: true as const }
+    }
+
+    logReventaCatalog('catalog', 'will-save-catalog', {
+      ingredientIds,
+      createCount: creates.length,
+      updateCount: updates.length,
+      deleteCount: deletes.length,
+    })
+
+    const createResult = creates.length ? await runConcurrentRequests(creates) : { ok: 0, fail: 0 }
+    const updateResult = updates.length ? await runConcurrentRequests(updates) : { ok: 0, fail: 0 }
+    const deleteResult = deletes.length ? await runConcurrentRequests(deletes) : { ok: 0, fail: 0 }
+
+    logReventaCatalog('catalog', 'save-catalog-done', {
+      create: createResult,
+      update: updateResult,
+      delete: deleteResult,
+    })
+
+    markBulkFieldsSaved(ingredientIds)
+    await refetchCatalog()
+
+    return {
+      ok: createResult.ok + updateResult.ok + deleteResult.ok,
+      fail: createResult.fail + updateResult.fail + deleteResult.fail,
+    }
   }
 
   async function refetchCatalog() {
@@ -843,6 +1014,9 @@ export function useResaleIngredientCatalog(currentTenant: Ref<{ id: string } | n
     commitBulkAvailabilityToItems,
     applyBulkCatalogToSelection,
     markBulkCategorySaved,
+    markBulkFieldsSaved,
+    saveBulkCatalogSelection,
+    selectionNeedsPriceForCreate,
     buildBulkCreateRequests,
     buildItemsWithStatus,
   }

--- a/composables/useReventaCatalogDebugLog.ts
+++ b/composables/useReventaCatalogDebugLog.ts
@@ -19,7 +19,14 @@ export function logReventaCatalog(
   if (!isReventaCatalogDebugEnabled()) return
   console.log(`[reventa/${scope}]`, phase, payload ?? '')
 
-  if (scope === 'bulk' || (scope === 'catalog' && phase === 'collect-bulk-product-ids')) {
+  if (
+    scope === 'bulk'
+    || (scope === 'catalog' && (
+      phase === 'collect-bulk-product-ids'
+      || phase === 'will-save-catalog'
+      || phase === 'save-catalog-done'
+    ))
+  ) {
     const summary = {
       phase,
       productIds: payload?.productIds ?? payload?.productIdsForPatch,

--- a/pages/menu/reventa/index.vue
+++ b/pages/menu/reventa/index.vue
@@ -551,7 +551,8 @@ const {
   commitBulkCategoryToItems,
   commitBulkAvailabilityToItems,
   applyBulkCatalogToSelection,
-  markBulkCategorySaved,
+  markBulkFieldsSaved,
+  saveBulkCatalogSelection,
   buildBulkCreateRequests,
   buildItemsWithStatus,
   itemsWithStatus,
@@ -837,10 +838,6 @@ function buildBulkPatchBody(): Record<string, string | boolean> {
   return body
 }
 
-function selectedProductIdsForBulkPatch() {
-  return collectProductIdsForBulkApply(selectedIds.value)
-}
-
 function bulkPatchSelectionDebug() {
   return selectedIds.value.map((ingredientId) => {
     const item = findItemByIngredientId(ingredientId)
@@ -867,6 +864,26 @@ function logBulkApplyState(phase: string, extra: Record<string, unknown> = {}) {
   })
 }
 
+async function persistBulkCatalogSelection(
+  ingredientIds: string[],
+): Promise<'saved' | 'blocked' | 'empty'> {
+  const result = await saveBulkCatalogSelection(ingredientIds)
+  if (result && 'blocked' in result && result.blocked) {
+    toast.warning(result.message, { title: 'En catálogo no guardado' })
+    return 'blocked'
+  }
+  if (result && 'empty' in result && result.empty) return 'empty'
+  if (result && result.ok + result.fail > 0) {
+    toastCatalogBulkResult(result, toast, {
+      title: 'Listo',
+      successLabel: 'Catálogo actualizado',
+      errorMessage: 'No se pudo guardar el catálogo en el servidor',
+    })
+    return 'saved'
+  }
+  return 'empty'
+}
+
 async function executeBulkCatalogApply() {
   if (!canBulkApply.value || isBulkBarSubmitting.value) return
 
@@ -880,12 +897,12 @@ async function executeBulkCatalogApply() {
 
   logBulkApplyState('pre-apply', {
     hasApiPatchPreview,
-    productIdsForPatch: hasApiPatchPreview ? selectedProductIdsForBulkPatch() : [],
     body: bodyPreview,
     selection: bulkPatchSelectionDebug(),
   })
 
   let cacheSnapshot: ReturnType<typeof optimisticPatchProductsResale> | undefined
+  let serverWriteDone = false
 
   try {
     applyBulkInCatalogToSelection()
@@ -896,12 +913,15 @@ async function executeBulkCatalogApply() {
 
     const body = buildBulkPatchBody()
     const hasApiPatch = Object.keys(body).length > 0
-    let productIds = hasApiPatch ? collectProductIdsForBulkApply(selectedIngredientIds) : []
+    let productIds: string[] = []
 
-    if (hasApiPatch && productIds.length === 0) {
-      linkProductsForBulkFromCache(selectedIngredientIds)
-      productIds = collectProductIdsForBulkApply(selectedIngredientIds)
-      logBulkApplyState('retry-resolve', { productIds, body })
+    if (hasApiPatch) {
+      productIds = await collectProductIdsForBulkApply(selectedIngredientIds)
+      if (productIds.length === 0) {
+        linkProductsForBulkFromCache(selectedIngredientIds)
+        productIds = await collectProductIdsForBulkApply(selectedIngredientIds)
+        logBulkApplyState('retry-resolve', { productIds, body })
+      }
     }
 
     if (appliedCategoryId) {
@@ -922,17 +942,21 @@ async function executeBulkCatalogApply() {
       try {
         const result = await runSequentialProductPatches(productIds, () => body)
         logBulkApplyState('patch-done', { result, productIds })
-        markBulkCategorySaved(selectedIngredientIds)
+        markBulkFieldsSaved(selectedIngredientIds)
         await refetchCatalog()
         if (appliedCategoryId) {
           commitBulkCategoryToItems(selectedIngredientIds, appliedCategoryId)
           finalizeBulkUiAfterApply(appliedCategoryId)
         }
-        clearSelection()
+        serverWriteDone = result.ok > 0
         toastCatalogBulkResult(result, toast, {
           title: 'Listo',
           errorMessage: 'No se pudo actualizar ningún producto',
         })
+        if (appliedInCatalog !== '') {
+          await persistBulkCatalogSelection(selectedIngredientIds)
+        }
+        clearSelection()
       } catch (error) {
         rollbackProductsResaleCache(cacheSnapshot)
         throw error
@@ -947,18 +971,38 @@ async function executeBulkCatalogApply() {
         logBulkApplyState('will-create', { createCount: createRequests.length, body })
         const result = await runSequentialRequests(createRequests)
         logBulkApplyState('create-done', { result })
-        markBulkCategorySaved(selectedIngredientIds)
+        markBulkFieldsSaved(selectedIngredientIds)
         await refetchCatalog()
         if (appliedCategoryId) {
           commitBulkCategoryToItems(selectedIngredientIds, appliedCategoryId)
           finalizeBulkUiAfterApply(appliedCategoryId)
         }
-        clearSelection()
+        serverWriteDone = result.ok > 0
         toastCatalogBulkResult(result, toast, {
           title: 'Listo',
           successLabel: 'Productos creados/actualizados',
           errorMessage: 'No se pudo crear ningún producto en el servidor',
         })
+        if (appliedInCatalog !== '') {
+          await persistBulkCatalogSelection(selectedIngredientIds)
+        }
+        clearSelection()
+        return
+      }
+    }
+
+    if (appliedInCatalog !== '') {
+      const catalogStatus = await persistBulkCatalogSelection(selectedIngredientIds)
+      if (catalogStatus === 'saved') {
+        if (appliedCategoryId) {
+          finalizeBulkUiAfterApply(appliedCategoryId)
+        }
+        clearSelection()
+        return
+      }
+      if (catalogStatus === 'blocked') {
+        tableRefreshKey.value += 1
+        clearSelection()
         return
       }
     }
@@ -970,26 +1014,24 @@ async function executeBulkCatalogApply() {
       tableRefreshKey.value += 1
     }
 
-    if (hasApiPatch && productIds.length === 0) {
-      toast.success(
-        'Cambios aplicados en la lista. Para guardar en servidor: precio > 0 y producto creado (Modo edición → Guardar).',
-        { title: 'Listo' },
+    if (hasApiPatch && productIds.length === 0 && !serverWriteDone) {
+      const outOfCatalog = selectedIngredientIds.filter((id) => {
+        const item = findItemByIngredientId(id)
+        return item && !isInCatalog(item)
+      }).length
+      toast.warning(
+        outOfCatalog > 0
+          ? 'Sin producto en servidor para estas filas. Activa «En catálogo», precio > 0 y categoría, o vincula el producto de reventa.'
+          : 'Sin producto vinculado en servidor. Los cambios quedaron solo en la lista (precio > 0 y en catálogo para crear producto).',
+        { title: 'No guardado en servidor' },
       )
-    } else if (appliedInCatalog !== '') {
-      toast.success(
-        'En catálogo actualizado en la selección. Usa Modo edición y Guardar para persistir productos nuevos o eliminados.',
-        { title: 'Listo' },
+    } else if (appliedAvailability !== '' && !serverWriteDone) {
+      toast.warning(
+        'Estado aplicado en la lista. Para guardar en servidor el producto debe existir (en catálogo con precio > 0).',
+        { title: 'No guardado en servidor' },
       )
-    } else if (appliedAvailability !== '') {
-      toast.success(
-        'Estado actualizado en la selección. Usa Modo edición y Guardar si el producto aún no está en el servidor.',
-        { title: 'Listo' },
-      )
-    } else {
-      toast.success(
-        'Cambios aplicados en la selección.',
-        { title: 'Listo' },
-      )
+    } else if (!serverWriteDone && appliedInCatalog === '') {
+      toast.success('Cambios aplicados en la selección.', { title: 'Listo' })
     }
 
     clearSelection()


### PR DESCRIPTION
## Summary

Fixes #840 — bulk **Estado**, **En catálogo**, and **Categoría** on `/menu/reventa` now target the server when possible instead of silently updating local state only.

- Resolve **ingredient id → product id** via cache map, loose name match, and strict API search fallback
- **PUT** when product IDs exist; **POST** fallback when in-catalog with price/category
- **En catálogo** bulk runs selection-scoped create/update/delete (`saveBulkCatalogSelection`)
- **Warning toasts** when no server write (no fake “Listo”)

## Stack

Nuxt 3 / Pinia Colada / Vue composables

## Changes

- `composables/useResaleIngredientCatalog.ts`: async `collectProductIdsForBulkApply`, `searchProductIdForIngredient`, `saveBulkCatalogSelection`, `markBulkFieldsSaved`
- `pages/menu/reventa/index.vue`: bulk apply flow, honest toasts, catalog persist
- `composables/useReventaCatalogDebugLog.ts`: log catalog save phases

## Testing

Manual on `/menu/reventa` (debug: `localStorage.setItem('waro:reventa-catalog-debug', '1')`):

1. Select rows **with** linked resale product → bulk Estado → expect `PUT` + reload persists
2. Bulk **solo En catálogo** → expect POST/PUT/DELETE (`will-save-catalog` in console)
3. Select unlinked rows → bulk Estado → warning toast, no false success
4. Bulk categoría on linked rows → `will-patch` when `productIds` resolved

Closes #840

Made with [Cursor](https://cursor.com)