### PR TITLE
feat(pos): show table code and name on floor plan

### DIFF
--- a/components/mesas/MesaPanel.vue
+++ b/components/mesas/MesaPanel.vue
@@ -70,12 +70,33 @@
               id="mesa-name"
               v-model="form.name"
               type="text"
-              :placeholder="`Ej: ${tableSingular} 1, Barra 2, Terraza 3`"
+              :placeholder="`Ej: ${tableSingular} 1, Terraza VIP`"
               maxlength="50"
               :class="inputClass"
               @input="clearError('name')"
             />
             <p v-if="errors.name" class="text-xs text-destructive">{{ errors.name }}</p>
+          </div>
+
+          <!-- Código POS -->
+          <div v-if="!table?.is_bar" class="flex flex-col gap-1.5">
+            <label for="mesa-code" class="text-sm font-medium text-text-primary">
+              Código POS
+              <span class="text-xs font-normal text-text-tertiary ml-1">(opcional, máx. 4 — ej. 12, T1)</span>
+            </label>
+            <input
+              id="mesa-code"
+              v-model="form.code"
+              type="text"
+              maxlength="4"
+              placeholder="Si vacío, se infiere del nombre"
+              :class="inputClass"
+              @input="clearError('code')"
+            />
+            <p v-if="errors.code" class="text-xs text-destructive">{{ errors.code }}</p>
+            <p v-else class="text-[11px] text-text-tertiary leading-snug">
+              Se muestra en el plano del POS. Si no lo defines, usamos el número o iniciales del nombre.
+            </p>
           </div>
 
           <!-- Capacidad -->
@@ -198,6 +219,7 @@ const inputClass = 'h-10 w-full rounded-lg border-2 border-border bg-background 
 
 const form = ref({
   name: '',
+  code: '',
   capacity: null as number | null,
   assignedMemberId: null as string | null,
 })
@@ -210,12 +232,13 @@ watch(() => props.table, (t) => {
   if (t) {
     form.value = {
       name: t.name ?? '',
+      code: t.code ?? '',
       capacity: t.capacity ?? null,
       assignedMemberId: t.assigned_member_id ?? null,
     }
     initialAssignedMemberId.value = t.assigned_member_id ?? null
   } else {
-    form.value = { name: '', capacity: null, assignedMemberId: null }
+    form.value = { name: '', code: '', capacity: null, assignedMemberId: null }
     initialAssignedMemberId.value = null
   }
   errors.value = {}
@@ -225,7 +248,7 @@ watch(() => props.table, (t) => {
 watch(() => props.modelValue, (open) => {
   if (!open) return
   if (!props.table) {
-    form.value = { name: '', capacity: null, assignedMemberId: null }
+    form.value = { name: '', code: '', capacity: null, assignedMemberId: null }
     initialAssignedMemberId.value = null
     errors.value = {}
   }
@@ -238,6 +261,10 @@ const clearError = (field: string) => {
 function validate() {
   const e: Record<string, string> = {}
   if (!form.value.name.trim()) e.name = 'El nombre es obligatorio'
+  const code = form.value.code.trim()
+  if (code && !/^[A-Za-z0-9]{1,4}$/.test(code)) {
+    e.code = 'El código debe ser 1–4 caracteres alfanuméricos'
+  }
   if (form.value.capacity !== null && form.value.capacity !== undefined && (form.value.capacity as number) < 1) {
     e.capacity = 'La capacidad debe ser mayor a 0'
   }
@@ -253,6 +280,19 @@ async function submit() {
   try {
     const body: Record<string, any> = { name: form.value.name.trim() }
     if (form.value.capacity) body.capacity = form.value.capacity
+
+    if (!props.table?.is_bar) {
+      const trimmedCode = form.value.code.trim()
+      const storedCode = (props.table?.code ?? '').trim().toUpperCase()
+      const nextCode = trimmedCode.toUpperCase()
+      if (isEdit.value) {
+        if (nextCode !== storedCode) {
+          body.code = trimmedCode ? nextCode : ''
+        }
+      } else if (trimmedCode) {
+        body.code = nextCode
+      }
+    }
 
     let result: any
     if (isEdit.value) {

--- a/components/pos/MesasFloorPlan.vue
+++ b/components/pos/MesasFloorPlan.vue
@@ -165,11 +165,8 @@ const badgeLabel = (status: string) => {
   return 'Libre'
 }
 
-// Extract number from name ("Mesa 3" → "3"), else first 3 chars
-const tableShortId = (name: string) => {
-  const match = name.match(/\d+/)
-  return match ? match[0] : name.slice(0, 3).toUpperCase()
-}
+
+const { displayTableCode } = useTableDisplayCode()
 
 const cardClass = (status: string) => {
   if (status === 'open') return 'border-green-500 bg-green-50 hover:shadow-md'
@@ -319,21 +316,24 @@ onUnmounted(() => {
             @click="handleTableClick(table)"
           >
             <!-- Top: table graphic -->
-            <div class="flex items-center justify-center py-7">
+            <div class="flex flex-col items-center justify-center py-5 px-2 gap-2">
               <div class="relative">
                 <!-- Chairs -->
                 <div class="absolute -top-3 left-1/2 -translate-x-1/2 w-8 h-3 rounded-t-sm transition-colors duration-200" :class="chairClass(table.status)" />
                 <div class="absolute -bottom-3 left-1/2 -translate-x-1/2 w-8 h-3 rounded-b-sm transition-colors duration-200" :class="chairClass(table.status)" />
                 <div class="absolute -left-3 top-1/2 -translate-y-1/2 w-3 h-8 rounded-l-sm transition-colors duration-200" :class="chairClass(table.status)" />
                 <div class="absolute -right-3 top-1/2 -translate-y-1/2 w-3 h-8 rounded-r-sm transition-colors duration-200" :class="chairClass(table.status)" />
-                <!-- Table square with number -->
+                <!-- Table square with short code -->
                 <div
-                  class="w-20 h-20 flex items-center justify-center rounded-xl border-2 transition-colors duration-150 group-hover:brightness-95"
+                  class="w-20 h-20 flex items-center justify-center rounded-xl border-2 transition-colors duration-150 group-hover:brightness-95 px-1"
                   :class="squareClass(table.status)"
                 >
-                  <span class="text-4xl font-black leading-none tabular-nums">{{ tableShortId(table.name) }}</span>
+                  <span class="text-2xl sm:text-3xl font-black leading-none tabular-nums text-center">{{ displayTableCode(table) }}</span>
                 </div>
               </div>
+              <span class="text-xs sm:text-sm font-semibold text-text-primary text-center leading-tight line-clamp-2 w-full px-1">
+                {{ table.name }}
+              </span>
             </div>
 
             <!-- Bottom strip: occupied → time + amount / reabrir → single action / libre → label -->

--- a/components/pos/MoveTableModal.vue
+++ b/components/pos/MoveTableModal.vue
@@ -55,11 +55,7 @@ const handleClose = () => {
   emit('close')
 }
 
-// Extract display number from table name ("Mesa 3" → "3"), else first 3 chars
-const tableShortId = (name: string) => {
-  const match = name.match(/\d+/)
-  return match ? match[0] : name.slice(0, 3).toUpperCase()
-}
+const { displayTableCode } = useTableDisplayCode()
 </script>
 
 <template>
@@ -136,7 +132,7 @@ const tableShortId = (name: string) => {
             >
               <!-- Table square -->
               <div
-                class="w-10 h-10 flex items-center justify-center rounded-lg font-black text-xl tabular-nums mb-1.5"
+                class="w-10 h-10 flex items-center justify-center rounded-lg font-black text-sm tabular-nums mb-1 px-0.5"
                 :class="
                   table.status !== 'free'
                     ? 'bg-surface-secondary text-text-secondary'
@@ -145,9 +141,9 @@ const tableShortId = (name: string) => {
                       : 'bg-surface-secondary text-text-primary'
                 "
               >
-                {{ tableShortId(table.name) }}
+                {{ displayTableCode(table) }}
               </div>
-              <span class="text-[10px] font-semibold text-text-secondary text-center leading-tight truncate w-full text-center">
+              <span class="text-[10px] font-semibold text-text-secondary text-center leading-tight line-clamp-2 w-full text-center">
                 {{ table.name }}
               </span>
               <span

--- a/composables/useTableDisplayCode.ts
+++ b/composables/useTableDisplayCode.ts
@@ -1,0 +1,16 @@
+/**
+ * POS table short code — mirrors API infer_table_code (warocol.com#927).
+ */
+export function inferTableCode(name: string): string {
+  const cleaned = (name || '').trim()
+  if (!cleaned) return '?'
+  const match = cleaned.match(/\d+/)
+  if (match) return match[0].slice(0, 4)
+  return cleaned.slice(0, 3).toUpperCase()
+}
+
+export function displayTableCode(table: { code?: string | null; name: string }): string {
+  const code = table.code?.trim()
+  if (code) return code
+  return inferTableCode(table.name)
+}

--- a/pages/operaciones/mesas.vue
+++ b/pages/operaciones/mesas.vue
@@ -79,12 +79,15 @@ const inactiveTables = computed(() => {
   return result
 })
 
+const { displayTableCode } = useTableDisplayCode()
+
 // ── Table columns ──────────────────────────────────────────────────────────
 // "Mesero" column only shows when waiter-attribution is on; the cell is
 // read-only — clicking "Editar" is the only way to change the assignment.
 const tableColumns = computed(() => {
   const cols: Array<{ key: string; title: string; sortable?: boolean }> = [
     { key: 'name', title: singular.value, sortable: false },
+    { key: 'code', title: 'Código POS', sortable: false },
     { key: 'capacity', title: 'Capacidad' },
   ]
   if (businessProfile.value?.waiter_attribution_enabled) {
@@ -446,7 +449,15 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
           <template #card="{ item }">
             <div class="flex items-center gap-3 py-2 px-3 border-b border-border transition-colors hover:bg-surface-secondary">
               <div class="flex-1 min-w-0">
-                <span class="text-sm font-bold text-text-primary">{{ item.name }}</span>
+                <div class="flex items-center gap-2 flex-wrap">
+                  <span class="text-sm font-bold text-text-primary">{{ item.name }}</span>
+                  <span
+                    v-if="!item.is_bar"
+                    class="text-[10px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-surface-secondary text-text-secondary tabular-nums"
+                  >
+                    {{ displayTableCode(item) }}
+                  </span>
+                </div>
                 <p class="text-xs text-text-secondary mt-0.5">
                   {{ item.capacity ? `${item.capacity} persona${item.capacity !== 1 ? 's' : ''}` : 'Sin capacidad definida' }}
                 </p>
@@ -488,6 +499,12 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
           <!-- Desktop: name -->
           <template #cell-name="{ value }">
             <span class="text-sm font-medium text-text-primary">{{ value }}</span>
+          </template>
+
+          <!-- Desktop: POS code -->
+          <template #cell-code="{ row }">
+            <span v-if="row.is_bar" class="text-xs text-text-tertiary">—</span>
+            <span v-else class="text-sm font-semibold text-text-secondary tabular-nums">{{ displayTableCode(row) }}</span>
           </template>
 
           <!-- Desktop: capacity -->


### PR DESCRIPTION
## Summary
- POS floor plan: short `code` in tile + full `name` caption below
- Move-table modal: same pattern
- Mesas admin: optional code field + list column
- Runtime fallback `code ?? infer(name)` for pre-backfill rows

Companion API PR: uno0uno/api-warolabs (wr-927-table-code)

## Test plan
- [ ] `/operaciones/mesas` — create/edit code optional
- [ ] `/pos` — tile shows code + name
- [ ] Move table modal — code + name on targets
- [ ] Long name truncates without layout break
- [ ] Rename in mesas reflects after refresh/poll

Closes #927

Made with [Cursor](https://cursor.com)