### PR TITLE
fix(pos): show tab item modifiers in cart and checkout

### DIFF
--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -100,7 +100,7 @@
         <PosCartItem
           :item="{
             product: { id: item.orderItemId, name: item.productName, price: item.unitPrice, image: '🍽️', category: '' },
-            modifiers: [],
+            modifiers: item.modifiers ?? [],
             quantity: item.quantity,
             notes: item.notes ?? undefined,
             fulfillmentStatus: item.fulfillmentStatus,

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -299,9 +299,9 @@ const cartItems = computed(() => {
   if (isKitchenServiceMode.value) {
     return storeTabItems.value.map(item => ({
       product: { id: '', name: item.productName, price: item.unitPrice, image: '🍽️', category: '' },
-      modifiers: [] as Array<{ id: string; name: string; price: number }>,
+      modifiers: item.modifiers ?? [],
       quantity: item.quantity,
-      notes: undefined as string | undefined
+      notes: item.notes ?? undefined
     }))
   }
   return posStore.cart
@@ -408,6 +408,11 @@ function mapTabItemsFromApi(rows: any[]): TabItem[] {
     quantity: i.quantity,
     unitPrice: i.unitPrice,
     subtotal: i.subtotal,
+    modifiers: (i.modifiers ?? []).map((m: any) => ({
+      id: m.id ?? '',
+      name: m.name,
+      price: Number(m.price) || 0,
+    })),
     notes: i.notes ?? null,
     fulfillmentStatus: i.fulfillmentStatus ?? 'new',
     sentAt: i.sentAt ?? null,

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -385,6 +385,11 @@ const mapTabItemsFromApi = (rows: any[]): TabItem[] =>
     quantity: i.quantity,
     unitPrice: i.unitPrice,
     subtotal: i.subtotal,
+    modifiers: (i.modifiers ?? []).map((m: any) => ({
+      id: m.id ?? '',
+      name: m.name,
+      price: Number(m.price) || 0,
+    })),
     notes: i.notes ?? null,
     fulfillmentStatus: i.fulfillmentStatus ?? 'new',
     sentAt: i.sentAt ?? null,

--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -41,12 +41,19 @@ export interface ActiveTableSession {
     effectiveWaiterMemberName?: string | null
 }
 
+export interface TabItemModifier {
+    id: string
+    name: string
+    price: number
+}
+
 export interface TabItem {
     orderItemId: string
     productName: string
     quantity: number
     unitPrice: number
     subtotal: number
+    modifiers: TabItemModifier[]
     notes?: string | null
     fulfillmentStatus: 'new' | 'sent' | 'preparing' | 'ready' | 'delivered' | 'cancelled'
     sentAt: string | null


### PR DESCRIPTION
## Summary
- Extend `TabItem` with modifiers from mesa current session
- Pass modifiers through CartPanel and checkout item lines

## Test plan
- [ ] Mesa/bar tab item with extras shows modifier breakdown and $43.000 line total
- [ ] Checkout items list matches order summary subtotal
- [ ] Counter/mostrador cart unchanged

Made with [Cursor](https://cursor.com)