### PR TITLE
feat(abastecimiento): unify submit overlays in purchase flows

### DIFF
--- a/components/abastecimiento/AbastecimientoStockAdjustmentFullForm.vue
+++ b/components/abastecimiento/AbastecimientoStockAdjustmentFullForm.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="page-layout">
-    <!-- Loading overlay during submit -->
-    <div v-if="isSubmitting" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div class="bg-white dark:bg-surface rounded-lg p-8 flex flex-col items-center">
-        <CommonsTheCustomLoader size="large" />
-        <p class="mt-4 text-lg font-semibold text-text-primary">Registrando ajuste...</p>
-      </div>
-    </div>
+    <UiSubmitBusyOverlay
+      :busy="isSubmitting"
+      label="Registrando ajuste..."
+      hint="Estamos guardando el ajuste y actualizando el inventario."
+      variant="glass"
+      indicator="matrix"
+    />
 
     <!-- Loading State -->
     <div v-if="isLoadingData || ingredientsLoading" class="flex items-center justify-center min-h-[400px]">

--- a/pages/abastecimiento/compra/[id]/acciones.vue
+++ b/pages/abastecimiento/compra/[id]/acciones.vue
@@ -1,14 +1,12 @@
 <template>
   <div>
-    <!-- Loading overlay during submit -->
-    <div v-if="isSubmitting || isApproving" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div class="bg-white rounded-lg p-8 flex flex-col items-center">
-        <CommonsTheCustomLoader size="large" />
-        <p class="mt-4 text-lg font-semibold text-text-primary">
-          Procesando acción...
-        </p>
-      </div>
-    </div>
+    <UiSubmitBusyOverlay
+      :busy="isSubmitting || isApproving"
+      :label="isApproving ? 'Aprobando orden...' : 'Procesando acción...'"
+      :hint="isApproving ? 'Estamos aprobando la orden y preparando la siguiente transición.' : 'Estamos ejecutando la acción seleccionada sobre la compra.'"
+      variant="glass"
+      indicator="matrix"
+    />
 
     <!-- Loading State for initial data -->
     <div v-if="isLoading" class="flex items-center justify-center min-h-[400px]">

--- a/pages/abastecimiento/compra/[id]/index.vue
+++ b/pages/abastecimiento/compra/[id]/index.vue
@@ -1,15 +1,12 @@
 <template>
   <div>
-    <!-- Loading overlay during submit/delete (always on top) -->
-    <div v-if="isSubmitting || isDeleting"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div class="bg-white rounded-lg p-8 flex flex-col items-center">
-        <CommonsTheCustomLoader size="large" />
-        <p class="mt-4 text-lg font-semibold text-text-primary">
-          {{ isSubmitting ? 'Guardando cambios...' : 'Eliminando orden...' }}
-        </p>
-      </div>
-    </div>
+    <UiSubmitBusyOverlay
+      :busy="isSubmitting || isDeleting"
+      :label="isSubmitting ? 'Guardando cambios...' : 'Eliminando orden...'"
+      :hint="isSubmitting ? 'Estamos actualizando la orden de compra.' : 'Estamos eliminando la orden y cerrando su flujo.'"
+      variant="glass"
+      indicator="matrix"
+    />
 
     <!-- Loading State for initial data -->
     <div v-if="isLoading" class="flex items-center justify-center min-h-[400px]">

--- a/pages/abastecimiento/compra/crear.vue
+++ b/pages/abastecimiento/compra/crear.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="page-layout">
-    <!-- Loading overlay during submit -->
-    <div v-if="isSubmitting" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div class="bg-white rounded-lg p-8 flex flex-col items-center">
-        <CommonsTheCustomLoader size="large" />
-        <p class="mt-4 text-lg font-semibold text-text-primary">Creando cotización...</p>
-      </div>
-    </div>
+    <UiSubmitBusyOverlay
+      :busy="isSubmitting"
+      label="Creando cotización..."
+      hint="Estamos guardando la orden y consolidando sus líneas de compra."
+      variant="glass"
+      indicator="matrix"
+    />
 
     <!-- Loading State -->
     <div v-if="isLoadingData" class="flex items-center justify-center min-h-[400px]">

--- a/pages/abastecimiento/compras-directas/[id]/editar.vue
+++ b/pages/abastecimiento/compras-directas/[id]/editar.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="page-layout">
-    <!-- Loading overlay during submit -->
-    <div v-if="isSubmitting" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div class="bg-white rounded-lg p-8 flex flex-col items-center">
-        <CommonsTheCustomLoader size="large" />
-        <p class="mt-4 text-lg font-semibold text-text-primary">Guardando cambios...</p>
-      </div>
-    </div>
+    <UiSubmitBusyOverlay
+      :busy="isSubmitting"
+      label="Guardando cambios..."
+      hint="Estamos actualizando la compra directa y sus datos asociados."
+      variant="glass"
+      indicator="matrix"
+    />
 
     <!-- Loading State -->
     <div v-if="isLoadingData" class="flex items-center justify-center min-h-[400px]">

--- a/pages/abastecimiento/compras-directas/[id]/index.vue
+++ b/pages/abastecimiento/compras-directas/[id]/index.vue
@@ -1,15 +1,12 @@
 <template>
   <div class="page-layout">
-    <!-- Loading overlay during save/upload -->
-    <div v-if="isSaving || isUploading"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div class="bg-white rounded-lg p-8 flex flex-col items-center">
-        <CommonsTheCustomLoader size="large" />
-        <p class="mt-4 text-lg font-semibold text-text-primary">
-          {{ isSaving ? 'Guardando cambios...' : 'Subiendo archivo...' }}
-        </p>
-      </div>
-    </div>
+    <UiSubmitBusyOverlay
+      :busy="isSaving || isUploading"
+      :label="isSaving ? 'Guardando cambios...' : 'Subiendo archivo...'"
+      :hint="isSaving ? 'Estamos actualizando la compra directa.' : 'Estamos subiendo el archivo y asociandolo a la compra.'"
+      variant="glass"
+      indicator="matrix"
+    />
 
     <!-- Loading State -->
     <div v-if="isLoading" class="flex items-center justify-center min-h-[400px]">


### PR DESCRIPTION
## Summary
- replace the legacy fullscreen submit scrim in the scoped abastecimiento purchase flows with `UiSubmitBusyOverlay`
- preserve route-specific labels and hints for create, edit, approve, delete, upload, and stock-adjustment actions
- keep initial loading states untouched so this batch only standardizes submit overlays

## Test plan
- [ ] `/abastecimiento/compra/crear` shows the shared submit overlay on save
- [ ] `/abastecimiento/compra/[id]/index` shows the shared overlay for save and delete
- [ ] `/abastecimiento/compra/[id]/acciones` shows the shared overlay while processing actions and approval
- [ ] `/abastecimiento/compras-directas/[id]/editar` shows the shared overlay on save
- [ ] `/abastecimiento/compras-directas/[id]/index` shows the shared overlay on save and file upload
- [ ] stock adjustment full form shows the shared overlay on submit
- [ ] Automated checks not run (build/lint/typecheck not requested in this turn)

Closes #896

Made with [Cursor](https://cursor.com)