### PR TITLE
feat(contabilidad): use slide-over for journal entry detail on asientos

### DIFF
--- a/components/Finanzas/contabilidad/AsientoDetailPanel.vue
+++ b/components/Finanzas/contabilidad/AsientoDetailPanel.vue
@@ -16,6 +16,7 @@ interface JournalEntryWithLines {
   description: string
   reference: string | null
   sourceModule: string | null
+  sourceId: string | null
   status: string
   totalDebit: number
   totalCredit: number
@@ -31,14 +32,19 @@ interface AccountLookup {
   name: string
 }
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   modelValue: boolean
   entryId: string | null
   allAccounts: AccountLookup[]
-}>()
+  allowActions?: boolean
+}>(), {
+  allowActions: false,
+})
 
 const emit = defineEmits<{
   'update:modelValue': [value: boolean]
+  'updated': []
+  'void-request': []
 }>()
 
 const close = () => emit('update:modelValue', false)
@@ -105,6 +111,35 @@ const accountById = computed<Record<string, AccountLookup>>(() => {
   for (const a of props.allAccounts) map[a.id] = a
   return map
 })
+
+const entryLink = computed((): string | null => {
+  if (!entry.value?.sourceId) return null
+  if (entry.value.sourceModule === 'orden' || entry.value.sourceModule === 'orden_cogs') {
+    return `/ventas/${entry.value.sourceId}`
+  }
+  if (entry.value.sourceModule === 'inventario') {
+    return `/abastecimiento/compras-directas/${entry.value.sourceId}`
+  }
+  return null
+})
+
+const posting = ref(false)
+const postError = ref('')
+
+const handlePost = async () => {
+  if (!entry.value) return
+  posting.value = true
+  postError.value = ''
+  try {
+    await $fetch(`/api/accounting/journal-entries/${entry.value.id}/post`, { method: 'POST' })
+    await fetchEntry(entry.value.id)
+    emit('updated')
+  } catch (err: any) {
+    postError.value = err?.data?.detail || err?.data?.message || 'Error al publicar el asiento'
+  } finally {
+    posting.value = false
+  }
+}
 
 const fetchEntry = async (id: string) => {
   loading.value = true
@@ -240,7 +275,14 @@ watch(
               <p class="text-xs uppercase tracking-wider text-text-secondary font-medium mb-1">
                 Descripción
               </p>
-              <p class="text-sm text-text-primary leading-relaxed">{{ entry.description }}</p>
+              <NuxtLink
+                v-if="entryLink"
+                :to="entryLink"
+                class="text-sm text-primary hover:underline leading-relaxed"
+              >
+                {{ entry.description }}
+              </NuxtLink>
+              <p v-else class="text-sm text-text-primary leading-relaxed">{{ entry.description }}</p>
             </div>
 
             <!-- Reference -->
@@ -302,12 +344,48 @@ watch(
                 <span class="font-medium text-destructive">Anulado:</span> {{ new Date(entry.voidedAt).toLocaleString('es-CO') }}
               </p>
             </div>
+
+            <div v-if="postError" class="rounded-xl border border-destructive/40 bg-destructive/8 px-4 py-3">
+              <p class="text-sm text-destructive font-medium">{{ postError }}</p>
+            </div>
           </template>
         </div>
 
         <!-- Sticky footer -->
         <div class="flex-shrink-0 border-t border-border bg-surface px-6 py-4">
+          <div v-if="allowActions && entry && !loading && !error" class="flex items-center gap-3">
+            <button
+              type="button"
+              class="min-h-[44px] px-4 py-2 rounded-lg border border-border text-sm font-semibold text-text-secondary hover:bg-surface-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+              @click="close"
+            >
+              Cerrar
+            </button>
+            <div class="flex-1" />
+            <button
+              v-if="entry.status === 'draft'"
+              type="button"
+              :disabled="posting"
+              class="min-h-[44px] px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              @click="handlePost"
+            >
+              <svg v-if="posting" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+              </svg>
+              <span>{{ posting ? 'Publicando...' : 'Publicar' }}</span>
+            </button>
+            <button
+              v-if="entry.status === 'posted'"
+              type="button"
+              class="min-h-[44px] px-4 py-2 rounded-lg border-2 border-destructive/50 text-destructive text-sm font-semibold hover:bg-destructive/10 transition-colors"
+              @click="emit('void-request')"
+            >
+              Anular
+            </button>
+          </div>
           <button
+            v-else
             type="button"
             class="w-full min-h-[44px] rounded-lg border border-border text-sm font-semibold text-text-secondary hover:bg-surface-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
             @click="close"

--- a/pages/finanzas/contabilidad/asientos/index.vue
+++ b/pages/finanzas/contabilidad/asientos/index.vue
@@ -36,20 +36,6 @@ interface JournalEntry {
   createdAt: string
 }
 
-interface JournalLine {
-  id: string
-  journalEntryId: string
-  accountId: string
-  debit: number
-  credit: number
-  description: string | null
-  lineOrder: number
-}
-
-interface JournalEntryWithLines extends JournalEntry {
-  lines: JournalLine[]
-}
-
 const statusFilter = ref<string>('')
 const sourceModuleFilter = ref<string>('')
 const { dateRangeDates, presetDates, formatDateRange, dateRange, clearDateRange } = useDateRangePresets()
@@ -75,13 +61,9 @@ const { data: accountsData } = useQuery({
   staleTime: 300_000,
 })
 
-const accountsMap = computed<Map<string, { code: string; name: string }>>(() => {
-  const m = new Map<string, { code: string; name: string }>()
-  for (const a of accountsData.value?.data ?? []) {
-    m.set(a.id, { code: a.code, name: a.name })
-  }
-  return m
-})
+const allAccountsForPanel = computed(() =>
+  (accountsData.value?.data ?? []).map(a => ({ id: a.id, code: a.code, name: a.name })),
+)
 
 // ── Data: journal entries (paginated) ───────────────────────────────────────
 const { data: entriesData, asyncStatus, error: fetchError, refetch } = useQuery({
@@ -145,11 +127,6 @@ const formatDate = (iso: string) => {
   return d.toLocaleDateString('es-CO', { day: '2-digit', month: '2-digit', year: 'numeric' })
 }
 
-const formatDateTime = (iso: string) => {
-  if (!iso) return '—'
-  return new Date(iso).toLocaleString('es-CO', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' })
-}
-
 const SOURCE_MODULE_LABELS: Record<string, string> = {
   gastos: 'Gastos',
   ventas: 'Ventas',
@@ -189,56 +166,22 @@ const entryLink = (entry: JournalEntry): string | null => {
   return null
 }
 
-// ── Detail modal ─────────────────────────────────────────────────────────────
-const showDetailModal = ref(false)
+// ── Detail slide-over (#916 — reuse AsientoDetailPanel from #531) ─────────────
+const showDetailPanel = ref(false)
 const selectedEntryId = ref<string | null>(null)
-const selectedEntryDetail = ref<JournalEntryWithLines | null>(null)
-const detailLoading = ref(false)
-const detailError = ref<string | null>(null)
 
-const openDetail = async (entry: JournalEntry) => {
+const openDetail = (entry: JournalEntry) => {
   selectedEntryId.value = entry.id
-  selectedEntryDetail.value = null
-  detailError.value = null
-  detailLoading.value = true
-  showDetailModal.value = true
-  try {
-    const res = await $fetch<{ success: boolean; data: JournalEntryWithLines }>(
-      `/api/accounting/journal-entries/${entry.id}`
-    )
-    selectedEntryDetail.value = res.data
-  } catch (err: any) {
-    detailError.value = err?.data?.detail || err?.data?.message || 'Error al cargar el asiento'
-  } finally {
-    detailLoading.value = false
-  }
+  showDetailPanel.value = true
 }
 
 const closeDetail = () => {
-  showDetailModal.value = false
+  showDetailPanel.value = false
   selectedEntryId.value = null
-  selectedEntryDetail.value = null
-  detailError.value = null
-  postError.value = null
 }
 
-// ── Post action ──────────────────────────────────────────────────────────────
-const posting = ref(false)
-const postError = ref<string | null>(null)
-
-const handlePost = async () => {
-  if (!selectedEntryId.value) return
-  posting.value = true
-  postError.value = null
-  try {
-    await $fetch(`/api/accounting/journal-entries/${selectedEntryId.value}/post`, { method: 'POST' })
-    closeDetail()
-    await refetch()
-  } catch (err: any) {
-    postError.value = err?.data?.detail || err?.data?.message || 'Error al publicar el asiento'
-  } finally {
-    posting.value = false
-  }
+const onDetailUpdated = async () => {
+  await refetch()
 }
 
 // ── Void action ──────────────────────────────────────────────────────────────
@@ -277,23 +220,6 @@ const handleVoid = async () => {
     voiding.value = false
   }
 }
-
-// ── Lines columns ────────────────────────────────────────────────────────────
-const linesColumns = [
-  { key: 'lineOrder',   title: '#',          sortable: false },
-  { key: 'account',     title: 'Cuenta',     sortable: false },
-  { key: 'debit',       title: 'Débito',     sortable: false },
-  { key: 'credit',      title: 'Crédito',    sortable: false },
-  { key: 'description', title: 'Descripción', sortable: false },
-]
-
-const resolvedLines = computed(() => {
-  if (!selectedEntryDetail.value?.lines) return []
-  return selectedEntryDetail.value.lines.map(line => ({
-    ...line,
-    accountResolved: accountsMap.value.get(line.accountId),
-  }))
-})
 
 // ── Layout integration ───────────────────────────────────────────────────────
 registerProgressiveLoading(isRefreshing)
@@ -516,302 +442,14 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
 
     </div>
 
-    <!-- ── Entry detail modal (desktop) ───────────────────────────────────── -->
-    <UiModal v-model="showDetailModal" title="Detalle del asiento" max-height="xl">
-      <div class="overflow-y-auto max-h-[70vh]">
-        <!-- Loading detail -->
-        <div v-if="detailLoading" class="flex items-center justify-center py-12">
-          <CommonsTheCustomLoader size="medium" />
-        </div>
-
-        <!-- Error detail -->
-        <div v-else-if="detailError" class="p-6">
-          <div class="p-4 rounded-lg bg-destructive/10 border border-destructive/20 text-sm text-destructive">
-            {{ detailError }}
-          </div>
-        </div>
-
-        <!-- Entry detail content -->
-        <div v-else-if="selectedEntryDetail" class="p-6 flex flex-col gap-4">
-          <!-- Header fields -->
-          <div class="grid grid-cols-2 gap-3 text-sm">
-            <div>
-              <span class="text-xs font-medium text-text-secondary uppercase tracking-wide">Fecha</span>
-              <p class="mt-0.5 text-text-primary">{{ formatDate(selectedEntryDetail.entryDate) }}</p>
-            </div>
-            <div>
-              <span class="text-xs font-medium text-text-secondary uppercase tracking-wide">Estado</span>
-              <div class="mt-0.5">
-                <UiStatusBadge
-                  :value="STATUS_LABELS[selectedEntryDetail.status] || selectedEntryDetail.status"
-                  format="text"
-                  :variant="selectedEntryDetail.status === 'posted' ? 'success' : selectedEntryDetail.status === 'voided' ? 'destructive' : 'secondary'"
-                  size="sm"
-                />
-              </div>
-            </div>
-            <div class="col-span-2">
-              <span class="text-xs font-medium text-text-secondary uppercase tracking-wide">Descripción</span>
-              <p class="mt-0.5 text-text-primary">
-                <NuxtLink
-                  v-if="entryLink(selectedEntryDetail)"
-                  :to="entryLink(selectedEntryDetail) || ''"
-                  class="text-primary hover:underline"
-                >{{ selectedEntryDetail.description }}</NuxtLink>
-                <span v-else>{{ selectedEntryDetail.description }}</span>
-              </p>
-            </div>
-            <div>
-              <span class="text-xs font-medium text-text-secondary uppercase tracking-wide">Módulo</span>
-              <p class="mt-0.5 text-text-primary">{{ SOURCE_MODULE_LABELS[selectedEntryDetail.sourceModule] || selectedEntryDetail.sourceModule }}</p>
-            </div>
-            <div v-if="selectedEntryDetail.postedAt">
-              <span class="text-xs font-medium text-text-secondary uppercase tracking-wide">Publicado</span>
-              <p class="mt-0.5 text-text-primary">{{ formatDateTime(selectedEntryDetail.postedAt) }}</p>
-            </div>
-            <div v-if="selectedEntryDetail.voidedAt">
-              <span class="text-xs font-medium text-text-secondary uppercase tracking-wide">Anulado</span>
-              <p class="mt-0.5 text-text-primary">{{ formatDateTime(selectedEntryDetail.voidedAt) }}</p>
-            </div>
-          </div>
-
-          <!-- Totals -->
-          <div class="flex items-center gap-4 p-3 rounded-lg bg-surface-secondary text-sm">
-            <div>
-              <span class="text-xs text-text-secondary">Total débito</span>
-              <p class="font-semibold text-text-primary tabular-nums">{{ formatCurrency(selectedEntryDetail.totalDebit) }}</p>
-            </div>
-            <div>
-              <span class="text-xs text-text-secondary">Total crédito</span>
-              <p class="font-semibold text-text-primary tabular-nums">{{ formatCurrency(selectedEntryDetail.totalCredit) }}</p>
-            </div>
-          </div>
-
-          <!-- Lines table -->
-          <div>
-            <h4 class="text-xs font-bold text-text-secondary uppercase tracking-wide mb-2">Líneas del asiento</h4>
-            <UiResponsiveDataView
-              row-size="sm"
-              :columns="linesColumns"
-              :data="resolvedLines"
-              empty-message="Sin líneas"
-              variant="default"
-            >
-              <template #card="{ item, index }">
-                <div
-                  class="flex items-start gap-2 py-2 px-3 border-b border-border"
-                  :class="index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'"
-                >
-                  <div class="flex-1 min-w-0">
-                    <p class="text-xs font-mono text-text-secondary">
-                      {{ item.accountResolved ? `${item.accountResolved.code} · ${item.accountResolved.name}` : item.accountId }}
-                    </p>
-                    <p v-if="item.description" class="text-xs text-text-secondary mt-0.5">{{ item.description }}</p>
-                  </div>
-                  <div class="text-right flex-shrink-0">
-                    <p v-if="item.debit > 0" class="text-xs tabular-nums text-text-primary">D: {{ formatCurrency(item.debit) }}</p>
-                    <p v-if="item.credit > 0" class="text-xs tabular-nums text-text-primary">C: {{ formatCurrency(item.credit) }}</p>
-                  </div>
-                </div>
-              </template>
-
-              <template #cell-lineOrder="{ value }">
-                <span class="text-xs text-text-secondary tabular-nums">{{ value + 1 }}</span>
-              </template>
-
-              <template #cell-account="{ row }">
-                <div>
-                  <span v-if="row.accountResolved" class="text-sm text-text-primary">
-                    <span class="font-mono text-xs text-text-secondary">{{ row.accountResolved.code }}</span>
-                    {{ ' ' }}{{ row.accountResolved.name }}
-                  </span>
-                  <span v-else class="text-xs font-mono text-text-secondary">{{ row.accountId }}</span>
-                </div>
-              </template>
-
-              <template #cell-debit="{ row }">
-                <span v-if="row.debit > 0" class="text-sm tabular-nums text-text-primary">{{ formatCurrency(row.debit) }}</span>
-                <span v-else class="text-sm text-text-secondary">—</span>
-              </template>
-
-              <template #cell-credit="{ row }">
-                <span v-if="row.credit > 0" class="text-sm tabular-nums text-text-primary">{{ formatCurrency(row.credit) }}</span>
-                <span v-else class="text-sm text-text-secondary">—</span>
-              </template>
-
-              <template #cell-description="{ value }">
-                <span class="text-sm text-text-secondary">{{ value || '—' }}</span>
-              </template>
-            </UiResponsiveDataView>
-          </div>
-
-          <!-- Post error -->
-          <div v-if="postError" class="p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-sm text-destructive">
-            {{ postError }}
-          </div>
-        </div>
-      </div>
-
-      <!-- Footer actions -->
-      <template #footer>
-        <div v-if="selectedEntryDetail" class="flex items-center gap-3 p-4">
-          <button
-            type="button"
-            class="min-h-[44px] px-4 py-2 rounded-lg border-2 border-border text-sm text-text-secondary hover:text-text-primary transition-colors"
-            @click="closeDetail"
-          >
-            Cerrar
-          </button>
-          <div class="flex-1" />
-          <!-- Publish draft -->
-          <button
-            v-if="selectedEntryDetail.status === 'draft'"
-            type="button"
-            :disabled="posting"
-            class="min-h-[44px] px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-            @click="handlePost"
-          >
-            <svg v-if="posting" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
-            </svg>
-            <span>{{ posting ? 'Publicando...' : 'Publicar' }}</span>
-          </button>
-          <!-- Void posted -->
-          <button
-            v-if="selectedEntryDetail.status === 'posted'"
-            type="button"
-            class="min-h-[44px] px-4 py-2 rounded-lg border-2 border-destructive/50 text-destructive text-sm font-semibold hover:bg-destructive/10 transition-colors"
-            @click="openVoidModal"
-          >
-            Anular
-          </button>
-        </div>
-      </template>
-    </UiModal>
-
-    <!-- ── Entry detail modal (mobile bottom sheet) ───────────────────────── -->
-    <UiBottomSheetModal v-model="showDetailModal" title="Detalle del asiento">
-      <div class="overflow-y-auto max-h-[65vh]">
-        <!-- Loading -->
-        <div v-if="detailLoading" class="flex items-center justify-center py-12">
-          <CommonsTheCustomLoader size="medium" />
-        </div>
-
-        <!-- Error -->
-        <div v-else-if="detailError" class="p-4">
-          <div class="p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-sm text-destructive">
-            {{ detailError }}
-          </div>
-        </div>
-
-        <!-- Content -->
-        <div v-else-if="selectedEntryDetail" class="p-4 flex flex-col gap-3">
-          <!-- Header fields -->
-          <div class="grid grid-cols-2 gap-2 text-sm">
-            <div>
-              <span class="text-xs font-medium text-text-secondary">Fecha</span>
-              <p class="text-text-primary">{{ formatDate(selectedEntryDetail.entryDate) }}</p>
-            </div>
-            <div>
-              <span class="text-xs font-medium text-text-secondary">Estado</span>
-              <div class="mt-0.5">
-                <UiStatusBadge
-                  :value="STATUS_LABELS[selectedEntryDetail.status] || selectedEntryDetail.status"
-                  format="text"
-                  :variant="selectedEntryDetail.status === 'posted' ? 'success' : selectedEntryDetail.status === 'voided' ? 'destructive' : 'secondary'"
-                  size="sm"
-                />
-              </div>
-            </div>
-            <div class="col-span-2">
-              <span class="text-xs font-medium text-text-secondary">Descripción</span>
-              <p class="text-text-primary">
-                <NuxtLink
-                  v-if="entryLink(selectedEntryDetail)"
-                  :to="entryLink(selectedEntryDetail) || ''"
-                  class="text-primary hover:underline"
-                >{{ selectedEntryDetail.description }}</NuxtLink>
-                <span v-else>{{ selectedEntryDetail.description }}</span>
-              </p>
-            </div>
-            <div>
-              <span class="text-xs font-medium text-text-secondary">Módulo</span>
-              <p class="text-text-primary">{{ SOURCE_MODULE_LABELS[selectedEntryDetail.sourceModule] || selectedEntryDetail.sourceModule }}</p>
-            </div>
-          </div>
-
-          <!-- Totals -->
-          <div class="flex items-center gap-4 p-3 rounded-lg bg-surface-secondary text-sm">
-            <div>
-              <span class="text-xs text-text-secondary">Débito</span>
-              <p class="font-semibold tabular-nums">{{ formatCurrency(selectedEntryDetail.totalDebit) }}</p>
-            </div>
-            <div>
-              <span class="text-xs text-text-secondary">Crédito</span>
-              <p class="font-semibold tabular-nums">{{ formatCurrency(selectedEntryDetail.totalCredit) }}</p>
-            </div>
-          </div>
-
-          <!-- Lines list -->
-          <div>
-            <h4 class="text-xs font-bold text-text-secondary uppercase tracking-wide mb-2">Líneas</h4>
-            <div
-              v-for="(line, idx) in resolvedLines"
-              :key="line.id"
-              class="flex items-start gap-2 py-2 border-b border-border last:border-0"
-              :class="idx % 2 === 0 ? '' : 'bg-surface-secondary/30 px-1 rounded'"
-            >
-              <div class="flex-1 min-w-0">
-                <p class="text-xs font-mono text-text-secondary">
-                  {{ line.accountResolved ? `${line.accountResolved.code} · ${line.accountResolved.name}` : line.accountId }}
-                </p>
-                <p v-if="line.description" class="text-xs text-text-secondary mt-0.5">{{ line.description }}</p>
-              </div>
-              <div class="text-right flex-shrink-0 text-xs tabular-nums">
-                <p v-if="line.debit > 0">D: {{ formatCurrency(line.debit) }}</p>
-                <p v-if="line.credit > 0">C: {{ formatCurrency(line.credit) }}</p>
-              </div>
-            </div>
-          </div>
-
-          <!-- Post error -->
-          <div v-if="postError" class="p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-sm text-destructive">
-            {{ postError }}
-          </div>
-        </div>
-      </div>
-
-      <!-- Footer actions -->
-      <template #footer>
-        <div v-if="selectedEntryDetail" class="flex items-center gap-3 p-4">
-          <button
-            type="button"
-            class="min-h-[44px] flex-1 px-4 py-2 rounded-lg border-2 border-border text-sm text-text-secondary hover:text-text-primary transition-colors"
-            @click="closeDetail"
-          >
-            Cerrar
-          </button>
-          <button
-            v-if="selectedEntryDetail.status === 'draft'"
-            type="button"
-            :disabled="posting"
-            class="min-h-[44px] flex-1 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            @click="handlePost"
-          >
-            {{ posting ? 'Publicando...' : 'Publicar' }}
-          </button>
-          <button
-            v-if="selectedEntryDetail.status === 'posted'"
-            type="button"
-            class="min-h-[44px] flex-1 px-4 py-2 rounded-lg border-2 border-destructive/50 text-destructive text-sm font-semibold hover:bg-destructive/10 transition-colors"
-            @click="openVoidModal"
-          >
-            Anular
-          </button>
-        </div>
-      </template>
-    </UiBottomSheetModal>
+    <FinanzasContabilidadAsientoDetailPanel
+      v-model="showDetailPanel"
+      :entry-id="selectedEntryId"
+      :all-accounts="allAccountsForPanel"
+      allow-actions
+      @updated="onDetailUpdated"
+      @void-request="openVoidModal"
+    />
 
     <!-- ── Void reason modal ───────────────────────────────────────────────── -->
     <Teleport to="body">


### PR DESCRIPTION
## Summary
- Replace duplicated `UiModal` / `UiBottomSheetModal` detail on `/finanzas/contabilidad/asientos` with `AsientoDetailPanel` slide-over (#531 pattern)
- Extend `AsientoDetailPanel` with optional `allowActions` (Publicar / Anular), source navigation link, and `@updated` / `@void-request` events
- Removes ~280 lines of duplicated detail markup from the asientos list page

Closes #916

## Manual test checklist
- [ ] `/finanzas/contabilidad/asientos` — click row opens slide-over from right (desktop) / bottom sheet (mobile)
- [ ] Entry metadata and movimientos table display correctly
- [ ] Draft entry → **Publicar** works and list refreshes
- [ ] Posted entry → **Anular** opens reason modal, void succeeds, panel closes
- [ ] Orden/inventario source links work from description in panel
- [ ] Filters, pagination, and list navigation unchanged
- [ ] Account detail page (`cuentas/[id]`) panel still works (allowActions off by default)

## Companion
- API batch: https://github.com/uno0uno/api-warolabs/pull/308 (#915)

Made with [Cursor](https://cursor.com)