### PR TITLE
fix(pos): receipt print shows Factura not Prefactura after payment

### DIFF
--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1374,8 +1374,9 @@ const prefacturaDocumentLabel = computed(() => {
 
 const receiptDocumentLabel = computed(() => {
   const label = (receiptPrintSettings.value.document_label || '').trim()
+  // Prefactura-like labels first — /factura/i matches the "factura" substring in "Prefactura" (#942).
+  if (!label || /prefactura|pre-cuenta|pre cuenta|precuenta|pre-factura|pre factura/i.test(label)) return 'Factura'
   if (/factura/i.test(label)) return label
-  if (!label || /prefactura|pre-cuenta|pre cuenta|precuenta/i.test(label)) return 'Factura'
   return label
 })
 


### PR DESCRIPTION
## Summary
- Fix `receiptDocumentLabel` in POS checkout so the default tenant label `"Prefactura"` maps to **Factura** on post-payment print
- Root cause: `/factura/i` matched the substring inside `"Prefactura"` before prefactura-variant checks ran (#941 incomplete fix)

## Test plan
- [ ] Mesa flow: table + waiter + tip + cash → complete sale → success modal → **Imprimir comprobante** → header shows **Factura #N** (not Prefactura)
- [ ] Pre-payment **Imprimir prefactura** still shows **Prefactura** title + disclaimer footer
- [ ] Tenant with custom label (e.g. `Pedido N°`) → post-payment print preserves custom label
- [ ] Tenant with explicit `Factura` label → unchanged
- [ ] DIAN invoice block on `#pos-receipt` still renders when invoice generated
- [ ] Receipt email flow unchanged

Closes #942

Made with [Cursor](https://cursor.com)