### PR TITLE
fix(promotions): align product scope search with category picker UX

### DIFF
--- a/.wr/995.yaml
+++ b/.wr/995.yaml
@@ -1,0 +1,30 @@
+# wr-fast contract — issue #995
+issue: 995
+title: "fix(promotions): Match product scope search UX to category search input"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-995-product-search-input
+
+paths:
+  - composables/useProductSearch.ts
+  - components/ui/ProductSearchInput.vue
+  - components/promociones/PromocionPanel.vue
+
+ac:
+  - Dropdown on focus with initial product list
+  - Debounced /api/menu/products search with loading + Sin resultados
+  - Select adds chip, clears input; exclude already-selected from dropdown
+
+out_of_scope:
+  - /menu/productos MenuCatalogFiltersBar
+  - API changes
+
+hints:
+  entry: "PromocionPanel scope products — mirror UiCategorySearchInput"
+  pattern: "composables/useCategorySearch.ts + components/ui/CategorySearchInput.vue"
+  tests: "manual — promotions panel product scope picker"
+
+skip:
+  audits: [ux, color, typography]

--- a/components/promociones/PromocionPanel.vue
+++ b/components/promociones/PromocionPanel.vue
@@ -175,26 +175,12 @@
 
             <div v-if="form.scope_type === 'products'" class="space-y-2">
               <label for="promo-product-search" class="text-sm font-medium text-text-primary">Productos</label>
-              <input
-                id="promo-product-search"
-                v-model="productSearch"
-                type="search"
+              <UiProductSearchInput
+                input-id="promo-product-search"
                 placeholder="Buscar producto…"
-                :class="inputClass"
+                :exclude-ids="selectedProducts.map((p) => p.id)"
+                @select="onProductSelect"
               />
-              <ul
-                v-if="productResults.length && productSearch.trim()"
-                class="border border-border rounded-lg max-h-40 overflow-y-auto"
-              >
-                <li
-                  v-for="p in productResults"
-                  :key="p.id"
-                  class="px-3 py-2 text-sm hover:bg-surface-secondary cursor-pointer min-h-[44px] flex items-center"
-                  @click="addProduct(p)"
-                >
-                  {{ p.name }}
-                </li>
-              </ul>
               <ul v-if="selectedProducts.length" class="flex flex-wrap gap-2">
                 <li
                   v-for="p in selectedProducts"
@@ -330,7 +316,6 @@
 </template>
 
 <script setup lang="ts">
-import { useDebounceFn } from '@vueuse/core'
 import { useQueryCache } from '@pinia/colada'
 import type { FunctionalComponent } from 'vue'
 import {
@@ -339,6 +324,7 @@ import {
   ReceiptPercentIcon,
 } from '@heroicons/vue/24/outline'
 import type { CategoryRow } from '~/composables/useCategorySearch'
+import type { ProductRow } from '~/composables/useProductSearch'
 import {
   buildPromotionPreview,
   findOverlappingScheduleIndices,
@@ -428,8 +414,6 @@ const form = reactive({
 
 const selectedCategories = ref<CategoryRow[]>([])
 const selectedProducts = ref<{ id: string; name: string }[]>([])
-const productSearch = ref('')
-const productResults = ref<{ id: string; name: string }[]>([])
 const validationErrors = ref<string[]>([])
 const isSaving = ref(false)
 const loadError = ref(false)
@@ -449,8 +433,6 @@ function resetForm() {
   form.endsAtDate = ''
   selectedCategories.value = []
   selectedProducts.value = []
-  productSearch.value = ''
-  productResults.value = []
   validationErrors.value = []
   loadError.value = false
 }
@@ -555,35 +537,15 @@ function removeCategory(id: string) {
   selectedCategories.value = selectedCategories.value.filter((c) => c.id !== id)
 }
 
-function addProduct(p: { id: string; name: string }) {
+function onProductSelect(p: ProductRow) {
   if (!selectedProducts.value.some((x) => x.id === p.id)) {
     selectedProducts.value.push(p)
   }
-  productSearch.value = ''
-  productResults.value = []
 }
 
 function removeProduct(id: string) {
   selectedProducts.value = selectedProducts.value.filter((p) => p.id !== id)
 }
-
-const searchProducts = useDebounceFn(async (q: string) => {
-  if (!q.trim()) {
-    productResults.value = []
-    return
-  }
-  try {
-    const res = await $fetch<{ success: boolean; data: any[] }>('/api/menu/products', {
-      query: { search: q.trim(), limit: 20, page: 1 },
-    })
-    const items = Array.isArray(res.data) ? res.data : []
-    productResults.value = items.map((p) => ({ id: p.id, name: p.name }))
-  } catch {
-    productResults.value = []
-  }
-}, 300)
-
-watch(productSearch, (q) => searchProducts(q))
 
 async function hydrateProductNames(ids: string[]) {
   try {

--- a/components/ui/ProductSearchInput.vue
+++ b/components/ui/ProductSearchInput.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="relative">
+    <input
+      :id="inputId"
+      type="text"
+      v-model="searchTerm"
+      @input="onInput"
+      @focus="onFocus"
+      @blur="onBlur"
+      role="combobox"
+      :aria-expanded="showResults && visibleResults.length > 0"
+      aria-autocomplete="list"
+      aria-controls="product-search-results"
+      class="w-full px-3 py-2 pl-8 pr-8 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary bg-surface"
+      :placeholder="placeholder"
+      autocomplete="off"
+    />
+    <span class="absolute left-2.5 top-2.5 text-text-secondary pointer-events-none" aria-hidden="true">
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0"/>
+      </svg>
+    </span>
+    <span v-if="loading" class="absolute right-2.5 top-2.5 text-text-secondary pointer-events-none" aria-hidden="true">
+      <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
+      </svg>
+    </span>
+    <ul
+      v-if="showResults && (visibleResults.length > 0 || (!!query.trim() && !loading))"
+      id="product-search-results"
+      role="listbox"
+      class="absolute z-50 w-full mt-1 bg-surface border border-border rounded-lg shadow-lg max-h-48 overflow-y-auto"
+    >
+      <li
+        v-for="product in visibleResults"
+        :key="product.id"
+        role="option"
+        @mousedown.prevent="select(product)"
+        class="px-3 py-2 text-sm text-text-primary hover:bg-surface-secondary cursor-pointer min-h-[44px] flex items-center"
+      >
+        {{ product.name }}
+      </li>
+      <li
+        v-if="!visibleResults.length && !loading && query.trim()"
+        role="presentation"
+        aria-hidden="true"
+        class="px-3 py-2 text-sm text-text-secondary/60 select-none"
+      >
+        Sin resultados
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useProductSearch, type ProductRow } from '~/composables/useProductSearch'
+
+interface Props {
+  placeholder?: string
+  inputId?: string
+  excludeIds?: string[]
+}
+
+interface Emits {
+  (e: 'select', product: ProductRow): void
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  placeholder: 'Buscar producto…',
+  inputId: 'product-search-input',
+  excludeIds: () => [],
+})
+
+const emit = defineEmits<Emits>()
+
+const searchTerm = ref('')
+const showResults = ref(false)
+
+const { query, results, loading } = useProductSearch()
+
+const excludeSet = computed(() => new Set(props.excludeIds))
+
+const visibleResults = computed(() =>
+  results.value.filter((p) => !excludeSet.value.has(p.id)),
+)
+
+function onInput(e: Event) {
+  const val = (e.target as HTMLInputElement).value
+  query.value = val
+  showResults.value = true
+}
+
+function onFocus() {
+  query.value = searchTerm.value
+  showResults.value = true
+}
+
+function onBlur() {
+  setTimeout(() => { showResults.value = false }, 150)
+}
+
+function select(product: ProductRow) {
+  searchTerm.value = ''
+  showResults.value = false
+  query.value = ''
+  emit('select', product)
+}
+</script>

--- a/composables/useProductSearch.ts
+++ b/composables/useProductSearch.ts
@@ -1,0 +1,49 @@
+import { useDebounceFn } from '@vueuse/core'
+
+/**
+ * Debounced server-side product search for pickers (promotions scope, etc.).
+ *
+ * Usage:
+ *   const { query, results, loading } = useProductSearch()
+ */
+export interface ProductRow {
+  id: string
+  name: string
+}
+
+export const useProductSearch = () => {
+  const results = ref<ProductRow[]>([])
+  const loading = ref(false)
+  const error = ref<Error | null>(null)
+  const query = ref('')
+
+  const doSearch = useDebounceFn(async (q: string) => {
+    loading.value = true
+    error.value = null
+    try {
+      const res = await $fetch<{ success?: boolean; data?: ProductRow[] }>('/api/menu/products', {
+        query: q && q.trim().length > 0
+          ? { search: q.trim(), limit: 50, page: 1 }
+          : { limit: 50, page: 1 },
+      })
+      const items = Array.isArray(res?.data) ? res.data : []
+      results.value = items.map((p) => ({ id: p.id, name: p.name }))
+    } catch (e: any) {
+      error.value = e
+      results.value = []
+    } finally {
+      loading.value = false
+    }
+  }, 300)
+
+  watch(query, (val) => {
+    loading.value = true
+    doSearch(val)
+  })
+
+  onMounted(() => {
+    doSearch('')
+  })
+
+  return { query, results, loading, error }
+}


### PR DESCRIPTION
## Summary
- Add `useProductSearch` (debounced `/api/menu/products`) and `UiProductSearchInput` mirroring category search
- Replace inline product input in `PromocionPanel` with dropdown-on-focus, loading, empty state, and chip selection
- Hide already-selected products from the dropdown

Closes #995

## Test plan
- [ ] Promociones → nueva promoción → alcance Productos → focus shows list
- [ ] Type to filter; empty query shows Sin resultados when no matches
- [ ] Select product adds chip and clears input; selected items omitted from dropdown

## wr-context
See `.wr/995.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)