### PR TITLE
fix(despacho): import useActiveStationsQuery in comandas

### DIFF
--- a/pages/despacho/comandas.vue
+++ b/pages/despacho/comandas.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref, computed, watch } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
+import { useActiveStationsQuery } from '@/composables/queries/useActiveStations'
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
 // @ts-ignore
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'


### PR DESCRIPTION
## Summary
Fixes `ReferenceError: useActiveStationsQuery is not defined` on `/despacho/comandas` after batch #883 filters work.

## Test plan
- [ ] Open `/despacho/comandas` — page loads, station filter dropdown populated

Made with [Cursor](https://cursor.com)