### PR TITLE
fix(pos): checkout Cancel navigates only; motivo modal on destructive POS actions

### DIFF
--- a/components/pos/PosDestructiveReasonModal.vue
+++ b/components/pos/PosDestructiveReasonModal.vue
@@ -1,0 +1,149 @@
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-150"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-150"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="modelValue"
+        class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+        role="dialog"
+        aria-modal="true"
+        :aria-labelledby="titleId"
+        @click.self="!loading && close()"
+        @keydown.esc="!loading && close()"
+      >
+        <div class="w-full max-w-sm bg-surface rounded-2xl shadow-2xl overflow-hidden">
+          <div class="px-5 pt-5 pb-4">
+            <div class="flex items-start gap-3">
+              <div
+                class="flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center"
+                :class="variant === 'warning' ? 'bg-status-warning-bg' : 'bg-destructive/10'"
+              >
+                <svg
+                  class="w-5 h-5"
+                  :class="variant === 'warning' ? 'text-status-warning-text' : 'text-destructive'"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  aria-hidden="true"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+                  />
+                </svg>
+              </div>
+              <div class="flex-1 min-w-0">
+                <h3 :id="titleId" class="text-base font-bold text-text-primary leading-tight">
+                  {{ title }}
+                </h3>
+                <p v-if="message" class="text-sm text-text-secondary mt-1 leading-snug">
+                  {{ message }}
+                </p>
+              </div>
+            </div>
+
+            <label
+              :for="reasonInputId"
+              class="block text-xs font-medium text-text-secondary uppercase tracking-wide mt-4 mb-1.5"
+            >
+              Motivo <span class="text-destructive">*</span>
+            </label>
+            <textarea
+              :id="reasonInputId"
+              v-model="reason"
+              rows="2"
+              :disabled="loading"
+              :placeholder="reasonPlaceholder"
+              class="w-full px-3 py-2 bg-surface-secondary border border-border rounded-lg text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50"
+            />
+            <p v-if="error" class="mt-2 text-sm text-destructive">
+              {{ error }}
+            </p>
+          </div>
+
+          <div class="px-5 pb-5 flex gap-2">
+            <button
+              type="button"
+              :disabled="loading"
+              class="flex-1 min-h-[44px] rounded-xl border border-border text-sm font-semibold text-text-secondary hover:bg-surface-secondary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+              @click="close"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              :disabled="loading || !reason.trim()"
+              class="flex-1 min-h-[44px] rounded-xl text-sm font-semibold active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              :class="variant === 'warning'
+                ? 'bg-slate-700 text-white hover:bg-slate-800 focus-visible:ring-slate-500'
+                : 'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive'"
+              @click="submit"
+            >
+              <UiLoadingDots v-if="loading" size="9px" :color="variant === 'warning' ? 'white' : 'white'" />
+              <span v-else>{{ confirmLabel }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  modelValue: boolean
+  title: string
+  message?: string
+  confirmLabel?: string
+  reasonPlaceholder?: string
+  loading?: boolean
+  error?: string
+  variant?: 'destructive' | 'warning'
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  message: '',
+  confirmLabel: 'Confirmar',
+  reasonPlaceholder: 'Ej: cliente cambió de opinión',
+  loading: false,
+  error: '',
+  variant: 'destructive',
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'confirm', reason: string): void
+  (e: 'cancel'): void
+}>()
+
+const uid = useId()
+const titleId = `pos-destructive-title-${uid}`
+const reasonInputId = `pos-destructive-reason-${uid}`
+const reason = ref('')
+
+watch(
+  () => props.modelValue,
+  (open) => {
+    if (open) reason.value = ''
+  },
+)
+
+const close = () => {
+  if (props.loading) return
+  emit('update:modelValue', false)
+  emit('cancel')
+}
+
+const submit = () => {
+  if (props.loading || !reason.value.trim()) return
+  emit('confirm', reason.value.trim())
+}
+</script>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1219,17 +1219,25 @@ const paymentGridClass = computed(() => {
   return 'grid-cols-2 md:grid-cols-4'
 })
 
-const cancelOrder = async () => {
+// Issue #956 — checkout Cancelar is navigation-only; partial payments stay intact.
+const showAbandonCheckoutModal = ref(false)
+
+const goBackToPos = () => {
+  sessionStorage.setItem('posNavigation', 'true')
+  router.push('/pos')
+}
+
+const cancelOrder = () => {
   if (splitPayments.value.length > 0) {
-    if (!window.confirm('Ya hay pagos parciales registrados. ¿Seguro que quieres cancelar?')) return
+    showAbandonCheckoutModal.value = true
+    return
   }
-  if (posStore.activeTableSession?.isBar) {
-    // Bar session — clear local cart but keep session alive (it's permanent)
-    posStore.clearCart()
-    router.push('/pos')
-  } else {
-    router.push('/pos')
-  }
+  goBackToPos()
+}
+
+const confirmAbandonCheckout = () => {
+  showAbandonCheckoutModal.value = false
+  goBackToPos()
 }
 
 const closeSuccessModal = () => {
@@ -3096,6 +3104,16 @@ onUnmounted(() => {
         </div>
       </div>
     </Teleport>
+
+    <!-- Issue #956 — abandon checkout with partial payments (no void, navigation only) -->
+    <UiConfirmActionModal
+      v-model="showAbandonCheckoutModal"
+      title="¿Volver al POS?"
+      message="Ya hay pagos parciales registrados. Si sales ahora, los pagos se mantienen y podrás retomar el cobro después."
+      confirm-label="Sí, volver al POS"
+      variant="primary"
+      @confirm="confirmAbandonCheckout"
+    />
 
     <Teleport to="body">
       <div

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -481,41 +481,153 @@ registerTableSessionRefresh(
   { isMutationActive: isTableSessionMutationActive },
 )
 
-// ID of a tab item pending confirmation before removal (already fired to kitchen)
-const pendingRemoveItemId = ref<string | null>(null)
-const removeTabReason = ref('')
-const removeTabError = ref('')
+// Issue #956 — unified destructive-action confirmation with required motivo
+type DestructiveFlow =
+  | { kind: 'remove-tab-item'; orderItemId: string }
+  | { kind: 'clear-cart' }
+  | { kind: 'remove-cart-item'; index: number }
+  | { kind: 'release-table' }
+  | { kind: 'clear-bar-tab' }
+
+const destructiveFlow = ref<DestructiveFlow | null>(null)
+const destructiveLoading = ref(false)
+const destructiveError = ref('')
+
+const destructiveModalOpen = computed({
+  get: () => destructiveFlow.value !== null,
+  set: (open: boolean) => {
+    if (!open && !destructiveLoading.value) {
+      destructiveFlow.value = null
+      destructiveError.value = ''
+    }
+  },
+})
+
+const isTabItemFired = (orderItemId: string) => {
+  const item = storeTabItems.value.find((i: TabItem) => i.orderItemId === orderItemId)
+  return !!(item && item.fulfillmentStatus && item.fulfillmentStatus !== 'new')
+}
+
+const destructiveModalTitle = computed(() => {
+  const flow = destructiveFlow.value
+  if (!flow) return ''
+  switch (flow.kind) {
+    case 'remove-tab-item':
+      return '¿Eliminar producto?'
+    case 'clear-cart':
+      return posStore.activeTableSession ? '¿Limpiar la cuenta?' : '¿Limpiar carrito?'
+    case 'remove-cart-item':
+      return '¿Eliminar producto?'
+    case 'release-table':
+      return `¿Liberar la ${tableSingularLower.value}?`
+    case 'clear-bar-tab':
+      return '¿Limpiar la barra?'
+    default:
+      return '¿Confirmar acción?'
+  }
+})
+
+const destructiveModalMessage = computed(() => {
+  const flow = destructiveFlow.value
+  if (!flow) return ''
+  switch (flow.kind) {
+    case 'remove-tab-item': {
+      const item = storeTabItems.value.find((i: TabItem) => i.orderItemId === flow.orderItemId)
+      const name = item?.productName ?? 'Este producto'
+      if (comandasEnabled.value && isTabItemFired(flow.orderItemId)) {
+        return `${name} ya fue enviado a cocina. Se notificará al cocinero que lo anule.`
+      }
+      return `Se eliminará ${name} de la cuenta.`
+    }
+    case 'clear-cart':
+      return posStore.activeTableSession
+        ? `Se borrarán todos los ítems pendientes de la ${tableSingularLower.value} y del carrito.`
+        : 'Se borrarán todos los productos del carrito actual.'
+    case 'remove-cart-item': {
+      const item = posStore.cart[flow.index]
+      return item ? `Se eliminará ${item.product.name} del carrito.` : 'Se eliminará este producto del carrito.'
+    }
+    case 'release-table': {
+      const session = posStore.activeTableSession
+      if (session && session.runningTotal > 0) {
+        return `Esta ${tableSingularLower.value} tiene ${formatCurrencyPOS(session.runningTotal)} en consumo. Si la liberas ahora, se cerrará sin cobrar.`
+      }
+      return `Se cerrará la ${tableSingularLower.value} sin cobrar.`
+    }
+    case 'clear-bar-tab':
+      return 'Se borrarán todos los ítems pendientes de la barra. La sesión permanece abierta.'
+    default:
+      return ''
+  }
+})
+
+const destructiveModalConfirmLabel = computed(() => {
+  const flow = destructiveFlow.value
+  if (!flow) return 'Confirmar'
+  switch (flow.kind) {
+    case 'remove-tab-item':
+    case 'remove-cart-item':
+      return 'Sí, eliminar'
+    case 'clear-cart':
+      return 'Sí, limpiar'
+    case 'release-table':
+      return `Sí, liberar ${tableSingularLower.value}`
+    case 'clear-bar-tab':
+      return 'Sí, limpiar'
+    default:
+      return 'Confirmar'
+  }
+})
+
+const destructiveModalVariant = computed(() =>
+  destructiveFlow.value?.kind === 'release-table' ? 'warning' as const : 'destructive' as const,
+)
+
+const pendingRemoveItemId = computed(() =>
+  destructiveFlow.value?.kind === 'remove-tab-item' ? destructiveFlow.value.orderItemId : null,
+)
 
 const removeTabItem = (orderItemId: string) => {
   if (!posStore.activeTableSession) return
-  // If comandas is enabled and the item is already in the kitchen, ask for confirmation
-  if (comandasEnabled.value) {
-    const item = storeTabItems.value.find((i: TabItem) => i.orderItemId === orderItemId)
-    const isFired = item && item.fulfillmentStatus && item.fulfillmentStatus !== 'new'
-    if (isFired) {
-      pendingRemoveItemId.value = orderItemId
-      removeTabReason.value = ''
-      removeTabError.value = ''
-      return
+  destructiveError.value = ''
+  destructiveFlow.value = { kind: 'remove-tab-item', orderItemId }
+}
+
+const cancelDestructiveFlow = () => {
+  if (destructiveLoading.value) return
+  destructiveFlow.value = null
+  destructiveError.value = ''
+}
+
+const confirmDestructiveFlow = async (reason: string) => {
+  const flow = destructiveFlow.value
+  if (!flow) return
+  destructiveLoading.value = true
+  destructiveError.value = ''
+  try {
+    switch (flow.kind) {
+      case 'remove-tab-item':
+        await executeRemoveTabItem(flow.orderItemId, reason)
+        break
+      case 'clear-cart':
+        await executeClearCart(reason)
+        break
+      case 'remove-cart-item':
+        await executeRemoveFromCart(flow.index, reason)
+        break
+      case 'release-table':
+        await executeBannerClose(reason)
+        break
+      case 'clear-bar-tab':
+        await executeClearBarTab(reason)
+        break
     }
+    if (!destructiveError.value) {
+      destructiveFlow.value = null
+    }
+  } finally {
+    destructiveLoading.value = false
   }
-  executeRemoveTabItem(orderItemId)
-}
-
-const confirmRemoveTabItem = () => {
-  if (!pendingRemoveItemId.value) return
-  if (!removeTabReason.value.trim()) {
-    removeTabError.value = 'Indica el motivo de eliminación'
-    return
-  }
-  removeTabError.value = ''
-  executeRemoveTabItem(pendingRemoveItemId.value, removeTabReason.value.trim())
-}
-
-const cancelPendingRemove = () => {
-  pendingRemoveItemId.value = null
-  removeTabReason.value = ''
-  removeTabError.value = ''
 }
 
 const executeRemoveTabItem = async (orderItemId: string, reason?: string) => {
@@ -529,9 +641,6 @@ const executeRemoveTabItem = async (orderItemId: string, reason?: string) => {
       method: 'DELETE',
       body: { reason: reason ?? null },
     })
-    pendingRemoveItemId.value = null
-    removeTabReason.value = ''
-    removeTabError.value = ''
     await refreshTableSession()
   } catch (e: any) {
     bumpTableSessionFetchGen()
@@ -540,8 +649,8 @@ const executeRemoveTabItem = async (orderItemId: string, reason?: string) => {
       ?? (typeof e?.data?.detail === 'string' ? e.data.detail : null)
       ?? e?.data?.detail
     const errText = beMessage ?? 'Error al eliminar el producto'
-    if (reason) {
-      removeTabError.value = errText
+    if (destructiveFlow.value?.kind === 'remove-tab-item') {
+      destructiveError.value = errText
     } else {
       tabError.value = errText
     }
@@ -666,39 +775,29 @@ const handleMoveDone = async (result: { targetTableId: string; targetSessionId: 
 }
 
 // ── Liberar mesa from the active-mesa banner ───────────────────────────────
-const confirmBannerClose = ref(false)
-const isBannerClosing = ref(false)
+const isBannerClosing = computed(() =>
+  destructiveLoading.value && destructiveFlow.value?.kind === 'release-table',
+)
 
 const handleBannerCerrar = () => {
-  const session = posStore.activeTableSession
-  if (!session) return
-  if (session.runningTotal > 0) {
-    confirmBannerClose.value = true
-  } else {
-    executeBannerClose()
-  }
+  if (!posStore.activeTableSession) return
+  destructiveError.value = ''
+  destructiveFlow.value = { kind: 'release-table' }
 }
 
-const executeBannerClose = async () => {
+const executeBannerClose = async (_reason: string) => {
   const session = posStore.activeTableSession
   if (!session) return
-  // Keep modal open while loading; close it only after the request settles
-  // so the button can show its inline loading dots.
-  isBannerClosing.value = true
   try {
     await $fetch(`/api/tables/${session.tableId}/close`, { method: 'POST' })
   } catch {
     // Non-critical
-  } finally {
-    isBannerClosing.value = false
-    confirmBannerClose.value = false
   }
   posStore.clearAll()
   cache.invalidateQueries({ key: ['tables', currentTenant.value?.id] })
 }
 
-// Bar branch: clear pending tab items, never close the (permanent) session.
-const clearBarTab = async () => {
+const executeClearBarTab = async (_reason: string) => {
   const session = posStore.activeTableSession
   if (!session || posStore.isCancellingMesa) return
   posStore.isCancellingMesa = true
@@ -713,16 +812,13 @@ const clearBarTab = async () => {
   cache.invalidateQueries({ key: ['tables', currentTenant.value?.id] })
 }
 
-// Cart-panel "Liberar mesa" — bar clears the tab; table reuses the existing
-// banner-confirmation flow (skips confirm when runningTotal = 0).
 const handleReleaseMesa = () => {
   const session = posStore.activeTableSession
   if (!session) return
-  if (session.isBar) {
-    clearBarTab()
-  } else {
-    handleBannerCerrar()
-  }
+  destructiveError.value = ''
+  destructiveFlow.value = session.isBar
+    ? { kind: 'clear-bar-tab' }
+    : { kind: 'release-table' }
 }
 
 const formatDuration = (openedAt: string): string => {
@@ -912,7 +1008,12 @@ const handleOpenSaleConfirm = async (payload: { amount: number; description?: st
   }
 }
 
-const removeFromCart = async (index: number) => {
+const removeFromCart = (index: number) => {
+  destructiveError.value = ''
+  destructiveFlow.value = { kind: 'remove-cart-item', index }
+}
+
+const executeRemoveFromCart = async (index: number, _reason: string) => {
   await posStore.removeFromCart(index)
 }
 
@@ -921,6 +1022,11 @@ const incrementCartItem = async (index: number) => {
 }
 
 const decrementCartItem = async (index: number) => {
+  const item = posStore.cart[index]
+  if (item && item.quantity <= 1) {
+    removeFromCart(index)
+    return
+  }
   await posStore.updateQuantity(index, -1)
 }
 
@@ -928,7 +1034,12 @@ const duplicateCartItem = async (index: number) => {
   await posStore.duplicateCartItem(index)
 }
 
-const clearCart = async () => {
+const clearCart = () => {
+  destructiveError.value = ''
+  destructiveFlow.value = { kind: 'clear-cart' }
+}
+
+const executeClearCart = async (_reason: string) => {
   const session = posStore.activeTableSession
   if (session) {
     bumpTableSessionFetchGen()
@@ -1391,129 +1502,18 @@ onUnmounted(() => {
     </div>
   </div>
 
-  <!-- Liberar mesa confirmation modal — shown by handleBannerCerrar when runningTotal > 0 -->
-  <Teleport to="body">
-    <Transition
-      enter-active-class="transition-opacity duration-150"
-      enter-from-class="opacity-0"
-      enter-to-class="opacity-100"
-      leave-active-class="transition-opacity duration-150"
-      leave-from-class="opacity-100"
-      leave-to-class="opacity-0"
-    >
-      <div
-        v-if="confirmBannerClose && posStore.activeTableSession"
-        class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
-        @click.self="!isBannerClosing && (confirmBannerClose = false)"
-      >
-        <div class="w-full max-w-sm bg-surface rounded-2xl shadow-2xl overflow-hidden">
-          <div class="px-5 pt-5 pb-4">
-            <div class="flex items-start gap-3">
-              <div class="flex-shrink-0 w-10 h-10 rounded-xl bg-status-warning-bg flex items-center justify-center">
-                <svg class="w-5 h-5 text-status-warning-text" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
-                </svg>
-              </div>
-              <div class="flex-1 min-w-0">
-                <h3 class="text-base font-bold text-text-primary leading-tight">{{ `¿Liberar la ${tableSingularLower}?` }}</h3>
-                <p class="text-sm text-text-secondary mt-1 leading-snug">
-                  {{ `Esta ${tableSingularLower} tiene` }} <strong class="text-text-primary">{{ formatCurrencyPOS(posStore.activeTableSession.runningTotal) }}</strong> en consumo. Si la liberas ahora, se cerrará sin cobrar.
-                </p>
-              </div>
-            </div>
-          </div>
-          <div class="px-5 pb-5 flex gap-2">
-            <button
-              type="button"
-              :disabled="isBannerClosing"
-              class="flex-1 min-h-[44px] rounded-xl border border-border text-sm font-semibold text-text-secondary hover:bg-surface-secondary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
-              @click="confirmBannerClose = false"
-            >
-              Cancelar
-            </button>
-            <button
-              type="button"
-              :disabled="isBannerClosing"
-              class="flex-1 min-h-[44px] rounded-xl bg-slate-700 text-white text-sm font-semibold hover:bg-slate-800 active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 focus-visible:ring-offset-1 disabled:opacity-70 disabled:cursor-not-allowed"
-              @click="executeBannerClose"
-            >
-              <UiLoadingDots v-if="isBannerClosing" size="9px" color="white" aria-hidden="true" />
-              <span v-else>{{ `Sí, liberar ${tableSingularLower}` }}</span>
-            </button>
-          </div>
-        </div>
-      </div>
-    </Transition>
-  </Teleport>
-
-  <!-- Remove item confirmation modal -->
-  <Teleport to="body">
-    <Transition
-      enter-active-class="transition-opacity duration-150"
-      enter-from-class="opacity-0"
-      enter-to-class="opacity-100"
-      leave-active-class="transition-opacity duration-150"
-      leave-from-class="opacity-100"
-      leave-to-class="opacity-0"
-    >
-      <div
-        v-if="pendingRemoveItemId"
-        class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
-        @click.self="cancelPendingRemove"
-      >
-        <div class="w-full max-w-sm bg-surface rounded-2xl shadow-2xl overflow-hidden">
-          <!-- Header -->
-          <div class="px-5 pt-5 pb-4">
-            <div class="flex items-start gap-3">
-              <div class="flex-shrink-0 w-10 h-10 rounded-xl bg-destructive/10 flex items-center justify-center">
-                <svg class="w-5 h-5 text-destructive" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
-                </svg>
-              </div>
-              <div>
-                <h3 class="text-base font-bold text-text-primary leading-tight">¿Eliminar producto?</h3>
-                <p class="text-sm text-text-secondary mt-0.5 leading-snug">
-                  <span class="font-semibold text-text-primary">{{ storeTabItems.find(i => i.orderItemId === pendingRemoveItemId)?.productName ?? 'Este producto' }}</span>
-                  ya fue enviado a cocina. Se notificará al cocinero que lo anule.
-                </p>
-              </div>
-            </div>
-            <label for="remove-tab-reason" class="block text-xs font-medium text-text-secondary uppercase tracking-wide mt-4 mb-1.5">
-              Motivo de eliminación <span class="text-destructive">*</span>
-            </label>
-            <textarea
-              id="remove-tab-reason"
-              v-model="removeTabReason"
-              rows="2"
-              placeholder="Ej: cliente cambió de opinión"
-              class="w-full px-3 py-2 bg-surface-secondary border border-border rounded-lg text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
-            />
-            <p v-if="removeTabError" class="mt-2 text-sm text-destructive">
-              {{ removeTabError }}
-            </p>
-          </div>
-          <!-- Actions -->
-          <div class="px-5 pb-5 flex gap-2">
-            <button
-              type="button"
-              class="flex-1 h-11 rounded-xl border border-border text-sm font-semibold text-text-secondary hover:bg-surface-secondary transition-colors"
-              @click="cancelPendingRemove"
-            >
-              Cancelar
-            </button>
-            <button
-              type="button"
-              :disabled="!removeTabReason.trim()"
-              class="flex-1 h-11 rounded-xl bg-destructive text-white text-sm font-semibold hover:bg-destructive/90 active:scale-95 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-              @click="confirmRemoveTabItem"
-            >
-              Sí, eliminar
-            </button>
-          </div>
-        </div>
-      </div>
-    </Transition>
-  </Teleport>
+  <!-- Issue #956 — destructive POS actions (motivo required) -->
+  <PosDestructiveReasonModal
+    v-model="destructiveModalOpen"
+    :title="destructiveModalTitle"
+    :message="destructiveModalMessage"
+    :confirm-label="destructiveModalConfirmLabel"
+    :variant="destructiveModalVariant"
+    :loading="destructiveLoading"
+    :error="destructiveError"
+    @confirm="confirmDestructiveFlow"
+    @cancel="cancelDestructiveFlow"
+  />
 
   <PosOpenSaleModal
     ref="openSaleModalRef"


### PR DESCRIPTION
## Summary
- **Checkout Cancelar** now only navigates back to `/pos` (`sessionStorage.posNavigation` preserved). No `clearCart()`, `clearAll()`, or API void/cancel side effects.
- Partial-payment abandon uses `UiConfirmActionModal` instead of `window.confirm`; payments remain intact.
- New `PosDestructiveReasonModal` — all destructive POS actions on `/pos` require **Motivo** before executing: remove tab item (always), clear cart/tab, liberar mesa, clear bar tab, remove cart line (including decrement-to-zero).
- Void partial payment (#649) unchanged — motivo stays optional.

## API note
Motivo is sent to the backend on `DELETE .../tab/items/{id}` (existing). `clear_tab`, `close`, and POS cart delete/clear endpoints do not yet accept `reason` — motivo is collected in UI; bitácora persistence for those actions is a follow-up in `api_warocol.com`.

## Test plan
- [ ] `/pos/checkout` → Cancelar (no partials): returns to `/pos`, cart and table session unchanged
- [ ] `/pos/checkout` with split partials → Cancelar: modal warns, confirm returns to `/pos`, partials still visible on return
- [ ] Bar session checkout → Cancelar: cart NOT cleared on backend
- [ ] Remove tab item (fired and unfired): modal + required motivo; DELETE sends `{ reason }`
- [ ] Limpiar carrito / Limpiar (mesa): modal + motivo before DELETE tab + clearCart
- [ ] Liberar mesa (with and without balance): modal + motivo before close
- [ ] Bar liberar / clear tab: modal + motivo
- [ ] Remove cart line (trash and decrement to 0): modal + motivo
- [ ] Void partial payment: still optional motivo (#649)

Closes #956

Made with [Cursor](https://cursor.com)