### PR TITLE
Clarify Ingrediente vs Producto de menú in inline search and create flows

### DIFF
--- a/components/menu/CreateCatalogEntityChooser.vue
+++ b/components/menu/CreateCatalogEntityChooser.vue
@@ -21,7 +21,7 @@
         v-if="modelValue && showChooserUi"
         role="dialog"
         aria-modal="true"
-        aria-label="Elegir tipo de ítem a crear"
+        aria-label="Elegir ingrediente o producto de menú a crear"
         class="fixed z-50 flex flex-col bg-surface shadow-2xl
                inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh]
                md:inset-y-0 md:right-0 md:bottom-auto md:left-auto md:inset-x-auto md:rounded-none md:w-full md:max-w-md md:max-h-none md:h-full"
@@ -47,10 +47,10 @@
                 </h2>
                 <p class="text-xs text-text-secondary leading-snug mt-0.5">
                   <template v-if="initialName.trim()">
-                    “{{ initialName.trim() }}” no está en tu catálogo
+                    “{{ initialName.trim() }}” no aparece en la búsqueda
                   </template>
                   <template v-else>
-                    Elige si es un insumo o un producto de menú
+                    Elige ingrediente (bodega) o producto de menú (venta)
                   </template>
                 </p>
               </div>
@@ -83,9 +83,9 @@
               <svg class="w-6 h-6 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="1.6" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
               </svg>
-              <span class="text-sm font-bold tracking-wide">Insumo</span>
+              <span class="text-sm font-bold tracking-wide">Ingrediente</span>
               <span :class="optionDescClass('supply')">
-                Recetas y compras · gr, ml, und
+                Abastecimiento y recetas · gr, ml, und
               </span>
             </button>
 
@@ -98,9 +98,9 @@
               <svg class="w-6 h-6 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="1.6" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
               </svg>
-              <span class="text-sm font-bold tracking-wide">Producto</span>
+              <span class="text-sm font-bold tracking-wide">Producto de menú</span>
               <span :class="optionDescClass('menu-product')">
-                Menú y POS · precio, categoría
+                Venta en menú y POS · precio, categoría
               </span>
             </button>
           </div>

--- a/components/menu/MenuIngredientProductHint.vue
+++ b/components/menu/MenuIngredientProductHint.vue
@@ -1,0 +1,6 @@
+<template>
+  <p class="text-xs text-text-secondary leading-relaxed">
+    <strong class="font-medium text-text-primary">Ingrediente</strong> — materia prima en bodega (harina, queso).
+    <strong class="font-medium text-text-primary">Producto de menú</strong> — lo que vendes en caja; si es reventa (gaseosa, snack), el stock se crea solo al elegir esa opción.
+  </p>
+</template>

--- a/components/ui/IngredientSearchInput.vue
+++ b/components/ui/IngredientSearchInput.vue
@@ -54,8 +54,14 @@
             row.parent_id ? 'pl-6' : ''
           ]"
         >
-          <span>{{ row.name }} <span class="text-text-secondary">({{ row.unit }})</span></span>
-          <span v-if="row.is_custom" class="text-xs bg-primary/10 text-primary rounded px-1 flex-shrink-0">Personalizado</span>
+          <span class="min-w-0 flex-1 flex flex-wrap items-center gap-1.5">
+            <span class="truncate">{{ row.name }} <span class="text-text-secondary">({{ row.unit }})</span></span>
+            <span
+              v-if="row.is_resale"
+              class="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-primary/10 text-primary flex-shrink-0"
+            >Reventa</span>
+            <span v-else-if="row.is_custom" class="text-xs bg-surface-secondary text-text-secondary rounded px-1 flex-shrink-0">Personalizado</span>
+          </span>
         </li>
       </template>
       <!-- "No results" message when search ran but found nothing -->
@@ -106,7 +112,7 @@ interface Emits {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  placeholder: 'Buscar ingrediente...',
+  placeholder: 'Buscar ingrediente o reventa...',
   initialValue: '',
   allowCreate: false,
   baseOnly: false,

--- a/composables/useCatalogEntityCreation.ts
+++ b/composables/useCatalogEntityCreation.ts
@@ -19,11 +19,11 @@ export function resolveCreationIntent(
   context: CatalogCreationContext,
 ): CatalogCreationIntent | null {
   switch (context) {
-    case 'recipe':
-    case 'modifier':
     case 'purchase':
     case 'supply-hub':
       return 'supply'
+    case 'recipe':
+    case 'modifier':
     case 'product':
       return null
     default: {

--- a/composables/useInlineCatalogProductLink.ts
+++ b/composables/useInlineCatalogProductLink.ts
@@ -1,0 +1,23 @@
+import { useQueryCache } from '@pinia/colada'
+import { fetchResaleLinkedIngredient } from '@/composables/useResaleLinkedIngredient'
+import { useTenantReactive } from '@/composables/useTenantReactive'
+
+/**
+ * After inline ProductQuickCreatePanel saves, resolve linked resale ingredient and callback.
+ */
+export function useInlineCatalogProductLink() {
+  const cache = useQueryCache()
+  const { currentTenant } = useTenantReactive()
+
+  async function linkCreatedProductToRow(
+    product: Record<string, unknown>,
+    onLink: (ingredient: Record<string, unknown>) => void | Promise<void>,
+  ) {
+    await cache.invalidateQueries({ key: ['menu-ingredients', currentTenant.value?.id ?? 'default'] })
+    const ingredient = await fetchResaleLinkedIngredient(product)
+    if (!ingredient) return
+    await onLink(ingredient)
+  }
+
+  return { linkCreatedProductToRow }
+}

--- a/docs/usuarios/menu.md
+++ b/docs/usuarios/menu.md
@@ -4,6 +4,21 @@ Desde el módulo de Menú configuras todo lo que le ofreces a tus clientes: las 
 
 ---
 
+## Ingrediente vs producto de menú
+
+Al buscar en un formulario de receta o producto verás **ingredientes** (y a veces filas marcadas **Reventa**). Si lo que buscas no existe, el sistema te pregunta qué quieres crear:
+
+| Opción | Qué es | Cuándo usarla |
+|--------|--------|---------------|
+| **Ingrediente** | Materia prima en bodega (harina, queso, aceite) | Lo compras y usas en recetas o compras |
+| **Producto de menú** | Lo que cobras en POS / domicilios | Platos preparados o **reventa** (gaseosa, snack vendido tal cual) |
+
+**Reventa:** al crear un **producto de menú** de venta directa, el sistema crea solo el ingrediente de stock (1 unidad vendida = 1 und descontada). No hace falta crear primero un ingrediente suelto con el mismo nombre.
+
+En **compras directas** (factura), “Crear…” solo abre ingrediente — no producto de menú.
+
+---
+
 ## Recetas
 
 Una receta es una **composición reutilizable de ingredientes** que puedes asignar a uno o varios productos. Sirve para evitar repetir la misma lista de ingredientes en cada producto.
@@ -37,7 +52,7 @@ Ve a **Menú → Recetas → Nueva receta**. El formulario tiene 3 pasos:
 
 **Paso 2 — Ingredientes**
 
-Busca el ingrediente por nombre, escribe la cantidad y la unidad. Repite para cada ingrediente. Si el ingrediente no existe, haz clic en **+ Crear ingrediente** para crearlo ahí mismo sin salir del formulario.
+Busca el ingrediente por nombre, escribe la cantidad y la unidad. Repite para cada ingrediente. Si no aparece en la búsqueda, usa **Crear "…"** y elige **Ingrediente** o **Producto de menú** según corresponda.
 
 **Paso 3 — Revisión y confirmación**
 
@@ -176,10 +191,6 @@ No. El botón de agregar al carrito no se activa hasta que el cliente elija.
 ## Productos de reventa
 
 Los **productos de reventa** son ítems que vendes tal como los compras, sin preparación: una lata de gaseosa, un paquete de papas, una botella de agua. Se comportan como productos normales en el POS y en domicilios, pero su stock se controla directamente sobre el ingrediente.
-
-### Requisito previo
-
-El ingrediente debe estar marcado como `is_resale = true` en el catálogo. Si un ingrediente no aparece en la lista de reventa, contacta al administrador para activar esa propiedad.
 
 ### Cómo gestionar productos de reventa
 

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -280,6 +280,7 @@
         <!-- Step 2: Modificadores -->
         <div v-else-if="currentStep === 2" key="step-2" class="bg-surface border border-border rounded-lg">
           <div class="p-4 sm:p-6">
+            <MenuIngredientProductHint class="mb-4" />
             <div class="flex justify-between items-center mb-4 sm:mb-6">
               <h3 class="text-base sm:text-lg font-semibold text-text-primary">Modificadores</h3>
               <button
@@ -625,7 +626,8 @@
     <MenuInlineCatalogCreateShell
       ref="inlineCreateShell"
       context="modifier"
-      @saved="onCustomIngredientCreated"
+      :on-ingredient-saved="onCustomIngredientCreated"
+      :on-product-saved="onInlineProductCreated"
     />
   </div>
 </template>
@@ -778,6 +780,17 @@ function onCustomIngredientCreated(ingredient: any) {
   if (index < 0 || index >= form.value.modifiers.length) return
   selectIngredient(form.value.modifiers[index], ingredient)
   customIngModalModIndex.value = -1
+}
+
+const { linkCreatedProductToRow } = useInlineCatalogProductLink()
+
+async function onInlineProductCreated(product: Record<string, unknown>) {
+  const index = customIngModalModIndex.value
+  if (index < 0 || index >= form.value.modifiers.length) return
+  await linkCreatedProductToRow(product, async (ingredient) => {
+    selectIngredient(form.value.modifiers[index], ingredient)
+    customIngModalModIndex.value = -1
+  })
 }
 
 // Computed

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -311,7 +311,7 @@
                 <div class="grid grid-cols-1 md:grid-cols-12 gap-3 mb-3">
                   <!-- Ingredient Selector -->
                   <div class="md:col-span-4">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente *</label>
+                    <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
                     <UiIngredientSearchInput
                       :initialValue="modifier.ingredient_name || ''"
                       :allow-create="true"

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -289,6 +289,7 @@
         <!-- Step 2: Modificadores -->
         <div v-else-if="currentStep === 2" key="step-2" class="bg-surface border border-border rounded-lg">
           <div class="p-4 sm:p-6">
+            <MenuIngredientProductHint class="mb-4" />
             <div class="flex justify-between items-center mb-4 sm:mb-6">
               <h3 class="text-base sm:text-lg font-semibold text-text-primary">Modificadores</h3>
               <button
@@ -667,7 +668,8 @@
     <MenuInlineCatalogCreateShell
       ref="inlineCreateShell"
       context="modifier"
-      @saved="onCustomIngredientCreated"
+      :on-ingredient-saved="onCustomIngredientCreated"
+      :on-product-saved="onInlineProductCreated"
     />
   </div>
 </template>
@@ -833,6 +835,17 @@ function onCustomIngredientCreated(ingredient: any) {
   if (index < 0 || index >= form.value.modifiers.length) return
   selectIngredient(form.value.modifiers[index], ingredient)
   customIngModalModIndex.value = -1
+}
+
+const { linkCreatedProductToRow } = useInlineCatalogProductLink()
+
+async function onInlineProductCreated(product: Record<string, unknown>) {
+  const index = customIngModalModIndex.value
+  if (index < 0 || index >= form.value.modifiers.length) return
+  await linkCreatedProductToRow(product, async (ingredient) => {
+    selectIngredient(form.value.modifiers[index], ingredient)
+    customIngModalModIndex.value = -1
+  })
 }
 
 function removeModifier(index: number) {

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -320,7 +320,7 @@
                 <div class="grid grid-cols-1 md:grid-cols-12 gap-3 mb-3">
                   <!-- Ingredient Selector -->
                   <div class="md:col-span-4">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente *</label>
+                    <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
                     <UiIngredientSearchInput
                       :allow-create="true"
                       @select="(ing) => selectIngredient(modifier, ing)"

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -492,12 +492,12 @@
             </div>
           </div>
 
-          <!-- Ingredientes Adicionales -->
+          <!-- Ingredientes y reventa adicionales -->
           <div class="mt-8">
             <MenuIngredientProductHint class="mb-4" />
-            <h3 class="text-lg font-semibold text-text-primary mb-2">Ingredientes Adicionales</h3>
+            <h3 class="text-lg font-semibold text-text-primary mb-2">Ingredientes y reventa (adicionales)</h3>
             <p class="text-sm text-text-secondary mb-4">
-              Agrega ingredientes adicionales específicos para este producto
+              Materias primas o productos de reventa que descuentan inventario al vender este plato
             </p>
             <p v-if="quantityError" class="text-sm text-destructive flex items-center gap-1 mb-3">
               <svg class="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
@@ -576,7 +576,7 @@
               @click="addIngredient"
             >
               <Icon name="heroicons:plus" class="h-5 w-5 mr-2" />
-              Agregar Ingrediente
+              Agregar línea
             </UiButton>
           </div>
           </template>
@@ -679,7 +679,7 @@
             </div>
 
             <div class="flex justify-between text-sm gap-2">
-              <span class="text-text-secondary flex-shrink-0">{{ isResaleProduct ? 'Insumo:' : 'Ingredientes:' }}</span>
+              <span class="text-text-secondary flex-shrink-0">{{ isResaleProduct ? 'Insumo:' : 'Líneas receta:' }}</span>
               <span class="font-semibold text-text-primary text-right truncate">
                 <template v-if="isResaleProduct">
                   {{ linkedResaleIngredient?.name ?? '—' }}

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -494,6 +494,7 @@
 
           <!-- Ingredientes Adicionales -->
           <div class="mt-8">
+            <MenuIngredientProductHint class="mb-4" />
             <h3 class="text-lg font-semibold text-text-primary mb-2">Ingredientes Adicionales</h3>
             <p class="text-sm text-text-secondary mb-4">
               Agrega ingredientes adicionales específicos para este producto
@@ -1021,17 +1022,15 @@ async function onCustomIngredientCreated(ingredient: any) {
   customIngModalIndex.value = -1
 }
 
+const { linkCreatedProductToRow } = useInlineCatalogProductLink()
+
 async function onInlineProductCreated(product: Record<string, unknown>) {
   const index = customIngModalIndex.value
   if (index < 0 || index >= form.value.ingredients.length) return
-
-  await cache.invalidateQueries({ key: ['menu-ingredients', currentTenant.value?.id ?? 'default'] })
-
-  const ingredient = await fetchResaleLinkedIngredient(product)
-  if (!ingredient) return
-
-  await selectIngredient(ingredient, index, product)
-  customIngModalIndex.value = -1
+  await linkCreatedProductToRow(product, async (ingredient) => {
+    await selectIngredient(ingredient, index, product)
+    customIngModalIndex.value = -1
+  })
 }
 
 // ── Category search + create flow (issue #458) ────────────────────────────

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -158,7 +158,7 @@
                 <p class="text-xs sm:text-sm font-medium truncate" :class="currentStep >= 2 ? 'text-text-primary' : 'text-text-secondary'">
                   Receta
                 </p>
-                <p class="text-xs text-text-secondary hidden sm:block">Ingredientes y costos</p>
+                <p class="text-xs text-text-secondary hidden sm:block">Receta e inventario</p>
               </div>
               <div class="flex-1 h-0.5 sm:h-1 mx-1 sm:mx-4" :class="currentStep > 2 ? 'bg-secondary' : 'bg-border'"></div>
             </div>
@@ -489,7 +489,7 @@
             </div>
           </div>
           <div class="p-4 sm:p-6" :class="{ 'pointer-events-none opacity-50': inlineCatalogBusy }">
-            <h3 class="text-base sm:text-lg font-semibold text-text-primary mb-4">Receta / Ingredientes</h3>
+            <h3 class="text-base sm:text-lg font-semibold text-text-primary mb-4">Receta e inventario</h3>
 
             <!-- Toggle: ¿Este producto controla inventario? -->
             <div class="flex items-start gap-3 p-4 mb-6 bg-surface-secondary border border-border rounded-lg">
@@ -612,16 +612,16 @@
               </div>
             </div>
 
-            <!-- Ingredientes Adicionales -->
+            <!-- Líneas adicionales: ingrediente o reventa -->
             <MenuIngredientProductHint class="mb-4" />
             <div class="flex justify-between items-center mb-4">
-              <h4 class="text-sm font-semibold text-text-primary">Ingredientes Adicionales</h4>
+              <h4 class="text-sm font-semibold text-text-primary">Ingredientes y reventa (adicionales)</h4>
               <button
                 type="button"
                 @click="addIngredient"
                 class="btn-secondary px-3 sm:px-4 py-2 rounded-lg text-sm"
               >
-                + Agregar Ingrediente
+                + Agregar
               </button>
             </div>
 
@@ -630,8 +630,8 @@
               <svg class="w-16 h-16 mx-auto mb-4 text-titan-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
               </svg>
-              <p class="text-base font-medium mb-1">No hay ingredientes agregados</p>
-              <p class="text-sm">Agrega ingredientes para calcular el costo del producto</p>
+              <p class="text-base font-medium mb-1">No hay líneas adicionales</p>
+              <p class="text-sm">Agrega ingredientes o productos de reventa para calcular el costo</p>
             </div>
 
             <!-- Ingredients List -->
@@ -644,7 +644,7 @@
                 <div class="grid grid-cols-1 md:grid-cols-12 gap-3">
                   <!-- Ingredient -->
                   <div class="md:col-span-5">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente</label>
+                    <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa</label>
                     <UiIngredientSearchInput
                       :key="ingredient.ingredient_id || `new-${index}`"
                       :initial-value="getIngredientSearchLabel(ingredient)"
@@ -788,10 +788,10 @@
               <!-- Ingredientes adicionales -->
               <div class="bg-surface border border-border rounded-lg p-4">
                 <p class="text-xs font-semibold text-text-secondary uppercase tracking-wide mb-3">
-                  Ingredientes Adicionales ({{ form.ingredients.length }})
+                  Adicionales ({{ form.ingredients.length }})
                 </p>
                 <div v-if="form.ingredients.length === 0" class="text-sm text-text-secondary">
-                  Sin ingredientes adicionales
+                  Sin líneas adicionales
                 </div>
                 <div v-else class="space-y-2">
                   <div

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -613,6 +613,7 @@
             </div>
 
             <!-- Ingredientes Adicionales -->
+            <MenuIngredientProductHint class="mb-4" />
             <div class="flex justify-between items-center mb-4">
               <h4 class="text-sm font-semibold text-text-primary">Ingredientes Adicionales</h4>
               <button
@@ -962,7 +963,6 @@
 import { ref, computed, watch } from 'vue'
 import { useQuery, useQueryCache } from '@pinia/colada'
 import { useMenuIngredientsQuery } from '@/composables/queries/useMenuIngredients'
-import { fetchResaleLinkedIngredient } from '@/composables/useResaleLinkedIngredient'
 import { useActiveStationsQuery } from '@/composables/queries/useActiveStations'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 
@@ -1362,17 +1362,15 @@ async function onCustomIngredientCreated(ingredient: any) {
   customIngModalIndex.value = -1
 }
 
+const { linkCreatedProductToRow } = useInlineCatalogProductLink()
+
 async function onInlineProductCreated(product: Record<string, unknown>) {
   const index = customIngModalIndex.value
   if (index < 0 || index >= form.value.ingredients.length) return
-
-  await cache.invalidateQueries({ key: ['menu-ingredients', currentTenant.value?.id ?? 'default'] })
-
-  const ingredient = await fetchResaleLinkedIngredient(product)
-  if (!ingredient) return
-
-  await selectIngredient(ingredient, index, product)
-  customIngModalIndex.value = -1
+  await linkCreatedProductToRow(product, async (ingredient) => {
+    await selectIngredient(ingredient, index, product)
+    customIngModalIndex.value = -1
+  })
 }
 
 // ── Category search + create flow (issue #458) ────────────────────────────

--- a/pages/menu/recetas/[id].vue
+++ b/pages/menu/recetas/[id].vue
@@ -62,6 +62,7 @@
 
           <!-- Ingredientes -->
           <div class="mt-8">
+            <MenuIngredientProductHint class="mb-4" />
             <div class="flex justify-between items-center mb-6">
               <h3 class="text-lg font-semibold text-text-primary">Ingredientes de la Receta Base</h3>
               <UiButton
@@ -250,7 +251,8 @@
     <MenuInlineCatalogCreateShell
       ref="inlineCreateShell"
       context="recipe"
-      @saved="onCustomIngredientCreated"
+      :on-ingredient-saved="onCustomIngredientCreated"
+      :on-product-saved="onInlineProductCreated"
     />
   </div>
 </template>
@@ -377,6 +379,17 @@ function onCustomIngredientCreated(ingredient: any) {
   if (index < 0 || index >= form.value.ingredients.length) return
   selectIngredient(ingredient, index)
   customIngModalIndex.value = -1
+}
+
+const { linkCreatedProductToRow } = useInlineCatalogProductLink()
+
+async function onInlineProductCreated(product: Record<string, unknown>) {
+  const index = customIngModalIndex.value
+  if (index < 0 || index >= form.value.ingredients.length) return
+  await linkCreatedProductToRow(product, async (ingredient) => {
+    selectIngredient(ingredient, index)
+    customIngModalIndex.value = -1
+  })
 }
 
 // Form state

--- a/pages/menu/recetas/[id].vue
+++ b/pages/menu/recetas/[id].vue
@@ -64,22 +64,22 @@
           <div class="mt-8">
             <MenuIngredientProductHint class="mb-4" />
             <div class="flex justify-between items-center mb-6">
-              <h3 class="text-lg font-semibold text-text-primary">Ingredientes de la Receta Base</h3>
+              <h3 class="text-lg font-semibold text-text-primary">Ingredientes y reventa de la receta</h3>
               <UiButton
                 type="button"
                 variant="outline"
                 size="sm"
                 @click="addIngredient"
               >
-                + Agregar Ingrediente
+                + Agregar
               </UiButton>
             </div>
 
             <!-- Empty State -->
             <div v-if="form.ingredients.length === 0" class="text-center py-12 text-text-secondary border border-border rounded-lg">
               <Icon name="heroicons:cube" class="h-16 w-16 mx-auto mb-4 text-titan-300" />
-              <p class="text-base font-medium mb-1">No hay ingredientes agregados</p>
-              <p class="text-sm">Agrega los ingredientes que componen esta receta base</p>
+              <p class="text-base font-medium mb-1">No hay líneas en la receta</p>
+              <p class="text-sm">Agrega ingredientes o productos de reventa que componen esta receta base</p>
             </div>
 
             <!-- Lista de ingredientes -->
@@ -92,7 +92,7 @@
                 <div class="flex-1 grid grid-cols-1 md:grid-cols-12 gap-3">
                   <!-- Ingrediente -->
                   <div class="md:col-span-5">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente *</label>
+                    <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
                     <UiIngredientSearchInput
                       :initialValue="ingredient.ingredient_name"
                       :allow-create="true"

--- a/pages/menu/recetas/crear.vue
+++ b/pages/menu/recetas/crear.vue
@@ -222,6 +222,7 @@
         <!-- Step 2: Ingredientes -->
         <div v-else-if="currentStep === 2" key="step-2" class="bg-surface border border-border rounded-lg">
           <div class="p-4 sm:p-6">
+            <MenuIngredientProductHint class="mb-4" />
             <div class="flex justify-between items-center mb-4 sm:mb-6">
               <h3 class="text-base sm:text-lg font-semibold text-text-primary">Ingredientes de la Receta Base</h3>
               <button
@@ -515,7 +516,8 @@
     <MenuInlineCatalogCreateShell
       ref="inlineCreateShell"
       context="recipe"
-      @saved="onCustomIngredientCreated"
+      :on-ingredient-saved="onCustomIngredientCreated"
+      :on-product-saved="onInlineProductCreated"
     />
   </div>
 </template>
@@ -615,6 +617,17 @@ function onCustomIngredientCreated(ingredient: any) {
   if (index < 0 || index >= form.value.ingredients.length) return
   selectIngredient(ingredient, index)
   customIngModalIndex.value = -1
+}
+
+const { linkCreatedProductToRow } = useInlineCatalogProductLink()
+
+async function onInlineProductCreated(product: Record<string, unknown>) {
+  const index = customIngModalIndex.value
+  if (index < 0 || index >= form.value.ingredients.length) return
+  await linkCreatedProductToRow(product, async (ingredient) => {
+    selectIngredient(ingredient, index)
+    customIngModalIndex.value = -1
+  })
 }
 
 const isLoadingData = ref(false)

--- a/pages/menu/recetas/crear.vue
+++ b/pages/menu/recetas/crear.vue
@@ -224,7 +224,7 @@
           <div class="p-4 sm:p-6">
             <MenuIngredientProductHint class="mb-4" />
             <div class="flex justify-between items-center mb-4 sm:mb-6">
-              <h3 class="text-base sm:text-lg font-semibold text-text-primary">Ingredientes de la Receta Base</h3>
+              <h3 class="text-base sm:text-lg font-semibold text-text-primary">Ingredientes y reventa de la receta</h3>
               <button
                 type="button"
                 @click="addIngredient"
@@ -245,8 +245,8 @@
               <svg class="w-16 h-16 mx-auto mb-4 text-titan-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
               </svg>
-              <p class="text-base font-medium mb-1">No hay ingredientes agregados</p>
-              <p class="text-sm">Agrega los ingredientes que componen esta receta base</p>
+              <p class="text-base font-medium mb-1">No hay líneas en la receta</p>
+              <p class="text-sm">Agrega ingredientes o productos de reventa que componen esta receta base</p>
             </div>
 
             <!-- Ingredients List -->
@@ -259,7 +259,7 @@
                 <div class="grid grid-cols-1 md:grid-cols-12 gap-3">
                   <!-- Ingredient -->
                   <div class="md:col-span-4">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente *</label>
+                    <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
                     <UiIngredientSearchInput
                       :allow-create="true"
                       @select="(ing) => selectIngredient(ing, index)"


### PR DESCRIPTION
## Summary
Reduces confusion between **Ingrediente** (stock/recipes) and **Producto de menú** (POS/reventa) when searching and creating from recipe/product/modifier forms.

## Changes
- Chooser copy: Ingrediente / Producto de menú (not Insumo / catálogo)
- `IngredientSearchInput`: Reventa badge on `is_resale` rows; updated placeholder
- Chooser enabled for `recipe` and `modifier` contexts (+ `product-saved` wiring)
- `MenuIngredientProductHint` on create/edit forms
- `useInlineCatalogProductLink` shared helper
- Compras directas unchanged (ingredient-only)
- `docs/usuarios/menu.md` definitions section

## Testing
- [ ] `productos/crear` step 2 → search miss → chooser with new labels
- [ ] `recetas/crear` → same chooser; Producto de menú links row
- [ ] Search existing resale ingredient → Reventa badge
- [ ] `compras-directas/crear` → Crear still opens ingredient panel only

Closes #865

Made with [Cursor](https://cursor.com)