### PR TITLE
fix(pos): send reason on clear/liberar destructive flows

### DIFF
--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -607,6 +607,15 @@ const removeTabItem = (orderItemId: string) => {
   void executeRemoveTabItem(orderItemId)
 }
 
+const destructiveFetchError = (e: unknown, fallback: string): string => {
+  const err = e as { data?: { message?: string; detail?: string | unknown } }
+  const detail = err?.data?.detail
+  return err?.data?.message
+    ?? (typeof detail === 'string' ? detail : null)
+    ?? (typeof detail === 'object' && detail ? String(detail) : null)
+    ?? fallback
+}
+
 const cancelDestructiveFlow = () => {
   if (destructiveLoading.value) return
   destructiveFlow.value = null
@@ -814,31 +823,38 @@ const handleBannerCerrar = () => {
   destructiveFlow.value = { kind: 'release-table' }
 }
 
-const executeBannerClose = async (_reason: string) => {
+const executeBannerClose = async (reason: string) => {
   const session = posStore.activeTableSession
   if (!session) return
   try {
-    await $fetch(`/api/tables/${session.tableId}/close`, { method: 'POST' })
-  } catch {
-    // Non-critical
+    await $fetch(`/api/tables/${session.tableId}/close`, {
+      method: 'POST',
+      body: { reason: reason.trim() || null },
+    })
+  } catch (e: unknown) {
+    destructiveError.value = destructiveFetchError(e, `Error al liberar la ${tableSingularLower.value}`)
+    return
   }
   posStore.clearAll()
   cache.invalidateQueries({ key: ['tables', currentTenant.value?.id] })
 }
 
-const executeClearBarTab = async (_reason: string) => {
+const executeClearBarTab = async (reason: string) => {
   const session = posStore.activeTableSession
   if (!session || posStore.isCancellingMesa) return
   posStore.isCancellingMesa = true
   try {
-    await $fetch(`/api/tables/${session.tableId}/tab`, { method: 'DELETE' })
-  } catch {
-    // Non-critical — clear local state regardless
+    await $fetch(`/api/tables/${session.tableId}/tab`, {
+      method: 'DELETE',
+      body: { reason: reason.trim() || null },
+    })
+    posStore.clearAll()
+    cache.invalidateQueries({ key: ['tables', currentTenant.value?.id] })
+  } catch (e: unknown) {
+    destructiveError.value = destructiveFetchError(e, 'Error al limpiar la barra')
   } finally {
     posStore.isCancellingMesa = false
   }
-  posStore.clearAll()
-  cache.invalidateQueries({ key: ['tables', currentTenant.value?.id] })
 }
 
 const handleReleaseMesa = () => {
@@ -1041,8 +1057,8 @@ const removeFromCart = async (index: number) => {
   await posStore.removeFromCart(index)
 }
 
-const executeRemoveFromCart = async (index: number, _reason: string) => {
-  await posStore.removeFromCart(index)
+const executeRemoveFromCart = async (index: number, reason: string) => {
+  await posStore.removeFromCart(index, reason)
 }
 
 const incrementCartItem = async (index: number) => {
@@ -1067,24 +1083,41 @@ const clearCart = () => {
   destructiveFlow.value = { kind: 'clear-cart' }
 }
 
-const executeClearCart = async (_reason: string) => {
+const executeClearCart = async (reason: string) => {
   const session = posStore.activeTableSession
   if (session) {
     bumpTableSessionFetchGen()
     isClearingTab.value = true
     try {
-      await $fetch(`/api/tables/${session.tableId}/tab`, { method: 'DELETE' })
-    } catch {
-      // Non-critical
+      await $fetch(`/api/tables/${session.tableId}/tab`, {
+        method: 'DELETE',
+        body: { reason: reason.trim() || null },
+      })
+      posStore.setTabItems([])
+      if (posStore.activeTableSession) {
+        posStore.setTableSession({
+          ...posStore.activeTableSession,
+          runningTotal: 0,
+          isBar: posStore.activeTableSession.isBar,
+        })
+      }
+    } catch (e: unknown) {
+      destructiveError.value = destructiveFetchError(
+        e,
+        posStore.activeTableSession
+          ? `Error al limpiar la ${tableSingularLower.value}`
+          : 'Error al limpiar la cuenta',
+      )
+      return
     } finally {
       isClearingTab.value = false
     }
-    posStore.setTabItems([])
-    if (posStore.activeTableSession) {
-      posStore.setTableSession({ ...posStore.activeTableSession, runningTotal: 0, isBar: posStore.activeTableSession.isBar })
-    }
   }
-  await posStore.clearCart()
+  try {
+    await posStore.clearCart(reason)
+  } catch (e: unknown) {
+    destructiveError.value = destructiveFetchError(e, 'Error al limpiar el carrito')
+  }
 }
 
 const processOrder = async () => {

--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -127,11 +127,12 @@ export const usePOSStore = defineStore('pos', () => {
         return `?${params.toString()}`
     }
 
-    const deleteSyncedCartLine = async (item: PosCartItem): Promise<boolean> => {
+    const deleteSyncedCartLine = async (item: PosCartItem, reason?: string): Promise<boolean> => {
         if (!cartId.value || !item.id || isSyncing.value) return false
         const qs = buildCartAuditQuery()
         await $fetch(`/api/pos/cart/${cartId.value}/items/${item.id}${qs}`, {
             method: 'DELETE',
+            body: { reason: reason?.trim() || null },
         })
         return true
     }
@@ -165,20 +166,15 @@ export const usePOSStore = defineStore('pos', () => {
         invalidateSyncedCart()
     }
 
-    const removeFromCart = async (index: number) => {
+    const removeFromCart = async (index: number, reason?: string) => {
         isDeleting.value = true
         try {
             if (index < 0 || index >= cart.value.length) return
             const item = cart.value[index]
             const isSynced = Boolean(cartId.value && item.id && !isSyncing.value)
             if (isSynced) {
-                try {
-                    await deleteSyncedCartLine(item)
-                    cart.value.splice(index, 1)
-                } catch {
-                    cart.value.splice(index, 1)
-                    invalidateSyncedCart()
-                }
+                await deleteSyncedCartLine(item, reason)
+                cart.value.splice(index, 1)
             } else {
                 cart.value.splice(index, 1)
                 invalidateSyncedCart()
@@ -227,17 +223,21 @@ export const usePOSStore = defineStore('pos', () => {
 
     // ── Backend cart operations ────────────────────────────────────────────────
 
-    const clearCart = async () => {
+    const clearCart = async (reason?: string) => {
         const oldCartId = cartId.value
+        const previousCart = [...cart.value]
         cart.value = []
         cartId.value = null
         if (oldCartId && !isSyncing.value) {
             try {
                 await $fetch(`/api/pos/cart/${oldCartId}${buildCartAuditQuery()}`, {
                     method: 'DELETE',
+                    body: { reason: reason?.trim() || null },
                 })
             } catch {
-                // Non-critical — local state already cleared
+                cart.value = previousCart
+                cartId.value = oldCartId
+                throw new Error('Error al limpiar el carrito')
             }
         }
     }


### PR DESCRIPTION
## Summary

Completes warocol.com#958 / api-warolabs#317 integration: the destructive modal collected motivo but Limpiar/Liberar did not send `reason` to the API. The backend returned 400 while the POS cleared the UI, leaving comandas active in KDS.

- Send `body: { reason }` on `DELETE /tab`, `POST /close`, and synced cart DELETE
- Do not clear local tab/cart state when the API fails; show error in modal

## Test plan

- [ ] Mesa with fired item → Limpiar → motivo → cuenta vacía y comanda cancelada en KDS
- [ ] Liberar barra con ítems pendientes → motivo → sesión liberada
- [ ] Limpiar sin motivo (edge) → modal muestra error, UI no se vacía sola

Made with [Cursor](https://cursor.com)