### PR TITLE
feat(promotions): back-office UI to create and manage promotions

### DIFF
--- a/.wr/981.yaml
+++ b/.wr/981.yaml
@@ -1,0 +1,33 @@
+issue: 981
+title: "feat(promotions): back-office UI to create and manage promotions"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-981-promotions-backoffice-ui
+
+paths:
+  - pages/gestion/promociones/index.vue
+  - pages/gestion/promociones/[id].vue
+  - pages/gestion/promociones.vue
+  - components/DashboardSidebar.vue
+  - layouts/dashboard.vue
+  - utils/promotionPreview.ts
+
+ac:
+  - Route /gestion/promociones list + create/edit; module mi_negocio
+  - CRUD via /api/api/promotions
+  - Form types, schedule bitmask, scope pickers, preview text
+  - Client validation empty scope + overlapping schedules
+
+out_of_scope:
+  - POS apply (#982-983)
+  - API changes
+
+hints:
+  entry: "pages/gestion/promociones/[id].vue"
+  pattern: "pages/facturacion/index.vue — useQuery; useCategorySearch for categories"
+  tests: "Manual: create BOGO 2x1 on two products"
+
+skip:
+  audits: [ux, color, typography]

--- a/components/DashboardSidebar.vue
+++ b/components/DashboardSidebar.vue
@@ -151,6 +151,7 @@ import {
   MagnifyingGlassIcon,
   MapPinIcon,
   QueueListIcon,
+  ReceiptPercentIcon,
   ShoppingCartIcon,
   Squares2X2Icon,
   TruckIcon,
@@ -203,8 +204,9 @@ const secondaryItems: SidebarItem[] = [
 ]
 
 const cuentaItems: SidebarItem[] = [
-  { to: '/negocio',         page: 'negocio', label: 'Mi Negocio', icon: BuildingStorefrontIcon, module: 'mi_negocio' },
-  { to: '/gestion/billing', page: 'admin',   label: 'Mi Plan',    icon: CreditCardIcon,         module: 'mi_plan' },
+  { to: '/negocio',              page: 'negocio', label: 'Mi Negocio',   icon: BuildingStorefrontIcon, module: 'mi_negocio' },
+  { to: '/gestion/promociones',  page: 'negocio', label: 'Promociones',  icon: ReceiptPercentIcon,     module: 'mi_negocio' },
+  { to: '/gestion/billing',      page: 'admin',   label: 'Mi Plan',      icon: CreditCardIcon,         module: 'mi_plan' },
 ]
 
 // ── Module-based filtering (#559) ──────────────────────────────

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -907,6 +907,16 @@ const getPageConfig = () => {
       breadcrumbPage: undefined,
       backButton: undefined
     }
+  } else if (path.startsWith('/gestion/promociones')) {
+    return {
+      pageTitle: 'Promociones',
+      pageSubtitle: 'Descuentos y reglas para el menú',
+      searchPlaceholder: undefined,
+      activePage: 'negocio' as const,
+      showBreadcrumb: false,
+      breadcrumbPage: undefined,
+      backButton: undefined
+    }
   } else if (path === '/operaciones/bitacora' || path === '/operaciones/bitacora/') {
     return {
       pageTitle: 'Bitácora de operaciones',

--- a/pages/gestion/promociones.vue
+++ b/pages/gestion/promociones.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="flex flex-col gap-3 md:gap-4">
+    <UiModuleNavigation :navigation-items="navigationItems" />
+    <NuxtPage :key="route.fullPath" />
+  </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({ layout: 'dashboard', module: 'mi_negocio' })
+
+const route = useRoute()
+
+const navigationItems = [
+  { to: '/gestion/promociones', label: 'Promociones', exact: true },
+]
+</script>

--- a/pages/gestion/promociones/[id].vue
+++ b/pages/gestion/promociones/[id].vue
@@ -1,0 +1,578 @@
+<template>
+  <div>
+    <div v-if="isLoading" class="flex items-center justify-center min-h-[400px]">
+      <CommonsTheCustomLoader size="large" />
+    </div>
+
+    <CommonsTheErrorState v-else-if="loadError" />
+
+    <div v-else class="page-layout max-w-2xl">
+      <div class="flex flex-col gap-4">
+        <NuxtLink
+          to="/gestion/promociones"
+          class="text-sm text-primary hover:underline inline-flex items-center min-h-[44px]"
+        >
+          ← Volver a promociones
+        </NuxtLink>
+
+        <h2 class="text-lg font-semibold text-text-primary">
+          {{ isCreate ? 'Nueva promoción' : 'Editar promoción' }}
+        </h2>
+
+        <p
+          v-if="previewText"
+          class="text-sm text-text-secondary bg-surface-secondary border border-border rounded-lg px-3 py-2"
+        >
+          {{ previewText }}
+        </p>
+
+        <div
+          v-if="validationErrors.length"
+          role="alert"
+          class="text-sm text-status-critical-text bg-status-critical-bg border border-border rounded-lg px-3 py-2 space-y-1"
+        >
+          <p v-for="(err, i) in validationErrors" :key="i">{{ err }}</p>
+        </div>
+
+        <form class="flex flex-col gap-4" @submit.prevent="onSubmit">
+          <div>
+            <label class="block text-sm font-medium text-text-primary mb-1">Nombre</label>
+            <input
+              v-model="form.name"
+              type="text"
+              required
+              maxlength="120"
+              class="w-full px-3 py-2 border border-border rounded-lg text-sm bg-surface"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-text-primary mb-1">Tipo</label>
+            <select v-model="form.promo_type" class="w-full px-3 py-2 border border-border rounded-lg text-sm bg-surface">
+              <option value="percent_off">% descuento</option>
+              <option value="fixed_off">Descuento fijo (COP)</option>
+              <option value="bogo">2×1 / BOGO</option>
+            </select>
+          </div>
+
+          <div v-if="form.promo_type === 'percent_off'">
+            <label class="block text-sm font-medium text-text-primary mb-1">Porcentaje</label>
+            <input
+              v-model.number="form.percent"
+              type="number"
+              min="0.01"
+              max="100"
+              step="0.01"
+              class="w-full px-3 py-2 border border-border rounded-lg text-sm bg-surface"
+            />
+          </div>
+
+          <div v-else-if="form.promo_type === 'fixed_off'">
+            <label class="block text-sm font-medium text-text-primary mb-1">Monto (COP)</label>
+            <input
+              v-model.number="form.amountCop"
+              type="number"
+              min="1"
+              step="1"
+              class="w-full px-3 py-2 border border-border rounded-lg text-sm bg-surface"
+            />
+          </div>
+
+          <div v-else class="flex gap-3">
+            <div class="flex-1">
+              <label class="block text-sm font-medium text-text-primary mb-1">Compra (unidades)</label>
+              <input
+                v-model.number="form.buyQty"
+                type="number"
+                min="1"
+                class="w-full px-3 py-2 border border-border rounded-lg text-sm bg-surface"
+              />
+            </div>
+            <div class="flex-1">
+              <label class="block text-sm font-medium text-text-primary mb-1">Lleva gratis</label>
+              <input
+                v-model.number="form.getQty"
+                type="number"
+                min="1"
+                class="w-full px-3 py-2 border border-border rounded-lg text-sm bg-surface"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-text-primary mb-1">Alcance</label>
+            <select v-model="form.scope_type" class="w-full px-3 py-2 border border-border rounded-lg text-sm bg-surface">
+              <option value="all_products">Todos los productos</option>
+              <option value="categories">Categorías</option>
+              <option value="products">Productos</option>
+            </select>
+          </div>
+
+          <div v-if="form.scope_type === 'categories'" class="space-y-2">
+            <label class="block text-sm font-medium text-text-primary">Categorías</label>
+            <UiCategorySearchInput
+              placeholder="Buscar categoría…"
+              @select="onCategorySelect"
+            />
+            <ul v-if="selectedCategories.length" class="flex flex-wrap gap-2">
+              <li
+                v-for="cat in selectedCategories"
+                :key="cat.id"
+                class="text-xs bg-primary/10 text-primary px-2 py-1 rounded-full flex items-center gap-1"
+              >
+                {{ cat.name }}
+                <button type="button" class="hover:opacity-70" @click="removeCategory(cat.id)">×</button>
+              </li>
+            </ul>
+          </div>
+
+          <div v-if="form.scope_type === 'products'" class="space-y-2">
+            <label class="block text-sm font-medium text-text-primary">Productos</label>
+            <input
+              v-model="productSearch"
+              type="search"
+              placeholder="Buscar producto…"
+              class="w-full px-3 py-2 border border-border rounded-lg text-sm bg-surface"
+            />
+            <ul
+              v-if="productResults.length && productSearch.trim()"
+              class="border border-border rounded-lg max-h-40 overflow-y-auto"
+            >
+              <li
+                v-for="p in productResults"
+                :key="p.id"
+                class="px-3 py-2 text-sm hover:bg-surface-secondary cursor-pointer"
+                @click="addProduct(p)"
+              >
+                {{ p.name }}
+              </li>
+            </ul>
+            <ul v-if="selectedProducts.length" class="flex flex-wrap gap-2">
+              <li
+                v-for="p in selectedProducts"
+                :key="p.id"
+                class="text-xs bg-primary/10 text-primary px-2 py-1 rounded-full flex items-center gap-1"
+              >
+                {{ p.name }}
+                <button type="button" class="hover:opacity-70" @click="removeProduct(p.id)">×</button>
+              </li>
+            </ul>
+          </div>
+
+          <div class="space-y-3">
+            <div class="flex items-center justify-between">
+              <label class="text-sm font-medium text-text-primary">Horarios</label>
+              <button
+                type="button"
+                class="text-sm text-primary font-medium min-h-[44px]"
+                @click="addSchedule"
+              >
+                + Agregar horario
+              </button>
+            </div>
+            <div
+              v-for="(sched, idx) in form.schedules"
+              :key="idx"
+              class="border border-border rounded-lg p-3 space-y-2"
+            >
+              <div class="flex flex-wrap gap-2">
+                <label
+                  v-for="day in dayOptions"
+                  :key="day.bit"
+                  class="text-xs flex items-center gap-1 min-h-[36px]"
+                >
+                  <input
+                    type="checkbox"
+                    :checked="!!(sched.days_of_week & day.bit)"
+                    @change="toggleDay(sched, day.bit)"
+                  />
+                  {{ day.label }}
+                </label>
+              </div>
+              <div class="flex gap-2 flex-wrap">
+                <input
+                  v-model="sched.start_time"
+                  type="time"
+                  class="px-2 py-2 border border-border rounded-lg text-sm bg-surface"
+                />
+                <span class="self-center text-text-secondary">a</span>
+                <input
+                  v-model="sched.end_time"
+                  type="time"
+                  class="px-2 py-2 border border-border rounded-lg text-sm bg-surface"
+                />
+              </div>
+              <label class="text-xs flex items-center gap-1">
+                <input v-model="sched.crosses_midnight" type="checkbox" />
+                Cruza medianoche
+              </label>
+              <button
+                v-if="form.schedules.length > 1"
+                type="button"
+                class="text-xs text-destructive"
+                @click="form.schedules.splice(idx, 1)"
+              >
+                Quitar horario
+              </button>
+            </div>
+          </div>
+
+          <div class="flex gap-3 flex-wrap">
+            <div class="flex-1 min-w-[140px]">
+              <label class="block text-sm font-medium text-text-primary mb-1">Válida desde (opcional)</label>
+              <input v-model="form.startsAtDate" type="date" class="w-full px-3 py-2 border border-border rounded-lg text-sm bg-surface" />
+            </div>
+            <div class="flex-1 min-w-[140px]">
+              <label class="block text-sm font-medium text-text-primary mb-1">Válida hasta (opcional)</label>
+              <input v-model="form.endsAtDate" type="date" class="w-full px-3 py-2 border border-border rounded-lg text-sm bg-surface" />
+            </div>
+          </div>
+
+          <label class="flex items-center gap-2 text-sm min-h-[44px]">
+            <input v-model="form.is_active" type="checkbox" class="rounded border-border" />
+            Promoción activa
+          </label>
+
+          <div class="flex flex-wrap gap-2 pt-2">
+            <button
+              type="submit"
+              class="btn-primary px-4 py-2 rounded-lg text-sm font-medium min-h-[44px]"
+              :disabled="isSaving"
+            >
+              {{ isSaving ? 'Guardando…' : isCreate ? 'Crear' : 'Guardar' }}
+            </button>
+            <button
+              v-if="!isCreate"
+              type="button"
+              class="px-4 py-2 rounded-lg text-sm font-medium border border-destructive text-destructive min-h-[44px]"
+              :disabled="isSaving"
+              @click="onDelete"
+            >
+              Eliminar
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useDebounceFn } from '@vueuse/core'
+import { useQueryCache } from '@pinia/colada'
+import type { CategoryRow } from '~/composables/useCategorySearch'
+import {
+  buildPromotionPreview,
+  findOverlappingScheduleIndices,
+  type PromotionScheduleRow,
+} from '~/utils/promotionPreview'
+import { bogotaDateAtNoon, combineBogotaDateAndTimeISO } from '~/utils/bogotaDate'
+
+definePageMeta({ layout: 'dashboard', module: 'mi_negocio' })
+
+const route = useRoute()
+const router = useRouter()
+const toast = useToast()
+const cache = useQueryCache()
+const { currentTenant } = useTenantReactive()
+
+const promotionId = computed(() => String(route.params.id))
+const isCreate = computed(() => promotionId.value === 'nuevo')
+
+interface ScheduleFormRow {
+  days_of_week: number
+  start_time: string
+  end_time: string
+  crosses_midnight: boolean
+}
+
+const dayOptions = [
+  { bit: 1, label: 'Lun' },
+  { bit: 2, label: 'Mar' },
+  { bit: 4, label: 'Mié' },
+  { bit: 8, label: 'Jue' },
+  { bit: 16, label: 'Vie' },
+  { bit: 32, label: 'Sáb' },
+  { bit: 64, label: 'Dom' },
+] as const
+
+const defaultSchedule = (): ScheduleFormRow => ({
+  days_of_week: 62,
+  start_time: '17:00',
+  end_time: '20:00',
+  crosses_midnight: false,
+})
+
+const form = reactive({
+  name: '',
+  promo_type: 'percent_off' as 'percent_off' | 'fixed_off' | 'bogo',
+  percent: 10,
+  amountCop: 5000,
+  buyQty: 2,
+  getQty: 1,
+  scope_type: 'all_products' as 'all_products' | 'categories' | 'products',
+  schedules: [defaultSchedule()] as ScheduleFormRow[],
+  is_active: true,
+  startsAtDate: '',
+  endsAtDate: '',
+})
+
+const selectedCategories = ref<CategoryRow[]>([])
+const selectedProducts = ref<{ id: string; name: string }[]>([])
+const productSearch = ref('')
+const productResults = ref<{ id: string; name: string }[]>([])
+const validationErrors = ref<string[]>([])
+const isSaving = ref(false)
+const loadError = ref(false)
+
+const { data: categoriesData } = useQuery({
+  key: () => ['tenant', 'menu-categories', currentTenant.value?.id],
+  query: () => $fetch<{ success: boolean; data: CategoryRow[] }>('/api/menu/categories', { query: { limit: 250 } }),
+  enabled: () => !!currentTenant.value && !isCreate.value,
+  staleTime: 60_000,
+})
+
+const { data: promotionData, asyncStatus: loadStatus, error: promoFetchError } = useQuery({
+  key: () => ['tenant', 'promotion', promotionId.value],
+  query: () =>
+    $fetch<{ success: boolean; data: any }>(`/api/api/promotions/${promotionId.value}`, {
+      query: { at: new Date().toISOString() },
+    }),
+  enabled: () => !!currentTenant.value && !isCreate.value,
+})
+
+watch(promoFetchError, (e) => {
+  if (e) loadError.value = true
+})
+
+watch(promotionData, (payload) => {
+  const p = payload?.data
+  if (!p) return
+  form.name = p.name
+  form.promo_type = p.promo_type
+  form.scope_type = p.scope_type
+  form.is_active = p.is_active
+  if (p.promo_type === 'percent_off') form.percent = Number(p.value_json?.percent ?? 10)
+  if (p.promo_type === 'fixed_off') form.amountCop = Number(p.value_json?.amount_cop ?? 0)
+  if (p.promo_type === 'bogo') {
+    form.buyQty = Number(p.value_json?.buy_qty ?? 2)
+    form.getQty = Number(p.value_json?.get_qty ?? 1)
+  }
+  form.schedules =
+    (p.schedules?.length ? p.schedules : [defaultSchedule()]).map((s: PromotionScheduleRow) => ({
+      days_of_week: s.days_of_week,
+      start_time: (s.start_time || '09:00').slice(0, 5),
+      end_time: (s.end_time || '18:00').slice(0, 5),
+      crosses_midnight: !!s.crosses_midnight,
+    }))
+  form.startsAtDate = p.starts_at ? p.starts_at.slice(0, 10) : ''
+  form.endsAtDate = p.ends_at ? p.ends_at.slice(0, 10) : ''
+  const cats = categoriesData.value?.data ?? []
+  selectedCategories.value = (p.category_ids ?? [])
+    .map((id: string) => cats.find((c) => c.id === id))
+    .filter(Boolean) as CategoryRow[]
+  selectedProducts.value = (p.product_ids ?? []).map((id: string) => ({
+    id,
+    name: `Producto ${id.slice(0, 8)}…`,
+  }))
+  if (p.product_ids?.length) hydrateProductNames(p.product_ids)
+})
+
+const isLoading = computed(
+  () => !isCreate.value && loadStatus.value === 'loading' && !promotionData.value,
+)
+
+const previewText = computed(() =>
+  buildPromotionPreview({
+    isActive: form.is_active,
+    schedules: form.schedules.map(normalizeScheduleForPreview),
+    scopeType: form.scope_type,
+    categoryNames: selectedCategories.value.map((c) => c.name),
+    productNames: selectedProducts.value.map((p) => p.name),
+  }),
+)
+
+function normalizeScheduleForPreview(s: ScheduleFormRow): PromotionScheduleRow {
+  return {
+    days_of_week: s.days_of_week,
+    start_time: s.start_time.length === 5 ? `${s.start_time}:00` : s.start_time,
+    end_time: s.end_time.length === 5 ? `${s.end_time}:00` : s.end_time,
+    crosses_midnight: s.crosses_midnight,
+  }
+}
+
+function toggleDay(sched: ScheduleFormRow, bit: number) {
+  sched.days_of_week ^= bit
+}
+
+function addSchedule() {
+  form.schedules.push(defaultSchedule())
+}
+
+function onCategorySelect(cat: CategoryRow) {
+  if (!selectedCategories.value.some((c) => c.id === cat.id)) {
+    selectedCategories.value.push(cat)
+  }
+}
+
+function removeCategory(id: string) {
+  selectedCategories.value = selectedCategories.value.filter((c) => c.id !== id)
+}
+
+function addProduct(p: { id: string; name: string }) {
+  if (!selectedProducts.value.some((x) => x.id === p.id)) {
+    selectedProducts.value.push(p)
+  }
+  productSearch.value = ''
+  productResults.value = []
+}
+
+function removeProduct(id: string) {
+  selectedProducts.value = selectedProducts.value.filter((p) => p.id !== id)
+}
+
+const searchProducts = useDebounceFn(async (q: string) => {
+  if (!q.trim()) {
+    productResults.value = []
+    return
+  }
+  try {
+    const res = await $fetch<{ success: boolean; data: any[]; total?: number }>(
+      '/api/menu/products',
+      { query: { search: q.trim(), limit: 20, page: 1 } },
+    )
+    const items = Array.isArray(res.data) ? res.data : []
+    productResults.value = (items as any[]).map((p) => ({ id: p.id, name: p.name }))
+  } catch {
+    productResults.value = []
+  }
+}, 300)
+
+watch(productSearch, (q) => searchProducts(q))
+
+async function hydrateProductNames(ids: string[]) {
+  try {
+    const res = await $fetch<{ success: boolean; data: any }>('/api/menu/products', {
+      query: { limit: 100, page: 1 },
+    })
+    const items = Array.isArray(res.data) ? res.data : []
+    selectedProducts.value = ids.map((id) => {
+      const found = (items as any[]).find((p) => p.id === id)
+      return { id, name: found?.name ?? `Producto ${id.slice(0, 8)}…` }
+    })
+  } catch {
+    /* keep placeholders */
+  }
+}
+
+function buildPayload() {
+  const value_json: Record<string, unknown> = {}
+  if (form.promo_type === 'percent_off') value_json.percent = form.percent
+  else if (form.promo_type === 'fixed_off') value_json.amount_cop = form.amountCop
+  else {
+    value_json.buy_qty = form.buyQty
+    value_json.get_qty = form.getQty
+  }
+
+  const schedules = form.schedules.map((s) => ({
+    days_of_week: s.days_of_week,
+    start_time: s.start_time.length === 5 ? `${s.start_time}:00` : s.start_time,
+    end_time: s.end_time.length === 5 ? `${s.end_time}:00` : s.end_time,
+    crosses_midnight: s.crosses_midnight,
+    sort_order: 0,
+  }))
+
+  let starts_at: string | null = null
+  let ends_at: string | null = null
+  if (form.startsAtDate) {
+    starts_at = combineBogotaDateAndTimeISO(form.startsAtDate, '00:00') ?? bogotaDateAtNoon(form.startsAtDate).toISOString()
+  }
+  if (form.endsAtDate) {
+    ends_at = combineBogotaDateAndTimeISO(form.endsAtDate, '23:59') ?? null
+  }
+
+  return {
+    name: form.name.trim(),
+    promo_type: form.promo_type,
+    value_json,
+    scope_type: form.scope_type,
+    category_ids: form.scope_type === 'categories' ? selectedCategories.value.map((c) => c.id) : [],
+    product_ids: form.scope_type === 'products' ? selectedProducts.value.map((p) => p.id) : [],
+    schedules,
+    is_active: form.is_active,
+    starts_at,
+    ends_at,
+    priority: 0,
+    stackable: false,
+  }
+}
+
+function validate(): boolean {
+  const errors: string[] = []
+  if (!form.name.trim()) errors.push('El nombre es obligatorio.')
+  if (form.scope_type === 'categories' && !selectedCategories.value.length) {
+    errors.push('Selecciona al menos una categoría.')
+  }
+  if (form.scope_type === 'products' && !selectedProducts.value.length) {
+    errors.push('Selecciona al menos un producto.')
+  }
+  for (const s of form.schedules) {
+    if (!s.days_of_week) errors.push('Cada horario debe incluir al menos un día.')
+    if (!s.crosses_midnight && s.end_time <= s.start_time) {
+      errors.push('La hora de fin debe ser posterior al inicio (o marca cruza medianoche).')
+    }
+  }
+  const overlap = findOverlappingScheduleIndices(
+    form.schedules.map(normalizeScheduleForPreview),
+  )
+  if (overlap) errors.push(overlap)
+  validationErrors.value = errors
+  return errors.length === 0
+}
+
+async function onSubmit() {
+  if (!validate()) return
+  isSaving.value = true
+  try {
+    const body = buildPayload()
+    if (isCreate.value) {
+      const res = await $fetch<{ success: boolean; data: { id: string } }>('/api/api/promotions', {
+        method: 'POST',
+        body,
+      })
+      toast.add({ title: 'Promoción creada', color: 'success' })
+      cache.invalidateQueries({ key: ['tenant', 'promotions'] })
+      await router.replace(`/gestion/promociones/${res.data.id}`)
+    } else {
+      await $fetch(`/api/api/promotions/${promotionId.value}`, { method: 'PATCH', body })
+      toast.add({ title: 'Promoción actualizada', color: 'success' })
+      cache.invalidateQueries({ key: ['tenant', 'promotions'] })
+      cache.invalidateQueries({ key: ['tenant', 'promotion', promotionId.value] })
+    }
+  } catch (e: any) {
+    const detail = e?.data?.detail ?? e?.message ?? 'Error al guardar'
+    validationErrors.value = [typeof detail === 'string' ? detail : JSON.stringify(detail)]
+  } finally {
+    isSaving.value = false
+  }
+}
+
+async function onDelete() {
+  if (!confirm('¿Eliminar esta promoción?')) return
+  isSaving.value = true
+  try {
+    await $fetch(`/api/api/promotions/${promotionId.value}`, { method: 'DELETE' })
+    toast.add({ title: 'Promoción eliminada', color: 'success' })
+    cache.invalidateQueries({ key: ['tenant', 'promotions'] })
+    await router.push('/gestion/promociones')
+  } catch (e: any) {
+    toast.add({ title: e?.data?.detail ?? 'No se pudo eliminar', color: 'error' })
+  } finally {
+    isSaving.value = false
+  }
+}
+
+useHead(() => ({
+  title: isCreate.value ? 'Nueva promoción' : 'Editar promoción',
+}))
+</script>

--- a/pages/gestion/promociones/index.vue
+++ b/pages/gestion/promociones/index.vue
@@ -1,0 +1,162 @@
+<template>
+  <div>
+    <div v-if="isLoading" class="flex items-center justify-center min-h-[400px]">
+      <CommonsTheCustomLoader size="large" />
+    </div>
+
+    <CommonsTheErrorState v-else-if="fetchError" />
+
+    <div v-else class="page-layout">
+      <div class="flex flex-col gap-3 md:gap-4">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <p class="text-sm text-text-secondary">
+            Configura descuentos y promociones con horario y alcance en el menú.
+          </p>
+          <NuxtLink
+            to="/gestion/promociones/nuevo"
+            class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap min-h-[44px] inline-flex items-center justify-center"
+          >
+            + Nueva promoción
+          </NuxtLink>
+        </div>
+
+        <label class="flex items-center gap-2 text-sm text-text-secondary min-h-[44px]">
+          <input v-model="showInactive" type="checkbox" class="rounded border-border" />
+          Mostrar promociones desactivadas
+        </label>
+
+        <UiResponsiveDataView
+          :columns="columns"
+          :data="promotions"
+          empty-message="No hay promociones"
+          empty-sub-message="Crea la primera para aplicarla en el POS (batch siguiente)."
+          variant="default"
+          row-size="sm"
+        >
+          <template #card="{ item }">
+            <NuxtLink
+              :to="`/gestion/promociones/${item.id}`"
+              class="flex flex-col gap-1 py-3 px-3 border-b border-border hover:bg-surface-secondary transition-colors"
+            >
+              <div class="flex items-center justify-between gap-2">
+                <span class="text-sm font-bold text-text-primary">{{ item.name }}</span>
+                <span
+                  class="text-xs font-medium px-2 py-0.5 rounded-full flex-shrink-0"
+                  :class="statusBadgeClass(item)"
+                >
+                  {{ statusBadgeLabel(item) }}
+                </span>
+              </div>
+              <p class="text-xs text-text-secondary">{{ rowPreview(item) }}</p>
+              <p class="text-xs text-text-tertiary">{{ formatPromoTypeLabel(item.promo_type) }}</p>
+            </NuxtLink>
+          </template>
+
+          <template #cell-name="{ value }">
+            <span class="text-sm font-medium text-text-primary">{{ value }}</span>
+          </template>
+
+          <template #cell-preview="{ item }">
+            <span class="text-sm text-text-secondary">{{ rowPreview(item) }}</span>
+          </template>
+
+          <template #cell-status="{ item }">
+            <span
+              class="text-xs font-medium px-2 py-0.5 rounded-full"
+              :class="statusBadgeClass(item)"
+            >
+              {{ statusBadgeLabel(item) }}
+            </span>
+          </template>
+
+          <template #cell-actions="{ item }">
+            <NuxtLink
+              :to="`/gestion/promociones/${item.id}`"
+              class="text-sm font-medium text-primary hover:underline min-h-[44px] inline-flex items-center"
+            >
+              Editar
+            </NuxtLink>
+          </template>
+        </UiResponsiveDataView>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Column } from '~/components/ui/ResponsiveDataView.vue'
+import {
+  buildPromotionPreview,
+  formatPromoTypeLabel,
+  type PromotionScheduleRow,
+} from '~/utils/promotionPreview'
+
+definePageMeta({ layout: 'dashboard', module: 'mi_negocio' })
+useHead({ title: 'Promociones' })
+
+interface PromotionRow {
+  id: string
+  name: string
+  promo_type: string
+  scope_type: string
+  is_active: boolean
+  is_currently_active?: boolean | null
+  schedules: PromotionScheduleRow[]
+  category_ids: string[]
+  product_ids: string[]
+}
+
+const { currentTenant } = useTenantReactive()
+const showInactive = ref(true)
+
+const columns: Column[] = [
+  { key: 'name', title: 'Nombre' },
+  { key: 'preview', title: 'Vista previa' },
+  { key: 'status', title: 'Estado' },
+  { key: 'actions', title: '', align: 'right' as const },
+]
+
+const {
+  data: listData,
+  error: fetchError,
+  asyncStatus: queryAsyncStatus,
+} = useQuery({
+  key: () => ['tenant', 'promotions', currentTenant.value?.id, { inactive: showInactive.value }],
+  query: () =>
+    $fetch<{ success: boolean; total: number; data: PromotionRow[] }>('/api/api/promotions', {
+      query: {
+        include_inactive: showInactive.value,
+        at: new Date().toISOString(),
+      },
+    }),
+  enabled: () => !!currentTenant.value,
+  staleTime: 30_000,
+})
+
+const promotions = computed(() => listData.value?.data ?? [])
+const isLoading = computed(
+  () => queryAsyncStatus.value === 'loading' && !listData.value,
+)
+
+const rowPreview = (item: PromotionRow) =>
+  buildPromotionPreview({
+    isActive: item.is_active,
+    isCurrentlyActive: item.is_currently_active,
+    schedules: item.schedules ?? [],
+    scopeType: item.scope_type,
+  })
+
+const statusBadgeLabel = (item: PromotionRow) => {
+  if (!item.is_active) return 'Desactivada'
+  if (item.is_currently_active === true) return 'Activa ahora'
+  if (item.is_currently_active === false) return 'Fuera de horario'
+  return 'Activa'
+}
+
+const statusBadgeClass = (item: PromotionRow) => {
+  if (!item.is_active) return 'bg-text-secondary/10 text-text-secondary'
+  if (item.is_currently_active === true) return 'bg-status-success-bg text-status-success-text'
+  if (item.is_currently_active === false) return 'bg-status-warning-bg text-status-warning-text'
+  return 'bg-primary/10 text-primary'
+}
+</script>

--- a/utils/promotionPreview.ts
+++ b/utils/promotionPreview.ts
@@ -1,0 +1,131 @@
+/** Human-readable promotion schedule + scope preview (warocol.com#981). */
+
+export type PromotionScheduleRow = {
+  days_of_week: number
+  start_time: string
+  end_time: string
+  crosses_midnight?: boolean
+}
+
+const DAY_BITS = [
+  { bit: 1, short: 'lun' },
+  { bit: 2, short: 'mar' },
+  { bit: 4, short: 'mié' },
+  { bit: 8, short: 'jue' },
+  { bit: 16, short: 'vie' },
+  { bit: 32, short: 'sáb' },
+  { bit: 64, short: 'dom' },
+] as const
+
+export function formatDaysBitmask(mask: number): string {
+  const days = DAY_BITS.filter((d) => mask & d.bit).map((d) => d.short)
+  if (days.length === 0) return 'sin días'
+  if (days.length === 7) return 'todos los días'
+  return days.join('–')
+}
+
+function formatTimeHHMM(t: string): string {
+  if (!t) return ''
+  return t.slice(0, 5)
+}
+
+export function formatScheduleWindow(sched: PromotionScheduleRow): string {
+  const days = formatDaysBitmask(sched.days_of_week)
+  const start = formatTimeHHMM(sched.start_time)
+  const end = formatTimeHHMM(sched.end_time)
+  if (!start && !end) return days
+  return `${days} ${start}–${end}`
+}
+
+export function formatPromoTypeLabel(promoType: string): string {
+  switch (promoType) {
+    case 'percent_off':
+      return '% descuento'
+    case 'fixed_off':
+      return 'Descuento fijo'
+    case 'bogo':
+      return '2×1 / BOGO'
+    default:
+      return promoType
+  }
+}
+
+export function formatScopeLabel(
+  scopeType: string,
+  categoryNames: string[],
+  productNames: string[],
+): string {
+  if (scopeType === 'all_products') return 'todos los productos'
+  if (scopeType === 'categories') {
+    if (!categoryNames.length) return 'categorías (sin seleccionar)'
+    return categoryNames.length === 1
+      ? categoryNames[0]
+      : `${categoryNames.length} categorías`
+  }
+  if (scopeType === 'products') {
+    if (!productNames.length) return 'productos (sin seleccionar)'
+    return productNames.length === 1
+      ? productNames[0]
+      : `${productNames.length} productos`
+  }
+  return scopeType
+}
+
+export function buildPromotionPreview(opts: {
+  isActive: boolean
+  isCurrentlyActive?: boolean | null
+  schedules: PromotionScheduleRow[]
+  scopeType: string
+  categoryNames?: string[]
+  productNames?: string[]
+}): string {
+  const activeWord =
+    opts.isCurrentlyActive === true
+      ? 'Activa'
+      : opts.isCurrentlyActive === false
+        ? 'Inactiva ahora'
+        : opts.isActive
+          ? 'Activa'
+          : 'Desactivada'
+  const schedPart =
+    opts.schedules.length > 0
+      ? formatScheduleWindow(opts.schedules[0])
+      : 'sin horario'
+  const scopePart = formatScopeLabel(
+    opts.scopeType,
+    opts.categoryNames ?? [],
+    opts.productNames ?? [],
+  )
+  return `${activeWord} ${schedPart} en ${scopePart}`
+}
+
+/** Client-side overlap check for two schedule rows (same tenant promo form). */
+export function schedulesOverlap(a: PromotionScheduleRow, b: PromotionScheduleRow): boolean {
+  if (!(a.days_of_week & b.days_of_week)) return false
+  const toMin = (t: string) => {
+    const [h, m] = t.slice(0, 5).split(':').map(Number)
+    return h * 60 + m
+  }
+  const aStart = toMin(a.start_time)
+  const aEnd = toMin(a.end_time)
+  const bStart = toMin(b.start_time)
+  const bEnd = toMin(b.end_time)
+  const rangesOverlap = (s1: number, e1: number, s2: number, e2: number) =>
+    s1 < e2 && s2 < e1
+  if (!a.crosses_midnight && !b.crosses_midnight) {
+    return rangesOverlap(aStart, aEnd, bStart, bEnd)
+  }
+  // Midnight-crossing: conservative overlap if any shared day bit
+  return true
+}
+
+export function findOverlappingScheduleIndices(schedules: PromotionScheduleRow[]): string | null {
+  for (let i = 0; i < schedules.length; i++) {
+    for (let j = i + 1; j < schedules.length; j++) {
+      if (schedulesOverlap(schedules[i], schedules[j])) {
+        return `Los horarios ${i + 1} y ${j + 1} se superponen en los mismos días.`
+      }
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- Add `/gestion/promociones` list and create/edit screens (Pinia Colada + `/api/api/promotions`).
- Reuse category search and menu product search for scope; schedule preview in Bogotá local time.
- Sidebar + dashboard titles under Mi Negocio (`mi_negocio` module).

Closes #981

## Test plan
- [ ] Open `/gestion/promociones` as owner — list loads with `include_inactive`
- [ ] Create BOGO 2×1 on two products — saves and appears in list
- [ ] Preview text shows schedule + scope (e.g. lun–vie 17:00–20:00)
- [ ] Toggle inactive / edit / delete

## wr-context
See `.wr/981.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)