### PR TITLE
feat(pos): replace modifier checkbox with +/- stepper for adiciones

### DIFF
--- a/components/pos/CartItem.vue
+++ b/components/pos/CartItem.vue
@@ -43,8 +43,8 @@
     <div class="mt-1.5 pl-[2.125rem] space-y-0.5">
       <p class="text-xs text-slate-500">{{ formatCurrency(Number(item.product.price)) }} c/u</p>
       <div v-for="mod in item.modifiers" :key="mod.id" class="flex justify-between text-xs gap-2">
-        <span class="text-slate-400">+ {{ mod.name }}</span>
-        <span class="text-slate-500 tabular-nums flex-shrink-0">{{ formatCurrency(Number(mod.price)) }}</span>
+        <span class="text-slate-400">+ {{ mod.name }}<template v-if="(mod.quantity ?? 1) > 1"> ×{{ mod.quantity }}</template></span>
+        <span class="text-slate-500 tabular-nums flex-shrink-0">{{ formatCurrency(Number(mod.price) * (mod.quantity ?? 1)) }}</span>
       </div>
       <p v-if="item.notes" class="text-xs text-slate-400 italic">Nota: {{ item.notes }}</p>
     </div>
@@ -126,7 +126,7 @@ interface CartItem {
     image: string
     category: string
   }
-  modifiers: Array<{ id: string; name: string; price: number }>
+  modifiers: Array<{ id: string; name: string; price: number; quantity?: number }>
   quantity: number
   notes?: string
   is_resale?: boolean
@@ -154,7 +154,10 @@ defineEmits<Emits>()
 
 const itemTotal = computed(() => {
   const basePrice = Number(props.item.product.price) || 0
-  const modifiersPrice = props.item.modifiers.reduce((sum, mod) => sum + Number(mod.price), 0)
+  const modifiersPrice = props.item.modifiers.reduce(
+    (sum, mod) => sum + Number(mod.price) * (mod.quantity ?? 1),
+    0
+  )
   return (basePrice + modifiersPrice) * Number(props.item.quantity)
 })
 

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -412,6 +412,7 @@ function mapTabItemsFromApi(rows: any[]): TabItem[] {
       id: m.id ?? '',
       name: m.name,
       price: Number(m.price) || 0,
+      quantity: Number(m.quantity) || 1,
     })),
     notes: i.notes ?? null,
     fulfillmentStatus: i.fulfillmentStatus ?? 'new',
@@ -893,7 +894,10 @@ const formatCurrency = (value: number) => {
 
 const getItemTotal = (item: any) => {
   const basePrice = Number(item.product.price) || 0
-  const modifiersPrice = item.modifiers.reduce((sum: number, mod: any) => sum + (Number(mod.price) || 0), 0)
+  const modifiersPrice = item.modifiers.reduce(
+    (sum: number, mod: any) => sum + (Number(mod.price) || 0) * (Number(mod.quantity) || 1),
+    0
+  )
   return (basePrice + modifiersPrice) * (Number(item.quantity) || 1)
 }
 
@@ -1861,7 +1865,7 @@ onUnmounted(() => {
                 <!-- Modifiers -->
                 <div v-if="item.modifiers && item.modifiers.length > 0" class="mt-0.5 space-y-0">
                   <p v-for="mod in item.modifiers" :key="mod.id" class="text-text-tertiary text-xs">
-                    + {{ mod.name }} · {{ formatCurrency(mod.price) }}
+                    + {{ mod.name }}<template v-if="(mod.quantity ?? 1) > 1"> ×{{ mod.quantity ?? 1 }}</template> · {{ formatCurrency((Number(mod.price) || 0) * (Number(mod.quantity) || 1)) }}
                   </p>
                 </div>
 

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -389,6 +389,7 @@ const mapTabItemsFromApi = (rows: any[]): TabItem[] =>
       id: m.id ?? '',
       name: m.name,
       price: Number(m.price) || 0,
+      quantity: Number(m.quantity) || 1,
     })),
     notes: i.notes ?? null,
     fulfillmentStatus: i.fulfillmentStatus ?? 'new',
@@ -743,7 +744,12 @@ const addToTab = async () => {
       product_id: item.product.id,
       quantity: item.quantity,
       unit_price: Number(item.product.price),
-      modifiers: item.modifiers.map((m) => ({ id: m.id, name: m.name, price: m.price })),
+      modifiers: item.modifiers.map((m) => ({
+        id: m.id,
+        name: m.name,
+        price: m.price,
+        quantity: m.quantity ?? 1,
+      })),
       notes: item.notes ?? null,
     }))
     const addRes = await $fetch(`/api/tables/${posStore.activeTableSession.tableId}/tab/add`, {

--- a/pages/pos/producto/[id].vue
+++ b/pages/pos/producto/[id].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, inject, watch } from 'vue'
 import { usePOSStore } from '~/stores/usePOSStore'
+import type { CartModifier } from '~/stores/online_cart'
 import {
   ShoppingCartIcon,
   CheckIcon
@@ -62,7 +63,7 @@ const product = computed(() => {
 })
 
 // State
-const selectedModifiers = ref<Array<{ id: string; name: string; price: number }>>([])
+const selectedModifiers = ref<CartModifier[]>([])
 const notes = ref('')
 const isAdding = ref(false)
 
@@ -79,6 +80,7 @@ interface ModifierOption {
   id: string
   name: string
   price: number
+  max_limit: number
   icon?: string
 }
 
@@ -337,6 +339,7 @@ const modifierGroups = computed<ModifierGroup[]>(() => {
             id: mod.id,
             name: mod.name,
             price: Number(mod.price) || 0,
+            max_limit: Number(mod.max_limit) || 1,
             icon: getModifierIcon(mod.name)
           }))
           .sort((a: any, b: any) => (a.sort_order || 0) - (b.sort_order || 0))
@@ -347,49 +350,87 @@ const modifierGroups = computed<ModifierGroup[]>(() => {
   }
 })
 
+const modifierLineTotal = (mod: CartModifier) => Number(mod.price) * (mod.quantity ?? 1)
+
 // Computed
 const totalPrice = computed(() => {
   if (!product.value) return 0
   const basePrice = Number(product.value.price) || 0
-  const modifiersPrice = selectedModifiers.value.reduce((sum, mod) => sum + Number(mod.price), 0)
+  const modifiersPrice = selectedModifiers.value.reduce((sum, mod) => sum + modifierLineTotal(mod), 0)
   return basePrice + modifiersPrice // Always 1 item
 })
 
 // Methods
-const toggleModifier = (modifier: { id: string; name: string; price: number }, groupId: string) => {
+const getModifierQty = (modifierId: string) =>
+  selectedModifiers.value.find(m => m.id === modifierId)?.quantity ?? 0
+
+const isSingleSelectGroup = (group: ModifierGroup) => group.maxSelections === 1
+
+const selectRadioModifier = (modifier: ModifierOption, groupId: string) => {
   const group = modifierGroups.value.find(g => g.id === groupId)
   if (!group) return
 
-  const index = selectedModifiers.value.findIndex(m => m.id === modifier.id)
+  selectedModifiers.value = selectedModifiers.value.filter(m =>
+    !group.options.some(opt => opt.id === m.id)
+  )
+  selectedModifiers.value.push({ id: modifier.id, name: modifier.name, price: modifier.price, quantity: 1 })
+}
 
-  if (index !== -1) {
-    // Remove modifier
-    selectedModifiers.value.splice(index, 1)
-  } else {
-    // Check max selections for group
-    const groupModifiers = selectedModifiers.value.filter(m =>
-      group.options.some(opt => opt.id === m.id)
-    )
+const canIncrementModifier = (option: ModifierOption, groupId: string) => {
+  const group = modifierGroups.value.find(g => g.id === groupId)
+  if (!group) return false
 
-    if (groupModifiers.length >= group.maxSelections) {
-      // Remove oldest modifier from this group
-      const oldestInGroup = selectedModifiers.value.find(m =>
-        group.options.some(opt => opt.id === m.id)
-      )
-      if (oldestInGroup) {
-        const oldIndex = selectedModifiers.value.indexOf(oldestInGroup)
-        selectedModifiers.value.splice(oldIndex, 1)
-      }
-    }
+  const index = selectedModifiers.value.findIndex(m => m.id === option.id)
+  const currentQty = index === -1 ? 0 : (selectedModifiers.value[index].quantity ?? 1)
+  if (currentQty >= option.max_limit) return false
 
-    // Add new modifier
-    selectedModifiers.value.push(modifier)
+  if (index === -1) {
+    const distinctInGroup = selectedModifiers.value.filter(m =>
+      group.options.some(opt => opt.id === m.id) && (m.quantity ?? 0) > 0
+    ).length
+    if (distinctInGroup >= group.maxSelections) return false
+  }
+
+  return true
+}
+
+const incrementModifier = (option: ModifierOption, groupId: string) => {
+  if (!canIncrementModifier(option, groupId)) return
+
+  const index = selectedModifiers.value.findIndex(m => m.id === option.id)
+  if (index === -1) {
+    selectedModifiers.value.push({
+      id: option.id,
+      name: option.name,
+      price: option.price,
+      quantity: 1,
+    })
+    return
+  }
+
+  const currentQty = selectedModifiers.value[index].quantity ?? 1
+  selectedModifiers.value[index] = {
+    ...selectedModifiers.value[index],
+    quantity: currentQty + 1,
   }
 }
 
-const isModifierSelected = (modifierId: string) => {
-  return selectedModifiers.value.some(m => m.id === modifierId)
+const decrementModifier = (option: ModifierOption, groupId: string) => {
+  const index = selectedModifiers.value.findIndex(m => m.id === option.id)
+  if (index === -1) return
+
+  const currentQty = selectedModifiers.value[index].quantity ?? 1
+  if (currentQty <= 1) {
+    selectedModifiers.value.splice(index, 1)
+  } else {
+    selectedModifiers.value[index] = {
+      ...selectedModifiers.value[index],
+      quantity: currentQty - 1,
+    }
+  }
 }
+
+const isModifierSelected = (modifierId: string) => getModifierQty(modifierId) > 0
 
 const addToCart = async () => {
   if (!product.value || isAdding.value) return
@@ -453,7 +494,10 @@ watch(product, (newProduct) => {
     const cartItem = posStore.getCartItem(editCartIndex.value)
     if (cartItem) {
       // Don't load quantity - always work with quantity 1
-      selectedModifiers.value = [...cartItem.modifiers]
+      selectedModifiers.value = cartItem.modifiers.map(m => ({
+        ...m,
+        quantity: m.quantity ?? 1,
+      }))
       notes.value = cartItem.notes || ''
     }
   }
@@ -535,8 +579,8 @@ onUnmounted(() => {
             </span>
           </div>
 
-          <!-- Size Options (Radio style) -->
-          <div v-if="group.name === 'Tamaño'" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
+          <!-- Single-select groups (radio style) -->
+          <div v-if="isSingleSelectGroup(group)" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
             <label
               v-for="option in group.options"
               :key="option.id"
@@ -547,7 +591,7 @@ onUnmounted(() => {
                 :name="'group-' + group.id"
                 class="sr-only"
                 :checked="isModifierSelected(option.id)"
-                @change="toggleModifier(option, group.id)"
+                @change="selectRadioModifier(option, group.id)"
               />
               <div
                 class="border-2 rounded-xl p-3 md:p-4 transition-all duration-200 bg-surface h-full flex flex-col justify-between"
@@ -585,49 +629,49 @@ onUnmounted(() => {
             </label>
           </div>
 
-          <!-- Extras Options (Checkbox style) -->
+          <!-- Multi-select adiciones (stepper style) -->
           <div v-else class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
-            <label
+            <div
               v-for="option in group.options"
               :key="option.id"
-              class="cursor-pointer relative"
+              class="border rounded-xl p-2 md:p-3 flex items-center justify-between gap-2 transition-all bg-surface"
+              :class="getModifierQty(option.id) > 0
+                ? 'border-primary bg-primary/5'
+                : 'border-border'"
             >
-              <input
-                type="checkbox"
-                class="sr-only"
-                :checked="isModifierSelected(option.id)"
-                @change="toggleModifier(option, group.id)"
-              />
-              <div
-                class="border rounded-xl p-2 md:p-3 flex items-center justify-between transition-all bg-surface"
-                :class="isModifierSelected(option.id)
-                  ? 'border-primary bg-primary/5'
-                  : 'border-border hover:bg-surface-secondary'"
-              >
-                <div class="flex items-center gap-2 md:gap-3">
-                  <div class="bg-surface-secondary p-1.5 md:p-2 rounded-lg text-text-secondary">
-                    <svg class="h-4 md:h-5 w-4 md:w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-                    </svg>
-                  </div>
-                  <div>
-                    <div class="font-medium text-text-primary text-xs md:text-sm">{{ option.name }}</div>
-                    <div class="text-xs text-primary font-semibold">+ {{ formatCurrency(option.price) }}</div>
-                  </div>
+              <div class="flex items-center gap-2 md:gap-3 min-w-0 flex-1">
+                <div class="bg-surface-secondary p-1.5 md:p-2 rounded-lg text-text-secondary flex-shrink-0">
+                  <svg class="h-4 md:h-5 w-4 md:w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                  </svg>
                 </div>
-                <div
-                  class="w-4 md:w-5 h-4 md:h-5 rounded border flex items-center justify-center transition-all flex-shrink-0"
-                  :class="isModifierSelected(option.id)
-                    ? 'border-primary bg-primary'
-                    : 'border-border bg-surface'"
-                >
-                  <CheckIcon
-                    v-if="isModifierSelected(option.id)"
-                    class="h-2.5 md:h-3 w-2.5 md:w-3 text-primary-foreground"
-                  />
+                <div class="min-w-0">
+                  <div class="font-medium text-text-primary text-xs md:text-sm truncate">{{ option.name }}</div>
+                  <div class="text-xs text-primary font-semibold">+ {{ formatCurrency(option.price) }}</div>
                 </div>
               </div>
-            </label>
+              <div class="flex items-center border border-border rounded-lg bg-surface flex-shrink-0">
+                <button
+                  type="button"
+                  class="min-w-[44px] min-h-[44px] flex items-center justify-center text-text-secondary hover:bg-surface-secondary rounded-l-lg disabled:opacity-40 disabled:cursor-not-allowed"
+                  :disabled="getModifierQty(option.id) <= 0"
+                  :aria-label="`Reducir ${option.name}`"
+                  @click="decrementModifier(option, group.id)"
+                >
+                  −
+                </button>
+                <span class="w-6 text-center text-xs font-medium text-text-primary tabular-nums">{{ getModifierQty(option.id) }}</span>
+                <button
+                  type="button"
+                  class="min-w-[44px] min-h-[44px] flex items-center justify-center text-text-secondary hover:bg-surface-secondary rounded-r-lg disabled:opacity-40 disabled:cursor-not-allowed"
+                  :disabled="!canIncrementModifier(option, group.id)"
+                  :aria-label="`Aumentar ${option.name}`"
+                  @click="incrementModifier(option, group.id)"
+                >
+                  +
+                </button>
+              </div>
+            </div>
           </div>
         </section>
 
@@ -657,8 +701,8 @@ onUnmounted(() => {
 
             <!-- Selected Modifiers -->
             <div v-for="modifier in selectedModifiers" :key="modifier.id" class="flex justify-between text-xs md:text-sm text-text-secondary">
-              <span>+ {{ modifier.name }}</span>
-              <span>{{ formatCurrency(modifier.price) }}</span>
+              <span>+ {{ modifier.name }}<template v-if="(modifier.quantity ?? 1) > 1"> ×{{ modifier.quantity }}</template></span>
+              <span>{{ formatCurrency(modifierLineTotal(modifier)) }}</span>
             </div>
           </div>
 
@@ -706,8 +750,8 @@ onUnmounted(() => {
 
           <!-- Selected Modifiers -->
           <div v-for="modifier in selectedModifiers" :key="modifier.id" class="flex justify-between text-xs md:text-sm text-text-secondary">
-            <span>+ {{ modifier.name }}</span>
-            <span>{{ formatCurrency(modifier.price) }}</span>
+            <span>+ {{ modifier.name }}<template v-if="(modifier.quantity ?? 1) > 1"> ×{{ modifier.quantity }}</template></span>
+            <span>{{ formatCurrency(modifierLineTotal(modifier)) }}</span>
           </div>
         </div>
 

--- a/stores/online_cart.ts
+++ b/stores/online_cart.ts
@@ -19,13 +19,18 @@ let _recoveryPromise: Promise<void> | null = null
 // JSON.stringify is order-sensitive; sorting by id first ensures
 // [A, B] and [B, A] produce the same key and deduplicate correctly.
 function modifiersKey(mods: CartModifier[]): string {
-  return JSON.stringify([...mods].sort((a, b) => a.id.localeCompare(b.id)))
+  return JSON.stringify(
+    [...mods]
+      .sort((a, b) => a.id.localeCompare(b.id))
+      .map(m => ({ id: m.id, q: m.quantity ?? 1 }))
+  )
 }
 
 export interface CartModifier {
   id: string
   name: string
   price: number
+  quantity?: number
 }
 
 export interface OnlineCartItem {

--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -2,6 +2,15 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import type { CartModifier } from '~/stores/online_cart'
 
+const modifierLineTotal = (mod: CartModifier) => Number(mod.price) * (mod.quantity ?? 1)
+
+const modifiersSignature = (mods: CartModifier[]) =>
+    JSON.stringify(
+        [...mods]
+            .sort((a, b) => a.id.localeCompare(b.id))
+            .map(m => ({ id: m.id, q: m.quantity ?? 1 }))
+    )
+
 export interface PosCartItem {
     id?: string // ID del item en la BD (para poder eliminarlo/actualizarlo)
     product: {
@@ -45,6 +54,7 @@ export interface TabItemModifier {
     id: string
     name: string
     price: number
+    quantity?: number
 }
 
 export interface TabItem {
@@ -107,7 +117,7 @@ export const usePOSStore = defineStore('pos', () => {
     const cartTotal = computed(() => {
         return cart.value.reduce((sum, item) => {
             const productTotal = Number(item.product.price) * Number(item.quantity)
-            const modifiersTotal = item.modifiers.reduce((modSum, mod) => modSum + Number(mod.price), 0) * Number(item.quantity)
+            const modifiersTotal = item.modifiers.reduce((modSum, mod) => modSum + modifierLineTotal(mod), 0) * Number(item.quantity)
             return sum + productTotal + modifiersTotal
         }, 0)
     })
@@ -161,8 +171,7 @@ export const usePOSStore = defineStore('pos', () => {
             return (
                 c.product.id === item.product.id &&
                 c.notes === (item.notes ?? undefined) &&
-                c.modifiers.length === (item.modifiers?.length ?? 0) &&
-                c.modifiers.every((m, i) => m.id === item.modifiers?.[i]?.id)
+                modifiersSignature(c.modifiers) === modifiersSignature(item.modifiers ?? [])
             )
         })
         if (existingIndex !== -1) {
@@ -324,7 +333,8 @@ export const usePOSStore = defineStore('pos', () => {
                     modifiers: (item.modifiers || []).map((mod: any) => ({
                         id: mod.id,
                         name: mod.name,
-                        price: Number(mod.price) || 0
+                        price: Number(mod.price) || 0,
+                        quantity: Number(mod.quantity) || 1,
                     })),
                     notes: item.notes,
                     is_resale: item.is_resale || false
@@ -420,7 +430,8 @@ export const usePOSStore = defineStore('pos', () => {
                 modifiers: item.modifiers.map(mod => ({
                     id: mod.id,
                     name: mod.name,
-                    price: mod.price
+                    price: mod.price,
+                    quantity: mod.quantity ?? 1,
                 })),
                 notes: item.notes || null
             }))


### PR DESCRIPTION
## Summary
- Replace adiciones checkbox UX with +/- stepper on POS product customization page
- Propagate `modifier.quantity` through cart totals, mesa tab payloads, checkout display, and cart sync
- Keep radio selection for single-select modifier groups (`maxSelections === 1`)

## Test plan
- [ ] `/pos/producto/:id` — adiciones group: tap + twice on same option → qty 2, resumen shows ×2 and doubled price
- [ ] Tap − to 0 → modifier removed from selection
- [ ] Single-select group (e.g. Tamaño) still uses radio, qty stays 1
- [ ] Cart panel shows modifier qty and correct line total
- [ ] Mesa mode: Agregar y enviar sends modifier `quantity` in tab/add payload
- [ ] Checkout review shows modifier qty and correct totals
- [ ] Manual: Santa Inquisición + 2× Carne adición → $18k modifier line (requires `max_limit > 1` in admin/API follow-up for stepper cap)

## Notes
- POS products API still omits `max_limit`; stepper defaults per-option cap to 1 until API exposes the field.

Closes #968

Made with [Cursor](https://cursor.com)