### PR TITLE
feat(arqueo): carry-forward UI for drawer float and default fondo

### DIFF
--- a/components/Finanzas/CierrePanel.vue
+++ b/components/Finanzas/CierrePanel.vue
@@ -119,6 +119,10 @@
                     {{ detail.cashDifference >= 0 ? '+' : '' }}{{ formatCurrency(detail.cashDifference) }}
                   </span>
                 </div>
+                <div v-if="(detail.cashLeftInDrawer ?? 0) > 0" class="flex justify-between px-6 py-2.5 text-sm">
+                  <span class="text-text-secondary">Dejó en caja</span>
+                  <span class="font-medium text-text-primary">{{ formatCurrency(detail.cashLeftInDrawer) }}</span>
+                </div>
               </div>
             </div>
 

--- a/composables/useCashDenominationCount.ts
+++ b/composables/useCashDenominationCount.ts
@@ -40,6 +40,11 @@ export function useCashDenominationCount() {
     denomRefs.value[idx + 1]?.focus()
   }
 
+  const setFromAmount = (amount: number) => {
+    for (const d of CASH_DENOMINATIONS) counts.value[d] = '0'
+    monedasAmount.value = String(Math.max(0, Math.round(amount)))
+  }
+
   return {
     denominations: CASH_DENOMINATIONS,
     counts,
@@ -51,5 +56,6 @@ export function useCashDenominationCount() {
     totalCounted,
     toBreakdown,
     focusNext,
+    setFromAmount,
   }
 }

--- a/pages/finanzas/arqueo/[id].vue
+++ b/pages/finanzas/arqueo/[id].vue
@@ -140,6 +140,10 @@
                 {{ cierre.cashDifference >= 0 ? '+' : '' }}{{ formatCurrency(cierre.cashDifference) }}
               </span>
             </div>
+            <div v-if="(cierre.cashLeftInDrawer ?? 0) > 0" class="flex justify-between px-4 py-2.5 text-sm">
+              <span class="text-text-secondary">Dejó en caja</span>
+              <span class="font-medium text-text-primary">{{ formatCurrency(cierre.cashLeftInDrawer) }}</span>
+            </div>
           </div>
         </div>
 

--- a/pages/finanzas/arqueo/apertura.vue
+++ b/pages/finanzas/arqueo/apertura.vue
@@ -110,6 +110,20 @@
         <h2 class="text-sm font-semibold text-text-primary mb-1">Fondo de caja</h2>
         <p class="text-xs text-text-secondary mb-3">Cuenta billetes y monedas que hay en el cajón al iniciar:</p>
 
+        <div
+          v-if="suggestedOpeningCash > 0"
+          class="rounded-lg border border-primary/20 bg-primary/5 px-3 py-2.5 text-sm text-text-primary mb-3 flex flex-wrap items-center gap-2"
+        >
+          Sugerido del cierre anterior: {{ formatCurrency(suggestedOpeningCash) }}
+          <button
+            type="button"
+            class="text-xs font-semibold text-primary hover:underline"
+            @click="applySuggestedOpening"
+          >
+            Usar sugerido
+          </button>
+        </div>
+
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
           <div class="bg-background rounded-lg border border-border overflow-hidden">
             <div class="px-3 py-2 bg-surface border-b border-border">
@@ -215,7 +229,7 @@ const dateOnlyFormats = { input: 'dd/MM/yyyy', preview: 'dd/MM/yyyy' }
 
 const {
   denominations, counts, monedasAmount, setDenomRef,
-  sanitizeInt, sanitizeIntStr, totalCounted, toBreakdown, focusNext,
+  sanitizeInt, sanitizeIntStr, totalCounted, toBreakdown, focusNext, setFromAmount,
 } = useCashDenominationCount()
 
 const periodStart = computed(() => bogotaISOFromDate(anchorDate.value))
@@ -258,6 +272,16 @@ const { data: rawShiftStatus, refetch: refetchShiftStatus } = useQuery({
 
 const existingShift = computed(() => rawShiftStatus.value?.data ?? null)
 
+const suggestedOpeningCash = computed(() => {
+  const data = existingShift.value
+  if (!data || isShiftOpen(data)) return 0
+  return Number(data.suggestedOpeningCash ?? 0)
+})
+
+const applySuggestedOpening = () => {
+  if (suggestedOpeningCash.value > 0) setFromAmount(suggestedOpeningCash.value)
+}
+
 const formatTemplateDateOnly = () => fnsFormat(anchorDate.value, 'dd/MM/yyyy', { locale: es })
 
 const templateHoursLabel = computed(() => {
@@ -284,6 +308,9 @@ const goToCount = () => {
     return
   }
   currentStep.value = 2
+  if (suggestedOpeningCash.value > 0 && totalCounted.value === 0) {
+    applySuggestedOpening()
+  }
 }
 
 const submitOpening = async () => {

--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -127,6 +127,29 @@
         </div>
       </div>
 
+      <!-- ── Fondo por defecto ─────────────────────────────────────────────── -->
+      <div class="flex flex-wrap items-end gap-2 p-3 rounded-lg border-2 border-border bg-surface">
+        <div class="flex-1 min-w-[12rem]">
+          <label class="text-xs font-medium text-text-secondary uppercase tracking-wide">Fondo por defecto</label>
+          <p class="text-xs text-text-secondary mt-0.5">Se usa al abrir turno si no hay cierre anterior.</p>
+        </div>
+        <input
+          v-model="defaultOpeningInput"
+          type="text"
+          inputmode="numeric"
+          class="h-10 w-36 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+          @input="defaultOpeningInput = sanitizeDefaultOpening($event)"
+        />
+        <button
+          type="button"
+          class="h-10 px-4 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 disabled:opacity-50"
+          :disabled="isSavingDefault"
+          @click="saveDefaultOpening"
+        >
+          {{ isSavingDefault ? 'Guardando…' : 'Guardar' }}
+        </button>
+      </div>
+
       <!-- ── Nuevo arqueo (hub) ─────────────────────────────────────────────── -->
       <div>
         <h2 class="text-sm font-semibold text-text-primary mb-2">Nuevo arqueo</h2>
@@ -322,7 +345,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useQueryCache } from '@pinia/colada'
 import { useFormatters } from '~/composables/useFormatters'
 import { es } from 'date-fns/locale'
@@ -425,6 +448,42 @@ const { data: todayShiftRows, status: todayShiftsStatus } = useQuery({
   staleTime: 30_000,
 })
 const todayShiftsLoading = computed(() => todayShiftsStatus.value === 'pending' && !todayShiftRows.value)
+
+const { data: rawCashSettings, refetch: refetchCashSettings } = useQuery({
+  key: () => ['cierre', 'cash-settings', currentTenant.value?.id],
+  query: () => $fetch<{ success: boolean; data: { defaultOpeningCash: number } }>('/api/cierre/cash-settings'),
+  enabled: () => !!currentTenant.value,
+  staleTime: 60_000,
+})
+
+const defaultOpeningInput = ref('0')
+const isSavingDefault = ref(false)
+
+watch(rawCashSettings, (res) => {
+  if (res?.data != null) {
+    defaultOpeningInput.value = String(Math.round(res.data.defaultOpeningCash ?? 0))
+  }
+}, { immediate: true })
+
+const sanitizeDefaultOpening = (e: Event): string => {
+  const el = e.target as HTMLInputElement
+  const v = el.value.replace(/\D/g, '').replace(/^0+(?=\d)/, '') || '0'
+  el.value = v
+  return v
+}
+
+const saveDefaultOpening = async () => {
+  isSavingDefault.value = true
+  try {
+    await $fetch('/api/cierre/cash-settings', {
+      method: 'PATCH',
+      body: { defaultOpeningCash: parseInt(defaultOpeningInput.value) || 0 },
+    })
+    await refetchCashSettings()
+  } finally {
+    isSavingDefault.value = false
+  }
+}
 
 const { data: rawHistorial, status, asyncStatus, error: fetchError, refetch } = useQuery({
   key: () => ['cierre', 'list', currentTenant.value?.id, activeStart.value, activeEnd.value],

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -850,6 +850,23 @@
           </div>
         </div>
 
+        <!-- Efectivo que queda en caja -->
+        <div class="bg-background rounded-lg border border-border p-3 mb-3">
+          <label class="text-xs font-medium text-text-secondary uppercase tracking-wide">
+            Efectivo que queda en caja
+          </label>
+          <p class="text-xs text-text-secondary mt-0.5 mb-2">
+            Declara cuánto efectivo dejas en el cajón para el próximo turno (fondo para cambio).
+          </p>
+          <input
+            v-model="cashLeftInDrawer"
+            type="text"
+            inputmode="numeric"
+            class="w-full max-w-xs h-10 px-3 rounded-lg border-2 border-border bg-surface text-sm font-semibold text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+            @input="cashLeftInDrawer = sanitizeDrawerAmount($event)"
+          />
+        </div>
+
         <!-- Banner de advertencia irreversible -->
         <div class="flex items-start gap-3 p-3 rounded-lg border mb-3 transition-colors"
           :class="confirmArmed
@@ -1296,6 +1313,7 @@ const counts = ref<Record<number, string>>(
 const monedasAmount  = ref('0')
 const methodAmounts  = ref<Record<string, string>>({})
 const notes          = ref('')
+const cashLeftInDrawer = ref('0')
 const denomRefs     = ref<HTMLInputElement[]>([])
 
 const setDenomRef = (el: any, idx: number) => {
@@ -1426,6 +1444,7 @@ const submitCierre = async () => {
       periodStart: periodStart.value,
       periodEnd: periodEnd.value,
       cashCounted: totalCounted.value,
+      cashLeftInDrawer: parseInt(cashLeftInDrawer.value) || totalCounted.value,
       notes: notes.value || null,
     }
     if (arqueoWindowMode.value === 'template' && selectedTemplateId.value) {
@@ -1459,6 +1478,12 @@ const sanitizeInt = (e: Event): string => {
   return v
 }
 const sanitizeIntStr = (e: Event): string => sanitizeInt(e)
+
+const sanitizeDrawerAmount = (e: Event): string => {
+  const v = (e.target as HTMLInputElement).value.replace(/\D/g, '').replace(/^0+(?=\d)/, '') || '0'
+  ;(e.target as HTMLInputElement).value = v
+  return v
+}
 
 const focusNext = (idx: number) => {
   nextTick(() => {
@@ -1519,6 +1544,12 @@ watch(previewData, (data) => {
     currentStep.value = 2
   }
 }, { immediate: true })
+
+watch(currentStep, (step) => {
+  if (step === 5) {
+    cashLeftInDrawer.value = String(totalCounted.value || 0)
+  }
+})
 
 onMounted(() => {
   if (typeof window === 'undefined') return


### PR DESCRIPTION
## Summary
- Z close step 5: declare cash left in drawer (pre-filled from counted cash)
- Apertura: suggest/pre-fill from `shift-status.suggestedOpeningCash`
- Arqueo hub: tenant default fondo setting via `/api/cierre/cash-settings`
- Detail + slide-over: show "Dejó en caja"

Requires API PR (api-warolabs) merged + migration applied.

Closes #922

## Test plan
- [ ] Close Z leaving $200k → historial shows "Dejó en caja"
- [ ] Open next shift → apertura suggests $200k, "Usar sugerido" works
- [ ] Set default fondo on hub → new tenant shift suggests default
- [ ] Manual override at apertura still allowed


Made with [Cursor](https://cursor.com)