### PR TITLE
Sync resale product name with linked ingredient on edit (catalog + product page)

### DIFF
--- a/composables/useResaleIngredientSync.ts
+++ b/composables/useResaleIngredientSync.ts
@@ -1,0 +1,86 @@
+import { fetchResaleLinkedIngredient } from '@/composables/useResaleLinkedIngredient'
+
+export type ResaleIngredientSyncResult = {
+  synced: boolean
+  warning?: string
+}
+
+export function normalizeResaleProductName(name: string): string {
+  return name.trim()
+}
+
+type ProductWithRecipes = {
+  is_resale?: boolean
+  name?: string
+  ingredients?: Array<{ ingredient_id?: string }>
+  resale_ingredient_id?: string | null
+}
+
+/**
+ * Resolves the linked resale ingredient id for a product (GET + fallbacks).
+ */
+export async function resolveResaleLinkedIngredientId(
+  productId: string,
+): Promise<string | null> {
+  const res = await $fetch<{ data?: ProductWithRecipes }>(`/api/menu/products/${productId}`)
+  const product = res?.data
+  if (!product?.is_resale) return null
+
+  const linked = await fetchResaleLinkedIngredient(product as Record<string, unknown>)
+  if (linked?.id != null) return String(linked.id)
+
+  const rows = product.ingredients ?? []
+  if (rows.length === 1 && rows[0]?.ingredient_id) {
+    return String(rows[0].ingredient_id)
+  }
+
+  return null
+}
+
+export type ResaleIngredientPatchBody = {
+  name?: string
+  unit_weight_gr?: number
+  unit_weight_unit?: 'gr' | 'ml'
+}
+
+export async function patchResaleLinkedIngredient(
+  ingredientId: string,
+  body: ResaleIngredientPatchBody,
+): Promise<void> {
+  if (Object.keys(body).length === 0) return
+  await $fetch(`/api/suppliers/ingredients/${ingredientId}`, {
+    method: 'PATCH',
+    body,
+  })
+}
+
+/**
+ * PATCH linked ingredient name when a resale product was renamed (product → ingredient, one-way).
+ */
+export async function syncResaleIngredientName(
+  productId: string,
+  newName: string,
+  previousName?: string,
+): Promise<ResaleIngredientSyncResult> {
+  const trimmed = normalizeResaleProductName(newName)
+  if (!trimmed) return { synced: false }
+
+  if (
+    previousName !== undefined
+    && normalizeResaleProductName(previousName) === trimmed
+  ) {
+    return { synced: false }
+  }
+
+  const ingredientId = await resolveResaleLinkedIngredientId(productId)
+  if (!ingredientId) return { synced: false }
+
+  try {
+    await patchResaleLinkedIngredient(ingredientId, { name: trimmed })
+    return { synced: true }
+  } catch (err: unknown) {
+    const e = err as { data?: { detail?: string }; message?: string }
+    const detail = e?.data?.detail ?? e?.message ?? 'No se pudo actualizar el insumo vinculado'
+    return { synced: false, warning: String(detail) }
+  }
+}

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -799,6 +799,10 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useQuery, useQueryCache } from '@pinia/colada'
 import { useMenuIngredientsQuery } from '@/composables/queries/useMenuIngredients'
 import { fetchResaleLinkedIngredient } from '@/composables/useResaleLinkedIngredient'
+import {
+  normalizeResaleProductName,
+  patchResaleLinkedIngredient,
+} from '@/composables/useResaleIngredientSync'
 import { useActiveStationsQuery } from '@/composables/queries/useActiveStations'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 
@@ -1384,15 +1388,44 @@ const handleSubmit = async () => {
       const gr = resaleUnitWeightGr.value
       const unit = resaleUnitWeightUnit.value
       const snap = resaleWeightSnapshot.value
+      const trimmedName = normalizeResaleProductName(form.value.name)
+      const linkedName = linkedResaleIngredient.value.name != null
+        ? normalizeResaleProductName(String(linkedResaleIngredient.value.name))
+        : ''
+      const patchBody: {
+        name?: string
+        unit_weight_gr?: number
+        unit_weight_unit?: 'gr' | 'ml'
+      } = {}
+      if (trimmedName && trimmedName !== linkedName) {
+        patchBody.name = trimmedName
+      }
       if (gr != null && gr > 0 && (gr !== snap.gr || unit !== snap.unit)) {
-        await $fetch(`/api/suppliers/ingredients/${ingId}`, {
-          method: 'PATCH',
-          body: {
-            unit_weight_gr: gr,
-            unit_weight_unit: unit,
-          },
-        })
-        resaleWeightSnapshot.value = { gr, unit }
+        patchBody.unit_weight_gr = gr
+        patchBody.unit_weight_unit = unit
+      }
+      if (Object.keys(patchBody).length > 0) {
+        try {
+          await patchResaleLinkedIngredient(ingId, patchBody)
+          if (patchBody.unit_weight_gr != null) {
+            resaleWeightSnapshot.value = { gr, unit }
+          }
+          if (patchBody.name) {
+            linkedResaleIngredient.value = {
+              ...linkedResaleIngredient.value,
+              name: patchBody.name,
+            }
+          }
+        } catch (ingErr: unknown) {
+          const e = ingErr as { data?: { detail?: string }; message?: string }
+          const detail = e?.data?.detail ?? e?.message
+          toast.error(
+            detail
+              ? `Producto guardado, pero el insumo no se actualizó: ${detail}`
+              : 'Producto guardado, pero no se pudo actualizar el insumo vinculado',
+            { title: 'Insumo no sincronizado' },
+          )
+        }
       }
     }
 

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -791,6 +791,7 @@ import { useQueryCache } from '@pinia/colada'
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import { runSequentialProductPatches, runSequentialRequests, toastCatalogBulkResult, toastCatalogDeleteResult } from '@/composables/useMenuCatalogBulkSave'
+import { syncResaleIngredientName } from '@/composables/useResaleIngredientSync'
 import { useMenuCatalogEditMode } from '@/composables/useMenuCatalogEditMode'
 import { useMenuCatalogSelection } from '@/composables/useMenuCatalogSelection'
 import { useTenantReactive } from '@/composables/useTenantReactive'
@@ -1277,6 +1278,26 @@ async function saveChanges() {
       if (!draft) return null
       return buildSavePatchBody(draft)
     })
+
+    const syncWarnings: string[] = []
+    for (const id of idsToSave) {
+      const row = products.value.find((p: { id: string }) => p.id === id)
+      const draft = productDrafts.value[id]
+      if (!row?.is_resale || !draft || draft.name === draft.originalName) continue
+      const sync = await syncResaleIngredientName(id, draft.name, draft.originalName)
+      if (sync.warning) {
+        syncWarnings.push(`${draft.name.trim()}: ${sync.warning}`)
+      }
+    }
+    if (syncWarnings.length > 0) {
+      toast.error(syncWarnings.slice(0, 3).join('\n'), {
+        title:
+          syncWarnings.length > 1
+            ? 'Algunos insumos no se renombraron'
+            : 'Insumo no sincronizado',
+        duration: 6000,
+      })
+    }
 
     cache.invalidateQueries({ key: ['menu', 'products'] })
     cache.invalidateQueries({ key: ['menu', 'products-resale'] })

--- a/types/menu-catalog.ts
+++ b/types/menu-catalog.ts
@@ -38,6 +38,7 @@ export type ProductDraft = {
 export type ProductDraftSource = {
   id: string
   name: string
+  is_resale?: boolean
   category_id?: string
   category_name?: string
   price: number


### PR DESCRIPTION
## Summary
When a resale product is renamed, the linked tenant ingredient name is updated via PATCH so catalog, Abastecimiento, and edit UI stay aligned.

## Stack
Nuxt 3 / Vue

## Changes
- `composables/useResaleIngredientSync.ts`: resolve linked ingredient id, sync name
- `pages/menu/productos/[id].vue`: combined PATCH for name + weight on save
- `pages/menu/productos/index.vue`: post-sync after catalog Modo edición save
- `types/menu-catalog.ts`: `is_resale` on `ProductDraftSource`

## Testing
- [ ] Create venta directa → rename on `[id]` → ingredient name matches in Abastecimiento
- [ ] Rename same product in catalog Modo edición → ingredient matches
- [ ] Rename menu product with recipe → recipe ingredients unchanged
- [ ] Rename resale to conflicting ingredient name → product saves, error toast on ingredient

Closes #863

Made with [Cursor](https://cursor.com)