### PR TITLE
feat(arqueo): front shift opening flow and hub status

### DIFF
--- a/components/Finanzas/CierrePanel.vue
+++ b/components/Finanzas/CierrePanel.vue
@@ -93,6 +93,10 @@
                 <span class="text-xs font-semibold uppercase tracking-wide text-text-secondary">Caja</span>
               </div>
               <div class="divide-y divide-border">
+                <div v-if="(detail.openingCash ?? 0) > 0" class="flex justify-between px-6 py-2.5 text-sm">
+                  <span class="text-text-secondary">Fondo inicial</span>
+                  <span class="font-medium text-text-primary">+ {{ formatCurrency(detail.openingCash) }}</span>
+                </div>
                 <div class="flex justify-between px-6 py-2.5 text-sm">
                   <span class="text-text-secondary">Efectivo recibido</span>
                   <span class="font-medium text-text-primary">{{ formatCurrency(detail.totalCash) }}</span>

--- a/composables/useCashDenominationCount.ts
+++ b/composables/useCashDenominationCount.ts
@@ -1,0 +1,55 @@
+import { ref, computed } from 'vue'
+
+export const CASH_DENOMINATIONS = [100000, 50000, 20000, 10000, 5000, 2000, 1000] as const
+
+export function useCashDenominationCount() {
+  const counts = ref<Record<number, string>>(
+    Object.fromEntries(CASH_DENOMINATIONS.map(d => [d, '0'])),
+  )
+  const monedasAmount = ref('0')
+  const denomRefs = ref<HTMLInputElement[]>([])
+
+  const setDenomRef = (el: unknown, idx: number) => {
+    if (el) denomRefs.value[idx] = el as HTMLInputElement
+  }
+
+  const sanitizeInt = (e: Event): string => {
+    const el = e.target as HTMLInputElement
+    return el.value.replace(/\D/g, '').replace(/^0+(?=\d)/, '') || '0'
+  }
+
+  const sanitizeIntStr = (e: Event): string => sanitizeInt(e)
+
+  const totalCounted = computed(() =>
+    CASH_DENOMINATIONS.reduce((sum, d) => sum + d * (parseInt(counts.value[d]) || 0), 0)
+    + (parseInt(monedasAmount.value) || 0),
+  )
+
+  const toBreakdown = (): Record<string, number> => {
+    const breakdown: Record<string, number> = {}
+    for (const d of CASH_DENOMINATIONS) {
+      const n = parseInt(counts.value[d]) || 0
+      if (n > 0) breakdown[String(d)] = n
+    }
+    const monedas = parseInt(monedasAmount.value) || 0
+    if (monedas > 0) breakdown.monedas = monedas
+    return breakdown
+  }
+
+  const focusNext = (idx: number) => {
+    denomRefs.value[idx + 1]?.focus()
+  }
+
+  return {
+    denominations: CASH_DENOMINATIONS,
+    counts,
+    monedasAmount,
+    denomRefs,
+    setDenomRef,
+    sanitizeInt,
+    sanitizeIntStr,
+    totalCounted,
+    toBreakdown,
+    focusNext,
+  }
+}

--- a/composables/useCierreShiftWindow.ts
+++ b/composables/useCierreShiftWindow.ts
@@ -1,0 +1,24 @@
+/** Shared period params for cierre preview, shift-status, and open-shift (#920/#921). */
+export function buildCierreWindowParams(opts: {
+  periodStart: string
+  periodEnd: string
+  shiftTemplateId?: string | null
+  periodStartTime?: string | null
+  periodEndTime?: string | null
+}): Record<string, string> {
+  const base: Record<string, string> = {
+    period_start: opts.periodStart,
+    period_end: opts.periodEnd,
+  }
+  if (opts.shiftTemplateId) {
+    base.shift_template_id = opts.shiftTemplateId
+    return base
+  }
+  if (opts.periodStartTime) base.period_start_time = opts.periodStartTime
+  if (opts.periodEndTime) base.period_end_time = opts.periodEndTime
+  return base
+}
+
+export function isShiftOpen(data: Record<string, any> | null | undefined): boolean {
+  return data?.status === 'open' || !!data?.openingCash
+}

--- a/pages/finanzas/arqueo/[id].vue
+++ b/pages/finanzas/arqueo/[id].vue
@@ -114,6 +114,10 @@
             <h3 class="text-sm font-semibold text-text-primary uppercase tracking-wide">Caja</h3>
           </div>
           <div class="divide-y divide-border">
+            <div v-if="(cierre.openingCash ?? 0) > 0" class="flex justify-between px-4 py-2.5 text-sm">
+              <span class="text-text-secondary">Fondo inicial</span>
+              <span class="font-medium">+ {{ formatCurrency(cierre.openingCash) }}</span>
+            </div>
             <div class="flex justify-between px-4 py-2.5 text-sm">
               <span class="text-text-secondary">Gastos en efectivo</span>
               <span class="font-medium">{{ formatCurrency(cierre.gastosEfectivo) }}</span>

--- a/pages/finanzas/arqueo/apertura.vue
+++ b/pages/finanzas/arqueo/apertura.vue
@@ -1,0 +1,317 @@
+<template>
+  <div class="page-layout">
+    <UiSubmitBusyOverlay
+      :busy="isSubmitting"
+      label="Abriendo turno..."
+      hint="Registrando el fondo de caja para este turno."
+      variant="glass"
+      indicator="matrix"
+    />
+
+    <div v-if="openSuccess" class="flex flex-col items-center justify-center py-16 gap-6 text-center">
+      <div class="w-16 h-16 rounded-full bg-emerald-100 flex items-center justify-center">
+        <svg class="w-9 h-9 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+      </div>
+      <div>
+        <p class="text-xl font-semibold text-text-primary">Turno abierto</p>
+        <p class="text-sm text-text-secondary mt-1">Fondo registrado: {{ formatCurrency(successOpeningCash) }}</p>
+      </div>
+      <div class="flex flex-wrap gap-3 justify-center">
+        <NuxtLink
+          v-if="closeLink"
+          :to="closeLink"
+          class="min-h-[44px] px-5 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors flex items-center"
+        >
+          Ir al cierre Z
+        </NuxtLink>
+        <NuxtLink
+          to="/finanzas/arqueo"
+          class="min-h-[44px] px-5 py-2 rounded-lg border-2 border-border text-sm font-medium text-text-secondary hover:text-text-primary transition-colors flex items-center"
+        >
+          Volver al arqueo
+        </NuxtLink>
+      </div>
+    </div>
+
+    <template v-else>
+      <div class="bg-surface border-2 border-border rounded-lg mb-3 sm:mb-4 p-3 sm:p-4">
+        <h1 class="text-lg font-semibold text-text-primary">Abrir turno</h1>
+        <p class="text-sm text-text-secondary mt-1">
+          Declara el efectivo en caja (fondo para cambio) antes de operar o cerrar el turno.
+        </p>
+      </div>
+
+      <div v-if="currentStep === 1" class="bg-surface border-2 border-border rounded-lg p-3 sm:p-4 flex flex-col gap-4">
+        <div>
+          <label class="text-xs font-medium text-text-secondary uppercase tracking-wide">Turno</label>
+          <select
+            v-model="selectedTemplateId"
+            class="mt-1.5 w-full h-10 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+          >
+            <option value="">Selecciona un turno…</option>
+            <option v-for="t in shiftTemplates" :key="t.id" :value="t.id">
+              {{ t.name }} ({{ t.startTime }}–{{ t.endTime }})
+            </option>
+          </select>
+        </div>
+
+        <div>
+          <label class="text-xs font-medium text-text-secondary uppercase tracking-wide">Día</label>
+          <VueDatePicker
+            v-model="anchorDate"
+            :teleport="true"
+            :enable-time-picker="false"
+            :formats="dateOnlyFormats"
+            :locale="es"
+            auto-apply
+            :max-date="new Date()"
+            :clearable="false"
+            menu-class-name="dp-custom-menu"
+            calendar-cell-class-name="dp-custom-cell"
+            class="mt-1.5"
+          />
+        </div>
+
+        <p v-if="templateHoursLabel" class="text-sm font-mono text-text-secondary">
+          Ventana: {{ formatTemplateDateOnly() }} · {{ templateHoursLabel }}
+        </p>
+
+        <div
+          v-if="isShiftOpen(existingShift)"
+          class="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2.5 text-sm text-emerald-800"
+        >
+          Este turno ya está abierto con fondo {{ formatCurrency(existingShift.openingCash) }}.
+          <NuxtLink v-if="closeLink" :to="closeLink" class="font-semibold underline ml-1">Ir al cierre</NuxtLink>
+        </div>
+
+        <p v-if="stepError" class="text-sm text-destructive">{{ stepError }}</p>
+
+        <div class="flex gap-3">
+          <NuxtLink
+            to="/finanzas/arqueo"
+            class="min-h-[44px] px-4 py-2 rounded-lg border-2 border-border text-sm text-text-secondary hover:text-text-primary transition-colors flex items-center"
+          >
+            Cancelar
+          </NuxtLink>
+          <button
+            type="button"
+            class="min-h-[44px] px-6 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
+            :disabled="!selectedTemplateId || isShiftOpen(existingShift)"
+            @click="goToCount"
+          >
+            Contar efectivo →
+          </button>
+        </div>
+      </div>
+
+      <div v-else class="bg-surface border-2 border-border rounded-lg p-3 sm:p-4">
+        <h2 class="text-sm font-semibold text-text-primary mb-1">Fondo de caja</h2>
+        <p class="text-xs text-text-secondary mb-3">Cuenta billetes y monedas que hay en el cajón al iniciar:</p>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
+          <div class="bg-background rounded-lg border border-border overflow-hidden">
+            <div class="px-3 py-2 bg-surface border-b border-border">
+              <span class="text-xs font-semibold uppercase tracking-wide text-text-secondary">Billetes y monedas</span>
+            </div>
+            <div class="divide-y divide-border">
+              <div
+                v-for="(denom, idx) in denominations"
+                :key="denom"
+                class="flex items-center gap-2 px-3 py-2"
+              >
+                <span class="text-sm w-24 text-right flex-shrink-0">{{ formatCurrency(denom) }}</span>
+                <span class="text-text-tertiary text-xs">×</span>
+                <input
+                  :ref="el => setDenomRef(el, idx)"
+                  v-model="counts[denom]"
+                  type="text"
+                  inputmode="numeric"
+                  class="w-14 px-2 py-1 rounded-md border border-border bg-surface text-sm text-center focus:outline-none focus:ring-2 focus:ring-primary"
+                  @input="counts[denom] = sanitizeInt($event)"
+                  @keydown.enter.prevent="focusNext(idx)"
+                />
+                <span class="text-sm flex-1 text-right">{{ formatCurrency(denom * (parseInt(counts[denom]) || 0)) }}</span>
+              </div>
+              <div class="flex items-center gap-2 px-3 py-2">
+                <span class="text-sm w-24 text-right">Monedas</span>
+                <span class="text-transparent text-xs">×</span>
+                <input
+                  v-model="monedasAmount"
+                  type="text"
+                  inputmode="numeric"
+                  class="w-14 px-2 py-1 rounded-md border border-border bg-surface text-sm text-center focus:outline-none focus:ring-2 focus:ring-primary"
+                  @input="monedasAmount = sanitizeIntStr($event)"
+                />
+                <span class="text-sm flex-1 text-right">{{ formatCurrency(parseInt(monedasAmount) || 0) }}</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="flex flex-col gap-3">
+            <div class="bg-background rounded-lg border border-border p-4">
+              <p class="text-xs text-text-secondary uppercase tracking-wide">Total fondo</p>
+              <p class="text-2xl font-bold text-primary mt-1">{{ formatCurrency(totalCounted) }}</p>
+            </div>
+            <p v-if="submitError" class="text-sm text-destructive">{{ submitError }}</p>
+            <div class="flex gap-3 mt-auto">
+              <button type="button" class="min-h-[44px] px-4 py-2 rounded-lg border-2 border-border text-sm" @click="currentStep = 1">
+                ← Atrás
+              </button>
+              <button
+                type="button"
+                class="min-h-[44px] flex-1 px-6 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 disabled:opacity-50"
+                :disabled="isSubmitting || totalCounted <= 0"
+                @click="submitOpening"
+              >
+                Abrir turno
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { es } from 'date-fns/locale'
+import { format as fnsFormat } from 'date-fns'
+import { useFormatters } from '~/composables/useFormatters'
+import { useCashDenominationCount } from '~/composables/useCashDenominationCount'
+import { buildCierreWindowParams, isShiftOpen } from '~/composables/useCierreShiftWindow'
+import { bogotaDateAtNoon, bogotaISOFromDate, todayBogotaISO } from '~/utils/bogotaDate'
+
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
+useHead({ title: 'Abrir turno — Arqueo - Warocol' })
+
+interface ShiftTemplateOption {
+  id: string
+  name: string
+  startTime: string
+  endTime: string
+}
+
+const route = useRoute()
+const { currentTenant } = useTenantReactive()
+const { formatCurrency } = useFormatters()
+
+const today = todayBogotaISO()
+const initStart = (route.query.start as string) || today
+const initTemplate = (route.query.template as string) || ''
+
+const currentStep = ref(1)
+const selectedTemplateId = ref(initTemplate)
+const anchorDate = ref<Date>(bogotaDateAtNoon(initStart))
+const stepError = ref<string | null>(null)
+const submitError = ref<string | null>(null)
+const isSubmitting = ref(false)
+const openSuccess = ref(false)
+const successOpeningCash = ref(0)
+
+const dateOnlyFormats = { input: 'dd/MM/yyyy', preview: 'dd/MM/yyyy' }
+
+const {
+  denominations, counts, monedasAmount, setDenomRef,
+  sanitizeInt, sanitizeIntStr, totalCounted, toBreakdown, focusNext,
+} = useCashDenominationCount()
+
+const periodStart = computed(() => bogotaISOFromDate(anchorDate.value))
+const periodEnd = computed(() => periodStart.value)
+
+const { data: rawShiftTemplates, status: templatesStatus } = useQuery({
+  key: () => ['cierre', 'shift-templates', currentTenant.value?.id],
+  query: () => $fetch<{ success: boolean; data: ShiftTemplateOption[] }>('/api/cierre/shift-templates'),
+  enabled: () => !!currentTenant.value,
+  staleTime: 120_000,
+})
+const shiftTemplates = computed(() => rawShiftTemplates.value?.data ?? [])
+
+const { data: rawTemplateWindow } = useQuery({
+  key: () => ['cierre', 'shift-window', currentTenant.value?.id, selectedTemplateId.value, periodStart.value],
+  query: () => $fetch<{ success: boolean; data: { periodStartTime: string; periodEndTime: string } }>(
+    '/api/cierre/shift-window',
+    { params: { shift_template_id: selectedTemplateId.value, date: periodStart.value } },
+  ),
+  enabled: () => !!currentTenant.value && !!selectedTemplateId.value,
+  staleTime: 30_000,
+})
+
+const windowParams = computed(() =>
+  buildCierreWindowParams({
+    periodStart: periodStart.value,
+    periodEnd: periodEnd.value,
+    shiftTemplateId: selectedTemplateId.value || null,
+  }),
+)
+
+const { data: rawShiftStatus, refetch: refetchShiftStatus } = useQuery({
+  key: () => ['cierre', 'shift-status', currentTenant.value?.id, selectedTemplateId.value, periodStart.value],
+  query: () => $fetch<{ success: boolean; data: Record<string, any> }>('/api/cierre/shift-status', {
+    params: windowParams.value,
+  }),
+  enabled: () => !!currentTenant.value && !!selectedTemplateId.value,
+  staleTime: 0,
+})
+
+const existingShift = computed(() => rawShiftStatus.value?.data ?? null)
+
+const formatTemplateDateOnly = () => fnsFormat(anchorDate.value, 'dd/MM/yyyy', { locale: es })
+
+const templateHoursLabel = computed(() => {
+  const w = rawTemplateWindow.value?.data
+  if (!w?.periodStartTime || !w?.periodEndTime) return null
+  return `${fnsFormat(new Date(w.periodStartTime), 'HH:mm')} – ${fnsFormat(new Date(w.periodEndTime), 'HH:mm')}`
+})
+
+const closeLink = computed(() => {
+  if (!selectedTemplateId.value) return null
+  return `/finanzas/arqueo/z?mode=template&start=${periodStart.value}&end=${periodEnd.value}&template=${selectedTemplateId.value}`
+})
+
+watch(selectedTemplateId, () => { stepError.value = null })
+
+const goToCount = () => {
+  stepError.value = null
+  if (!selectedTemplateId.value) {
+    stepError.value = 'Selecciona un turno'
+    return
+  }
+  if (isShiftOpen(existingShift.value)) {
+    stepError.value = 'Este turno ya está abierto'
+    return
+  }
+  currentStep.value = 2
+}
+
+const submitOpening = async () => {
+  submitError.value = null
+  if (totalCounted.value <= 0) {
+    submitError.value = 'El fondo debe ser mayor a cero'
+    return
+  }
+  isSubmitting.value = true
+  try {
+    const breakdown = toBreakdown()
+    await $fetch('/api/cierre/open-shift', {
+      method: 'POST',
+      body: {
+        periodStart: periodStart.value,
+        periodEnd: periodEnd.value,
+        shiftTemplateId: selectedTemplateId.value,
+        openingCash: totalCounted.value,
+        openingBreakdown: Object.keys(breakdown).length ? breakdown : undefined,
+      },
+    })
+    successOpeningCash.value = totalCounted.value
+    openSuccess.value = true
+    await refetchShiftStatus()
+  } catch (err: any) {
+    submitError.value = err?.data?.detail ?? err?.data?.message ?? 'No se pudo abrir el turno'
+  } finally {
+    isSubmitting.value = false
+  }
+}
+</script>

--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -82,6 +82,51 @@
         </div>
       </div>
 
+      <!-- ── Turnos de hoy ─────────────────────────────────────────────────── -->
+      <div v-if="shiftTemplates.length > 0">
+        <div class="flex items-center justify-between gap-2 mb-2">
+          <h2 class="text-sm font-semibold text-text-primary">Turnos de hoy</h2>
+          <NuxtLink
+            to="/finanzas/arqueo/apertura"
+            class="text-xs font-medium text-primary hover:underline whitespace-nowrap"
+          >
+            Abrir turno
+          </NuxtLink>
+        </div>
+        <div v-if="todayShiftsLoading" class="text-xs text-text-secondary py-2">Cargando turnos…</div>
+        <div v-else class="flex flex-wrap gap-2">
+          <div
+            v-for="row in todayShiftRows"
+            :key="row.template.id"
+            class="flex items-center gap-2 px-3 py-2 rounded-lg border-2 min-h-[44px]"
+            :class="row.isOpen ? 'border-emerald-200 bg-emerald-50/60' : 'border-border bg-surface'"
+          >
+            <span class="text-sm font-medium text-text-primary">{{ row.template.name }}</span>
+            <span class="text-xs text-text-secondary font-mono">{{ row.template.startTime }}–{{ row.template.endTime }}</span>
+            <span
+              v-if="row.isOpen"
+              class="text-xs font-semibold text-emerald-700 px-1.5 py-0.5 rounded bg-emerald-100"
+            >
+              Abierto · {{ formatCurrency(row.openingCash) }}
+            </span>
+            <NuxtLink
+              v-else
+              :to="`/finanzas/arqueo/apertura?template=${row.template.id}&start=${today}`"
+              class="text-xs font-semibold text-primary hover:underline ml-auto"
+            >
+              Abrir →
+            </NuxtLink>
+            <NuxtLink
+              v-if="row.isOpen"
+              :to="`/finanzas/arqueo/z?mode=template&start=${today}&end=${today}&template=${row.template.id}`"
+              class="text-xs font-medium text-text-secondary hover:text-primary ml-auto"
+            >
+              Cerrar →
+            </NuxtLink>
+          </div>
+        </div>
+      </div>
+
       <!-- ── Nuevo arqueo (hub) ─────────────────────────────────────────────── -->
       <div>
         <h2 class="text-sm font-semibold text-text-primary mb-2">Nuevo arqueo</h2>
@@ -289,6 +334,7 @@ import {
   bogotaMonthBounds,
   todayBogotaISO,
 } from '~/utils/bogotaDate'
+import { buildCierreWindowParams, isShiftOpen } from '~/composables/useCierreShiftWindow'
 import MetricCard from '~/components/shared/MetricCard.vue'
 // @ts-ignore
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
@@ -339,6 +385,46 @@ const { data: todayPreview } = useQuery({
   staleTime: 60_000,
 })
 const openTablesCount = computed(() => todayPreview.value?.data?.openTablesCount ?? 0)
+
+interface ShiftTemplateOption {
+  id: string
+  name: string
+  startTime: string
+  endTime: string
+}
+
+const { data: rawShiftTemplates } = useQuery({
+  key: () => ['cierre', 'shift-templates', currentTenant.value?.id],
+  query: () => $fetch<{ success: boolean; data: ShiftTemplateOption[] }>('/api/cierre/shift-templates'),
+  enabled: () => !!currentTenant.value,
+  staleTime: 120_000,
+})
+const shiftTemplates = computed(() => rawShiftTemplates.value?.data ?? [])
+
+const { data: todayShiftRows, status: todayShiftsStatus } = useQuery({
+  key: () => ['cierre', 'shift-status-today', currentTenant.value?.id, today, shiftTemplates.value.map(t => t.id).join(',')],
+  query: async () => {
+    const templates = shiftTemplates.value
+    const rows = await Promise.all(templates.map(async (template) => {
+      const params = buildCierreWindowParams({
+        periodStart: today,
+        periodEnd: today,
+        shiftTemplateId: template.id,
+      })
+      const res = await $fetch<{ success: boolean; data: Record<string, any> }>('/api/cierre/shift-status', { params })
+      const data = res.data
+      return {
+        template,
+        isOpen: isShiftOpen(data),
+        openingCash: data?.openingCash ?? 0,
+      }
+    }))
+    return rows
+  },
+  enabled: () => !!currentTenant.value && shiftTemplates.value.length > 0,
+  staleTime: 30_000,
+})
+const todayShiftsLoading = computed(() => todayShiftsStatus.value === 'pending' && !todayShiftRows.value)
 
 const { data: rawHistorial, status, asyncStatus, error: fetchError, refetch } = useQuery({
   key: () => ['cierre', 'list', currentTenant.value?.id, activeStart.value, activeEnd.value],

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -249,6 +249,7 @@
           <div class="bg-surface border-2 border-border rounded-lg">
             <div class="p-3 border-b border-border"><h3 class="text-sm font-semibold text-text-primary uppercase tracking-wide">Estado de caja</h3></div>
             <div class="divide-y divide-border">
+              <div v-if="(xPreviewData.openingCash ?? 0) > 0" class="flex justify-between px-4 py-2.5 text-sm"><span class="text-text-secondary">Fondo inicial</span><span class="font-medium">+ {{ formatCurrency(xPreviewData.openingCash) }}</span></div>
               <div class="flex justify-between px-4 py-2.5 text-sm"><span class="text-text-secondary">Efectivo recibido</span><span class="font-medium">{{ formatCurrency(xPreviewData.totalCash) }}</span></div>
               <div v-if="(xPreviewData.cashTips ?? 0) > 0" class="flex justify-between px-4 py-2.5 text-sm"><span class="text-text-secondary">Propinas en efectivo</span><span class="font-medium">+ {{ formatCurrency(xPreviewData.cashTips) }}</span></div>
               <div class="flex justify-between px-4 py-2.5 text-sm"><span class="text-text-secondary">Gastos en efectivo</span><span class="font-medium text-destructive">− {{ formatCurrency(xPreviewData.gastosEfectivo) }}</span></div>
@@ -271,11 +272,20 @@
           </div>
         </div>
 
+        <div
+          v-if="requiresShiftOpen && !shiftOpenForWindow"
+          class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+        >
+          Debes abrir el turno y declarar el fondo de caja antes de cerrar.
+          <NuxtLink :to="aperturaLink" class="font-semibold underline ml-1">Abrir turno</NuxtLink>
+        </div>
+
         <!-- CTA — always visible once not loading -->
         <div class="flex gap-3">
           <button
             @click="goToStep1"
-            class="min-h-[44px] px-6 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+            class="min-h-[44px] px-6 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
+            :disabled="requiresShiftOpen && !shiftOpenForWindow"
           >
             Continuar al cierre →
           </button>
@@ -700,6 +710,10 @@
               <span class="text-xs font-semibold uppercase tracking-wide text-text-secondary">Efectivo</span>
             </div>
             <div class="divide-y divide-border">
+              <div v-if="(previewData?.openingCash ?? 0) > 0" class="flex justify-between px-3 py-2 text-xs">
+                <span class="text-text-secondary">Fondo inicial</span>
+                <span class="font-medium text-text-primary">+ {{ formatCurrency(previewData?.openingCash) }}</span>
+              </div>
               <div class="flex justify-between px-3 py-2 text-xs">
                 <span class="text-text-secondary">Recibido</span>
                 <span class="font-medium text-text-primary">{{ formatCurrency(previewData?.totalCash) }}</span>
@@ -907,6 +921,7 @@ import { ref, computed, reactive, onMounted, onUnmounted, watch, nextTick } from
 import { useFormatters } from '~/composables/useFormatters'
 import { es } from 'date-fns/locale'
 import { format as fnsFormat, formatDistanceStrict } from 'date-fns'
+import { buildCierreWindowParams, isShiftOpen } from '~/composables/useCierreShiftWindow'
 import {
   addDaysBogotaISO,
   bogotaDateAtNoon,
@@ -936,7 +951,8 @@ interface ShiftTemplateOption {
 const arqueoWindowMode = ref<ArqueoWindowMode>(
   (route.query.mode as string) === 'template' ? 'template' : 'custom',
 )
-const selectedTemplateId = ref<string>('')
+const initTemplate = (route.query.template as string) || ''
+const selectedTemplateId = ref<string>(initTemplate)
 const suggestedLoading = ref(false)
 
 const today = todayBogotaISO()
@@ -1174,6 +1190,40 @@ const buildPreviewParams = (completedOnly: boolean) => {
   return base
 }
 
+const shiftWindowParams = computed(() =>
+  buildCierreWindowParams({
+    periodStart: periodStart.value,
+    periodEnd: periodEnd.value,
+    shiftTemplateId: previewShiftTemplateId.value,
+    periodStartTime: periodStartTime.value,
+    periodEndTime: periodEndTime.value,
+  }),
+)
+
+const requiresShiftOpen = computed(() => arqueoWindowMode.value === 'template' || arqueoWindowMode.value === 'custom')
+
+const { data: rawShiftStatus } = useQuery({
+  key: () => ['cierre', 'shift-status', currentTenant.value?.id, arqueoWindowMode.value, JSON.stringify(shiftWindowParams.value)],
+  query: () => $fetch<{ success: boolean; data: Record<string, any> }>('/api/cierre/shift-status', {
+    params: shiftWindowParams.value,
+  }),
+  enabled: () =>
+    !!currentTenant.value
+    && requiresShiftOpen.value
+    && (arqueoWindowMode.value !== 'template' || !!selectedTemplateId.value),
+  staleTime: 0,
+})
+
+const shiftOpenForWindow = computed(() => isShiftOpen(rawShiftStatus.value?.data))
+
+const aperturaLink = computed(() => {
+  const q = new URLSearchParams({ start: periodStart.value })
+  if (arqueoWindowMode.value === 'template' && selectedTemplateId.value) {
+    q.set('template', selectedTemplateId.value)
+  }
+  return `/finanzas/arqueo/apertura?${q.toString()}`
+})
+
 const shiftLabel = computed(() => {
   if (!enableTimePicker.value) return null
   const startIso = periodStartTime.value
@@ -1211,6 +1261,10 @@ const goToStep1 = () => {
     }
   } else if (isMultiDay.value && (!startTimeInput.value || !endTimeInput.value)) {
     timeError.value = 'Para períodos de varios días debes especificar hora de inicio y fin'
+    return
+  }
+  if (requiresShiftOpen.value && !shiftOpenForWindow.value) {
+    timeError.value = 'Abre el turno y declara el fondo de caja antes de continuar'
     return
   }
   currentStep.value = 1
@@ -1361,6 +1415,10 @@ const handleConfirmButton = async () => {
 
 // ── Submit ────────────────────────────────────────────────────────────────
 const submitCierre = async () => {
+  if (requiresShiftOpen.value && !shiftOpenForWindow.value) {
+    submitError.value = 'Abre el turno y declara el fondo de caja antes de cerrar.'
+    return
+  }
   isSubmitting.value = true
   submitError.value  = null
   try {


### PR DESCRIPTION
## Summary
- Add `/finanzas/arqueo/apertura` wizard to declare opening cash float by denomination
- Show today's shift status on arqueo hub with open/close CTAs
- Display **Fondo inicial** in Z close wizard, cierre detail, and slide-over panel
- Block template/custom Z close until shift is opened (links to apertura flow)

Closes #921

## Test plan
- [ ] `/finanzas/arqueo` — "Turnos de hoy" shows each template as Abierto or Abrir →
- [ ] `/finanzas/arqueo/apertura?template=X&start=today` — count cash and open shift
- [ ] `/finanzas/arqueo/z?mode=template&template=X` — shows fondo inicial; can complete close
- [ ] Z without open shift — blocked with alert + link to apertura
- [ ] Historial detail + slide-over — fondo inicial visible when > 0
- [ ] Requires API batch #920 deployed (`shift-status`, `open-shift`)


Made with [Cursor](https://cursor.com)