### PR TITLE
feat(menu): migrate submit overlays to shared busy component

### DIFF
--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -1,12 +1,12 @@
 <template>
   <div class="w-full">
-    <!-- Loading overlay during submit -->
-    <div v-if="isSubmitting" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div class="bg-white rounded-lg p-8 flex flex-col items-center">
-        <CommonsTheCustomLoader size="large" />
-        <p class="mt-4 text-lg font-semibold text-text-primary">Actualizando grupo de modificadores...</p>
-      </div>
-    </div>
+    <UiSubmitBusyOverlay
+      :busy="isSubmitting"
+      label="Actualizando grupo de modificadores..."
+      hint="Estamos guardando los cambios del grupo y sincronizando sus opciones."
+      variant="glass"
+      indicator="matrix"
+    />
 
     <!-- Loading State -->
     <div v-if="isLoadingData" class="flex items-center justify-center min-h-[400px]">

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="w-full">
-    <!-- Loading overlay during submit -->
-    <div v-if="isSubmitting" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div class="bg-white rounded-lg p-8 flex flex-col items-center">
-        <CommonsTheCustomLoader size="large" />
-        <p class="mt-4 text-lg font-semibold text-text-primary">Creando grupo de modificadores...</p>
-      </div>
-    </div>
+    <UiSubmitBusyOverlay
+      :busy="isSubmitting"
+      label="Creando grupo de modificadores..."
+      hint="Estamos guardando la configuración y opciones del grupo."
+      variant="glass"
+      indicator="matrix"
+    />
 
     <!-- Loading State -->
     <div v-if="isLoadingData" class="flex items-center justify-center min-h-[400px]">

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="page-layout">
-    <!-- Loading overlay during submit -->
-    <div v-if="isSubmitting" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div class="bg-white rounded-lg p-8 flex flex-col items-center">
-        <CommonsTheCustomLoader size="large" />
-        <p class="mt-4 text-lg font-semibold text-text-primary">Creando producto...</p>
-      </div>
-    </div>
+    <UiSubmitBusyOverlay
+      :busy="isSubmitting"
+      label="Creando producto..."
+      hint="Estamos guardando la configuración del producto y preparando su catálogo."
+      variant="glass"
+      indicator="matrix"
+    />
 
     <!-- Loading State -->
     <div v-if="isLoadingData" class="flex items-center justify-center min-h-[400px]">

--- a/pages/menu/recetas/crear.vue
+++ b/pages/menu/recetas/crear.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="w-full">
-    <!-- Loading overlay during submit -->
-    <div v-if="isSubmitting" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div class="bg-white rounded-lg p-8 flex flex-col items-center">
-        <CommonsTheCustomLoader size="large" />
-        <p class="mt-4 text-lg font-semibold text-text-primary">Creando receta base...</p>
-      </div>
-    </div>
+    <UiSubmitBusyOverlay
+      :busy="isSubmitting"
+      label="Creando receta base..."
+      hint="Estamos guardando la receta y consolidando sus ingredientes."
+      variant="glass"
+      indicator="matrix"
+    />
 
     <!-- Loading State -->
     <div v-if="isLoadingData" class="flex items-center justify-center min-h-[400px]">


### PR DESCRIPTION
## Summary
- migrate menu fullscreen submit overlays to `UiSubmitBusyOverlay`
- preserve matrix loading as the menu submit visual language
- keep menu inline busy overlays out of scope for the dedicated follow-up batch

## Test plan
- [ ] Open `/menu/productos/crear` and trigger submit
- [ ] Open `/menu/recetas/crear` and trigger submit
- [ ] Open `/menu/modificadores/crear` and trigger submit
- [ ] Open `/menu/modificadores/[id]` and trigger update submit
- [ ] Confirm each route now uses the shared glass overlay with matrix mode

Closes #895

Made with [Cursor](https://cursor.com)