### PR TITLE
Componentize inline catalog create busy state for IngredientSearchInput flows

### DIFF
--- a/components/menu/CatalogInlineCreateBusyOverlay.vue
+++ b/components/menu/CatalogInlineCreateBusyOverlay.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="relative">
+    <div
+      v-if="busy"
+      class="absolute inset-0 z-20 flex items-center justify-center rounded-lg bg-surface/85 backdrop-blur-[2px]"
+      aria-live="polite"
+      :aria-busy="busy"
+    >
+      <div class="flex items-center gap-3 px-5 py-3.5 rounded-xl border border-border bg-surface shadow-md mx-4 max-w-md">
+        <div
+          class="h-5 w-5 flex-shrink-0 rounded-full border-2 border-primary border-t-transparent animate-spin"
+          role="status"
+          :aria-label="statusLabel"
+        />
+        <div class="min-w-0">
+          <p class="text-sm font-medium text-text-primary">
+            {{ label || 'Procesando…' }}
+          </p>
+          <p v-if="hint" class="text-sm text-text-secondary mt-0.5">
+            {{ hint }}
+          </p>
+        </div>
+      </div>
+    </div>
+    <div :class="{ 'pointer-events-none opacity-50': busy }">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = withDefaults(
+  defineProps<{
+    busy?: boolean
+    label?: string
+    hint?: string
+  }>(),
+  {
+    busy: false,
+    label: '',
+    hint: '',
+  },
+)
+
+const statusLabel = computed(() => props.label || 'Procesando')
+</script>

--- a/components/menu/InlineCatalogCreateShell.vue
+++ b/components/menu/InlineCatalogCreateShell.vue
@@ -31,6 +31,7 @@ const props = defineProps<{
   initialType?: string
   busy?: boolean
   busyLabel?: string
+  busyHint?: string
   onIngredientSaved?: (ingredient: Record<string, unknown>) => void | Promise<void>
   onProductSaved?: (product: Record<string, unknown>) => void | Promise<void>
 }>()
@@ -40,6 +41,7 @@ const emit = defineEmits<{
   'product-saved': [product: Record<string, unknown>]
   'update:busy': [value: boolean]
   'update:busyLabel': [value: string]
+  'update:busyHint': [value: string]
 }>()
 
 async function handleIngredientSaved(ingredient: Record<string, unknown>) {
@@ -65,6 +67,7 @@ const {
   pendingName,
   isBusy,
   busyMessage,
+  busyHint,
   hideResaleToggle,
   panelInitialType,
   openFromSearch,
@@ -89,5 +92,9 @@ watch(busyMessage, (value) => {
   emit('update:busyLabel', value)
 }, { immediate: true })
 
-defineExpose({ openFromSearch, isBusy, busyMessage })
+watch(busyHint, (value) => {
+  emit('update:busyHint', value)
+}, { immediate: true })
+
+defineExpose({ openFromSearch, isBusy, busyMessage, busyHint })
 </script>

--- a/composables/useCatalogInlineCreate.ts
+++ b/composables/useCatalogInlineCreate.ts
@@ -5,6 +5,13 @@ import {
   type CatalogCreationIntent,
 } from '@/composables/useCatalogEntityCreation'
 
+export type CatalogInlineBusyPhase =
+  | 'creating-ingredient'
+  | 'creating-product'
+  | 'linking-ingredient'
+  | 'linking-product'
+  | null
+
 export function useCatalogInlineCreate(options: {
   context: CatalogCreationContext
   onIngredientSaved: (ingredient: Record<string, unknown>) => void | Promise<void>
@@ -19,14 +26,47 @@ export function useCatalogInlineCreate(options: {
   const productPanelBusy = ref(false)
   const supplyPanelBusy = ref(false)
   const linkingBusy = ref(false)
+  const lastSavedKind = ref<'ingredient' | 'product' | null>(null)
 
   const isBusy = computed(() => productPanelBusy.value || supplyPanelBusy.value || linkingBusy.value)
 
+  const busyPhase = computed((): CatalogInlineBusyPhase => {
+    if (linkingBusy.value) {
+      return lastSavedKind.value === 'product' ? 'linking-product' : 'linking-ingredient'
+    }
+    if (productPanelBusy.value) return 'creating-product'
+    if (supplyPanelBusy.value) return 'creating-ingredient'
+    return null
+  })
+
   const busyMessage = computed(() => {
-    if (linkingBusy.value) return 'Vinculando ingrediente creado...'
-    if (productPanelBusy.value) return 'Creando producto...'
-    if (supplyPanelBusy.value) return 'Creando ingrediente...'
-    return ''
+    switch (busyPhase.value) {
+      case 'linking-ingredient':
+        return 'Vinculando ingrediente…'
+      case 'linking-product':
+        return 'Vinculando reventa al catálogo…'
+      case 'creating-product':
+        return 'Creando producto de menú…'
+      case 'creating-ingredient':
+        return 'Creando ingrediente…'
+      default:
+        return ''
+    }
+  })
+
+  const busyHint = computed(() => {
+    switch (busyPhase.value) {
+      case 'linking-ingredient':
+        return 'Se agregará a la fila y se actualizará la lista de ingredientes.'
+      case 'linking-product':
+        return 'Buscando el insumo de reventa vinculado al producto.'
+      case 'creating-product':
+        return 'Al guardar, se vinculará a la fila de la receta o modificador.'
+      case 'creating-ingredient':
+        return 'Al guardar, se vinculará a la fila seleccionada.'
+      default:
+        return ''
+    }
   })
 
   const hideResaleToggle = computed(
@@ -62,22 +102,26 @@ export function useCatalogInlineCreate(options: {
   }
 
   async function onPanelSaved(ingredient: Record<string, unknown>) {
+    lastSavedKind.value = 'ingredient'
     linkingBusy.value = true
     try {
       await options.onIngredientSaved(ingredient)
     } finally {
       pendingName.value = ''
       linkingBusy.value = false
+      lastSavedKind.value = null
     }
   }
 
   async function onProductPanelSaved(product: Record<string, unknown>) {
+    lastSavedKind.value = 'product'
     linkingBusy.value = true
     try {
       await options.onProductSaved(product)
     } finally {
       pendingName.value = ''
       linkingBusy.value = false
+      lastSavedKind.value = null
     }
   }
 
@@ -96,7 +140,9 @@ export function useCatalogInlineCreate(options: {
     showProductPanel,
     pendingName,
     isBusy,
+    busyPhase,
     busyMessage,
+    busyHint,
     hideResaleToggle,
     panelInitialType,
     openFromSearch,

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -346,7 +346,11 @@
               </button>
             </div>
 
-          <div class="relative">
+          <MenuCatalogInlineCreateBusyOverlay
+            :busy="inlineCatalogBusy"
+            :label="inlineCatalogBusyLabel"
+            :hint="inlineCatalogBusyHint"
+          >
              <!-- AI Loading Overlay -->
             <div v-if="isScanning" class="w-full py-4 flex flex-col items-center justify-center gap-2 bg-surface rounded-lg border border-dashed border-border">
               <UiLoadingDots size="9px" />
@@ -882,7 +886,7 @@
 
             </div>
 
-          </div>
+          </MenuCatalogInlineCreateBusyOverlay>
           </div>
         </div>
 
@@ -1255,6 +1259,9 @@
   <!-- Create Ingredient Panel -->
   <MenuInlineCatalogCreateShell
     ref="inlineCreateShell"
+    v-model:busy="inlineCatalogBusy"
+    v-model:busy-label="inlineCatalogBusyLabel"
+    v-model:busy-hint="inlineCatalogBusyHint"
     context="purchase"
     :initial-type="selectedIngredientType"
     @saved="onIngredientCreated"
@@ -1993,6 +2000,9 @@ const handleScanFileSelect = async (event: Event) => {
 // --- Create Ingredient Modal ---
 const inlineCreateShell = ref<{ openFromSearch: (name: string) => void } | null>(null)
 const createModalItemIndex = ref(-1)
+const inlineCatalogBusy = ref(false)
+const inlineCatalogBusyLabel = ref('')
+const inlineCatalogBusyHint = ref('')
 
 function openCreateModal(index: number, name: string) {
   createModalItemIndex.value = index

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -279,6 +279,11 @@
 
         <!-- Step 2: Modificadores -->
         <div v-else-if="currentStep === 2" key="step-2" class="bg-surface border border-border rounded-lg">
+          <MenuCatalogInlineCreateBusyOverlay
+            :busy="inlineCatalogBusy"
+            :label="inlineCatalogBusyLabel"
+            :hint="inlineCatalogBusyHint"
+          >
           <div class="p-4 sm:p-6">
             <MenuIngredientProductHint class="mb-4" />
             <div class="flex justify-between items-center mb-4 sm:mb-6">
@@ -435,6 +440,7 @@
               </div>
             </div>
           </div>
+          </MenuCatalogInlineCreateBusyOverlay>
         </div>
 
         <!-- Step 3: Review -->
@@ -625,6 +631,9 @@
 
     <MenuInlineCatalogCreateShell
       ref="inlineCreateShell"
+      v-model:busy="inlineCatalogBusy"
+      v-model:busy-label="inlineCatalogBusyLabel"
+      v-model:busy-hint="inlineCatalogBusyHint"
       context="modifier"
       :on-ingredient-saved="onCustomIngredientCreated"
       :on-product-saved="onInlineProductCreated"
@@ -769,6 +778,9 @@ function selectIngredient(modifier: any, ing: any) {
 
 const inlineCreateShell = ref<{ openFromSearch: (name: string) => void } | null>(null)
 const customIngModalModIndex = ref(-1)
+const inlineCatalogBusy = ref(false)
+const inlineCatalogBusyLabel = ref('')
+const inlineCatalogBusyHint = ref('')
 
 function openCustomIngModal(name: string, index: number) {
   customIngModalModIndex.value = index

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -288,6 +288,11 @@
 
         <!-- Step 2: Modificadores -->
         <div v-else-if="currentStep === 2" key="step-2" class="bg-surface border border-border rounded-lg">
+          <MenuCatalogInlineCreateBusyOverlay
+            :busy="inlineCatalogBusy"
+            :label="inlineCatalogBusyLabel"
+            :hint="inlineCatalogBusyHint"
+          >
           <div class="p-4 sm:p-6">
             <MenuIngredientProductHint class="mb-4" />
             <div class="flex justify-between items-center mb-4 sm:mb-6">
@@ -443,6 +448,7 @@
               </div>
             </div>
           </div>
+          </MenuCatalogInlineCreateBusyOverlay>
         </div>
 
         <!-- Step 3: Review -->
@@ -667,6 +673,9 @@
 
     <MenuInlineCatalogCreateShell
       ref="inlineCreateShell"
+      v-model:busy="inlineCatalogBusy"
+      v-model:busy-label="inlineCatalogBusyLabel"
+      v-model:busy-hint="inlineCatalogBusyHint"
       context="modifier"
       :on-ingredient-saved="onCustomIngredientCreated"
       :on-product-saved="onInlineProductCreated"
@@ -824,6 +833,9 @@ function selectIngredient(modifier: any, ing: any) {
 
 const inlineCreateShell = ref<{ openFromSearch: (name: string) => void } | null>(null)
 const customIngModalModIndex = ref(-1)
+const inlineCatalogBusy = ref(false)
+const inlineCatalogBusyLabel = ref('')
+const inlineCatalogBusyHint = ref('')
 
 function openCustomIngModal(name: string, index: number) {
   customIngModalModIndex.value = index

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -356,22 +356,12 @@
           </div>
 
           <!-- Toggle: ¿Controla inventario? (solo productos de menú con receta) -->
-          <div v-if="!isResaleProduct" class="relative mt-8">
-            <div
-              v-if="inlineCatalogBusy"
-              class="absolute inset-0 z-20 flex items-center justify-center rounded-lg bg-surface/85 backdrop-blur-[2px]"
-              aria-live="polite"
-              aria-busy="true"
+          <div v-if="!isResaleProduct" class="mt-8">
+            <MenuCatalogInlineCreateBusyOverlay
+              :busy="inlineCatalogBusy"
+              :label="inlineCatalogBusyLabel"
+              :hint="inlineCatalogBusyHint"
             >
-              <div class="flex items-center gap-3 px-5 py-3.5 rounded-xl border border-border bg-surface shadow-md mx-4">
-                <UiLoadingDots size="10px" color="var(--color-primary)" />
-                <div>
-                  <p class="text-sm font-medium text-text-primary">{{ inlineCatalogBusyLabel || 'Procesando...' }}</p>
-                  <p class="text-xs text-text-secondary mt-0.5">Espera mientras se crea y vincula el catálogo</p>
-                </div>
-              </div>
-            </div>
-            <div :class="{ 'pointer-events-none opacity-50': inlineCatalogBusy }">
           <div class="flex items-start gap-3 p-4 bg-surface-secondary border border-border rounded-lg">
             <button
               type="button"
@@ -580,7 +570,7 @@
             </UiButton>
           </div>
           </template>
-            </div>
+            </MenuCatalogInlineCreateBusyOverlay>
           </div>
 
           <!-- Configuración -->
@@ -769,6 +759,7 @@
       ref="inlineCreateShell"
       v-model:busy="inlineCatalogBusy"
       v-model:busy-label="inlineCatalogBusyLabel"
+      v-model:busy-hint="inlineCatalogBusyHint"
       context="product"
       :on-ingredient-saved="onCustomIngredientCreated"
       :on-product-saved="onInlineProductCreated"
@@ -1009,6 +1000,7 @@ const inlineCreateShell = ref<{ openFromSearch: (name: string) => void } | null>
 const customIngModalIndex = ref(-1)
 const inlineCatalogBusy = ref(false)
 const inlineCatalogBusyLabel = ref('')
+const inlineCatalogBusyHint = ref('')
 
 function openCustomIngModal(name: string, index: number) {
   customIngModalIndex.value = index

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -473,22 +473,13 @@
         </div>
 
         <!-- Step 2: Receta / Ingredientes -->
-        <div v-else-if="currentStep === 2 && !isResaleDirectMode" key="step-2" class="bg-surface border border-border rounded-lg relative">
-          <div
-            v-if="inlineCatalogBusy"
-            class="absolute inset-0 z-20 flex items-center justify-center rounded-lg bg-surface/85 backdrop-blur-[2px]"
-            aria-live="polite"
-            aria-busy="true"
+        <div v-else-if="currentStep === 2 && !isResaleDirectMode" key="step-2" class="bg-surface border border-border rounded-lg">
+          <MenuCatalogInlineCreateBusyOverlay
+            :busy="inlineCatalogBusy"
+            :label="inlineCatalogBusyLabel"
+            :hint="inlineCatalogBusyHint"
           >
-            <div class="flex items-center gap-3 px-5 py-3.5 rounded-xl border border-border bg-surface shadow-md mx-4">
-              <UiLoadingDots size="10px" color="var(--color-primary)" />
-              <div>
-                <p class="text-sm font-medium text-text-primary">{{ inlineCatalogBusyLabel || 'Procesando...' }}</p>
-                <p class="text-xs text-text-secondary mt-0.5">Espera mientras se crea y vincula el catálogo</p>
-              </div>
-            </div>
-          </div>
-          <div class="p-4 sm:p-6" :class="{ 'pointer-events-none opacity-50': inlineCatalogBusy }">
+          <div class="p-4 sm:p-6">
             <h3 class="text-base sm:text-lg font-semibold text-text-primary mb-4">Receta e inventario</h3>
 
             <!-- Toggle: ¿Este producto controla inventario? -->
@@ -715,6 +706,7 @@
             </div>
             </template>
           </div>
+          </MenuCatalogInlineCreateBusyOverlay>
         </div>
 
         <!-- Step 3: Review - Product Summary -->
@@ -933,6 +925,7 @@
       ref="inlineCreateShell"
       v-model:busy="inlineCatalogBusy"
       v-model:busy-label="inlineCatalogBusyLabel"
+      v-model:busy-hint="inlineCatalogBusyHint"
       context="product"
       :on-ingredient-saved="onCustomIngredientCreated"
       :on-product-saved="onInlineProductCreated"
@@ -1349,6 +1342,7 @@ const inlineCreateShell = ref<{ openFromSearch: (name: string) => void } | null>
 const customIngModalIndex = ref(-1)
 const inlineCatalogBusy = ref(false)
 const inlineCatalogBusyLabel = ref('')
+const inlineCatalogBusyHint = ref('')
 
 function openCustomIngModal(name: string, index: number) {
   customIngModalIndex.value = index

--- a/pages/menu/recetas/[id].vue
+++ b/pages/menu/recetas/[id].vue
@@ -61,7 +61,12 @@
           </div>
 
           <!-- Ingredientes -->
-          <div class="mt-8">
+          <MenuCatalogInlineCreateBusyOverlay
+            class="mt-8 block"
+            :busy="inlineCatalogBusy"
+            :label="inlineCatalogBusyLabel"
+            :hint="inlineCatalogBusyHint"
+          >
             <MenuIngredientProductHint class="mb-4" />
             <div class="flex justify-between items-center mb-6">
               <h3 class="text-lg font-semibold text-text-primary">Ingredientes y reventa de la receta</h3>
@@ -175,7 +180,7 @@
                 </button>
               </div>
             </div>
-          </div>
+          </MenuCatalogInlineCreateBusyOverlay>
         </div>
       </div>
 
@@ -250,6 +255,9 @@
 
     <MenuInlineCatalogCreateShell
       ref="inlineCreateShell"
+      v-model:busy="inlineCatalogBusy"
+      v-model:busy-label="inlineCatalogBusyLabel"
+      v-model:busy-hint="inlineCatalogBusyHint"
       context="recipe"
       :on-ingredient-saved="onCustomIngredientCreated"
       :on-product-saved="onInlineProductCreated"
@@ -368,6 +376,9 @@ function selectIngredient(ing: any, index: number) {
 
 const inlineCreateShell = ref<{ openFromSearch: (name: string) => void } | null>(null)
 const customIngModalIndex = ref(-1)
+const inlineCatalogBusy = ref(false)
+const inlineCatalogBusyLabel = ref('')
+const inlineCatalogBusyHint = ref('')
 
 function openCustomIngModal(name: string, index: number) {
   customIngModalIndex.value = index

--- a/pages/menu/recetas/crear.vue
+++ b/pages/menu/recetas/crear.vue
@@ -221,6 +221,11 @@
 
         <!-- Step 2: Ingredientes -->
         <div v-else-if="currentStep === 2" key="step-2" class="bg-surface border border-border rounded-lg">
+          <MenuCatalogInlineCreateBusyOverlay
+            :busy="inlineCatalogBusy"
+            :label="inlineCatalogBusyLabel"
+            :hint="inlineCatalogBusyHint"
+          >
           <div class="p-4 sm:p-6">
             <MenuIngredientProductHint class="mb-4" />
             <div class="flex justify-between items-center mb-4 sm:mb-6">
@@ -348,6 +353,7 @@
 
               </div>
           </div>
+          </MenuCatalogInlineCreateBusyOverlay>
         </div>
 
         <!-- Step 3: Review -->
@@ -515,6 +521,9 @@
 
     <MenuInlineCatalogCreateShell
       ref="inlineCreateShell"
+      v-model:busy="inlineCatalogBusy"
+      v-model:busy-label="inlineCatalogBusyLabel"
+      v-model:busy-hint="inlineCatalogBusyHint"
       context="recipe"
       :on-ingredient-saved="onCustomIngredientCreated"
       :on-product-saved="onInlineProductCreated"
@@ -606,6 +615,9 @@ function selectIngredient(ingredient: any, index: number) {
 
 const inlineCreateShell = ref<{ openFromSearch: (name: string) => void } | null>(null)
 const customIngModalIndex = ref(-1)
+const inlineCatalogBusy = ref(false)
+const inlineCatalogBusyLabel = ref('')
+const inlineCatalogBusyHint = ref('')
 
 function openCustomIngModal(name: string, index: number) {
   customIngModalIndex.value = index


### PR DESCRIPTION
## Summary
- Adds `MenuCatalogInlineCreateBusyOverlay` with brand crocus ring spinner (no binary `UiLoadingDots` in this flow).
- Extends `useCatalogInlineCreate` with phase-aware `busyMessage` / `busyHint` (ingrediente vs producto de menú vs reventa).
- Wires `v-model:busy`, `busy-label`, and `busy-hint` on all 7 `MenuInlineCatalogCreateShell` hosts.

## Stack
Nuxt 3 · Vue · Tailwind (Crocus primary tokens)

## Changes
- `components/menu/CatalogInlineCreateBusyOverlay.vue` — shared overlay + a11y
- `composables/useCatalogInlineCreate.ts` — busy phases and Spanish copy
- `components/menu/InlineCatalogCreateShell.vue` — emit `busyHint`
- Productos crear/edit, recetas crear/edit, modificadores crear/edit, compras-directas crear — overlay integration

## Testing
- [ ] `/menu/productos/crear` step 2 → Crear from search (ingredient + reventa): spinner + message, no `0 1 0`
- [ ] Same on recetas/modificadores crear and edit
- [ ] Compras directas → inline create ingredient on item row
- [ ] Section blocked (`opacity-50`) while linking

Closes #867

Made with [Cursor](https://cursor.com)