### PR TITLE
feat(facturacion): customizable tip label on POS tickets

### DIFF
--- a/.wr/977.yaml
+++ b/.wr/977.yaml
@@ -1,0 +1,38 @@
+# Machine contract for wr-fast / wr-ship — warocol.com#977
+issue: 977
+title: "feat(facturacion): customizable tip label on POS tickets"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-977-tip-label
+
+paths:
+  - pages/facturacion/index.vue
+  - composables/useReceiptPrintSettings.ts
+  - pages/pos/checkout.vue
+  - ../api_warocol.com/sql/20260529_add_receipt_tip_label.sql
+  - ../api_warocol.com/app/routers/tenant_config.py
+  - ../api_warocol.com/app/services/pos_context_service.py
+  - ../api_warocol.com/app/templates/pos_receipt_template.py
+  - ../api_warocol.com/app/services/email_helpers.py
+
+ac:
+  - Tip label field on /facturacion Personalizar tickets POS (default Propina, max 40)
+  - Persist receipt_tip_label in tenant_fiscal_data; expose as receipt_print_settings.tip_label
+  - Prefactura + final receipt print use custom label
+  - POS receipt email uses custom label via tenant_id lookup
+
+out_of_scope:
+  - Dashboard/arqueo/ventas UI labels
+  - Checkout on-screen modal labels
+
+hints:
+  entry: "tenant_config._normalize_receipt_document_label — mirror for tip label"
+  pattern: "receipt_document_label flow (#930) — same column/API/context pattern"
+  tests: "pytest tests/test_pos_receipt_template.py -v"
+  api_branch: wr-977-tip-label
+  api_remote: uno0uno/api-warolabs
+
+skip:
+  audits: [ux, color, typography]

--- a/composables/useReceiptPrintSettings.ts
+++ b/composables/useReceiptPrintSettings.ts
@@ -14,7 +14,7 @@ export function useReceiptPrintSettings() {
   })
 
   const receiptPrintSettings = computed(() =>
-    settingsData.value?.data?.receipt_print_settings ?? { document_label: 'Prefactura', show_logo: true },
+    settingsData.value?.data?.receipt_print_settings ?? { document_label: 'Prefactura', tip_label: 'Propina', show_logo: true },
   )
 
   const receiptLogoUrl = computed(() => {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -51,6 +51,8 @@ export default defineNuxtConfig({
     '/gestion/**': { ssr: false },
     '/domicilios/**': { ssr: false },
     '/finanzas/**': { ssr: false },
+    '/facturacion': { ssr: false },
+    '/facturacion/**': { ssr: false },
     '/negocio': { ssr: false },
     '/cocina': { ssr: false },
     '/cocina/**': { ssr: false },

--- a/pages/facturacion/index.vue
+++ b/pages/facturacion/index.vue
@@ -293,6 +293,7 @@ const fiscalForm = reactive({
   phone: '',
   email: '',
   receipt_document_label: 'Prefactura',
+  receipt_tip_label: 'Propina',
   show_logo_on_receipts: true,
 })
 const isSavingFiscal = ref(false)
@@ -310,6 +311,7 @@ watch(fiscal, (f) => {
   fiscalForm.phone = f.phone || ''
   fiscalForm.email = f.email || ''
   fiscalForm.receipt_document_label = f.receipt_document_label || 'Prefactura'
+  fiscalForm.receipt_tip_label = f.receipt_tip_label || 'Propina'
   fiscalForm.show_logo_on_receipts = f.show_logo_on_receipts !== false
 }, { immediate: true })
 
@@ -321,6 +323,7 @@ const savePrintSettings = async () => {
       body: {
         ...fiscalForm,
         receipt_document_label: fiscalForm.receipt_document_label.trim() || 'Prefactura',
+        receipt_tip_label: fiscalForm.receipt_tip_label.trim() || 'Propina',
       },
     })
     await refreshFiscal()
@@ -868,6 +871,23 @@ const taxLevels = [
           />
           <p class="text-[11px] text-text-tertiary leading-snug">
             Texto que encabeza el ticket (máx. 40 caracteres). Ej: <span class="font-medium">Prefactura</span>, <span class="font-medium">Pedido N°</span>.
+          </p>
+        </div>
+
+        <div class="flex flex-col gap-1 sm:col-span-2">
+          <label for="receipt-tip-label" class="text-sm font-medium text-text-primary">
+            Etiqueta de propina / servicio
+          </label>
+          <input
+            id="receipt-tip-label"
+            v-model="fiscalForm.receipt_tip_label"
+            type="text"
+            maxlength="40"
+            placeholder="Propina, Servicio, Cargo por servicio…"
+            class="min-h-[44px] px-3 py-2 border border-border rounded-lg text-sm text-text-primary bg-background focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+          />
+          <p class="text-[11px] text-text-tertiary leading-snug">
+            Texto de la línea de propina en prefactura, recibo impreso y email (máx. 40 caracteres). Ej: <span class="font-medium">Servicio</span>.
           </p>
         </div>
 

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1374,8 +1374,13 @@ const printReceipt = async () => {
 const fiscalData = computed(() => settingsData.value?.data?.fiscal_data ?? null)
 
 const receiptPrintSettings = computed(() =>
-  settingsData.value?.data?.receipt_print_settings ?? { document_label: 'Prefactura', show_logo: true },
+  settingsData.value?.data?.receipt_print_settings ?? { document_label: 'Prefactura', tip_label: 'Propina', show_logo: true },
 )
+
+const receiptTipLabel = computed(() => {
+  const label = (receiptPrintSettings.value.tip_label || 'Propina').trim()
+  return label || 'Propina'
+})
 
 const receiptLogoUrl = computed(() => {
   if (!receiptPrintSettings.value.show_logo) return null
@@ -3504,7 +3509,7 @@ onUnmounted(() => {
         <span>{{ formatCurrency(prefacturaPrintData.orderTotal) }}</span>
       </div>
       <div class="receipt-item">
-        <span>Propina</span>
+        <span>{{ receiptTipLabel }}</span>
         <span>{{ formatCurrency(prefacturaPrintData.tipAmount) }}</span>
       </div>
       <div v-if="prefacturaPrintData.tipTaxAmount > 0" class="receipt-item">
@@ -3632,7 +3637,7 @@ onUnmounted(() => {
         <span>{{ formatCurrency(orderResult?.total_amount ?? 0) }}</span>
       </div>
       <div class="receipt-item">
-        <span>Propina</span>
+        <span>{{ receiptTipLabel }}</span>
         <span>{{ formatCurrency(orderResult.tip_amount) }}</span>
       </div>
       <div class="receipt-total">


### PR DESCRIPTION
## Summary
- New **Etiqueta de propina / servicio** field in Personalizar tickets POS on `/facturacion`
- Prefactura and final receipt print blocks use `receipt_print_settings.tip_label`
- Requires API migration + companion PR on api-warolabs

Closes #977

## Test plan
- [ ] Deploy API PR + run migration first
- [ ] `/facturacion` → set label to "Servicio" → save
- [ ] POS checkout with tip → prefactura print shows "Servicio" instead of "Propina"
- [ ] Completed order receipt print uses custom label

## wr-context
See `.wr/977.yaml` on this branch.

Made with [Cursor](https://cursor.com)