### PR TITLE
Menu nav: single Productos page — remove Reventa submenu

### DIFF
--- a/composables/useMenuCatalogFilters.ts
+++ b/composables/useMenuCatalogFilters.ts
@@ -5,7 +5,7 @@ import { useTenantReactive } from '@/composables/useTenantReactive'
 const DEFAULT_SORT = 'created_at_desc'
 
 /**
- * Persisted catalog filters for Menú → Productos / Reventa (Pinia, per tenant).
+ * Persisted catalog filters for Menú → Productos (Pinia, per tenant).
  */
 export function useMenuCatalogFilters() {
   const store = useMenuFiltersStore()
@@ -102,7 +102,7 @@ export function useMenuCatalogFilters() {
       || !!categoryFilter.value
       || !!stationFilter.value
       || sortFilter.value !== DEFAULT_SORT
-      || productTypeFilter.value !== 'menu'
+      || productTypeFilter.value !== 'all'
       || onlineOnly.value
       || qrOnly.value
       || noRecipeOnly.value

--- a/docs/usuarios/menu.md
+++ b/docs/usuarios/menu.md
@@ -183,22 +183,14 @@ El ingrediente debe estar marcado como `is_resale = true` en el catálogo. Si un
 
 ### Cómo gestionar productos de reventa
 
-Ve a **Menú → Reventa → Gestionar**.
+Ve a **Menú → Productos** y usa el filtro **Reventa** (o **Todos** para ver menú y reventa juntos).
 
-1. **Selecciona** los ingredientes que quieres vender — actívalos con la casilla
-2. **Asigna el precio de venta** — escribe el valor en pesos (obligatorio para guardar)
-3. **Disponibilidad** — activa o desactiva cada ítem con el toggle
-4. Presiona **Guardar Cambios**
+1. **Crea o edita** el producto desde el catálogo — en creación elige el modo *Reventa · pieza (und)* o filtra la lista por Reventa
+2. **Asigna el precio de venta** y la categoría
+3. **Disponibilidad** — activa o desactiva con el toggle de estado o en modo edición masiva
+4. Guarda los cambios
 
-Cada producto creado desde esta pantalla usa **1 unidad** (`und`) del ingrediente en receta — es decir, al vender una unidad del producto se descuenta una unidad del ingrediente en inventario. Para cantidades fraccionadas (por ejemplo vender medio envase en mililitros), configura la receta desde **Menú → Productos** (edición individual).
-
-### Estados de cada ítem
-
-| Badge | Significado |
-|-------|-------------|
-| **Nuevo** | Se creará el producto en este guardado |
-| **Existe** | Ya hay un producto activo para este ingrediente |
-| **A eliminar** | Se eliminará el producto al guardar |
+Cada producto de reventa usa **1 unidad** (`und`) del ingrediente vinculado — al vender una unidad del producto se descuenta una unidad del ingrediente en inventario. Para cantidades fraccionadas (por ejemplo vender medio envase en mililitros), configura la equivalencia gr/ml en la edición del producto.
 
 ### Preguntas frecuentes — Reventa
 
@@ -206,7 +198,7 @@ Cada producto creado desde esta pantalla usa **1 unidad** (`und`) del ingredient
 Sí. Cada vez que se vende una unidad del producto de reventa, se descuenta una unidad del ingrediente correspondiente en inventario.
 
 **¿Puedo cambiar el precio después?**
-Sí. Vuelve a **Menú → Reventa → Gestionar**, edita el precio y guarda.
+Sí. Ve a **Menú → Productos**, filtra por **Reventa**, abre el producto y edita el precio.
 
 **¿Qué pasa si desactivo un ítem que ya tiene ventas?**
 Las ventas anteriores no se modifican. Solo deja de aparecer disponible en el POS y domicilios.

--- a/pages/menu.vue
+++ b/pages/menu.vue
@@ -30,29 +30,9 @@ watch(
   }
 )
 
-function isResaleProductosQuery(tipo: unknown): boolean {
-  return tipo === 'reventa' || tipo === 'resale'
-}
-
-// Navigation configuration based on conceptual document
 const navigationItems = [
   { to: '/menu/recetas', label: 'Recetas', matchPath: '/menu/recetas' },
-  {
-    to: '/menu/productos',
-    label: 'Productos',
-    isActive: (r) => {
-      if (r.path.startsWith('/menu/productos/')) return true
-      if (r.path !== '/menu/productos') return false
-      return !isResaleProductosQuery(r.query.tipo)
-    },
-  },
-  {
-    to: '/menu/productos?tipo=reventa',
-    label: 'Reventa',
-    isActive: (r) =>
-      (r.path === '/menu/productos' && isResaleProductosQuery(r.query.tipo))
-      || r.path === '/menu/reventa',
-  },
+  { to: '/menu/productos', label: 'Productos', matchPath: '/menu/productos' },
   { to: '/menu/modificadores', label: 'Modificadores', matchPath: '/menu/modificadores' },
   { to: '/menu/categorias', label: 'Categorías', matchPath: '/menu/categorias' },
 ]

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -879,14 +879,14 @@ const QUERY_TO_PRODUCT_TYPE: Record<string, ProductTypeFilter> = {
 }
 
 function productTypeFromRouteQuery(tipo: unknown): ProductTypeFilter {
-  if (typeof tipo !== 'string') return 'menu'
-  return QUERY_TO_PRODUCT_TYPE[tipo] ?? 'menu'
+  if (typeof tipo !== 'string') return 'all'
+  return QUERY_TO_PRODUCT_TYPE[tipo] ?? 'all'
 }
 
 function routeQueryTipoFromProductType(filter: ProductTypeFilter): string | undefined {
-  if (filter === 'menu') return undefined
+  if (filter === 'all') return undefined
   if (filter === 'resale') return 'reventa'
-  return 'all'
+  return 'menu'
 }
 
 const cache = useQueryCache()
@@ -909,15 +909,14 @@ const {
   hasActiveFilters,
 } = useMenuCatalogFilters()
 
-useHead(computed(() => ({
-  title: productTypeFilter.value === 'resale' ? 'Reventa' : 'Productos',
-})))
+useHead({ title: 'Productos' })
 
-const catalogTitle = computed(() =>
-  productTypeFilter.value === 'resale'
-    ? 'Catálogo comercial de productos de reventa'
-    : 'Catálogo y rentabilidad de productos',
-)
+const catalogTitle = computed(() => {
+  const base = 'Catálogo y rentabilidad de productos'
+  if (productTypeFilter.value === 'resale') return `${base} — reventa`
+  if (productTypeFilter.value === 'menu') return `${base} — menú`
+  return base
+})
 
 let syncingProductTypeRoute = false
 

--- a/stores/menuFilters.ts
+++ b/stores/menuFilters.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
-/** Shared catalog filters (Menú → Productos / Reventa). */
+/** Shared catalog filters (Menú → Productos). */
 export type ProductTypeFilter = 'menu' | 'resale' | 'all'
 
 export interface MenuCatalogFiltersState {
@@ -39,7 +39,7 @@ function defaultCatalog(): MenuCatalogFiltersState {
     statusFilter: '',
     stationFilter: '',
     sortFilter: 'created_at_desc',
-    productTypeFilter: 'menu',
+    productTypeFilter: 'all',
     onlineOnly: false,
     qrOnly: false,
     noRecipeOnly: false,


### PR DESCRIPTION
## Summary

- Removes the **Reventa** sibling tab from Menú module navigation; **Productos** is the single entry.
- Unifies page title to always **Productos**; catalog subtitle reflects active type filter.
- Defaults catalog filter to **Todos** (`all`) for new/cleared sessions; deep links (`?tipo=reventa`, `/menu/reventa`) still work.
- Fixes route↔filter sync so **Menú** chip uses `?tipo=menu` and **Todos** clears the query.
- Updates user docs to point to Menú → Productos + Reventa filter chip.

## Stack

Nuxt 3 frontend

## Changes

- `pages/menu.vue`: remove Reventa nav item; simplify Productos to `matchPath`
- `pages/menu/productos/index.vue`: unified titles; default route fallback `all`; route query mapping fix
- `stores/menuFilters.ts`: default `productTypeFilter: 'all'`
- `composables/useMenuCatalogFilters.ts`: `hasActiveFilters` baseline `!== 'all'`
- `docs/usuarios/menu.md`: replace stale Reventa → Gestionar instructions

## Testing

- [ ] Menú nav shows Recetas, Productos, Modificadores, Categorías (no Reventa)
- [ ] `/menu/productos` loads all product types by default
- [ ] Chips Todos / Menú / Reventa filter correctly; URL updates (`?tipo=menu`, `?tipo=reventa`, none for Todos)
- [ ] `/menu/reventa` redirects and applies Reventa filter
- [ ] Nav highlight active on `/menu/productos`, `/menu/productos/crear`, `/menu/productos/[id]`
- [ ] Browser tab title stays "Productos" when filtering resale

Closes #859

Made with [Cursor](https://cursor.com)