### PR TITLE
feat(filters): batch 3 — inventario/abastecimiento stock, ingredientes, ajustes

### DIFF
--- a/pages/abastecimiento/ajustes/index.vue
+++ b/pages/abastecimiento/ajustes/index.vue
@@ -31,41 +31,40 @@
         />
       </UiStats>
 
-      <!-- Filters Bar -->
-      <SharedFiltersBar
-        v-model:search="searchQuery"
-        v-model:date-filter="dateFilter"
-        search-label="Buscar"
+      <UiAdvancedFiltersBar
+        v-model:search="localSearchTerm"
+        v-model:date-range="dateRangeDates"
+        :search-fields="[]"
         search-placeholder="Buscar por ingrediente o motivo..."
-        show-date-filter
-        @search="handleSearch"
-        @clear-filters="clearFilters"
+        :preset-dates="presetDates"
+        :format-date-range="formatDateRange"
+        :show-clear="hasActiveFilters"
+        @search="performSearch"
+        @clear="clearFilters"
       >
         <template #additional-filters>
-          <!-- Ingredient Filter -->
           <select
             v-model="ingredientFilter"
-            class="h-10 pl-3 pr-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent cursor-pointer flex-shrink-0"
-            @change="applyFilters"
+            :class="filterSelectClass"
+            aria-label="Filtrar por ingrediente"
           >
-            <option value="">Todos los ingredientes</option>
+            <option value="">Ingrediente</option>
             <option v-for="ingredient in ingredients" :key="ingredient.id" :value="ingredient.id">
               {{ ingredient.name }}
             </option>
           </select>
 
-          <!-- Adjustment Type Filter -->
           <select
             v-model="adjustmentTypeFilter"
-            class="h-10 pl-3 pr-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent cursor-pointer flex-shrink-0"
-            @change="applyFilters"
+            :class="filterSelectClass"
+            aria-label="Filtrar por tipo de ajuste"
           >
-            <option value="">Todos los ajustes</option>
+            <option value="">Tipo ajuste</option>
             <option value="positive">Incrementos</option>
             <option value="negative">Decrementos</option>
           </select>
         </template>
-      </SharedFiltersBar>
+      </UiAdvancedFiltersBar>
 
       <!-- Responsive Data View -->
       <HealthSemaphore :is-unlocked="true" title="Historial de Ajustes">
@@ -156,7 +155,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { INGREDIENTS_FETCH_LIMIT } from '@/composables/useMenuIngredients'
@@ -167,13 +166,22 @@ useHead({ title: 'Ajustes de Inventario' })
 // Tenant reactivity
 const { currentTenant } = useTenantReactive()
 
-// State
-const searchQuery = ref('')
+const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
+const { dateRangeDates, presetDates, formatDateRange, dateRange, clearDateRange } = useDateRangePresets()
 const ingredientFilter = ref('')
 const adjustmentTypeFilter = ref('')
-const dateFilter = ref('')
 
-// Sorting state
+const hasActiveFilters = computed(
+  () =>
+    !!localSearchTerm.value
+    || !!appliedSearch.value
+    || !!dateRangeDates.value
+    || !!ingredientFilter.value
+    || !!adjustmentTypeFilter.value,
+)
+
+const performSearch = () => applySearch()
+
 const sortField = ref('created_at')
 const sortDirection = ref('desc')
 
@@ -193,21 +201,16 @@ const ingredients = computed(() => {
   })).sort((a: any, b: any) => a.name.localeCompare(b.name))
 })
 
-// Compute date parts from filter string
 const dateParts = computed(() => {
-  if (!dateFilter.value) return {}
-  if (dateFilter.value.includes(' to ')) {
-    const [start, end] = dateFilter.value.split(' to ')
-    return { start_date: start, end_date: end }
-  }
-  return { start_date: dateFilter.value, end_date: dateFilter.value }
+  if (!dateRange.value.from || !dateRange.value.to) return {}
+  return { start_date: dateRange.value.from, end_date: dateRange.value.to }
 })
 
-// Load adjustments data from API
-const { data: adjustmentsData, status: queryStatus, asyncStatus: adjustmentsAsyncStatus, refetch } = useQuery({
+const { data: adjustmentsData, asyncStatus: adjustmentsAsyncStatus, refetch } = useQuery({
   key: () => ['inventory', 'adjustments', currentTenant.value?.id, {
     ingredient: ingredientFilter.value || null,
-    date: dateFilter.value || null,
+    from: dateRange.value.from,
+    to: dateRange.value.to,
   }],
   query: () => $fetch('/api/inventory/movements', {
     params: {
@@ -215,7 +218,7 @@ const { data: adjustmentsData, status: queryStatus, asyncStatus: adjustmentsAsyn
       movement_type: 'adjustment',
       ingredient_id: ingredientFilter.value || undefined,
       ...dateParts.value,
-    }
+    },
   }),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
@@ -259,15 +262,14 @@ const uniqueIngredientsAdjusted = computed(() => {
 })
 
 const filteredAdjustments = computed(() => {
-  return adjustments.value.filter(adjustment => {
-    const matchesSearch = adjustment.ingredient_name.toLowerCase().includes(searchQuery.value.toLowerCase()) ||
-                         (adjustment.reason && adjustment.reason.toLowerCase().includes(searchQuery.value.toLowerCase()))
-
-    // Filter by adjustment type (positive/negative)
-    const matchesType = adjustmentTypeFilter.value === '' ||
-                       (adjustmentTypeFilter.value === 'positive' && adjustment.quantity_change >= 0) ||
-                       (adjustmentTypeFilter.value === 'negative' && adjustment.quantity_change < 0)
-
+  const q = appliedSearch.value.trim().toLowerCase()
+  return adjustments.value.filter((adjustment) => {
+    const matchesSearch = !q
+      || adjustment.ingredient_name.toLowerCase().includes(q)
+      || (adjustment.reason && adjustment.reason.toLowerCase().includes(q))
+    const matchesType = adjustmentTypeFilter.value === ''
+      || (adjustmentTypeFilter.value === 'positive' && adjustment.quantity_change >= 0)
+      || (adjustmentTypeFilter.value === 'negative' && adjustment.quantity_change < 0)
     return matchesSearch && matchesType
   })
 })
@@ -305,20 +307,11 @@ const handleSort = (field) => {
   }
 }
 
-// Handle search
-const handleSearch = () => {
-  // Search is handled by computed filteredAdjustments
-}
-
-// Apply filters — reactive key triggers refetch automatically
-const applyFilters = () => {}
-
-// Clear filters
 const clearFilters = () => {
-  searchQuery.value = ''
+  clearSearch()
+  clearDateRange()
   ingredientFilter.value = ''
   adjustmentTypeFilter.value = ''
-  dateFilter.value = ''
 }
 
 // Table columns configuration

--- a/pages/abastecimiento/ingredientes-propios.vue
+++ b/pages/abastecimiento/ingredientes-propios.vue
@@ -13,27 +13,30 @@
         <UiStatsCard label="Con costo" :value="stats.withCost" icon="currency-dollar" />
       </UiStats>
 
-      <!-- Filters Bar -->
-      <SharedFiltersBar
-        v-model:search="searchQuery"
-        search-label="Buscar"
+      <UiAdvancedFiltersBar
+        v-model:search="localSearchTerm"
+        :search-fields="[]"
         search-placeholder="Buscar ingredientes..."
-        @search="() => {}"
-        @clear-filters="clearFilters"
+        :show-date-range="false"
+        :show-clear="hasActiveFilters"
+        @search="performSearch"
+        @clear="clearFilters"
       >
         <template #additional-filters>
           <select
             v-model="typeFilter"
-            class="h-10 pl-3 pr-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent cursor-pointer flex-shrink-0"
+            :class="filterSelectClass"
+            aria-label="Filtrar por tipo"
+            @change="currentPage = 1"
           >
-            <option value="all">Todos los tipos</option>
+            <option value="">Tipo</option>
             <option value="food">Alimento</option>
             <option value="supply">Insumo</option>
             <option value="service">Servicio</option>
           </select>
           <button
             type="button"
-            @click="showArchived = !showArchived"
+            @click="toggleArchived"
             :class="[
               'h-10 px-3 rounded-lg border-2 text-sm font-medium transition-colors flex-shrink-0 flex items-center gap-1.5',
               showArchived
@@ -47,7 +50,7 @@
             Archivados
           </button>
         </template>
-      </SharedFiltersBar>
+      </UiAdvancedFiltersBar>
 
       <!-- Data View -->
       <HealthSemaphore :is-unlocked="true" title="Ingredientes Personalizados">
@@ -61,7 +64,7 @@
         </template>
       <UiResponsiveDataView
         :columns="tableColumns"
-        :data="filteredIngredients"
+        :data="sortedIngredients"
         :sort-field="sortField"
         :sort-direction="sortDirection"
         @sort="handleSort"
@@ -232,7 +235,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 
 useHead({ title: 'Ingredientes Personalizados' })
@@ -241,9 +244,10 @@ const { currentTenant } = useTenantReactive()
 
 const TYPE_LABELS: Record<string, string> = { food: 'Alimento', supply: 'Insumo', service: 'Servicio' }
 
-// State
-const searchQuery = ref('')
-const typeFilter = ref('all')
+const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
+const typeFilter = ref('')
+const currentPage = ref(1)
+const itemsPerPage = ref(50)
 const sortField = ref('')
 const sortDirection = ref('asc')
 const showPanel = ref(false)
@@ -253,12 +257,41 @@ const showArchiveModal = ref(false)
 const archiveTarget = ref<any>(null)
 const archiving = ref(false)
 
-// Data
+const hasActiveFilters = computed(
+  () =>
+    !!localSearchTerm.value
+    || !!appliedSearch.value
+    || !!typeFilter.value
+    || showArchived.value,
+)
+
+const performSearch = () => applySearch(() => { currentPage.value = 1 })
+
+const toggleArchived = () => {
+  showArchived.value = !showArchived.value
+  currentPage.value = 1
+}
+
+watch(() => currentTenant.value?.id, () => { currentPage.value = 1 })
+
 const { data: ingredientsData, asyncStatus: queryAsyncStatus, refetch } = useQuery({
-  key: () => ['ingredients', 'custom', currentTenant.value?.id, showArchived.value],
-  query: () => $fetch('/api/suppliers/ingredients', {
-    params: { tenant_only: true, limit: 500, ...(showArchived.value && { show_archived: true }) }
-  }),
+  key: () => ['ingredients', 'custom', currentTenant.value?.id, {
+    archived: showArchived.value,
+    search: appliedSearch.value || null,
+    type: typeFilter.value || null,
+    page: currentPage.value,
+  }],
+  query: () => {
+    const params: Record<string, string | number | boolean> = {
+      tenant_only: true,
+      limit: itemsPerPage.value,
+      page: currentPage.value,
+    }
+    if (appliedSearch.value) params.search = appliedSearch.value
+    if (typeFilter.value) params.type = typeFilter.value
+    if (showArchived.value) params.show_archived = true
+    return $fetch('/api/suppliers/ingredients', { params })
+  },
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })
@@ -278,11 +311,21 @@ const stats = computed(() => ({
   withCost: supplyIngredients.value.filter((i: any) => i.costo_unitario != null).length,
 }))
 
-const filteredIngredients = computed(() => {
-  return supplyIngredients.value.filter((item: any) => {
-    const matchesSearch = item.name.toLowerCase().includes(searchQuery.value.toLowerCase())
-    const matchesType = typeFilter.value === 'all' || item.type === typeFilter.value
-    return matchesSearch && matchesType
+const sortedIngredients = computed(() => {
+  const list = supplyIngredients.value
+  if (!sortField.value) return list
+
+  return [...list].sort((a: any, b: any) => {
+    const aValue = a[sortField.value]
+    const bValue = b[sortField.value]
+    if (aValue === null || aValue === undefined) return 1
+    if (bValue === null || bValue === undefined) return -1
+    if (typeof aValue === 'number' && typeof bValue === 'number') {
+      return sortDirection.value === 'asc' ? aValue - bValue : bValue - aValue
+    }
+    const strA = String(aValue).toLowerCase()
+    const strB = String(bValue).toLowerCase()
+    return sortDirection.value === 'asc' ? strA.localeCompare(strB) : strB.localeCompare(strA)
   })
 })
 
@@ -341,8 +384,10 @@ const handleSort = (field: string) => {
 }
 
 const clearFilters = () => {
-  searchQuery.value = ''
-  typeFilter.value = 'all'
+  clearSearch()
+  typeFilter.value = ''
+  showArchived.value = false
+  currentPage.value = 1
 }
 
 const tableColumns = [

--- a/pages/abastecimiento/stock.vue
+++ b/pages/abastecimiento/stock.vue
@@ -31,50 +31,50 @@
         />
       </UiStats>
 
-      <!-- Filters Bar -->
-      <SharedFiltersBar
-        v-model:search="searchQuery"
-        search-label="Buscar"
+      <UiAdvancedFiltersBar
+        v-model:search="localSearchTerm"
+        :search-fields="[]"
         search-placeholder="Buscar ingredientes..."
-        @search="() => {}"
-        @clear-filters="clearFilters"
+        :show-date-range="false"
+        :show-clear="hasActiveFilters"
+        @search="performSearch"
+        @clear="clearFilters"
       >
         <template #additional-filters>
-          <!-- Category Filter -->
           <select
             v-model="categoryFilter"
-            class="h-10 pl-3 pr-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent cursor-pointer flex-shrink-0"
+            :class="filterSelectClass"
+            aria-label="Filtrar por categoría"
           >
-            <option value="">Todas las categorías</option>
+            <option value="">Categoría</option>
             <option v-for="category in categories" :key="category" :value="category">
               {{ category }}
             </option>
           </select>
 
-          <!-- Status Filter -->
           <select
             v-model="statusFilter"
-            class="h-10 pl-3 pr-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent cursor-pointer flex-shrink-0"
+            :class="filterSelectClass"
+            aria-label="Filtrar por estado"
+            @change="currentPage = 1"
           >
-            <option value="all">Todos los estados</option>
+            <option value="all">Estado</option>
             <option value="critical">Crítico</option>
             <option value="low">Bajo</option>
             <option value="ok">Normal</option>
           </select>
 
-          <!-- Unit Filter -->
           <select
             v-model="unitFilter"
-            class="h-10 pl-3 pr-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent cursor-pointer flex-shrink-0"
+            :class="filterSelectClass"
+            aria-label="Filtrar por unidad"
           >
-            <option value="">Todas las unidades</option>
+            <option value="">Unidad</option>
             <option v-for="unit in units" :key="unit" :value="unit">
               {{ unit }}
             </option>
           </select>
 
-          <!-- warocol.com#608 — Adjust stock for any ingredient (including
-               those with zero stock, which never render as rows). -->
           <button
             type="button"
             title="Ajustar stock"
@@ -87,13 +87,13 @@
             <span class="hidden sm:inline">Ajustar stock</span>
           </button>
         </template>
-      </SharedFiltersBar>
+      </UiAdvancedFiltersBar>
 
       <!-- Responsive Data View -->
       <HealthSemaphore :is-unlocked="true" title="Stock de Inventario">
       <UiResponsiveDataView
         :columns="stockTableColumns"
-        :data="filteredInventory"
+        :data="displayInventory"
         :sort-field="sortField"
         :sort-direction="sortDirection"
         @sort="handleSort"
@@ -200,6 +200,35 @@
           </div>
         </template>
       </UiResponsiveDataView>
+
+      <div
+        v-if="(inventoryData?.total ?? 0) > itemsPerPage"
+        class="mt-4 bg-white px-4 py-3 flex items-center justify-between border border-titan-200 rounded-lg"
+      >
+        <p class="text-sm text-titan-700">
+          Mostrando <span class="font-medium">{{ startItem }}</span> a
+          <span class="font-medium">{{ endItem }}</span> de
+          <span class="font-medium">{{ inventoryData?.total ?? 0 }}</span>
+        </p>
+        <div class="flex gap-2">
+          <button
+            type="button"
+            :disabled="!canGoPrevious"
+            class="px-4 py-2 border border-titan-300 text-sm rounded-md disabled:opacity-50"
+            @click="previousPage"
+          >
+            Anterior
+          </button>
+          <button
+            type="button"
+            :disabled="!canGoNext"
+            class="px-4 py-2 border border-titan-300 text-sm rounded-md disabled:opacity-50"
+            @click="nextPage"
+          >
+            Siguiente
+          </button>
+        </div>
+      </div>
       </HealthSemaphore>
     </div>
 
@@ -212,7 +241,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useQueryCache } from '@pinia/colada'
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
@@ -222,11 +251,27 @@ useHead({ title: 'Stock' })
 // Tenant reactivity
 const { currentTenant } = useTenantReactive()
 
-// State
-const searchQuery = ref('')
+const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
 const categoryFilter = ref('')
 const statusFilter = ref('all')
 const unitFilter = ref('')
+const currentPage = ref(1)
+const itemsPerPage = ref(50)
+
+const currentOffset = computed(() => (currentPage.value - 1) * itemsPerPage.value)
+
+const hasActiveFilters = computed(
+  () =>
+    !!localSearchTerm.value
+    || !!appliedSearch.value
+    || statusFilter.value !== 'all'
+    || !!categoryFilter.value
+    || !!unitFilter.value,
+)
+
+const performSearch = () => applySearch(() => { currentPage.value = 1 })
+
+watch(() => currentTenant.value?.id, () => { currentPage.value = 1 })
 
 // warocol.com#608 — stock adjustment slide-over
 const showAdjustmentPanel = ref(false)
@@ -238,20 +283,29 @@ const onAdjustmentSaved = () => {
   toast.success('Ajuste registrado', { title: 'Stock actualizado' })
 }
 
-// Sorting state
-const sortField = ref('')
-const sortDirection = ref('asc')
+const sortField = ref('current_stock')
+const sortDirection = ref('desc')
 
-// Load inventory data from API
-const { data: inventoryData, status: queryStatus, asyncStatus: queryAsyncStatus, refetch } = useQuery({
-  key: () => ['inventory', 'stock', currentTenant.value?.id],
-  query: () => $fetch('/api/inventory/stock', {
-    params: {
-      limit: 250,
-      sort_field: 'current_stock',
-      sort_direction: 'desc'
+const { data: inventoryData, asyncStatus: queryAsyncStatus, refetch } = useQuery({
+  key: () => ['inventory', 'stock', currentTenant.value?.id, {
+    search: appliedSearch.value || null,
+    status: statusFilter.value,
+    sort_field: sortField.value,
+    sort_direction: sortDirection.value,
+    page: currentPage.value,
+    limit: itemsPerPage.value,
+  }],
+  query: () => {
+    const params: Record<string, string | number> = {
+      limit: itemsPerPage.value,
+      offset: currentOffset.value,
+      sort_field: sortField.value,
+      sort_direction: sortDirection.value,
+      status_filter: statusFilter.value,
     }
-  }),
+    if (appliedSearch.value) params.search = appliedSearch.value
+    return $fetch('/api/inventory/stock', { params })
+  },
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })
@@ -290,55 +344,50 @@ const units = computed(() => {
   return Array.from(unitsSet).sort()
 })
 
-const filteredInventory = computed(() => {
-  return inventory.value.filter(item => {
-    const matchesSearch = item.ingredient_name.toLowerCase().includes(searchQuery.value.toLowerCase())
-    const matchesStatus = statusFilter.value === 'all' || item.status === statusFilter.value
+/** Category/unit: no API params — filters current page only. */
+const displayInventory = computed(() =>
+  inventory.value.filter((item) => {
     const matchesCategory = !categoryFilter.value || item.category === categoryFilter.value
     const matchesUnit = !unitFilter.value || item.unit === unitFilter.value
-    return matchesSearch && matchesStatus && matchesCategory && matchesUnit
-  })
-})
+    return matchesCategory && matchesUnit
+  }),
+)
 
-// Sorted inventory
-const sortedInventory = computed(() => {
-  if (!sortField.value) return filteredInventory.value
+const totalPages = computed(() =>
+  Math.ceil((inventoryData.value?.total ?? 0) / itemsPerPage.value),
+)
+const canGoPrevious = computed(() => currentPage.value > 1)
+const canGoNext = computed(() => currentPage.value < totalPages.value)
+const startItem = computed(() =>
+  inventoryData.value?.total ? (currentPage.value - 1) * itemsPerPage.value + 1 : 0,
+)
+const endItem = computed(() =>
+  Math.min(currentPage.value * itemsPerPage.value, inventoryData.value?.total ?? 0),
+)
 
-  const sorted = [...filteredInventory.value].sort((a, b) => {
-    const aValue = a[sortField.value]
-    const bValue = b[sortField.value]
+const previousPage = () => {
+  if (canGoPrevious.value) currentPage.value--
+}
+const nextPage = () => {
+  if (canGoNext.value) currentPage.value++
+}
 
-    if (aValue === null || aValue === undefined) return 1
-    if (bValue === null || bValue === undefined) return -1
-
-    if (typeof aValue === 'number' && typeof bValue === 'number') {
-      return sortDirection.value === 'asc' ? aValue - bValue : bValue - aValue
-    }
-
-    const strA = String(aValue).toLowerCase()
-    const strB = String(bValue).toLowerCase()
-    return sortDirection.value === 'asc' ? strA.localeCompare(strB) : strB.localeCompare(strA)
-  })
-
-  return sorted
-})
-
-// Handle sort
-const handleSort = (field) => {
+const handleSort = (field: string) => {
   if (sortField.value === field) {
     sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
   } else {
     sortField.value = field
     sortDirection.value = 'asc'
   }
+  currentPage.value = 1
 }
 
-// Clear filters
 const clearFilters = () => {
-  searchQuery.value = ''
+  clearSearch()
   categoryFilter.value = ''
   statusFilter.value = 'all'
   unitFilter.value = ''
+  currentPage.value = 1
 }
 
 // Table columns configuration

--- a/pages/inventario/ajustes/index.vue
+++ b/pages/inventario/ajustes/index.vue
@@ -34,41 +34,40 @@
         />
       </UiStats>
 
-      <!-- Filters Bar -->
-      <SharedFiltersBar
-        v-model:search="searchQuery"
-        v-model:date-filter="dateFilter"
-        search-label="Buscar"
+      <UiAdvancedFiltersBar
+        v-model:search="localSearchTerm"
+        v-model:date-range="dateRangeDates"
+        :search-fields="[]"
         search-placeholder="Buscar por ingrediente o motivo..."
-        show-date-filter
-        @search="handleSearch"
-        @clear-filters="clearFilters"
+        :preset-dates="presetDates"
+        :format-date-range="formatDateRange"
+        :show-clear="hasActiveFilters"
+        @search="performSearch"
+        @clear="clearFilters"
       >
         <template #additional-filters>
-          <!-- Ingredient Filter -->
           <select
             v-model="ingredientFilter"
-            class="px-4 py-2 border border-border rounded-lg bg-surface text-text-primary focus:outline-none focus:ring-2 focus:ring-ring"
-            @change="applyFilters"
+            :class="filterSelectClass"
+            aria-label="Filtrar por ingrediente"
           >
-            <option value="">Todos los ingredientes</option>
+            <option value="">Ingrediente</option>
             <option v-for="ingredient in ingredients" :key="ingredient.id" :value="ingredient.id">
               {{ ingredient.name }}
             </option>
           </select>
 
-          <!-- Adjustment Type Filter -->
           <select
             v-model="adjustmentTypeFilter"
-            class="px-4 py-2 border border-border rounded-lg bg-surface text-text-primary focus:outline-none focus:ring-2 focus:ring-ring"
-            @change="applyFilters"
+            :class="filterSelectClass"
+            aria-label="Filtrar por tipo de ajuste"
           >
-            <option value="">Todos los ajustes</option>
+            <option value="">Tipo ajuste</option>
             <option value="positive">Incrementos</option>
             <option value="negative">Decrementos</option>
           </select>
         </template>
-      </SharedFiltersBar>
+      </UiAdvancedFiltersBar>
 
       <!-- Responsive Data View -->
       <UiResponsiveDataView
@@ -184,28 +183,37 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
+import { INGREDIENTS_FETCH_LIMIT } from '@/composables/useMenuIngredients'
 
 useHead({ title: 'Ajustes de Inventario' })
 
-// Tenant reactivity
 const { currentTenant } = useTenantReactive()
 
-// State
-const searchQuery = ref('')
+const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
+const { dateRangeDates, presetDates, formatDateRange, dateRange, clearDateRange } = useDateRangePresets()
 const ingredientFilter = ref('')
 const adjustmentTypeFilter = ref('')
-const dateFilter = ref('')
 
-// Sorting state
+const hasActiveFilters = computed(
+  () =>
+    !!localSearchTerm.value
+    || !!appliedSearch.value
+    || !!dateRangeDates.value
+    || !!ingredientFilter.value
+    || !!adjustmentTypeFilter.value,
+)
+
+const performSearch = () => applySearch()
+
 const sortField = ref('created_at')
 const sortDirection = ref('desc')
 
 // Load ingredients for filter
 const { data: ingredientsData } = useQuery({
   key: () => ['inventory', 'ingredients-lookup', currentTenant.value?.id],
-  query: () => $fetch('/api/suppliers/ingredients', { params: { limit: 10000 } }),
+  query: () => $fetch('/api/suppliers/ingredients', { params: { limit: INGREDIENTS_FETCH_LIMIT } }),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })
@@ -218,21 +226,16 @@ const ingredients = computed(() => {
   })).sort((a: any, b: any) => a.name.localeCompare(b.name))
 })
 
-// Compute date parts from filter string
 const dateParts = computed(() => {
-  if (!dateFilter.value) return {}
-  if (dateFilter.value.includes(' to ')) {
-    const [start, end] = dateFilter.value.split(' to ')
-    return { start_date: start, end_date: end }
-  }
-  return { start_date: dateFilter.value, end_date: dateFilter.value }
+  if (!dateRange.value.from || !dateRange.value.to) return {}
+  return { start_date: dateRange.value.from, end_date: dateRange.value.to }
 })
 
-// Load adjustments data from API
-const { data: adjustmentsData, status: queryStatus, asyncStatus: queryAsyncStatus, refetch } = useQuery({
+const { data: adjustmentsData, asyncStatus: queryAsyncStatus, refetch } = useQuery({
   key: () => ['inventory', 'adjustments', currentTenant.value?.id, {
     ingredient: ingredientFilter.value || null,
-    date: dateFilter.value || null,
+    from: dateRange.value.from,
+    to: dateRange.value.to,
   }],
   query: () => $fetch('/api/inventory/movements', {
     params: {
@@ -240,7 +243,7 @@ const { data: adjustmentsData, status: queryStatus, asyncStatus: queryAsyncStatu
       movement_type: 'adjustment',
       ingredient_id: ingredientFilter.value || undefined,
       ...dateParts.value,
-    }
+    },
   }),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
@@ -284,15 +287,14 @@ const uniqueIngredientsAdjusted = computed(() => {
 })
 
 const filteredAdjustments = computed(() => {
-  return adjustments.value.filter(adjustment => {
-    const matchesSearch = adjustment.ingredient_name.toLowerCase().includes(searchQuery.value.toLowerCase()) ||
-                         (adjustment.reason && adjustment.reason.toLowerCase().includes(searchQuery.value.toLowerCase()))
-
-    // Filter by adjustment type (positive/negative)
-    const matchesType = adjustmentTypeFilter.value === '' ||
-                       (adjustmentTypeFilter.value === 'positive' && adjustment.quantity_change >= 0) ||
-                       (adjustmentTypeFilter.value === 'negative' && adjustment.quantity_change < 0)
-
+  const q = appliedSearch.value.trim().toLowerCase()
+  return adjustments.value.filter((adjustment) => {
+    const matchesSearch = !q
+      || adjustment.ingredient_name.toLowerCase().includes(q)
+      || (adjustment.reason && adjustment.reason.toLowerCase().includes(q))
+    const matchesType = adjustmentTypeFilter.value === ''
+      || (adjustmentTypeFilter.value === 'positive' && adjustment.quantity_change >= 0)
+      || (adjustmentTypeFilter.value === 'negative' && adjustment.quantity_change < 0)
     return matchesSearch && matchesType
   })
 })
@@ -330,20 +332,11 @@ const handleSort = (field) => {
   }
 }
 
-// Handle search
-const handleSearch = () => {
-  // Search is handled by computed filteredAdjustments
-}
-
-// Apply filters — reactive key triggers refetch automatically
-const applyFilters = () => {}
-
-// Clear filters
 const clearFilters = () => {
-  searchQuery.value = ''
+  clearSearch()
+  clearDateRange()
   ingredientFilter.value = ''
   adjustmentTypeFilter.value = ''
-  dateFilter.value = ''
 }
 
 // Table columns configuration

--- a/pages/inventario/stock.vue
+++ b/pages/inventario/stock.vue
@@ -31,56 +31,58 @@
         />
       </UiStats>
 
-      <!-- Filters Bar -->
-      <SharedFiltersBar
-        v-model:search="searchQuery"
-        search-label="Buscar"
+      <UiAdvancedFiltersBar
+        v-model:search="localSearchTerm"
+        :search-fields="[]"
         search-placeholder="Buscar ingredientes..."
-        @search="() => {}"
-        @clear-filters="clearFilters"
+        :show-date-range="false"
+        :show-clear="hasActiveFilters"
+        @search="performSearch"
+        @clear="clearFilters"
       >
         <template #additional-filters>
-          <!-- Category Filter -->
           <select
             v-model="categoryFilter"
-            class="px-4 py-2 border border-border rounded-lg bg-surface text-text-primary focus:outline-none focus:ring-2 focus:ring-ring"
+            :class="filterSelectClass"
+            aria-label="Filtrar por categoría"
           >
-            <option value="">Todas las categorías</option>
+            <option value="">Categoría</option>
             <option v-for="category in categories" :key="category" :value="category">
               {{ category }}
             </option>
           </select>
 
-          <!-- Status Filter -->
           <select
             v-model="statusFilter"
-            class="px-4 py-2 border border-border rounded-lg bg-surface text-text-primary focus:outline-none focus:ring-2 focus:ring-ring"
+            :class="filterSelectClass"
+            aria-label="Filtrar por estado"
+            @change="currentPage = 1"
           >
-            <option value="all">Todos los estados</option>
+            <option value="all">Estado</option>
             <option value="critical">Crítico</option>
             <option value="low">Bajo</option>
             <option value="ok">Normal</option>
           </select>
 
-          <!-- Unit Filter -->
           <select
             v-model="unitFilter"
-            class="px-4 py-2 border border-border rounded-lg bg-surface text-text-primary focus:outline-none focus:ring-2 focus:ring-ring"
+            :class="filterSelectClass"
+            aria-label="Filtrar por unidad"
           >
-            <option value="">Todas las unidades</option>
+            <option value="">Unidad</option>
             <option v-for="unit in units" :key="unit" :value="unit">
               {{ unit }}
             </option>
           </select>
         </template>
-      </SharedFiltersBar>
+      </UiAdvancedFiltersBar>
 
       <!-- Responsive Data View -->
       <HealthSemaphore :is-unlocked="true" title="Stock de Inventario">
       <UiResponsiveDataView
         row-size="sm"
         :columns="stockTableColumns"
-        :data="filteredInventory"
+        :data="displayInventory"
         :sort-field="sortField"
         :sort-direction="sortDirection"
         @sort="handleSort"
@@ -186,13 +188,42 @@
           </div>
         </template>
       </UiResponsiveDataView>
+
+      <div
+        v-if="(inventoryData?.total ?? 0) > itemsPerPage"
+        class="mt-4 bg-white px-4 py-3 flex items-center justify-between border border-titan-200 rounded-lg"
+      >
+        <p class="text-sm text-titan-700">
+          Mostrando <span class="font-medium">{{ startItem }}</span> a
+          <span class="font-medium">{{ endItem }}</span> de
+          <span class="font-medium">{{ inventoryData?.total ?? 0 }}</span>
+        </p>
+        <div class="flex gap-2">
+          <button
+            type="button"
+            :disabled="!canGoPrevious"
+            class="px-4 py-2 border border-titan-300 text-sm rounded-md disabled:opacity-50"
+            @click="previousPage"
+          >
+            Anterior
+          </button>
+          <button
+            type="button"
+            :disabled="!canGoNext"
+            class="px-4 py-2 border border-titan-300 text-sm rounded-md disabled:opacity-50"
+            @click="nextPage"
+          >
+            Siguiente
+          </button>
+        </div>
+      </div>
     </HealthSemaphore>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 // @ts-ignore
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 
@@ -201,26 +232,51 @@ useHead({ title: 'Stock' })
 // Tenant reactivity
 const { currentTenant } = useTenantReactive()
 
-// State
-const searchQuery = ref('')
+const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
 const categoryFilter = ref('')
 const statusFilter = ref('all')
 const unitFilter = ref('')
+const currentPage = ref(1)
+const itemsPerPage = ref(50)
 
-// Sorting state
-const sortField = ref('')
-const sortDirection = ref('asc')
+const currentOffset = computed(() => (currentPage.value - 1) * itemsPerPage.value)
 
-// Load inventory data from API
-const { data: inventoryData, status: queryStatus, asyncStatus: queryAsyncStatus, refetch } = useQuery({
-  key: () => ['inventory', 'stock', currentTenant.value?.id],
-  query: () => $fetch('/api/inventory/stock', {
-    params: {
-      limit: 250,
-      sort_field: 'current_stock',
-      sort_direction: 'desc'
+const hasActiveFilters = computed(
+  () =>
+    !!localSearchTerm.value
+    || !!appliedSearch.value
+    || statusFilter.value !== 'all'
+    || !!categoryFilter.value
+    || !!unitFilter.value,
+)
+
+const performSearch = () => applySearch(() => { currentPage.value = 1 })
+
+watch(() => currentTenant.value?.id, () => { currentPage.value = 1 })
+
+const sortField = ref('current_stock')
+const sortDirection = ref('desc')
+
+const { data: inventoryData, asyncStatus: queryAsyncStatus, refetch } = useQuery({
+  key: () => ['inventory', 'stock', currentTenant.value?.id, {
+    search: appliedSearch.value || null,
+    status: statusFilter.value,
+    sort_field: sortField.value,
+    sort_direction: sortDirection.value,
+    page: currentPage.value,
+    limit: itemsPerPage.value,
+  }],
+  query: () => {
+    const params: Record<string, string | number> = {
+      limit: itemsPerPage.value,
+      offset: currentOffset.value,
+      sort_field: sortField.value,
+      sort_direction: sortDirection.value,
+      status_filter: statusFilter.value,
     }
-  }),
+    if (appliedSearch.value) params.search = appliedSearch.value
+    return $fetch('/api/inventory/stock', { params })
+  },
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })
@@ -259,55 +315,49 @@ const units = computed(() => {
   return Array.from(unitsSet).sort()
 })
 
-const filteredInventory = computed(() => {
-  return inventory.value.filter(item => {
-    const matchesSearch = item.ingredient_name.toLowerCase().includes(searchQuery.value.toLowerCase())
-    const matchesStatus = statusFilter.value === 'all' || item.status === statusFilter.value
+const displayInventory = computed(() =>
+  inventory.value.filter((item) => {
     const matchesCategory = !categoryFilter.value || item.category === categoryFilter.value
     const matchesUnit = !unitFilter.value || item.unit === unitFilter.value
-    return matchesSearch && matchesStatus && matchesCategory && matchesUnit
-  })
-})
+    return matchesCategory && matchesUnit
+  }),
+)
 
-// Sorted inventory
-const sortedInventory = computed(() => {
-  if (!sortField.value) return filteredInventory.value
+const totalPages = computed(() =>
+  Math.ceil((inventoryData.value?.total ?? 0) / itemsPerPage.value),
+)
+const canGoPrevious = computed(() => currentPage.value > 1)
+const canGoNext = computed(() => currentPage.value < totalPages.value)
+const startItem = computed(() =>
+  inventoryData.value?.total ? (currentPage.value - 1) * itemsPerPage.value + 1 : 0,
+)
+const endItem = computed(() =>
+  Math.min(currentPage.value * itemsPerPage.value, inventoryData.value?.total ?? 0),
+)
 
-  const sorted = [...filteredInventory.value].sort((a, b) => {
-    const aValue = a[sortField.value]
-    const bValue = b[sortField.value]
+const previousPage = () => {
+  if (canGoPrevious.value) currentPage.value--
+}
+const nextPage = () => {
+  if (canGoNext.value) currentPage.value++
+}
 
-    if (aValue === null || aValue === undefined) return 1
-    if (bValue === null || bValue === undefined) return -1
-
-    if (typeof aValue === 'number' && typeof bValue === 'number') {
-      return sortDirection.value === 'asc' ? aValue - bValue : bValue - aValue
-    }
-
-    const strA = String(aValue).toLowerCase()
-    const strB = String(bValue).toLowerCase()
-    return sortDirection.value === 'asc' ? strA.localeCompare(strB) : strB.localeCompare(strA)
-  })
-
-  return sorted
-})
-
-// Handle sort
-const handleSort = (field) => {
+const handleSort = (field: string) => {
   if (sortField.value === field) {
     sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
   } else {
     sortField.value = field
     sortDirection.value = 'asc'
   }
+  currentPage.value = 1
 }
 
-// Clear filters
 const clearFilters = () => {
-  searchQuery.value = ''
+  clearSearch()
   categoryFilter.value = ''
   statusFilter.value = 'all'
   unitFilter.value = ''
+  currentPage.value = 1
 }
 
 // Table columns configuration


### PR DESCRIPTION
## Summary

Migrates batch #882 inventory/abastecimiento list pages from `SharedFiltersBar` to `UiAdvancedFiltersBar` with Pinia Colada keys aligned to API params (epic #879).

- **Stock** (`/abastecimiento/stock`, `/inventario/stock`): server `search`, `status_filter`, sort, pagination (`offset`/`limit`); category/unit remain client-side on the current page.
- **Ingredientes propios**: server `search`, `type`, `show_archived`, `page` on `/api/suppliers/ingredients`.
- **Ajustes** (both modules): same pattern as `inventario/movimientos` — date range + ingredient in Colada key; client text search and pos/neg type on up to 500 rows (API has no `search`).

Closes #882

## Test plan

- [ ] `/abastecimiento/stock` — search applies on Enter; status/sort refetch; category/unit filter current page; pagination when total > 50
- [ ] `/inventario/stock` — same as abastecimiento stock (no “Ajustar stock” button)
- [ ] `/abastecimiento/ingredientes-propios` — search/type/archived refetch; sort client-only on results; clear resets all filters
- [ ] `/abastecimiento/ajustes` — date presets; ingredient filter refetches; text search client; incremento/decremento client
- [ ] `/inventario/ajustes` — mirror abastecimiento ajustes
- [ ] Tenant switch resets stock pagination; Colada invalidates as expected

## Notes

- Does not touch `inventario/movimientos` (#765).
- Build/lint not run in agent session (manual smoke above).


Made with [Cursor](https://cursor.com)