### PR TITLE
feat(filters): batch 4 — despacho (domicilios, en-mesa, comandas)

### DIFF
--- a/pages/despacho/comandas.vue
+++ b/pages/despacho/comandas.vue
@@ -11,6 +11,35 @@ useHead({ title: 'Comandas — WARO' })
 
 const { currentTenant } = useTenantReactive()
 const { singular: tableSingular } = useTableLabel()
+const { activeStations } = useActiveStationsQuery()
+
+const selectedSourceType = ref('')
+const selectedStationId = ref('')
+const selectedStatus = ref('pending,preparing,ready')
+const selectedDate = ref('')
+
+const filters = computed(() => ({
+  source_type: selectedSourceType.value || undefined,
+  station_id: selectedStationId.value || undefined,
+  status: selectedStatus.value || undefined,
+  date: selectedDate.value || undefined,
+}))
+
+const hasActiveFilters = computed(
+  () =>
+    !!selectedSourceType.value
+    || !!selectedStationId.value
+    || selectedStatus.value !== 'pending,preparing,ready'
+    || !!selectedDate.value,
+)
+
+const clearFilters = () => {
+  selectedSourceType.value = ''
+  selectedStationId.value = ''
+  selectedStatus.value = 'pending,preparing,ready'
+  selectedDate.value = ''
+  clearSelection()
+}
 
 const SOURCE_LABELS = computed<Record<string, string>>(() => ({
   table:    tableSingular.value,
@@ -117,13 +146,15 @@ const {
   asyncStatus: comandasAsyncStatus,
   refetch: refetchComandas,
 } = useQuery({
-  key: () => ['comandas-monitor', currentTenant.value?.id],
+  key: () => ['comandas-monitor', currentTenant.value?.id, filters.value],
   query: () => $fetch<{ success: boolean; data: any[] }>('/api/api/comandas', {
-    params: { status: 'pending,preparing,ready' },
+    params: filters.value,
   }),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })
+
+watch(filters, () => { clearSelection() })
 
 const comandas = computed(() => comandasData.value?.data ?? [])
 const isLoadingComandas = computed(() => comandasStatus.value === 'loading' || (!comandasData.value && comandasStatus.value !== 'error'))
@@ -180,6 +211,57 @@ const getComandaStatusVariant = (status: string): string => {
 
     <!-- Main content -->
     <div v-else class="flex flex-col gap-3">
+      <UiAdvancedFiltersBar
+        :search-fields="[]"
+        :show-search="false"
+        :show-date-range="false"
+        :show-clear="hasActiveFilters"
+        @clear="clearFilters"
+      >
+        <template #additional-filters>
+          <select
+            v-model="selectedSourceType"
+            :class="filterSelectClass"
+            aria-label="Filtrar por origen"
+          >
+            <option value="">Origen</option>
+            <option value="table">{{ tableSingular }}</option>
+            <option value="pos">Mostrador</option>
+            <option value="delivery">Domicilio</option>
+            <option value="pickup">Recogida</option>
+          </select>
+          <select
+            v-model="selectedStationId"
+            :class="filterSelectClass"
+            aria-label="Filtrar por estación"
+          >
+            <option value="">Estación</option>
+            <option v-for="s in activeStations" :key="s.id" :value="s.id">
+              {{ s.kitchen_name || s.name }}
+            </option>
+          </select>
+          <select
+            v-model="selectedStatus"
+            :class="filterSelectClass"
+            aria-label="Filtrar por estado"
+          >
+            <option value="pending,preparing,ready">Activas</option>
+            <option value="ready">Listas</option>
+            <option value="pending">Pendientes</option>
+            <option value="preparing">En preparación</option>
+            <option value="delivered">Entregadas</option>
+            <option value="cancelled">Canceladas</option>
+            <option value="pending,preparing,ready,delivered,cancelled">Todas</option>
+          </select>
+          <input
+            v-model="selectedDate"
+            type="date"
+            :class="filterSelectClass"
+            class="min-w-[9rem] cursor-pointer"
+            aria-label="Filtrar por fecha"
+          >
+        </template>
+      </UiAdvancedFiltersBar>
 
       <!-- Bulk action bar -->
       <Transition

--- a/pages/despacho/domicilios/index.vue
+++ b/pages/despacho/domicilios/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted } from 'vue'
+import { onMounted, onUnmounted, watch } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
 // @ts-ignore
@@ -12,8 +12,31 @@ useHead({ title: 'Domicilios — WARO' })
 const { formatDateTime, formatCurrency } = useFormatters()
 const { currentTenant } = useTenantReactive()
 
+const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
+const { dateRangeDates, presetDates, formatDateRange, dateRange, clearDateRange } = useDateRangePresets()
+const statusFilter = ref<string | null>(null)
+const orderTypeFilter = ref<string | null>(null)
+
 const sortField = ref('order_date')
 const sortDirection = ref<'asc' | 'desc'>('desc')
+
+const hasActiveFilters = computed(
+  () =>
+    !!localSearchTerm.value
+    || !!appliedSearch.value
+    || !!dateRangeDates.value
+    || !!statusFilter.value
+    || !!orderTypeFilter.value,
+)
+
+const performSearch = () => applySearch()
+
+const clearFilters = () => {
+  clearSearch()
+  clearDateRange()
+  statusFilter.value = null
+  orderTypeFilter.value = null
+}
 
 const {
   data: ordersData,
@@ -25,12 +48,16 @@ const {
   key: () => ['online-orders', currentTenant.value?.id, {
     sortField: sortField.value,
     sortDirection: sortDirection.value,
+    status: statusFilter.value,
   }],
   query: () => $fetch('/api/online/orders', {
     params: {
+      limit: 200,
+      offset: 0,
       sort_field: sortField.value,
       sort_direction: sortDirection.value,
-    }
+      status: statusFilter.value || undefined,
+    },
   }),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,
@@ -38,7 +65,25 @@ const {
 
 const isLoadingOrders = computed(() => ordersStatus.value === 'loading' || (!ordersData.value && !fetchError.value))
 const isRefreshingOrders = computed(() => ordersAsyncStatus.value === 'loading' && ordersData.value != null)
-const orders = computed(() => ordersData.value?.data ?? [])
+const ordersRaw = computed(() => ordersData.value?.data ?? [])
+
+const displayOrders = computed(() => {
+  const q = appliedSearch.value.trim().toLowerCase()
+  const from = dateRange.value.from
+  const to = dateRange.value.to
+
+  return ordersRaw.value.filter((order: any) => {
+    if (orderTypeFilter.value && order.order_type !== orderTypeFilter.value) return false
+    if (from && to) {
+      const day = String(order.order_date ?? '').slice(0, 10)
+      if (!day || day < from || day > to) return false
+    }
+    if (!q) return true
+    const num = String(order.order_number ?? '')
+    const email = String(order.verified_email ?? '').toLowerCase()
+    return num.includes(q) || email.includes(q)
+  })
+})
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 onMounted(() => { setRefreshHandler(refetchOrders) })
@@ -46,18 +91,18 @@ onUnmounted(() => { clearRefreshHandler(refetchOrders) })
 registerProgressiveLoading(isRefreshingOrders)
 
 const columns: Column[] = [
-  { key: 'order_number',   title: '# Pedido',  sortable: true },
-  { key: 'order_date',     title: 'Fecha',      sortable: true },
+  { key: 'order_number', title: '# Pedido', sortable: true },
+  { key: 'order_date', title: 'Fecha', sortable: true },
   { key: 'scheduled_time', title: 'Programado', sortable: true },
-  { key: 'order_type',     title: 'Tipo',       sortable: true },
-  { key: 'status',         title: 'Estado',     sortable: false },
-  { key: 'total_amount',   title: 'Total',      sortable: true },
-  { key: 'verified_email', title: 'Cliente',    sortable: true },
+  { key: 'order_type', title: 'Tipo', sortable: true },
+  { key: 'status', title: 'Estado', sortable: false },
+  { key: 'total_amount', title: 'Total', sortable: true },
+  { key: 'verified_email', title: 'Cliente', sortable: true },
 ]
 
 const ORDER_TYPE_LABELS: Record<string, string> = {
-  delivery:  'Domicilio',
-  pickup:    'Recogida',
+  delivery: 'Domicilio',
+  pickup: 'Recogida',
   'dine-in': 'En mesa',
 }
 
@@ -71,25 +116,61 @@ const handleSort = ({ field, direction }: { field: string; direction: 'asc' | 'd
 const viewOrder = (order: any) => {
   navigateTo(`/despacho/domicilios/${order.id}`)
 }
+
 </script>
 
 <template>
   <div class="flex flex-col gap-3 md:gap-4">
-    <!-- Loading State -->
     <div v-if="isLoadingOrders" class="flex items-center justify-center min-h-[400px]">
       <CommonsTheCustomLoader size="large" />
     </div>
 
-    <!-- Error State -->
     <CommonsTheErrorState v-else-if="fetchError" />
 
-    <!-- Main Content -->
-    <div v-else>
+    <div v-else class="flex flex-col gap-3 md:gap-4">
+      <UiAdvancedFiltersBar
+        v-model:search="localSearchTerm"
+        v-model:date-range="dateRangeDates"
+        search-placeholder="Buscar # pedido o cliente..."
+        :search-fields="[]"
+        :preset-dates="presetDates"
+        :format-date-range="formatDateRange"
+        :show-clear="hasActiveFilters"
+        @search="performSearch"
+        @clear="clearFilters"
+      >
+        <template #additional-filters>
+          <select
+            v-model="statusFilter"
+            :class="filterSelectClass"
+            aria-label="Filtrar por estado"
+          >
+            <option :value="null">Estado</option>
+            <option value="pending">Pendiente</option>
+            <option value="confirmed">Confirmado</option>
+            <option value="preparing">En preparación</option>
+            <option value="delivered">Entregado</option>
+            <option value="completed">Completado</option>
+            <option value="cancelled">Cancelado</option>
+          </select>
+          <select
+            v-model="orderTypeFilter"
+            :class="filterSelectClass"
+            aria-label="Filtrar por tipo de pedido"
+          >
+            <option :value="null">Tipo</option>
+            <option value="delivery">Domicilio</option>
+            <option value="pickup">Recogida</option>
+            <option value="dine-in">En mesa</option>
+          </select>
+        </template>
+      </UiAdvancedFiltersBar>
+
       <HealthSemaphore :is-unlocked="true" title="Pedidos Online">
         <UiResponsiveDataView
           row-size="sm"
           :columns="columns"
-          :data="orders"
+          :data="displayOrders"
           :sort-field="sortField"
           :sort-direction="sortDirection"
           empty-message="Aún no hay pedidos online."
@@ -98,7 +179,6 @@ const viewOrder = (order: any) => {
           @sort="handleSort"
           @row-click="viewOrder"
         >
-          <!-- Mobile Card -->
           <template #card="{ item, index }">
             <div
               class="flex items-center gap-3 py-3 px-3 border-b border-border cursor-pointer transition-colors hover:bg-surface-secondary"
@@ -123,7 +203,6 @@ const viewOrder = (order: any) => {
             </div>
           </template>
 
-          <!-- Desktop Table Cells -->
           <template #cell-order_number="{ value }">
             <span class="text-sm font-bold text-text-primary">#{{ value }}</span>
           </template>

--- a/pages/despacho/en-mesa/index.vue
+++ b/pages/despacho/en-mesa/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted } from 'vue'
+import { onMounted, onUnmounted, watch } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
 // @ts-ignore
@@ -38,8 +38,23 @@ interface TableGroup {
   requests: TableQrRequest[]
 }
 
+const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
+const tableFilterId = ref('')
+
 const sortField = ref('created_at')
 const sortDirection = ref<'asc' | 'desc'>('desc')
+
+const hasActiveFilters = computed(
+  () => !!localSearchTerm.value || !!appliedSearch.value || !!tableFilterId.value,
+)
+
+const performSearch = () => applySearch()
+
+const clearFilters = () => {
+  clearSearch()
+  tableFilterId.value = ''
+  syncTableQuery()
+}
 
 const {
   data: pendingData,
@@ -60,6 +75,13 @@ const {
 const isLoading = computed(() => pendingStatus.value === 'loading' || (!pendingData.value && !fetchError.value))
 const isRefreshing = computed(() => pendingAsyncStatus.value === 'loading' && pendingData.value != null)
 
+const tableOptions = computed(() =>
+  (pendingData.value?.data?.tables ?? []).map(t => ({
+    id: t.table_id,
+    name: t.table_name,
+  })),
+)
+
 const requests = computed<TableQrRequestRow[]>(() =>
   (pendingData.value?.data?.tables ?? []).flatMap(t =>
     t.requests.map(r => ({
@@ -69,16 +91,13 @@ const requests = computed<TableQrRequestRow[]>(() =>
   ),
 )
 
-const tableFilterId = computed(() => route.query.table as string | undefined)
-
-const filterTableName = computed(() => {
-  if (!tableFilterId.value) return null
-  return requests.value.find(r => r.table_id === tableFilterId.value)?.table_name ?? null
-})
-
 const filteredRequests = computed(() => {
-  if (!tableFilterId.value) return requests.value
-  return requests.value.filter(r => r.table_id === tableFilterId.value)
+  const q = appliedSearch.value.trim().toLowerCase()
+  return requests.value.filter((r) => {
+    if (tableFilterId.value && r.table_id !== tableFilterId.value) return false
+    if (!q) return true
+    return r.table_name.toLowerCase().includes(q)
+  })
 })
 
 const sortedRequests = computed(() => {
@@ -110,8 +129,26 @@ const columns: Column[] = [
   { key: 'total_amount', title: 'Total', sortable: true },
 ]
 
+function syncTableQuery() {
+  const query = { ...route.query }
+  if (tableFilterId.value) {
+    query.table = tableFilterId.value
+  } else {
+    delete query.table
+  }
+  router.replace({ query })
+}
+
+watch(tableFilterId, () => {
+  syncTableQuery()
+})
+
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
-onMounted(() => { setRefreshHandler(refetchPending) })
+onMounted(() => {
+  const fromRoute = route.query.table as string | undefined
+  if (fromRoute) tableFilterId.value = fromRoute
+  setRefreshHandler(refetchPending)
+})
 onUnmounted(() => { clearRefreshHandler(refetchPending) })
 registerProgressiveLoading(isRefreshing)
 
@@ -123,11 +160,6 @@ const handleSort = ({ field, direction }: { field: string; direction: 'asc' | 'd
 const viewRequest = (request: TableQrRequestRow) => {
   navigateTo(`/despacho/en-mesa/${request.id}`)
 }
-
-function clearTableFilter() {
-  const { table: _table, ...rest } = route.query
-  router.replace({ query: rest })
-}
 </script>
 
 <template>
@@ -138,22 +170,29 @@ function clearTableFilter() {
 
     <CommonsTheErrorState v-else-if="fetchError" />
 
-    <div v-else>
-      <div
-        v-if="tableFilterId && filterTableName"
-        class="flex flex-wrap items-center gap-2 mb-1"
+    <div v-else class="flex flex-col gap-3 md:gap-4">
+      <UiAdvancedFiltersBar
+        v-model:search="localSearchTerm"
+        :search-fields="[]"
+        :show-date-range="false"
+        search-placeholder="Buscar mesa..."
+        :show-clear="hasActiveFilters"
+        @search="performSearch"
+        @clear="clearFilters"
       >
-        <span class="text-sm text-text-secondary">
-          Filtrando: <span class="font-medium text-text-primary">{{ filterTableName }}</span>
-        </span>
-        <button
-          type="button"
-          class="text-sm text-primary hover:underline"
-          @click="clearTableFilter"
-        >
-          Ver todos
-        </button>
-      </div>
+        <template #additional-filters>
+          <select
+            v-model="tableFilterId"
+            :class="filterSelectClass"
+            aria-label="Filtrar por mesa"
+          >
+            <option value="">Mesa</option>
+            <option v-for="t in tableOptions" :key="t.id" :value="t.id">
+              {{ t.name }}
+            </option>
+          </select>
+        </template>
+      </UiAdvancedFiltersBar>
 
       <HealthSemaphore :is-unlocked="true" title="Pedidos en mesa (QR)">
         <UiResponsiveDataView


### PR DESCRIPTION
## Summary

Migrates batch #883 despacho list pages to `UiAdvancedFiltersBar` (epic #879).

- **Domicilios** — server `status` + sort; client filter on ≤200 rows for tipo, date range, search (`useAppliedSearch` + `useDateRangePresets`)
- **En-mesa** — mesa select + search; keeps `?table=` deep link; API still `status=pending` only (table filter client-side)
- **Comandas** — server filters in Colada key: `source_type`, `station_id`, `status`, `date` (same params as `/comandas` monitor)

Closes #883

## Test plan

- [ ] `/despacho/domicilios` — status refetches; tipo/fecha/búsqueda filter visible list; clear resets
- [ ] `/despacho/en-mesa` (flags on) — mesa dropdown; `?table=` from notifications; search by mesa name
- [ ] `/despacho/comandas` (comandas_enabled) — origen/estación/estado/fecha refetch; bulk actions still work; clear restores “Activas”

## Notes

- No backend changes. `GET /api/online/orders` has no `order_type`/`date_from`/`search` — domicilios extras are client-side on fetched page.
- `GET /api/table-qr-requests` does not support `table_id` — en-mesa mesa filter remains client-side on pending list.


Made with [Cursor](https://cursor.com)