### PR TITLE
feat(promociones): list alcance uses scope summary, drop N+1 hydration

### DIFF
--- a/.wr/998.yaml
+++ b/.wr/998.yaml
@@ -1,0 +1,31 @@
+issue: 998
+title: "feat(promociones): list alcance uses scope summary, drop N+1 hydration"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-998-promo-list-scope-summary
+
+paths:
+  - pages/operaciones/promociones/index.vue
+  - utils/promotionPreview.ts
+
+ac:
+  - PromotionRow uses API product_count, category_count, *_names_preview
+  - Remove per-ID /api/menu/products hydration on list page
+  - formatScopeLabel count-only when scope > 5
+  - Mobile card shows valor, horario, alcance (rowValue/rowSchedule/rowScope)
+  - Legacy fallback uses ID counts only when summary fields absent
+
+out_of_scope:
+  - PromocionPanel.vue hydration
+  - Alcance popover (#999)
+  - POS badge
+
+hints:
+  entry: "index.vue rowScope — scopeLabelsFor + formatScopeLabel"
+  pattern: "promotionPreview.ts formatScopeLabel countOnlyThreshold: 5"
+  tests: "manual — /operaciones/promociones with large product scope promo"
+
+skip:
+  audits: [ux, color, typography]

--- a/pages/operaciones/promociones/index.vue
+++ b/pages/operaciones/promociones/index.vue
@@ -76,7 +76,11 @@
                     size="sm"
                   />
                 </div>
-                <p class="text-xs text-text-secondary mt-0.5 truncate">{{ rowPreview(item) }}</p>
+                <p class="text-xs text-text-secondary mt-0.5">
+                  <span class="font-medium text-text-primary">{{ rowValue(item) }}</span>
+                  · {{ rowSchedule(item) }}
+                </p>
+                <p class="text-xs text-text-tertiary mt-0.5 truncate">{{ rowScope(item) }}</p>
               </div>
               <div class="flex flex-col items-end gap-1.5 flex-shrink-0">
                 <UiStatusBadge
@@ -112,8 +116,16 @@
             />
           </template>
 
-          <template #cell-preview="{ item }">
-            <span class="text-sm text-text-secondary">{{ item ? rowPreview(item) : '' }}</span>
+          <template #cell-value="{ item }">
+            <span class="text-sm font-medium text-text-primary">{{ item ? rowValue(item) : '' }}</span>
+          </template>
+
+          <template #cell-schedule="{ item }">
+            <span class="text-sm text-text-secondary">{{ item ? rowSchedule(item) : '' }}</span>
+          </template>
+
+          <template #cell-scope="{ item }">
+            <span class="text-sm text-text-secondary">{{ item ? rowScope(item) : '' }}</span>
           </template>
 
           <template #cell-status="{ item }">
@@ -159,8 +171,10 @@ import { PencilSquareIcon } from '@heroicons/vue/24/outline'
 // @ts-ignore
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import {
-  buildPromotionPreview,
   formatPromoTypeLabel,
+  formatPromoValue,
+  formatScheduleWindows,
+  formatScopeLabel,
   type PromotionScheduleRow,
 } from '~/utils/promotionPreview'
 
@@ -172,11 +186,16 @@ interface PromotionRow {
   name: string
   promo_type: string
   scope_type: string
+  value_json?: Record<string, unknown>
   is_active: boolean
   is_currently_active?: boolean | null
   schedules: PromotionScheduleRow[]
   category_ids: string[]
   product_ids: string[]
+  category_count?: number
+  product_count?: number
+  category_names_preview?: string[]
+  product_names_preview?: string[]
 }
 
 const route = useRoute()
@@ -210,7 +229,9 @@ function clearFilters() {
 const columns: Column[] = [
   { key: 'name', title: 'Nombre', sortable: false },
   { key: 'promo_type', title: 'Tipo', sortable: false },
-  { key: 'preview', title: 'Vista previa', sortable: false },
+  { key: 'value', title: 'Valor', sortable: false },
+  { key: 'schedule', title: 'Horario', sortable: false },
+  { key: 'scope', title: 'Alcance', sortable: false },
   { key: 'status', title: 'Estado', sortable: false },
   { key: 'actions', title: '', align: 'right' as const },
 ]
@@ -234,6 +255,46 @@ const {
 })
 
 const promotions = computed(() => listData.value?.data ?? [])
+
+function hasScopeSummary(item: PromotionRow): boolean {
+  return (
+    typeof item.product_count === 'number'
+    || typeof item.category_count === 'number'
+    || Array.isArray(item.product_names_preview)
+    || Array.isArray(item.category_names_preview)
+  )
+}
+
+function scopeLabelsFor(item: PromotionRow) {
+  if (hasScopeSummary(item)) {
+    return {
+      categoryNames: item.category_names_preview ?? [],
+      productNames: item.product_names_preview ?? [],
+      categoryCount: item.category_count ?? item.category_ids?.length ?? 0,
+      productCount: item.product_count ?? item.product_ids?.length ?? 0,
+    }
+  }
+  return {
+    categoryNames: [] as string[],
+    productNames: [] as string[],
+    categoryCount: item.category_ids?.length ?? 0,
+    productCount: item.product_ids?.length ?? 0,
+  }
+}
+
+const rowValue = (item: PromotionRow) => formatPromoValue(item.promo_type, item.value_json)
+
+const rowSchedule = (item: PromotionRow) => formatScheduleWindows(item.schedules ?? [])
+
+const rowScope = (item: PromotionRow) => {
+  const { categoryNames, productNames, categoryCount, productCount } = scopeLabelsFor(item)
+  return formatScopeLabel(item.scope_type, categoryNames, productNames, {
+    categoryCount,
+    productCount,
+    countOnlyThreshold: 5,
+  })
+}
+
 // Full-page loader only on first fetch; refetches show matrix in header (optimistic).
 const isLoading = computed(() => !listData.value && !fetchError.value)
 const isRefreshing = computed(
@@ -327,14 +388,6 @@ watch(showPanel, (open) => {
 })
 
 watch(() => route.query, openFromQuery)
-
-const rowPreview = (item: PromotionRow) =>
-  buildPromotionPreview({
-    isActive: item.is_active,
-    isCurrentlyActive: item.is_currently_active,
-    schedules: item.schedules ?? [],
-    scopeType: item.scope_type,
-  })
 
 const statusBadgeLabel = (item: PromotionRow) => {
   if (!item.is_active) return 'Desactivada'

--- a/utils/promotionPreview.ts
+++ b/utils/promotionPreview.ts
@@ -56,23 +56,77 @@ export function formatPromoTypeLabel(promoType: string): string {
   }
 }
 
+/** Discount amount copy for list columns (percent, COP, BOGO qty). */
+export function formatPromoValue(
+  promoType: string,
+  valueJson?: Record<string, unknown> | null,
+): string {
+  const v = valueJson ?? {}
+  switch (promoType) {
+    case 'percent_off': {
+      const pct = Number(v.percent)
+      return Number.isFinite(pct) ? `${pct}%` : '—'
+    }
+    case 'fixed_off': {
+      const amount = Number(v.amount_cop)
+      if (!Number.isFinite(amount)) return '—'
+      return new Intl.NumberFormat('es-CO', {
+        style: 'currency',
+        currency: 'COP',
+        maximumFractionDigits: 0,
+      }).format(amount)
+    }
+    case 'bogo': {
+      const buy = Number(v.buy_qty)
+      const get = Number(v.get_qty)
+      if (!Number.isFinite(buy) || !Number.isFinite(get)) return '—'
+      return `Compra ${buy} · lleva ${get}`
+    }
+    default:
+      return '—'
+  }
+}
+
+export type ScopeLabelCounts = {
+  categoryCount?: number
+  productCount?: number
+  /** Above this count, show "N productos/categorías" only (list page default: 5). */
+  countOnlyThreshold?: number
+}
+
 export function formatScopeLabel(
   scopeType: string,
   categoryNames: string[],
   productNames: string[],
+  counts?: ScopeLabelCounts,
 ): string {
-  if (scopeType === 'all_products') return 'todos los productos'
+  const threshold = counts?.countOnlyThreshold ?? 5
+  if (scopeType === 'all_products') return 'Todos los productos'
   if (scopeType === 'categories') {
-    if (!categoryNames.length) return 'categorías (sin seleccionar)'
-    return categoryNames.length === 1
-      ? categoryNames[0]
-      : `${categoryNames.length} categorías`
+    const n = counts?.categoryCount ?? categoryNames.length
+    if (n > threshold) return `${n} categorías`
+    if (categoryNames.length === 1) return categoryNames[0]
+    if (categoryNames.length > 1) {
+      const head = categoryNames.slice(0, 2).join(', ')
+      const extra = categoryNames.length - 2
+      return extra > 0 ? `${head} +${extra}` : head
+    }
+    if (n === 1) return '1 categoría'
+    if (n > 1) return `${n} categorías`
+    return 'Categorías (sin seleccionar)'
   }
   if (scopeType === 'products') {
-    if (!productNames.length) return 'productos (sin seleccionar)'
-    return productNames.length === 1
-      ? productNames[0]
-      : `${productNames.length} productos`
+    const n = counts?.productCount ?? productNames.length
+    if (n > threshold) return `${n} productos`
+    if (productNames.length === 1) return productNames[0]
+    if (productNames.length > 1) {
+      const head = productNames.slice(0, 2).join(', ')
+      const extra = productNames.length - 2
+      return extra > 0 ? `${head} +${extra}` : head
+    }
+    if (n === 1) return '1 producto'
+    if (n > 1) return `${n} productos`
+    return 'Productos (sin seleccionar)'
   }
   return scopeType
 }
@@ -84,6 +138,8 @@ export function buildPromotionPreview(opts: {
   scopeType: string
   categoryNames?: string[]
   productNames?: string[]
+  categoryIds?: string[]
+  productIds?: string[]
 }): string {
   const activeWord =
     opts.isCurrentlyActive === true
@@ -98,6 +154,10 @@ export function buildPromotionPreview(opts: {
     opts.scopeType,
     opts.categoryNames ?? [],
     opts.productNames ?? [],
+    {
+      categoryCount: opts.categoryIds?.length,
+      productCount: opts.productIds?.length,
+    },
   )
   return `${activeWord} ${schedPart} en ${scopePart}`
 }


### PR DESCRIPTION
## Summary
- Promotions list consumes API `product_count`, `category_count`, and name preview fields instead of hydrating menu products per ID.
- `formatScopeLabel` shows count-only copy (e.g. `47 productos`) when scope size exceeds 5.
- List columns split into Valor, Horario, and Alcance on desktop and mobile cards.

Closes #998

## Test plan
- [ ] Open `/operaciones/promociones` with a promo scoped to 6+ products — alcance shows `N productos` without extra network calls for each product ID.
- [ ] Promo with 1–3 products shows preview names in alcance column.
- [ ] Mobile card shows valor, horario, and alcance lines (same as table).
- [ ] Against API without summary fields (legacy): alcance falls back to ID counts only.

## wr-context
See `.wr/998.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)