### PR TITLE
feat(pos): show promotion savings on printed and emailed POS receipts

### DIFF
--- a/.wr/993.yaml
+++ b/.wr/993.yaml
@@ -1,0 +1,29 @@
+issue: 993
+title: "feat(pos): Show promotion savings on printed and emailed POS receipts"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-993-pos-receipt-promo
+
+paths:
+  - pages/pos/checkout.vue
+
+ac:
+  - sendReceiptEmail sends promo_savings, promo_breakdown, and net-aware tax from orderResult
+  - Printed #pos-receipt shows promo breakdown when only promos apply
+  - Receipt tax uses orderResult.standard_tax from API (net-based after batch #337)
+  - Split-payment completion populates promo fields on orderResult
+
+out_of_scope:
+  - DIAN FE PDF/XML (batch 3)
+  - ventas/[id].vue order detail
+  - Per-line net pricing on print grid (optional AC deferred)
+
+hints:
+  entry: "sendReceiptEmail — pages/pos/checkout.vue:1751"
+  pattern: "orderResult promo spread — same as 1219-1238 POS complete path"
+  tests: "manual POS checkout with promo-only order"
+
+skip:
+  audits: [ux, color, typography]

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -786,6 +786,13 @@ const addSplitPayment = async () => {
         order_number: 0,
         total_amount: discountedTotal.value,
         payment_method: selectedPaymentMethod.value,
+        ...(promoBreakdown.value.length
+          ? {
+              promo_savings: promoSavings.value,
+              promo_breakdown: promoBreakdown.value,
+              subtotal: cartTotal.value,
+            }
+          : {}),
         ...(discountEnabled.value && discountAmount.value > 0
           ? { discount_amount: discountAmount.value, subtotal: cartTotal.value }
           : {}),
@@ -1774,6 +1781,8 @@ const sendReceiptEmail = async () => {
         standard_tax: orderResult.value.standard_tax ?? 0,
         liquor_tax: orderResult.value.liquor_tax ?? 0,
         standard_tax_label: orderResult.value.standard_tax_label ?? 'Impuesto',
+        promo_savings: orderResult.value.promo_savings ?? 0,
+        promo_breakdown: orderResult.value.promo_breakdown ?? [],
         invoice_prefix: invoiceResult.value?.prefix ?? null,
         invoice_number: invoiceResult.value?.invoice_number ?? null,
         invoice_cufe: invoiceResult.value?.cufe ?? null,


### PR DESCRIPTION
## Summary
- Pass `promo_savings` and `promo_breakdown` from `orderResult` in `sendReceiptEmail` so emailed receipts match the API template (batch #337).
- Populate promo fields on `orderResult` when split payments complete, keeping printed receipt totals consistent for promo-only orders.

Closes #993

## Test plan
- [ ] Complete a POS sale with promotion only (no manual discount) → print receipt shows subtotal + promo lines + net tax
- [ ] Send receipt email on same order → email body includes promo breakdown lines
- [ ] Complete a split-payment sale with promos → success modal and print receipt show promo breakdown
- [ ] Order with manual discount + promo → both lines appear before tax on print and email

## wr-context
See `.wr/993.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)