### PR TITLE
fix(abastecimiento): searchable ingredient filter and Historial de ajustes nav

### DIFF
--- a/components/ui/IngredientFilterSearch.vue
+++ b/components/ui/IngredientFilterSearch.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="relative w-44 sm:w-52 flex-shrink-0">
+    <UiIngredientSearchInput
+      :key="inputKey"
+      :initial-value="displayValue"
+      placeholder="Ingrediente..."
+      @select="onSelect"
+    />
+    <button
+      v-if="modelValue"
+      type="button"
+      aria-label="Quitar filtro de ingrediente"
+      class="absolute right-2 top-1/2 -translate-y-1/2 min-h-[28px] min-w-[28px] inline-flex items-center justify-center rounded-md text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+      @mousedown.prevent
+      @click="clear"
+    >
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, computed } from 'vue'
+
+const props = defineProps<{
+  modelValue: string
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const selectedName = ref('')
+const inputKey = ref(0)
+
+const displayValue = computed(() =>
+  props.modelValue && selectedName.value ? selectedName.value : '',
+)
+
+async function resolveIngredientName(id: string): Promise<string> {
+  try {
+    const res = await $fetch<{ data?: { name?: string }; name?: string }>(
+      `/api/suppliers/ingredients/${id}`,
+    )
+    return res?.data?.name ?? res?.name ?? ''
+  } catch {
+    return ''
+  }
+}
+
+watch(
+  () => props.modelValue,
+  async (id) => {
+    if (!id) {
+      selectedName.value = ''
+      return
+    }
+    if (!selectedName.value) {
+      selectedName.value = await resolveIngredientName(id)
+    }
+  },
+  { immediate: true },
+)
+
+function onSelect(ingredient: { id: string; name: string }) {
+  selectedName.value = ingredient.name
+  emit('update:modelValue', ingredient.id)
+}
+
+function clear() {
+  selectedName.value = ''
+  emit('update:modelValue', '')
+  inputKey.value++
+}
+
+defineExpose({ clear })
+</script>

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -288,9 +288,9 @@ const getPageConfig = () => {
       breadcrumbPage: undefined,
       backButton: { label: 'Volver' }
     }
-  } else if (path.startsWith('/abastecimiento/ajustes')) {
+  } else if (path === '/abastecimiento/ajustes' || path.startsWith('/abastecimiento/ajustes/')) {
     return {
-      pageTitle: 'Ajustes de Abastecimiento',
+      pageTitle: path.includes('/crear') ? 'Ajustar stock' : 'Historial de ajustes',
       pageSubtitle: undefined,
       searchPlaceholder: undefined,
       activePage: 'abastecimiento' as const,

--- a/pages/abastecimiento.vue
+++ b/pages/abastecimiento.vue
@@ -34,7 +34,7 @@ const navigationItems = [
   { to: '/abastecimiento/compras-directas', label: 'Compra Directa', matchPath: '/abastecimiento/compras-directas' },
   { to: '/abastecimiento/stock', label: 'Stock' },
   { to: '/abastecimiento/movimientos', label: 'Movimientos' },
-  { to: '/abastecimiento/ajustes', label: 'Ajustes', matchPath: '/abastecimiento/ajustes' },
+  { to: '/abastecimiento/ajustes', label: 'Historial de ajustes', matchPath: '/abastecimiento/ajustes' },
   { to: '/abastecimiento/ingredientes-propios', label: 'Ingredientes Propios' },
   { to: '/abastecimiento/calidad-datos', label: 'Calidad de Datos' }
 ]

--- a/pages/abastecimiento/ajustes/index.vue
+++ b/pages/abastecimiento/ajustes/index.vue
@@ -43,16 +43,7 @@
         @clear="clearFilters"
       >
         <template #additional-filters>
-          <select
-            v-model="ingredientFilter"
-            :class="filterSelectClass"
-            aria-label="Filtrar por ingrediente"
-          >
-            <option value="">Ingrediente</option>
-            <option v-for="ingredient in ingredients" :key="ingredient.id" :value="ingredient.id">
-              {{ ingredient.name }}
-            </option>
-          </select>
+          <UiIngredientFilterSearch v-model="ingredientFilter" />
 
           <select
             v-model="adjustmentTypeFilter"
@@ -67,7 +58,7 @@
       </UiAdvancedFiltersBar>
 
       <!-- Responsive Data View -->
-      <HealthSemaphore :is-unlocked="true" title="Historial de Ajustes">
+      <HealthSemaphore :is-unlocked="true" title="Historial de ajustes">
       <UiResponsiveDataView
         :columns="adjustmentsTableColumns"
         :data="sortedAdjustments"
@@ -75,7 +66,7 @@
         :sort-direction="sortDirection"
         @sort="handleSort"
         empty-message="No hay ajustes registrados"
-        empty-sub-message="Los ajustes se realizan desde la página de Stock de Inventario"
+        empty-sub-message="Para registrar un ajuste manual, ve a Stock → Ajustar stock"
         variant="default"
         row-size="sm"
       >
@@ -158,10 +149,9 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
-import { INGREDIENTS_FETCH_LIMIT } from '@/composables/useMenuIngredients'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 
-useHead({ title: 'Ajustes de Inventario' })
+useHead({ title: 'Historial de ajustes' })
 
 // Tenant reactivity
 const { currentTenant } = useTenantReactive()
@@ -184,22 +174,6 @@ const performSearch = () => applySearch()
 
 const sortField = ref('created_at')
 const sortDirection = ref('desc')
-
-// Load ingredients for filter
-const { data: ingredientsData } = useQuery({
-  key: () => ['inventory', 'ingredients-lookup', currentTenant.value?.id],
-  query: () => $fetch('/api/suppliers/ingredients', { params: { limit: INGREDIENTS_FETCH_LIMIT } }),
-  enabled: () => !!currentTenant.value,
-  staleTime: 30_000,
-})
-
-const ingredients = computed(() => {
-  if (!(ingredientsData.value as any)?.data) return []
-  return (ingredientsData.value as any).data.map((item: any) => ({
-    id: item.id,
-    name: item.name
-  })).sort((a: any, b: any) => a.name.localeCompare(b.name))
-})
 
 const dateParts = computed(() => {
   if (!dateRange.value.from || !dateRange.value.to) return {}

--- a/pages/abastecimiento/movimientos.vue
+++ b/pages/abastecimiento/movimientos.vue
@@ -17,16 +17,7 @@
         @clear="clearFilters"
       >
         <template #additional-filters>
-          <select
-            v-model="ingredientFilter"
-            :class="filterSelectClass"
-            aria-label="Filtrar por ingrediente"
-          >
-            <option value="">Ingrediente</option>
-            <option v-for="ingredient in ingredients" :key="ingredient.id" :value="ingredient.id">
-              {{ ingredient.name }}
-            </option>
-          </select>
+          <UiIngredientFilterSearch v-model="ingredientFilter" />
 
           <select
             v-model="movementTypeFilter"
@@ -140,7 +131,6 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
-import { INGREDIENTS_FETCH_LIMIT } from '@/composables/useMenuIngredients'
 import { useFormatters } from '~/composables/useFormatters'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
@@ -168,21 +158,6 @@ const performSearch = () => applySearch()
 
 const sortField = ref('')
 const sortDirection = ref('desc')
-
-const { data: ingredientsData } = useQuery({
-  key: () => ['inventory', 'ingredients-lookup', currentTenant.value?.id],
-  query: () => $fetch('/api/suppliers/ingredients', { params: { limit: INGREDIENTS_FETCH_LIMIT } }),
-  enabled: () => !!currentTenant.value,
-  staleTime: 30_000,
-})
-
-const ingredients = computed(() => {
-  if (!(ingredientsData.value as any)?.data) return []
-  return (ingredientsData.value as any).data.map((item: any) => ({
-    id: item.id,
-    name: item.name
-  })).sort((a: any, b: any) => a.name.localeCompare(b.name))
-})
 
 const dateParts = computed(() => {
   if (!dateRange.value.from || !dateRange.value.to) return {}


### PR DESCRIPTION
## Summary
- Add `UiIngredientFilterSearch` (server-side search + clear) for ingredient filters
- Replace native `<select>` on **Historial de ajustes** and **Movimientos**
- Rename sub-nav tab **Ajustes** → **Historial de ajustes**; align page titles
- Empty state hints operators to **Stock → Ajustar stock** for new adjustments

Closes #965

## Test plan
- [ ] `/abastecimiento/ajustes` — sub-nav shows **Historial de ajustes**
- [ ] Type "Pan" in ingredient filter → select Pan Artesanal → table filters
- [ ] Clear (×) resets ingredient filter
- [ ] `/abastecimiento/movimientos` — same searchable filter works
- [ ] `/abastecimiento/movimientos?ingredient_id=…` — shows ingredient name in filter
- [ ] Empty historial message mentions Stock → Ajustar stock

Made with [Cursor](https://cursor.com)