### PR TITLE
Productos list: Menú/Reventa/Todos filter + Tipo column

### DIFF
--- a/components/menu/MenuCatalogFiltersBar.vue
+++ b/components/menu/MenuCatalogFiltersBar.vue
@@ -3,6 +3,7 @@ import { computed, watch } from 'vue'
 import { filterChipClass } from '@/composables/useFilterSelectClass'
 import { useMenuCatalogFilters } from '@/composables/useMenuCatalogFilters'
 import { useTenantReactive } from '@/composables/useTenantReactive'
+import type { ProductTypeFilter } from '@/stores/menuFilters'
 
 const props = withDefaults(
   defineProps<{
@@ -12,6 +13,7 @@ const props = withDefaults(
     showOnline?: boolean
     showNoRecipe?: boolean
     showCostDrift?: boolean
+    showProductTypeFilter?: boolean
   }>(),
   {
     searchPlaceholder: 'Buscar productos...',
@@ -20,6 +22,7 @@ const props = withDefaults(
     showOnline: false,
     showNoRecipe: true,
     showCostDrift: false,
+    showProductTypeFilter: false,
   },
 )
 
@@ -39,6 +42,7 @@ const {
   statusFilter,
   stationFilter,
   sortFilter,
+  productTypeFilter,
   onlineOnly,
   qrOnly,
   noRecipeOnly,
@@ -70,6 +74,16 @@ const sortOptions = [
   { label: 'Margen menor', value: 'margin_asc' },
   { label: 'Margen mayor', value: 'margin_desc' },
 ]
+
+const productTypeOptions: { label: string; value: ProductTypeFilter }[] = [
+  { label: 'Todos', value: 'all' },
+  { label: 'Menú', value: 'menu' },
+  { label: 'Reventa', value: 'resale' },
+]
+
+function productTypeChipClass(value: ProductTypeFilter): string {
+  return filterChipClass(productTypeFilter.value === value)
+}
 
 const { data: categoriesData } = useQuery({
   key: () => ['menu', 'categories', currentTenant.value?.id],
@@ -103,6 +117,7 @@ watch(
     statusFilter,
     stationFilter,
     sortFilter,
+    productTypeFilter,
     onlineOnly,
     qrOnly,
     noRecipeOnly,
@@ -127,6 +142,24 @@ watch(
     @clear="onClear"
   >
     <template #additional-filters>
+      <div
+        v-if="showProductTypeFilter"
+        role="group"
+        aria-label="Tipo de producto"
+        class="flex flex-wrap items-center gap-2 flex-shrink-0"
+      >
+        <button
+          v-for="opt in productTypeOptions"
+          :key="opt.value"
+          type="button"
+          :class="productTypeChipClass(opt.value)"
+          :aria-pressed="productTypeFilter === opt.value"
+          @click="productTypeFilter = opt.value"
+        >
+          <span class="text-sm font-semibold">{{ opt.label }}</span>
+        </button>
+      </div>
+
       <UiFilterSelect
         v-model="categoryFilter"
         placeholder="Categoría"

--- a/composables/useMenuCatalogFilters.ts
+++ b/composables/useMenuCatalogFilters.ts
@@ -1,5 +1,5 @@
 import { computed } from 'vue'
-import { useMenuFiltersStore } from '@/stores/menuFilters'
+import { useMenuFiltersStore, type ProductTypeFilter } from '@/stores/menuFilters'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 
 const DEFAULT_SORT = 'created_at_desc'
@@ -47,6 +47,11 @@ export function useMenuCatalogFilters() {
   const sortFilter = computed({
     get: () => f.value.sortFilter,
     set: (v: string) => { f.value.sortFilter = v },
+  })
+
+  const productTypeFilter = computed({
+    get: () => f.value.productTypeFilter,
+    set: (v: ProductTypeFilter) => { f.value.productTypeFilter = v },
   })
 
   const onlineOnly = computed({
@@ -97,6 +102,7 @@ export function useMenuCatalogFilters() {
       || !!categoryFilter.value
       || !!stationFilter.value
       || sortFilter.value !== DEFAULT_SORT
+      || productTypeFilter.value !== 'menu'
       || onlineOnly.value
       || qrOnly.value
       || noRecipeOnly.value
@@ -112,6 +118,7 @@ export function useMenuCatalogFilters() {
     statusFilter,
     stationFilter,
     sortFilter,
+    productTypeFilter,
     onlineOnly,
     qrOnly,
     noRecipeOnly,

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -41,6 +41,7 @@
 
         <MenuCatalogFiltersBar
           show-station
+          show-product-type-filter
           :show-qr="showTableQrColumn"
           :show-online="showOnlineControls"
           @search="onCatalogSearch"
@@ -244,7 +245,18 @@
                   </div>
                 </template>
                 <template v-else>
-                  <span class="text-sm font-bold text-text-primary">{{ toTitleCase(item.name) }}</span>
+                  <div class="flex flex-wrap items-center gap-1.5">
+                    <span class="text-sm font-bold text-text-primary">{{ toTitleCase(item.name) }}</span>
+                    <span
+                      v-if="!isOpenSaleShell(item)"
+                      class="text-[10px] font-semibold px-1.5 py-0.5 rounded-full flex-shrink-0"
+                      :class="isResaleProduct(item)
+                        ? 'bg-primary/10 text-primary'
+                        : 'bg-surface-secondary text-text-secondary'"
+                    >
+                      {{ productTipoLabel(item) }}
+                    </span>
+                  </div>
                   <UiStatusBadge
                     v-if="isOpenSaleShell(item)"
                     value="POS"
@@ -358,6 +370,26 @@
                 />
               </template>
             </div>
+          </template>
+
+          <template #cell-tipo="{ item }">
+            <span
+              v-if="!isOpenSaleShell(item)"
+              class="text-[10px] font-semibold px-2 py-0.5 rounded-full whitespace-nowrap"
+              :class="isResaleProduct(item)
+                ? 'bg-primary/10 text-primary'
+                : 'bg-surface-secondary text-text-secondary'"
+            >
+              {{ productTipoLabel(item) }}
+            </span>
+            <UiStatusBadge
+              v-else
+              value="Sistema"
+              title="Producto contenedor de venta libre en el POS"
+              format="text"
+              variant="secondary"
+              size="sm"
+            />
           </template>
 
           <template #cell-category_name="{ value, item }">
@@ -869,6 +901,7 @@ const {
   qrOnly,
   noRecipeOnly,
   marginNegativeOnly,
+  productTypeFilter,
   performSearch: applyCatalogSearch,
   hasActiveFilters,
 } = useMenuCatalogFilters()
@@ -1015,6 +1048,7 @@ const { data: productsData, error: fetchError, asyncStatus: queryAsyncStatus, re
     qrOnly: qrOnly.value,
     noRecipeOnly: noRecipeOnly.value,
     marginNegativeOnly: marginNegativeOnly.value,
+    productType: productTypeFilter.value,
     sort: sortFilter.value,
   }],
   query: () => {
@@ -1022,6 +1056,13 @@ const { data: productsData, error: fetchError, asyncStatus: queryAsyncStatus, re
       page: currentPage.value,
       limit: itemsPerPage.value,
       sort: sortFilter.value,
+    }
+    if (productTypeFilter.value === 'menu') {
+      params.is_resale = false
+    } else if (productTypeFilter.value === 'resale') {
+      params.is_resale = true
+    } else if (productTypeFilter.value === 'all') {
+      params.include_all_types = true
     }
     if (appliedSearch.value) {
       params.search = appliedSearch.value
@@ -1065,6 +1106,11 @@ const products = computed(() => productsData.value?.data || [])
 
 /** Shell product for POS venta libre (#805) — not a normal catalog item. */
 const isOpenSaleShell = (row: { open_priced?: boolean }) => !!row.open_priced
+
+const isResaleProduct = (row: { is_resale?: boolean }) => !!row.is_resale
+
+const productTipoLabel = (row: { is_resale?: boolean }) =>
+  isResaleProduct(row) ? 'Reventa' : 'Menú'
 
 const isSubmitting = ref(false)
 
@@ -1162,6 +1208,7 @@ watch(
     qrOnly,
     noRecipeOnly,
     marginNegativeOnly,
+    productTypeFilter,
     appliedSearch,
   ],
   clearSelection,
@@ -1189,6 +1236,7 @@ async function executeBulkCatalogApply() {
       () => body,
     )
     cache.invalidateQueries({ key: ['menu', 'products'] })
+    cache.invalidateQueries({ key: ['menu', 'products-resale'] })
     await refetch()
     clearSelection()
     toastCatalogBulkResult(result, toast, {
@@ -1225,6 +1273,7 @@ async function saveChanges() {
     })
 
     cache.invalidateQueries({ key: ['menu', 'products'] })
+    cache.invalidateQueries({ key: ['menu', 'products-resale'] })
     await refetch()
     discardAllDrafts()
     clearSelection()
@@ -1339,6 +1388,13 @@ const productosTableColumns = computed(() => {
       title: 'Producto',
       sortable: false,
       format: 'text',
+      align: 'left'
+    },
+    {
+      key: 'tipo',
+      title: 'Tipo',
+      sortable: false,
+      format: 'custom',
       align: 'left'
     },
     {

--- a/stores/menuFilters.ts
+++ b/stores/menuFilters.ts
@@ -2,6 +2,8 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
 /** Shared catalog filters (Menú → Productos / Reventa). */
+export type ProductTypeFilter = 'menu' | 'resale' | 'all'
+
 export interface MenuCatalogFiltersState {
   localSearchTerm: string
   appliedSearch: string
@@ -10,6 +12,7 @@ export interface MenuCatalogFiltersState {
   statusFilter: string
   stationFilter: string
   sortFilter: string
+  productTypeFilter: ProductTypeFilter
   onlineOnly: boolean
   qrOnly: boolean
   noRecipeOnly: boolean
@@ -36,6 +39,7 @@ function defaultCatalog(): MenuCatalogFiltersState {
     statusFilter: '',
     stationFilter: '',
     sortFilter: 'created_at_desc',
+    productTypeFilter: 'menu',
     onlineOnly: false,
     qrOnly: false,
     noRecipeOnly: false,


### PR DESCRIPTION
## Summary
- Add Todos | Menú | Reventa chip filter on `/menu/productos` (default Menú)
- Map filter to `is_resale` or `include_all_types=true` for Todos
- Show **Tipo** column and mobile badges (Menú / Reventa)
- Invalidate `products-resale` cache on bulk save

## Stack
Nuxt 3 · Pinia Colada · UiResponsiveDataView

## Changes
- `stores/menuFilters.ts` — `ProductTypeFilter` state
- `composables/useMenuCatalogFilters.ts` — expose filter + active state
- `components/menu/MenuCatalogFiltersBar.vue` — chip group
- `pages/menu/productos/index.vue` — query params, Tipo column, cache invalidation

## Testing
- Productos → Menú shows only non-resale products (current default behavior)
- Reventa shows `is_resale=true` products
- Todos requires backend `include_all_types` (api-warolabs PR)
- Bulk edit still uses product UUIDs

Closes #847

Made with [Cursor](https://cursor.com)