### PR TITLE
feat(filters): batch 6 — equipo/gestion (#885)

### DIFF
--- a/pages/equipo/nomina.vue
+++ b/pages/equipo/nomina.vue
@@ -15,9 +15,9 @@ const { formatCurrency } = useFormatters()
 // ── Filters ───────────────────────────────────────────────────────────────
 const currentYear = new Date().getFullYear()
 const yearOptions = Array.from({ length: 5 }, (_, i) => currentYear - i)
-const selectedYear  = ref(currentYear)
+const selectedYear = ref(currentYear)
 const selectedMonth = ref<number | null>(null)
-const searchTerm    = ref('')
+const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
 
 const monthOptions = [
   { label: 'Enero',      value: 1  },
@@ -35,11 +35,16 @@ const monthOptions = [
 ]
 
 const hasActiveFilters = computed(
-  () => searchTerm.value !== '' || selectedMonth.value !== null
+  () =>
+    !!localSearchTerm.value
+    || !!appliedSearch.value
+    || selectedMonth.value !== null,
 )
 
+const performSearch = () => applySearch()
+
 const clearFilters = () => {
-  searchTerm.value    = ''
+  clearSearch()
   selectedMonth.value = null
 }
 
@@ -174,8 +179,9 @@ function getHorasExtrasTotal(id: string): number | null {
 const tableData = computed(() => {
   let list = allEmployeesRaw.value
 
-  if (searchTerm.value) {
-    const term = searchTerm.value.toLowerCase()
+  const q = appliedSearch.value.trim().toLowerCase()
+  if (q) {
+    const term = q
     list = list.filter((e: any) =>
       e.name?.toLowerCase().includes(term) || e.email?.toLowerCase().includes(term)
     )
@@ -631,52 +637,33 @@ onUnmounted(() => { clearRefreshHandler(loadData) })
     <!-- Main content -->
     <div v-else class="flex flex-col gap-3 md:gap-4">
 
-      <!-- Filters Bar -->
-      <div class="flex items-center gap-2 w-full overflow-x-auto scrollbar-hide">
-
-        <!-- Search -->
-        <div class="relative flex-1 min-w-[200px]">
-          <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary pointer-events-none">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
-            </svg>
-          </span>
-          <input
-            v-model="searchTerm"
-            placeholder="Buscar empleado..."
-            class="w-full h-10 pl-9 pr-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
-          />
-        </div>
-
-        <!-- Year -->
-        <select
-          v-model="selectedYear"
-          class="h-10 py-2 pl-3 pr-8 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer flex-shrink-0"
-        >
-          <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}</option>
-        </select>
-
-        <!-- Month -->
-        <select
-          v-model="selectedMonth"
-          class="h-10 py-2 pl-3 pr-8 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer flex-shrink-0"
-        >
-          <option :value="null">Todos los meses</option>
-          <option v-for="m in monthOptions" :key="m.value" :value="m.value">{{ m.label }}</option>
-        </select>
-
-        <!-- Clear -->
-        <button
-          v-if="hasActiveFilters"
-          @click="clearFilters"
-          class="h-10 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-secondary hover:text-text-primary hover:border-primary transition-colors"
-          aria-label="Limpiar filtros"
-        >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
-      </div>
+      <UiAdvancedFiltersBar
+        v-model:search="localSearchTerm"
+        :search-fields="[]"
+        :show-date-range="false"
+        search-placeholder="Buscar empleado..."
+        :show-clear="hasActiveFilters"
+        @search="performSearch"
+        @clear="clearFilters"
+      >
+        <template #additional-filters>
+          <select
+            v-model="selectedYear"
+            :class="filterSelectClass"
+            aria-label="Filtrar por año"
+          >
+            <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}</option>
+          </select>
+          <select
+            v-model="selectedMonth"
+            :class="filterSelectClass"
+            aria-label="Filtrar por mes"
+          >
+            <option :value="null">Mes</option>
+            <option v-for="m in monthOptions" :key="m.value" :value="m.value">{{ m.label }}</option>
+          </select>
+        </template>
+      </UiAdvancedFiltersBar>
 
       <!-- Bulk action bar -->
       <Transition name="slide-down">

--- a/pages/equipo/salarios/index.vue
+++ b/pages/equipo/salarios/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue'
+import { computed, onMounted, onUnmounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 // @ts-ignore
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
@@ -13,8 +13,15 @@ useHead({ title: 'Salarios' })
 // Tenant reactivity
 const { currentTenant } = useTenantReactive()
 
-// State
-const localSearchTerm = ref('')
+const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
+
+const hasActiveFilters = computed(
+  () => !!localSearchTerm.value || !!appliedSearch.value,
+)
+
+const performSearch = () => applySearch()
+
+const clearFilters = () => clearSearch()
 
 // Fetch employees with salary data
 const { data: employeesData, status: queryStatus, asyncStatus: queryAsyncStatus, refetch } = useQuery({
@@ -31,9 +38,9 @@ const isRefreshing = computed(() => queryAsyncStatus.value === 'loading' && empl
 const employees = computed(() => {
   let data = employeesData.value?.data || []
 
-  // Filter by search
-  if (localSearchTerm.value) {
-    const term = localSearchTerm.value.toLowerCase()
+  const q = appliedSearch.value.trim().toLowerCase()
+  if (q) {
+    const term = q
     data = data.filter(e =>
       (e.name && e.name.toLowerCase().includes(term)) ||
       (e.email && e.email.toLowerCase().includes(term)) ||
@@ -55,15 +62,6 @@ const stats = computed(() => {
     employeesWithSalary: data.filter(e => e.salary_type).length
   }
 })
-
-// Methods
-const performSearch = () => {
-  // Trigger reactivity by keeping the search term
-}
-
-const clearFilters = () => {
-  localSearchTerm.value = ''
-}
 
 const formatCurrency = (value: number) => {
   return new Intl.NumberFormat('es-CO', {
@@ -154,38 +152,15 @@ onUnmounted(() => {
         />
       </div>
 
-      <!-- Filters Bar -->
-      <div class="flex items-center gap-2 w-full overflow-x-auto scrollbar-hide">
-        <!-- Search Input -->
-        <div class="relative flex-1 min-w-[200px]">
-          <button
-            @click="performSearch"
-            class="absolute left-3 top-1/2 transform -translate-y-1/2 text-text-secondary hover:text-primary transition-colors cursor-pointer"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
-            </svg>
-          </button>
-          <input
-            v-model="localSearchTerm"
-            @keydown.enter="performSearch"
-            placeholder="Buscar empleados..."
-            class="w-full h-10 pl-9 pr-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
-          />
-        </div>
-
-        <!-- Clear Filters Button -->
-        <button
-          v-if="localSearchTerm"
-          @click="clearFilters"
-          class="h-10 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-secondary hover:text-text-primary hover:border-primary transition-colors"
-          title="Limpiar filtros"
-        >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
-      </div>
+      <UiAdvancedFiltersBar
+        v-model:search="localSearchTerm"
+        :search-fields="[]"
+        :show-date-range="false"
+        search-placeholder="Buscar empleados..."
+        :show-clear="hasActiveFilters"
+        @search="performSearch"
+        @clear="clearFilters"
+      />
 
       <!-- Responsive Data View -->
       <HealthSemaphore :is-unlocked="true" title="Gestión de Salarios">

--- a/pages/gestion/ingredientes/index.vue
+++ b/pages/gestion/ingredientes/index.vue
@@ -12,42 +12,54 @@
     <!-- Main Content -->
     <div v-else class="flex flex-col gap-3 md:gap-4">
 
-      <!-- Filters -->
-      <SharedFiltersBar
-        v-model:search="searchQuery"
-        search-label="Buscar"
+      <UiAdvancedFiltersBar
+        v-model:search="localSearchTerm"
+        :search-fields="[]"
+        :show-date-range="false"
         search-placeholder="Buscar ingredientes..."
-        @search="handleSearch"
-        @clear-filters="clearFilters"
+        :show-clear="hasActiveFilters"
+        @search="performSearch"
+        @clear="clearFilters"
       >
         <template #additional-filters>
           <select
             v-model="typeFilter"
-            class="px-3 py-2 border border-border rounded-lg text-sm text-text-primary bg-surface focus:outline-none focus:ring-2 focus:ring-primary"
+            :class="filterSelectClass"
             aria-label="Filtrar por tipo"
           >
-            <option value="">Todos los tipos</option>
+            <option value="">Tipo</option>
             <option value="food">Alimentos</option>
             <option value="service">Servicios</option>
             <option value="supply">Insumos</option>
           </select>
-          <!-- Hierarchy filter toggle -->
-          <div class="flex rounded-lg border border-border overflow-hidden text-sm" role="group" aria-label="Filtrar por jerarquía de ingredientes">
+          <div class="flex rounded-lg border border-border overflow-hidden text-sm shrink-0" role="group" aria-label="Filtrar por jerarquía de ingredientes">
             <button
+              type="button"
+              class="px-3 py-2 min-h-[44px] transition-colors"
+              :class="hierarchyFilter === '' ? 'bg-primary text-white' : 'bg-surface text-text-secondary hover:bg-surface-secondary'"
               @click="hierarchyFilter = ''"
-              :class="['px-3 py-2 min-h-[44px] transition-colors', hierarchyFilter === '' ? 'bg-primary text-white' : 'bg-surface text-text-secondary hover:bg-surface-secondary']"
-            >Ver todas</button>
+            >
+              Todas
+            </button>
             <button
+              type="button"
+              class="px-3 py-2 min-h-[44px] border-l border-border transition-colors"
+              :class="hierarchyFilter === 'bases' ? 'bg-primary text-white' : 'bg-surface text-text-secondary hover:bg-surface-secondary'"
               @click="hierarchyFilter = 'bases'"
-              :class="['px-3 py-2 min-h-[44px] border-l border-border transition-colors', hierarchyFilter === 'bases' ? 'bg-primary text-white' : 'bg-surface text-text-secondary hover:bg-surface-secondary']"
-            >Solo bases</button>
+            >
+              Bases
+            </button>
             <button
+              type="button"
+              class="px-3 py-2 min-h-[44px] border-l border-border transition-colors"
+              :class="hierarchyFilter === 'variantes' ? 'bg-primary text-white' : 'bg-surface text-text-secondary hover:bg-surface-secondary'"
               @click="hierarchyFilter = 'variantes'"
-              :class="['px-3 py-2 min-h-[44px] border-l border-border transition-colors', hierarchyFilter === 'variantes' ? 'bg-primary text-white' : 'bg-surface text-text-secondary hover:bg-surface-secondary']"
-            >Solo variantes</button>
+            >
+              Variantes
+            </button>
           </div>
         </template>
-      </SharedFiltersBar>
+      </UiAdvancedFiltersBar>
 
       <!-- Table -->
       <UiResponsiveDataView
@@ -450,15 +462,26 @@ definePageMeta({
 useHead({ title: 'Catálogo Global — WaRo Admin' })
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
+const { currentTenant } = useTenantReactive()
 
 // ── Constants ───────────────────────────────────────────────────────────────
 const PAGE_SIZE = 50
 
 // ── Filters & pagination ────────────────────────────────────────────────────
-const searchQuery = ref('')
+const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
 const typeFilter = ref('')
 const hierarchyFilter = ref<'' | 'bases' | 'variantes'>('bases')
 const currentPage = ref(1)
+
+const hasActiveFilters = computed(
+  () =>
+    !!localSearchTerm.value
+    || !!appliedSearch.value
+    || !!typeFilter.value
+    || hierarchyFilter.value !== 'bases',
+)
+
+const performSearch = () => applySearch(() => { currentPage.value = 1 })
 
 // ── Data fetch ──────────────────────────────────────────────────────────────
 const {
@@ -468,15 +491,20 @@ const {
   error: fetchError,
   refetch: refresh
 } = useQuery({
-  key: () => ['admin-ingredients', currentPage.value, PAGE_SIZE, searchQuery.value, hierarchyFilter.value],
+  key: () => ['admin-ingredients', currentTenant.value?.id, {
+    page: currentPage.value,
+    search: appliedSearch.value || null,
+    hierarchy: hierarchyFilter.value,
+  }],
   query: () => $fetch('/api/admin/ingredients', {
     params: {
       page: currentPage.value,
       limit: PAGE_SIZE,
-      search: searchQuery.value || undefined,
+      search: appliedSearch.value || undefined,
       bases_only: hierarchyFilter.value === 'bases' ? true : undefined,
-    }
+    },
   }),
+  enabled: () => !!currentTenant.value,
   staleTime: 30_000,
 })
 const isLoading = computed(() => !listData.value && queryStatus.value === 'loading')
@@ -497,14 +525,10 @@ const filteredBases = computed(() => {
   return rows
 })
 
-function handleSearch() {
-  currentPage.value = 1
-}
-
 function clearFilters() {
-  searchQuery.value = ''
+  clearSearch()
   typeFilter.value = ''
-  hierarchyFilter.value = ''
+  hierarchyFilter.value = 'bases'
   currentPage.value = 1
 }
 


### PR DESCRIPTION
## Summary
- **`/equipo/salarios`**: `UiAdvancedFiltersBar` + `useAppliedSearch`; client filter on `GET /api/salaries/employees` (no API search params).
- **`/equipo/nomina`**: same search pattern; year/month in `#additional-filters`; benefits still keyed by year (no refetch on keystroke).
- **`/gestion/ingredientes`**: replaces `SharedFiltersBar`; `useAppliedSearch` in Colada key; server `search`/`page`/`bases_only`; client `type` + hierarchy toggles.

## Out of scope
- **`/gestion/billing`**: `/api/billing/events` only supports `limit`/`offset` — left unchanged per epic delta.

## Test plan
- [ ] Salarios: search by name/email/role; clear filters
- [ ] Nómina: year/month + search; export still works
- [ ] Ingredientes: apply search resets page; hierarchy (bases/variantes) + type filter; tenant switch invalidates cache

Closes #885

Made with [Cursor](https://cursor.com)