### PR TITLE
feat(gestion): promociones hub at /gestion/promociones with submenu and mobile filters

### DIFF
--- a/.wr/989.yaml
+++ b/.wr/989.yaml
@@ -1,0 +1,32 @@
+issue: 989
+title: "feat(gestion): promociones hub at /gestion/promociones with submenu and mobile filters"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-989-gestion-promociones-hub
+
+paths:
+  - components/DashboardSidebar.vue
+  - layouts/dashboard.vue
+  - pages/gestion/promociones/index.vue
+  - pages/gestion/promociones.vue
+
+ac:
+  - /gestion/promociones renders in place (no redirect)
+  - Gestión sidebar section with Promociones (mi_negocio gate)
+  - UiModuleNavigation submenu in promociones.vue wrapper
+  - UiAdvancedFiltersBar with search, status/type toggles, clear
+  - Mobile min-h-[44px], UiResponsiveDataView cards, CTA in header-actions
+
+out_of_scope:
+  - promotion engine/API, POS apply, new promo types
+  - moving Mi Plan to Gestión section
+
+hints:
+  entry: "pages/gestion/promociones/index.vue"
+  pattern: "pages/gestion/ingredientes/index.vue — UiAdvancedFiltersBar + colored toggles"
+  tests: "Manual: phone-width filter, edit promo, return to list"
+
+skip:
+  audits: [ux, color, typography]

--- a/components/DashboardSidebar.vue
+++ b/components/DashboardSidebar.vue
@@ -83,6 +83,28 @@
         </div>
       </template>
 
+      <!-- ── GESTIÓN (above Cuenta) ── -->
+      <template v-if="visibleGestionItems.length">
+        <div class="my-1.5 mx-1 border-t nav-divider" />
+        <div class="space-y-0.5">
+          <p v-if="!collapsed" class="nav-section-label">Gestión</p>
+          <NuxtLink
+            v-for="item in visibleGestionItems"
+            :key="item.to"
+            :to="item.to"
+            :title="item.label"
+            :class="[
+              'nav-item',
+              collapsed ? 'justify-center' : '',
+              activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
+            ]"
+          >
+            <component :is="item.icon" class="nav-icon" />
+            <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">{{ item.label }}</span>
+          </NuxtLink>
+        </div>
+      </template>
+
       <!-- ── SPACER ── -->
       <div class="flex-1" style="min-height: 1rem;" />
 
@@ -160,7 +182,7 @@ import {
 } from '@heroicons/vue/24/outline'
 
 interface Props {
-  activePage?: 'dashboard' | 'ventas' | 'propinas' | 'pos' | 'despacho' | 'comandas' | 'financiero' | 'abastecimiento' | 'inventario' | 'menu' | 'pagos' | 'equipo' | 'integraciones' | 'analytics' | 'reportes' | 'configuracion' | 'admin' | 'negocio' | 'operaciones' | 'finanzas' | 'facturacion'
+  activePage?: 'dashboard' | 'ventas' | 'propinas' | 'pos' | 'despacho' | 'comandas' | 'financiero' | 'abastecimiento' | 'inventario' | 'menu' | 'pagos' | 'equipo' | 'integraciones' | 'analytics' | 'reportes' | 'configuracion' | 'admin' | 'negocio' | 'gestion' | 'operaciones' | 'finanzas' | 'facturacion'
 }
 const props = withDefaults(defineProps<Props>(), { activePage: 'financiero' })
 
@@ -203,10 +225,13 @@ const secondaryItems: SidebarItem[] = [
   { to: '/integraciones',                    page: 'integraciones',  label: 'Integraciones',    icon: KeyIcon,                   module: 'integraciones' },
 ]
 
+const gestionItems: SidebarItem[] = [
+  { to: '/gestion/promociones', page: 'gestion', label: 'Promociones', icon: ReceiptPercentIcon, module: 'mi_negocio' },
+]
+
 const cuentaItems: SidebarItem[] = [
-  { to: '/negocio',              page: 'negocio', label: 'Mi Negocio',   icon: BuildingStorefrontIcon, module: 'mi_negocio' },
-  { to: '/gestion/promociones',  page: 'negocio', label: 'Promociones',  icon: ReceiptPercentIcon,     module: 'mi_negocio' },
-  { to: '/gestion/billing',      page: 'admin',   label: 'Mi Plan',      icon: CreditCardIcon,         module: 'mi_plan' },
+  { to: '/negocio',         page: 'negocio', label: 'Mi Negocio', icon: BuildingStorefrontIcon, module: 'mi_negocio' },
+  { to: '/gestion/billing', page: 'admin',   label: 'Mi Plan',    icon: CreditCardIcon,         module: 'mi_plan' },
 ]
 
 // ── Module-based filtering (#559) ──────────────────────────────
@@ -218,6 +243,9 @@ const visiblePrimaryItems = computed(() =>
 )
 const visibleSecondaryItems = computed(() =>
   secondaryItems.filter((item) => can(item.module).value)
+)
+const visibleGestionItems = computed(() =>
+  gestionItems.filter((item) => can(item.module).value)
 )
 const visibleCuentaItems = computed(() =>
   cuentaItems.filter((item) => can(item.module).value)

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -912,7 +912,7 @@ const getPageConfig = () => {
       pageTitle: 'Promociones',
       pageSubtitle: 'Descuentos y reglas para el menú',
       searchPlaceholder: undefined,
-      activePage: 'negocio' as const,
+      activePage: 'gestion' as const,
       showBreadcrumb: false,
       breadcrumbPage: undefined,
       backButton: undefined

--- a/pages/gestion/promociones/index.vue
+++ b/pages/gestion/promociones/index.vue
@@ -8,31 +8,112 @@
 
     <div v-else class="page-layout">
       <div class="flex flex-col gap-3 md:gap-4">
-        <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <p class="text-sm text-text-secondary">
-            Configura descuentos y promociones con horario y alcance en el menú.
-          </p>
-          <NuxtLink
-            to="/gestion/promociones/nuevo"
-            class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap min-h-[44px] inline-flex items-center justify-center"
-          >
-            + Nueva promoción
-          </NuxtLink>
-        </div>
+        <p class="text-sm text-text-secondary">
+          Configura descuentos y promociones con horario y alcance en el menú.
+        </p>
 
-        <label class="flex items-center gap-2 text-sm text-text-secondary min-h-[44px]">
-          <input v-model="showInactive" type="checkbox" class="rounded border-border" />
-          Mostrar promociones desactivadas
-        </label>
+        <UiAdvancedFiltersBar
+          v-model:search="localSearchTerm"
+          :search-fields="[]"
+          :show-date-range="false"
+          search-placeholder="Buscar promociones..."
+          :show-clear="hasActiveFilters"
+          @search="performSearch"
+          @clear="clearFilters"
+        >
+          <template #additional-filters>
+            <div
+              class="flex rounded-lg border border-border overflow-hidden text-sm shrink-0"
+              role="group"
+              aria-label="Filtrar por estado"
+            >
+              <button
+                type="button"
+                class="px-3 py-2 min-h-[44px] transition-colors"
+                :class="statusFilter === '' ? 'bg-primary text-white' : 'bg-surface text-text-secondary hover:bg-surface-secondary'"
+                @click="statusFilter = ''"
+              >
+                Todas
+              </button>
+              <button
+                type="button"
+                class="px-3 py-2 min-h-[44px] border-l border-border transition-colors"
+                :class="statusFilter === 'active' ? 'bg-status-success-bg text-status-success-text' : 'bg-surface text-text-secondary hover:bg-surface-secondary'"
+                @click="statusFilter = 'active'"
+              >
+                Activas
+              </button>
+              <button
+                type="button"
+                class="px-3 py-2 min-h-[44px] border-l border-border transition-colors"
+                :class="statusFilter === 'inactive' ? 'bg-text-secondary/20 text-text-secondary' : 'bg-surface text-text-secondary hover:bg-surface-secondary'"
+                @click="statusFilter = 'inactive'"
+              >
+                Inactivas
+              </button>
+            </div>
+
+            <div
+              class="flex rounded-lg border border-border overflow-hidden text-sm shrink-0"
+              role="group"
+              aria-label="Filtrar por tipo de promoción"
+            >
+              <button
+                type="button"
+                class="px-3 py-2 min-h-[44px] transition-colors"
+                :class="promoTypeFilter === '' ? 'bg-primary text-white' : 'bg-surface text-text-secondary hover:bg-surface-secondary'"
+                @click="promoTypeFilter = ''"
+              >
+                Todos
+              </button>
+              <button
+                type="button"
+                class="px-3 py-2 min-h-[44px] border-l border-border transition-colors whitespace-nowrap"
+                :class="promoTypeFilter === 'percent_off' ? 'bg-primary/90 text-white' : 'bg-surface text-text-secondary hover:bg-surface-secondary'"
+                @click="promoTypeFilter = 'percent_off'"
+              >
+                % desc.
+              </button>
+              <button
+                type="button"
+                class="px-3 py-2 min-h-[44px] border-l border-border transition-colors whitespace-nowrap"
+                :class="promoTypeFilter === 'fixed_off' ? 'bg-primary/90 text-white' : 'bg-surface text-text-secondary hover:bg-surface-secondary'"
+                @click="promoTypeFilter = 'fixed_off'"
+              >
+                Fijo
+              </button>
+              <button
+                type="button"
+                class="px-3 py-2 min-h-[44px] border-l border-border transition-colors whitespace-nowrap"
+                :class="promoTypeFilter === 'bogo' ? 'bg-primary/90 text-white' : 'bg-surface text-text-secondary hover:bg-surface-secondary'"
+                @click="promoTypeFilter = 'bogo'"
+              >
+                2×1
+              </button>
+            </div>
+          </template>
+        </UiAdvancedFiltersBar>
 
         <UiResponsiveDataView
           :columns="columns"
-          :data="promotions"
+          :data="filteredPromotions"
           empty-message="No hay promociones"
           empty-sub-message="Crea la primera para aplicarla en el POS (batch siguiente)."
           variant="default"
           row-size="sm"
         >
+          <template #header-actions>
+            <NuxtLink
+              to="/gestion/promociones/nuevo"
+              class="flex items-center gap-2 px-4 py-2 bg-primary text-white rounded-lg hover:opacity-90 transition-opacity text-sm font-medium min-h-[44px] whitespace-nowrap"
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+              </svg>
+              Nueva promoción
+            </NuxtLink>
+          </template>
+
           <template #card="{ item }">
             <NuxtLink
               :to="`/gestion/promociones/${item.id}`"
@@ -107,7 +188,26 @@ interface PromotionRow {
 }
 
 const { currentTenant } = useTenantReactive()
-const showInactive = ref(true)
+
+const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
+const statusFilter = ref<'' | 'active' | 'inactive'>('')
+const promoTypeFilter = ref<'' | 'percent_off' | 'fixed_off' | 'bogo'>('')
+
+const hasActiveFilters = computed(
+  () =>
+    !!localSearchTerm.value
+    || !!appliedSearch.value
+    || !!statusFilter.value
+    || !!promoTypeFilter.value,
+)
+
+const performSearch = () => applySearch()
+
+function clearFilters() {
+  clearSearch()
+  statusFilter.value = ''
+  promoTypeFilter.value = ''
+}
 
 const columns: Column[] = [
   { key: 'name', title: 'Nombre' },
@@ -121,11 +221,11 @@ const {
   error: fetchError,
   asyncStatus: queryAsyncStatus,
 } = useQuery({
-  key: () => ['tenant', 'promotions', currentTenant.value?.id, { inactive: showInactive.value }],
+  key: () => ['tenant', 'promotions', currentTenant.value?.id, { inactive: true }],
   query: () =>
     $fetch<{ success: boolean; total: number; data: PromotionRow[] }>('/api/api/promotions', {
       query: {
-        include_inactive: showInactive.value,
+        include_inactive: true,
         at: new Date().toISOString(),
       },
     }),
@@ -137,6 +237,23 @@ const promotions = computed(() => listData.value?.data ?? [])
 const isLoading = computed(
   () => queryAsyncStatus.value === 'loading' && !listData.value,
 )
+
+const filteredPromotions = computed(() => {
+  let rows = promotions.value
+  const term = appliedSearch.value.trim().toLowerCase()
+  if (term) {
+    rows = rows.filter((row) => row.name.toLowerCase().includes(term))
+  }
+  if (statusFilter.value === 'active') {
+    rows = rows.filter((row) => row.is_active)
+  } else if (statusFilter.value === 'inactive') {
+    rows = rows.filter((row) => !row.is_active)
+  }
+  if (promoTypeFilter.value) {
+    rows = rows.filter((row) => row.promo_type === promoTypeFilter.value)
+  }
+  return rows
+})
 
 const rowPreview = (item: PromotionRow) =>
   buildPromotionPreview({


### PR DESCRIPTION
## Summary
- Add a **Gestión** sidebar section with **Promociones** (separate from Cuenta); highlight via `activePage: gestion`.
- Replace the inactive checkbox on the list with `UiAdvancedFiltersBar`: name search, clear, and colored toggles for status and promo type.
- Move “Nueva promoción” into `UiResponsiveDataView` header actions for mobile-friendly layout.

Closes #989

## Test plan
- [ ] Visit `/gestion/promociones` — list renders in place, no redirect
- [ ] Sidebar shows **Gestión → Promociones** (not under Cuenta)
- [ ] Filter by name, status (activas/inactivas/todas), and type (% / fijo / 2×1)
- [ ] Phone-width: filter, open card, edit, return — all on `/gestion/promociones*`

## wr-context
See `.wr/989.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)