### PR TITLE
fix(pos): show Factura on post-payment receipt

### DIFF
--- a/docs/usuarios/pos.md
+++ b/docs/usuarios/pos.md
@@ -156,7 +156,8 @@ Cuando confirmas el pago aparece una pantalla de éxito con dos opciones para en
 
 Antes de cobrar, usa **Imprimir prefactura** para que el cliente revise el consumo. No es factura electrónica (lleva el aviso *PREFACTURA — DOCUMENTO INFORMATIVO*).
 
-- El título del documento usa la etiqueta configurada en Facturación, salvo que diga «Factura» — en ese caso la prefactura muestra **Prefactura**.
+- El título de la **prefactura** (pre-cuenta) siempre se muestra como **Prefactura** (o la etiqueta personalizada si no es tipo factura).
+- El **comprobante** impreso al terminar la compra muestra **Factura** (o la etiqueta del tenant si configuró una distinta).
 - Si hay **propina** seleccionada: muestra **Total orden**, **Propina** y **TOTAL A COBRAR** (orden + impuestos + propina).
 - Si hay **cobro parcial** en curso: lista los pagos registrados y el **saldo pendiente** (incluye propina cuando aplica).
 

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -701,6 +701,8 @@ const addSplitPayment = async () => {
       splitMode.value = false
       posStore.clearAll()
       showSuccessModal.value = true
+      document.body.classList.remove('printing-prefactura')
+      prefacturaPrintSnapshot.value = null
     }
   } catch (e: any) {
     processingError.value = e.data?.message || 'Error al registrar el pago parcial'
@@ -978,6 +980,8 @@ const processOrder = async () => {
         posStore.exitSession()
       }
       showSuccessModal.value = true
+      document.body.classList.remove('printing-prefactura')
+      prefacturaPrintSnapshot.value = null
     } catch (error: any) {
       processingError.value = error.data?.message || error.message || `Error al cerrar la ${tableSingularLower.value}`
     } finally {
@@ -1102,6 +1106,8 @@ const processOrder = async () => {
         posStore.exitSession()
       }
       showSuccessModal.value = true
+      document.body.classList.remove('printing-prefactura')
+      prefacturaPrintSnapshot.value = null
     }
   } catch (error: any) {
     processingError.value = error.data?.message || error.message || 'Error processing order'
@@ -1335,6 +1341,8 @@ const generateInvoice = async () => {
 }
 
 const printReceipt = async () => {
+  // Ensure post-payment receipt wins over a prior prefactura print (#939).
+  document.body.classList.remove('printing-prefactura')
   await nextTick()
   window.print()
 }
@@ -1355,11 +1363,20 @@ const receiptLogoUrl = computed(() => {
   return url && String(url).startsWith('http') ? url : null
 })
 
-// warocol.com#939 — prefactura title must not reuse post-payment invoice-like labels.
+// warocol.com#939 — pre-bill always reads as prefactura; post-payment uses receiptDocumentLabel.
 const prefacturaDocumentLabel = computed(() => {
-  const label = (receiptPrintSettings.value.document_label || 'Prefactura').trim()
-  if (/factura/i.test(label)) return 'Prefactura'
-  return label || 'Prefactura'
+  const label = (receiptPrintSettings.value.document_label || '').trim()
+  if (!label || /factura/i.test(label) || /prefactura|pre-cuenta|pre cuenta|precuenta/i.test(label)) {
+    return 'Prefactura'
+  }
+  return label
+})
+
+const receiptDocumentLabel = computed(() => {
+  const label = (receiptPrintSettings.value.document_label || '').trim()
+  if (/factura/i.test(label)) return label
+  if (!label || /prefactura|pre-cuenta|pre cuenta|precuenta/i.test(label)) return 'Factura'
+  return label
 })
 
 const prefacturaTaxTotal = computed(() => {
@@ -3513,7 +3530,7 @@ onUnmounted(() => {
     />
     <div class="receipt-divider">================================</div>
     <div class="receipt-row receipt-small" style="font-weight:bold;">
-      {{ receiptPrintSettings.document_label }}<span v-if="(orderResult?.order_number ?? 0) > 0"> #{{ orderResult?.order_number }}</span>
+      {{ receiptDocumentLabel }}<span v-if="(orderResult?.order_number ?? 0) > 0"> #{{ orderResult?.order_number }}</span>
     </div>
     <div v-if="receiptPrintContext?.soldAt" class="receipt-row receipt-small">{{ receiptPrintContext.soldAt }}</div>
     <div v-if="receiptPrintContext?.wasMesa && receiptPrintContext.tableName" class="receipt-row receipt-small">


### PR DESCRIPTION
## Summary
- Post-payment **Imprimir comprobante** now uses `receiptDocumentLabel` → defaults to **Factura** when tenant label is Prefactura/empty.
- Prefactura pre-bill keeps **Prefactura** title via `prefacturaDocumentLabel`.
- Clears `printing-prefactura` body class before receipt print and on payment success (prevents wrong template).

Fixes #939

## Test plan
- [ ] Print prefactura before pay → title **Prefactura**
- [ ] Complete sale → **Imprimir comprobante** → title **Factura #N**
- [ ] After printing prefactura then completing sale → comprobante still shows Factura (not prefactura block)

Made with [Cursor](https://cursor.com)