### PR TITLE
feat(seo): 301 redirect cannibalized blog slugs to canonical guides

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,6 +3,25 @@ export default defineNuxtConfig({
   routeRules: {
     // Blog — prerender estático en build time para SEO óptimo
     '/blog': { prerender: true },
+    // SEO: consolidate cannibalized blog slugs (warocol.com#953)
+    '/blog/software-pos-restaurantes-colombia': {
+      redirect: { to: '/blog/mejores-software-restaurantes-colombia', statusCode: 301 }
+    },
+    '/blog/sistema-pos-colombia': {
+      redirect: { to: '/blog/mejores-software-restaurantes-colombia', statusCode: 301 }
+    },
+    '/blog/software-para-restaurante': {
+      redirect: { to: '/blog/mejores-software-restaurantes-colombia', statusCode: 301 }
+    },
+    '/blog/software-restaurantes-gratis-colombia': {
+      redirect: { to: '/blog/software-para-restaurante-gratis', statusCode: 301 }
+    },
+    '/blog/software-open-source-restaurantes': {
+      redirect: { to: '/blog/software-para-restaurante-gratis', statusCode: 301 }
+    },
+    '/blog/software-contable-restaurantes-gratis': {
+      redirect: { to: '/blog/software-para-restaurante-gratis', statusCode: 301 }
+    },
     '/blog/**': { prerender: true },
     // Homepage pública
     '/': { prerender: true },


### PR DESCRIPTION
## Summary

Adds six permanent 301 redirects in `nuxt.config.ts` `routeRules` (before `/blog/**` prerender) to consolidate cannibalized blog URLs into two canonical guides.

Closes #953

## Changes

- `nuxt.config.ts`: six Nitro redirects mirroring `/billing/renovar` pattern

**Group 1** → `/blog/mejores-software-restaurantes-colombia`:
- `/blog/software-pos-restaurantes-colombia`
- `/blog/sistema-pos-colombia`
- `/blog/software-para-restaurante`

**Group 2** → `/blog/software-para-restaurante-gratis`:
- `/blog/software-restaurantes-gratis-colombia`
- `/blog/software-open-source-restaurantes`
- `/blog/software-contable-restaurantes-gratis`

## Test plan

After deploy or `nuxt preview` + rebuild:

- [ ] `curl -I https://warocol.com/blog/software-pos-restaurantes-colombia` → `301` → `.../mejores-software-restaurantes-colombia`
- [ ] `curl -I https://warocol.com/blog/sistema-pos-colombia` → `301` → canonical POS guide
- [ ] `curl -I https://warocol.com/blog/software-para-restaurante` → `301` → canonical POS guide
- [ ] `curl -I https://warocol.com/blog/software-restaurantes-gratis-colombia` → `301` → `.../software-para-restaurante-gratis`
- [ ] `curl -I https://warocol.com/blog/software-open-source-restaurantes` → `301` → free guide
- [ ] `curl -I https://warocol.com/blog/software-contable-restaurantes-gratis` → `301` → free guide
- [ ] `curl -I https://warocol.com/blog/mejores-software-restaurantes-colombia` → `200`
- [ ] `curl -I https://warocol.com/blog/software-para-restaurante-gratis` → `200`

## Out of scope

DB article deletion, sitemap/IndexNow, internal link rewrites (per issue).

Made with [Cursor](https://cursor.com)