### PR TITLE
feat(promotions): happy-hour indicator and schedule polish (#983)

### DIFF
--- a/.wr/983.yaml
+++ b/.wr/983.yaml
@@ -1,0 +1,31 @@
+issue: 983
+title: "feat(promotions): happy-hour windows and category-wide rules"
+repo: both
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA
+stack: both
+branch: wr-983-happy-hour-indicator
+
+paths:
+  - front_nuxt/composables/useActivePromotions.ts
+  - front_nuxt/pages/pos/index.vue
+  - front_nuxt/pages/pos/checkout.vue
+  - front_nuxt/utils/promotionPreview.ts
+  - api_warocol.com/tests/test_promotions_schedule.py
+  - api_warocol.com/tests/test_promo_cart_evaluation.py
+
+ac:
+  - "Happy hour Mon–Fri 17:00–20:00 applies % off all items in category Cervezas"
+  - "Outside window, prices revert with no stale discounts"
+  - "Multiple hours_available ranges per day in API + UI"
+  - "Category-wide rules tested with large menus"
+  - "POS header/footer hint when any promo is live now"
+  - "Edge cases: promo starts/ends mid-shift (server clock Bogotá)"
+
+hints:
+  entry: "GET /api/api/promotions/active?only_current=true via useActivePromotions"
+  boundary: "msUntilNextPromoBoundary schedules refetch + invalidates tax-preview on change"
+  tests: "pytest tests/test_promotions_schedule.py tests/test_promo_cart_evaluation.py -v"
+
+skip:
+  audits: [ux, color, typography]

--- a/composables/useActivePromotions.ts
+++ b/composables/useActivePromotions.ts
@@ -1,0 +1,150 @@
+import { computed, onUnmounted, ref, watch, type ComputedRef, type Ref } from 'vue'
+import { $fetch } from 'ofetch'
+import type { PromotionScheduleRow } from '~/utils/promotionPreview'
+import { BOGOTA_TZ } from '~/utils/bogotaDate'
+
+export interface ActivePromotionRow {
+  id: string
+  name: string
+  promo_type: string
+  scope_type: string
+  schedules: PromotionScheduleRow[]
+  is_currently_active?: boolean
+}
+
+const MIN_REFETCH_MS = 30_000
+const MAX_REFETCH_MS = 5 * 60_000
+
+function bogotaNowParts(now = new Date()) {
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: BOGOTA_TZ,
+    weekday: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+  const parts = Object.fromEntries(
+    fmt.formatToParts(now).map((p) => [p.type, p.value]),
+  ) as Record<string, string>
+  const weekdayMap: Record<string, number> = {
+    Mon: 0,
+    Tue: 1,
+    Wed: 2,
+    Thu: 3,
+    Fri: 4,
+    Sat: 5,
+    Sun: 6,
+  }
+  const weekday = weekdayMap[parts.weekday] ?? 0
+  const [hour, minute] = parts.hour.split(':').map(Number)
+  return { weekday, minutes: hour * 60 + minute }
+}
+
+function timeToMinutes(t: string): number {
+  const [h, m] = t.slice(0, 5).split(':').map(Number)
+  return h * 60 + m
+}
+
+/** Ms until the next schedule start/end in Bogotá (for mid-shift refresh). */
+export function msUntilNextPromoBoundary(
+  schedules: PromotionScheduleRow[],
+  now = new Date(),
+): number {
+  if (schedules.length === 0) return MAX_REFETCH_MS
+
+  const { weekday, minutes: nowMin } = bogotaNowParts(now)
+  const todayBit = 1 << weekday
+  let bestMs = MAX_REFETCH_MS
+
+  for (const sched of schedules) {
+    if (!(sched.days_of_week & todayBit)) continue
+    const startMin = timeToMinutes(sched.start_time)
+    const endMin = timeToMinutes(sched.end_time)
+
+    if (sched.crosses_midnight) {
+      if (nowMin >= startMin) {
+        const minsUntilEnd = (24 * 60 - nowMin) + endMin
+        bestMs = Math.min(bestMs, minsUntilEnd * 60_000)
+      } else if (nowMin < endMin) {
+        bestMs = Math.min(bestMs, (endMin - nowMin) * 60_000)
+      } else {
+        bestMs = Math.min(bestMs, (startMin - nowMin) * 60_000)
+      }
+      continue
+    }
+
+    if (nowMin >= startMin && nowMin < endMin) {
+      bestMs = Math.min(bestMs, (endMin - nowMin) * 60_000)
+    } else if (nowMin < startMin) {
+      bestMs = Math.min(bestMs, (startMin - nowMin) * 60_000)
+    }
+  }
+
+  return Math.max(MIN_REFETCH_MS, Math.min(bestMs, MAX_REFETCH_MS))
+}
+
+export function useActivePromotions(options?: {
+  enabled?: Ref<boolean> | ComputedRef<boolean>
+  onActivePromosChanged?: () => void
+}) {
+  const { currentTenant } = useTenantReactive()
+  const activeSignature = ref('')
+  let boundaryTimer: ReturnType<typeof setTimeout> | null = null
+
+  const { data, asyncStatus, refetch } = useQuery({
+    key: () => ['pos', 'active-promotions', currentTenant.value?.id],
+    query: () =>
+      $fetch<{ success: boolean; total: number; data: ActivePromotionRow[] }>(
+        '/api/api/promotions/active',
+        { query: { only_current: true, at: new Date().toISOString() } },
+      ),
+    enabled: () => !!currentTenant.value && (options?.enabled?.value ?? true),
+    staleTime: 30_000,
+  })
+
+  const activePromos = computed(() => data.value?.data ?? [])
+  const hasActivePromos = computed(() => activePromos.value.length > 0)
+
+  const activePromoHint = computed(() => {
+    const names = activePromos.value.map((p) => p.name).filter(Boolean)
+    if (names.length === 0) return ''
+    if (names.length === 1) return names[0]
+    if (names.length === 2) return `${names[0]} y ${names[1]}`
+    return `${names[0]} y ${names.length - 1} más`
+  })
+
+  function scheduleBoundaryRefetch() {
+    if (boundaryTimer) clearTimeout(boundaryTimer)
+    if (!hasActivePromos.value) return
+    const allSchedules = activePromos.value.flatMap((p) => p.schedules ?? [])
+    const delay = msUntilNextPromoBoundary(allSchedules)
+    boundaryTimer = setTimeout(() => {
+      refetch()
+    }, delay)
+  }
+
+  watch(
+    activePromos,
+    (promos) => {
+      const nextSig = promos.map((p) => p.id).sort().join(',')
+      if (activeSignature.value && nextSig !== activeSignature.value) {
+        options?.onActivePromosChanged?.()
+      }
+      activeSignature.value = nextSig
+      scheduleBoundaryRefetch()
+    },
+    { immediate: true },
+  )
+
+  onUnmounted(() => {
+    if (boundaryTimer) clearTimeout(boundaryTimer)
+  })
+
+  return {
+    activePromos,
+    hasActivePromos,
+    activePromoHint,
+    activePromosStatus: asyncStatus,
+    refetchActivePromos: refetch,
+  }
+}

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -41,6 +41,17 @@ const { currentTenant, businessProfile } = useTenantReactive()
 const { singular: tableSingular } = useTableLabel()
 const tableSingularLower = computed(() => tableSingular.value.toLowerCase())
 
+function invalidateCheckoutPromoPreview() {
+  cache.invalidateQueries({ key: ['pos', 'cart', posStore.cartId ?? null, 'tax-preview'] })
+  if (isKitchenServiceMode.value && posStore.activeTableSession?.tableId) {
+    cache.invalidateQueries({ key: ['tables', posStore.activeTableSession.tableId, 'current'] })
+  }
+}
+
+const { hasActivePromos, activePromoHint } = useActivePromotions({
+  onActivePromosChanged: invalidateCheckoutPromoPreview,
+})
+
 // Inject subtitle setter from layout
 const setPageSubtitle = inject<(subtitle: string | undefined) => void>('setPageSubtitle', () => {})
 
@@ -1904,6 +1915,22 @@ onUnmounted(() => {
     <!-- Main Grid (cart has items and sync completed) -->
     <div v-else class="grid grid-cols-1 lg:grid-cols-12 gap-6 items-start">
 
+      <!-- Live promotion hint — checkout header (warocol.com#983) -->
+      <div
+        v-if="hasActivePromos"
+        role="status"
+        class="lg:col-span-12 flex items-center gap-3 min-h-[44px] px-4 py-3 bg-status-success-bg border border-status-success-text/25 rounded-xl"
+      >
+        <div class="flex-shrink-0 bg-status-success-text/15 p-1.5 rounded-lg">
+          <svg class="w-4 h-4 text-status-success-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z" />
+          </svg>
+        </div>
+        <p class="text-sm text-status-success-text font-medium">
+          Promo activa: {{ activePromoHint }}
+        </p>
+      </div>
+
       <!-- LEFT COLUMN: Order Items & Payment Method -->
       <div class="lg:col-span-8 space-y-6">
 
@@ -2947,6 +2974,21 @@ onUnmounted(() => {
       v-if="cartItems.length > 0 && !isSyncingCart && !syncError"
       class="lg:hidden mt-6 pb-4 space-y-3"
     >
+      <!-- Live promotion hint — checkout footer (warocol.com#983) -->
+      <div
+        v-if="hasActivePromos"
+        role="status"
+        class="flex items-center gap-3 min-h-[44px] px-4 py-3 bg-status-success-bg border border-status-success-text/25 rounded-xl"
+      >
+        <div class="flex-shrink-0 bg-status-success-text/15 p-1.5 rounded-lg">
+          <svg class="w-4 h-4 text-status-success-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z" />
+          </svg>
+        </div>
+        <p class="text-sm text-status-success-text font-medium">
+          Promo activa: {{ activePromoHint }}
+        </p>
+      </div>
 
       <!-- ACCORDION: Customer Insights (same as desktop) -->
       <div

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -32,6 +32,8 @@ const toast = useToast()
 const posStore = usePOSStore()
 const { tabItems: storeTabItems, tabTotal: storeTabTotal, activeTableSession } = storeToRefs(posStore)
 
+const { hasActivePromos, activePromoHint } = useActivePromotions()
+
 // Clear session at setup time (before first render) so showFloorPlan is correct immediately.
 // If navigating from a POS sub-page (checkout, producto), posNavigation flag preserves the session.
 if (typeof window !== 'undefined' && sessionStorage.getItem('posNavigation') !== 'true') {
@@ -1292,6 +1294,22 @@ onUnmounted(() => {
 
     <!-- POS Content (shown always after loading) -->
     <div v-else>
+      <!-- Live promotion hint (warocol.com#983) -->
+      <div
+        v-if="hasActivePromos"
+        role="status"
+        class="flex items-center gap-3 min-h-[44px] px-4 py-3 mb-4 bg-status-success-bg border border-status-success-text/25 rounded-xl"
+      >
+        <div class="flex-shrink-0 bg-status-success-text/15 p-1.5 rounded-lg">
+          <svg class="w-4 h-4 text-status-success-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z" />
+          </svg>
+        </div>
+        <p class="text-sm text-status-success-text font-medium">
+          Promo activa: {{ activePromoHint }}
+        </p>
+      </div>
+
       <!-- Mesa Banner skeleton while loading tab items -->
       <div v-if="isLoadingTabItems || isAddingToTab" class="bg-surface border border-border rounded-2xl mb-4 p-3.5 shadow-sm animate-pulse">
         <div class="flex items-center gap-3">

--- a/utils/promotionPreview.ts
+++ b/utils/promotionPreview.ts
@@ -37,6 +37,12 @@ export function formatScheduleWindow(sched: PromotionScheduleRow): string {
   return `${days} ${start}–${end}`
 }
 
+/** Join all schedule rows for list/preview copy (warocol.com#983). */
+export function formatScheduleWindows(schedules: PromotionScheduleRow[]): string {
+  if (schedules.length === 0) return 'sin horario'
+  return schedules.map(formatScheduleWindow).join('; ')
+}
+
 export function formatPromoTypeLabel(promoType: string): string {
   switch (promoType) {
     case 'percent_off':
@@ -87,10 +93,7 @@ export function buildPromotionPreview(opts: {
         : opts.isActive
           ? 'Activa'
           : 'Desactivada'
-  const schedPart =
-    opts.schedules.length > 0
-      ? formatScheduleWindow(opts.schedules[0])
-      : 'sin horario'
+  const schedPart = formatScheduleWindows(opts.schedules)
   const scopePart = formatScopeLabel(
     opts.scopeType,
     opts.categoryNames ?? [],


### PR DESCRIPTION
## Summary
- Add `useActivePromotions` composable calling `GET /api/promotions/active?only_current=true` with Bogotá schedule-boundary refetch
- Show **Promo activa** banner on POS catalog (`/pos`) and checkout (header + mobile footer)
- Invalidate tax-preview when active promos change so prices revert outside windows
- Format all schedule rows in `buildPromotionPreview` (not just the first)

## Test plan
- [ ] Create Mon–Fri 17:00–20:00 % promo scoped to category **Cervezas**
- [ ] Inside window: POS shows green **Promo activa** banner; checkout line items show promo savings
- [ ] Outside window: banner disappears; tax preview totals match full price (no stale discount)
- [ ] Add two non-overlapping ranges same day (e.g. 12–14 + 17–20): admin preview lists both; promo active in each window only
- [ ] Cross midnight: existing `crosses_midnight` checkbox still works (document if manual test skipped)

Closes #983

Made with [Cursor](https://cursor.com)