### PR TITLE
feat(finanzas-equipo): unify submit overlays in finance flows

### DIFF
--- a/pages/equipo/salarios/[id]/index.vue
+++ b/pages/equipo/salarios/[id]/index.vue
@@ -281,13 +281,13 @@ watch(employeeData, (data) => {
 
 <template>
   <div class="page-layout">
-    <!-- Loading overlay during submit -->
-    <div v-if="isSubmitting" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div class="bg-white rounded-lg p-8 flex flex-col items-center">
-        <CommonsTheCustomLoader size="large" />
-        <p class="mt-4 text-lg font-semibold text-text-primary">{{ isDeleting ? 'Eliminando empleado...' : 'Guardando cambios...' }}</p>
-      </div>
-    </div>
+    <UiSubmitBusyOverlay
+      :busy="isSubmitting"
+      :label="isDeleting ? 'Eliminando empleado...' : 'Guardando cambios...'"
+      :hint="isDeleting ? 'Estamos eliminando el empleado y cerrando su registro.' : 'Estamos actualizando el empleado y guardando los cambios.'"
+      variant="glass"
+      indicator="matrix"
+    />
 
     <!-- Loading State -->
     <div v-if="isLoadingEmployee" class="flex items-center justify-center min-h-[400px]">

--- a/pages/finanzas/gastos/[id]/editar.vue
+++ b/pages/finanzas/gastos/[id]/editar.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="page-layout">
-    <!-- Loading overlay during submit -->
-    <div v-if="isSubmitting" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div class="bg-white rounded-lg p-8 flex flex-col items-center">
-        <CommonsTheCustomLoader size="large" />
-        <p class="mt-4 text-lg font-semibold text-text-primary">Guardando cambios...</p>
-      </div>
-    </div>
+    <UiSubmitBusyOverlay
+      :busy="isSubmitting"
+      label="Guardando cambios..."
+      hint="Estamos actualizando el gasto y sus datos asociados."
+      variant="glass"
+      indicator="matrix"
+    />
 
     <!-- Loading State -->
     <div v-if="isLoading" class="flex items-center justify-center min-h-[400px]">

--- a/pages/finanzas/gastos/[id]/index.vue
+++ b/pages/finanzas/gastos/[id]/index.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="page-layout">
-    <!-- Loading overlay during submit -->
-    <div v-if="isSubmitting" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div class="bg-white rounded-lg p-8 flex flex-col items-center">
-        <CommonsTheCustomLoader size="large" />
-        <p class="mt-4 text-lg font-semibold text-text-primary">{{ isDeleting ? 'Eliminando gasto...' : 'Guardando cambios...' }}</p>
-      </div>
-    </div>
+    <UiSubmitBusyOverlay
+      :busy="isSubmitting"
+      :label="isDeleting ? 'Eliminando gasto...' : 'Guardando cambios...'"
+      :hint="isDeleting ? 'Estamos eliminando el gasto y cerrando su registro.' : 'Estamos actualizando el gasto y guardando los cambios.'"
+      variant="glass"
+      indicator="matrix"
+    />
 
     <!-- Loading State -->
     <div v-if="isLoading" class="flex items-center justify-center min-h-[400px]">

--- a/pages/finanzas/gastos/[id]/instancia.vue
+++ b/pages/finanzas/gastos/[id]/instancia.vue
@@ -147,13 +147,13 @@ watch(expenseData, (data) => {
 
 <template>
   <div class="page-layout">
-    <!-- Loading overlay during submit -->
-    <div v-if="isSubmitting" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div class="bg-white rounded-lg p-8 flex flex-col items-center">
-        <CommonsTheCustomLoader size="large" />
-        <p class="mt-4 text-lg font-semibold text-text-primary">Creando instancia...</p>
-      </div>
-    </div>
+    <UiSubmitBusyOverlay
+      :busy="isSubmitting"
+      label="Creando instancia..."
+      hint="Estamos registrando la instancia del gasto y consolidando sus datos."
+      variant="glass"
+      indicator="matrix"
+    />
 
     <!-- Loading State -->
     <div v-if="isLoading" class="flex items-center justify-center min-h-[400px]">

--- a/pages/finanzas/gastos/crear.vue
+++ b/pages/finanzas/gastos/crear.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="page-layout">
-    <!-- Loading overlay during submit -->
-    <div v-if="isSubmitting" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div class="bg-white rounded-lg p-8 flex flex-col items-center">
-        <CommonsTheCustomLoader size="large" />
-        <p class="mt-4 text-lg font-semibold text-text-primary">Registrando gasto...</p>
-      </div>
-    </div>
+    <UiSubmitBusyOverlay
+      :busy="isSubmitting"
+      label="Registrando gasto..."
+      hint="Estamos guardando el gasto y actualizando su registro financiero."
+      variant="glass"
+      indicator="matrix"
+    />
 
     <!-- Loading State -->
     <div v-if="isLoadingCategories" class="flex items-center justify-center min-h-[400px]">


### PR DESCRIPTION
## Summary
- replace the legacy fullscreen submit overlays in the scoped finance and salary flows with `UiSubmitBusyOverlay`
- preserve route-specific labels and dynamic save/delete copy for expense detail and employee detail flows
- keep initial fetch loaders untouched so this batch only standardizes submit overlays

## Test plan
- [ ] `/finanzas/gastos/crear` shows the shared submit overlay on save
- [ ] `/finanzas/gastos/[id]/editar` shows the shared submit overlay on save
- [ ] `/finanzas/gastos/[id]` shows the shared overlay with correct save/delete copy
- [ ] `/finanzas/gastos/[id]/instancia` shows the shared submit overlay on create
- [ ] `/equipo/salarios/[id]` shows the shared overlay with correct save/delete copy
- [ ] Automated checks not run (build/lint/typecheck not requested in this turn)

Closes #897

Made with [Cursor](https://cursor.com)