### PR TITLE
feat(promociones): alcance popover with paginated scope on list

### DIFF
--- a/.wr/999.yaml
+++ b/.wr/999.yaml
@@ -1,0 +1,34 @@
+issue: 999
+title: "feat(promociones): alcance popover with paginated scope on list"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-999-promo-scope-popover
+
+paths:
+  - pages/operaciones/promociones/index.vue
+  - components/promociones/PromotionScopePopover.vue
+  - utils/promotionPreview.ts
+
+ac:
+  - Alcance clickable when scope has products/categories
+  - Popover loads scope on demand via GET /promotions/{id}/scope
+  - Search + pagination for 50+ items
+  - Promo name + scope type header; loading/error/empty states
+  - Esc closes; Modal/BottomSheet responsive
+
+out_of_scope:
+  - PromocionPanel bulk modal (#1000)
+  - POS badge (#1001)
+
+hints:
+  entry: "index.vue isScopeClickable + openScopePopover"
+  pattern: "Modal + BottomSheetModal responsive; useQuery enabled on open"
+  tests: "manual — /operaciones/promociones click Alcance on scoped promo"
+
+skip:
+  audits: [ux, color, typography]
+
+companion:
+  api_pr: "api-warolabs wr-999-promo-scope-endpoint (merge first)"

--- a/components/promociones/PromotionScopePopover.vue
+++ b/components/promociones/PromotionScopePopover.vue
@@ -1,0 +1,278 @@
+<template>
+  <UiModal v-model="open" :title="modalTitle">
+    <div class="px-6 pb-6 space-y-4" role="document">
+      <input
+        ref="searchInputRef"
+        v-model="searchTerm"
+        type="search"
+        placeholder="Buscar en alcance…"
+        class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary bg-surface min-h-[44px]"
+        aria-label="Buscar en alcance"
+      />
+
+      <div v-if="isLoading" class="flex items-center justify-center py-10" aria-busy="true">
+        <div
+          class="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin"
+          aria-label="Cargando alcance"
+        />
+      </div>
+
+      <div v-else-if="scopeError" class="flex flex-col items-center gap-3 py-8 text-center">
+        <p class="text-sm text-text-secondary">No se pudo cargar el alcance.</p>
+        <button
+          type="button"
+          class="btn-primary px-4 py-2 rounded-lg text-sm min-h-[44px]"
+          @click="refetch()"
+        >
+          Reintentar
+        </button>
+      </div>
+
+      <p v-else-if="items.length === 0" class="text-sm text-text-secondary text-center py-8">
+        {{ appliedSearch ? 'Sin resultados para esta búsqueda.' : 'No hay ítems en el alcance.' }}
+      </p>
+
+      <ul v-else class="divide-y divide-border max-h-[50vh] overflow-y-auto">
+        <li
+          v-for="item in items"
+          :key="item.id"
+          class="py-2.5 text-sm text-text-primary min-h-[44px] flex items-center"
+        >
+          {{ item.name }}
+        </li>
+      </ul>
+
+      <div
+        v-if="showPagination"
+        class="flex items-center justify-between gap-2 pt-2 border-t border-border"
+      >
+        <p class="text-xs text-text-secondary">
+          Mostrando {{ startItem }}–{{ endItem }} de {{ total }}
+        </p>
+        <div class="flex gap-2">
+          <button
+            type="button"
+            :disabled="!canGoPrevious"
+            class="px-3 py-2 text-sm rounded-lg border min-h-[44px]"
+            :class="canGoPrevious ? 'border-border text-text-primary hover:bg-surface-secondary' : 'border-border/50 text-text-tertiary cursor-not-allowed'"
+            @click="previousPage"
+          >
+            Anterior
+          </button>
+          <button
+            type="button"
+            :disabled="!canGoNext"
+            class="px-3 py-2 text-sm rounded-lg border min-h-[44px]"
+            :class="canGoNext ? 'border-border text-text-primary hover:bg-surface-secondary' : 'border-border/50 text-text-tertiary cursor-not-allowed'"
+            @click="nextPage"
+          >
+            Siguiente
+          </button>
+        </div>
+      </div>
+    </div>
+  </UiModal>
+
+  <UiBottomSheetModal v-model="open" :title="modalTitle" max-height="lg">
+    <div class="px-4 pb-4 space-y-4" role="document">
+      <input
+        v-model="searchTerm"
+        type="search"
+        placeholder="Buscar en alcance…"
+        class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary bg-surface min-h-[44px]"
+        aria-label="Buscar en alcance"
+      />
+
+      <div v-if="isLoading" class="flex items-center justify-center py-10" aria-busy="true">
+        <div
+          class="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin"
+          aria-label="Cargando alcance"
+        />
+      </div>
+
+      <div v-else-if="scopeError" class="flex flex-col items-center gap-3 py-8 text-center">
+        <p class="text-sm text-text-secondary">No se pudo cargar el alcance.</p>
+        <button
+          type="button"
+          class="btn-primary px-4 py-2 rounded-lg text-sm min-h-[44px]"
+          @click="refetch()"
+        >
+          Reintentar
+        </button>
+      </div>
+
+      <p v-else-if="items.length === 0" class="text-sm text-text-secondary text-center py-8">
+        {{ appliedSearch ? 'Sin resultados para esta búsqueda.' : 'No hay ítems en el alcance.' }}
+      </p>
+
+      <ul v-else class="divide-y divide-border max-h-[50vh] overflow-y-auto">
+        <li
+          v-for="item in items"
+          :key="item.id"
+          class="py-2.5 text-sm text-text-primary min-h-[44px] flex items-center"
+        >
+          {{ item.name }}
+        </li>
+      </ul>
+
+      <div
+        v-if="showPagination"
+        class="flex items-center justify-between gap-2 pt-2 border-t border-border"
+      >
+        <p class="text-xs text-text-secondary">
+          Mostrando {{ startItem }}–{{ endItem }} de {{ total }}
+        </p>
+        <div class="flex gap-2">
+          <button
+            type="button"
+            :disabled="!canGoPrevious"
+            class="px-3 py-2 text-sm rounded-lg border min-h-[44px]"
+            :class="canGoPrevious ? 'border-border text-text-primary hover:bg-surface-secondary' : 'border-border/50 text-text-tertiary cursor-not-allowed'"
+            @click="previousPage"
+          >
+            Anterior
+          </button>
+          <button
+            type="button"
+            :disabled="!canGoNext"
+            class="px-3 py-2 text-sm rounded-lg border min-h-[44px]"
+            :class="canGoNext ? 'border-border text-text-primary hover:bg-surface-secondary' : 'border-border/50 text-text-tertiary cursor-not-allowed'"
+            @click="nextPage"
+          >
+            Siguiente
+          </button>
+        </div>
+      </div>
+    </div>
+  </UiBottomSheetModal>
+</template>
+
+<script setup lang="ts">
+import { formatScopeTypeLabel } from '~/utils/promotionPreview'
+
+interface ScopeItem {
+  id: string
+  name: string
+}
+
+interface ScopeResponse {
+  success: boolean
+  data: {
+    scope_type: string
+    promotion_name: string
+    items: ScopeItem[]
+    total: number
+    page: number
+    page_size: number
+  }
+}
+
+const props = defineProps<{
+  modelValue: boolean
+  promotionId: string | null
+  promotionName: string
+  scopeType: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+}>()
+
+const PAGE_SIZE = 50
+
+const open = computed({
+  get: () => props.modelValue,
+  set: (value: boolean) => emit('update:modelValue', value),
+})
+
+const searchTerm = ref('')
+const appliedSearch = ref('')
+const page = ref(1)
+const searchInputRef = ref<HTMLInputElement | null>(null)
+
+let searchDebounce: ReturnType<typeof setTimeout> | null = null
+
+watch(searchTerm, (value) => {
+  if (searchDebounce) clearTimeout(searchDebounce)
+  searchDebounce = setTimeout(() => {
+    appliedSearch.value = value.trim()
+    page.value = 1
+  }, 300)
+})
+
+const {
+  data: scopeData,
+  error: scopeError,
+  asyncStatus,
+  refetch,
+} = useQuery({
+  key: () => [
+    'tenant',
+    'promotions',
+    props.promotionId,
+    'scope',
+    { search: appliedSearch.value, page: page.value },
+  ],
+  query: () =>
+    $fetch<ScopeResponse>(`/api/api/promotions/${props.promotionId}/scope`, {
+      query: {
+        search: appliedSearch.value || undefined,
+        page: page.value,
+        page_size: PAGE_SIZE,
+      },
+    }),
+  enabled: () => open.value && !!props.promotionId,
+  staleTime: 10_000,
+})
+
+const isLoading = computed(() => asyncStatus.value === 'loading' && !scopeData.value)
+const items = computed(() => scopeData.value?.data.items ?? [])
+const total = computed(() => scopeData.value?.data.total ?? 0)
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / PAGE_SIZE)))
+const canGoPrevious = computed(() => page.value > 1)
+const canGoNext = computed(() => page.value < totalPages.value)
+const startItem = computed(() => (total.value === 0 ? 0 : (page.value - 1) * PAGE_SIZE + 1))
+const endItem = computed(() => Math.min(page.value * PAGE_SIZE, total.value))
+const showPagination = computed(() => total.value > PAGE_SIZE)
+
+const scopeTypeLabel = computed(() => formatScopeTypeLabel(props.scopeType))
+const modalTitle = computed(() => `${props.promotionName} · ${scopeTypeLabel.value}`)
+
+function closePanel() {
+  open.value = false
+}
+
+function previousPage() {
+  if (canGoPrevious.value) page.value -= 1
+}
+
+function nextPage() {
+  if (canGoNext.value) page.value += 1
+}
+
+function handleEscape(event: KeyboardEvent) {
+  if (event.key === 'Escape' && open.value) {
+    event.preventDefault()
+    closePanel()
+  }
+}
+
+watch(open, (isOpen) => {
+  if (!isOpen) {
+    searchTerm.value = ''
+    appliedSearch.value = ''
+    page.value = 1
+    return
+  }
+  nextTick(() => searchInputRef.value?.focus())
+})
+
+onMounted(() => {
+  document.addEventListener('keydown', handleEscape)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleEscape)
+  if (searchDebounce) clearTimeout(searchDebounce)
+})
+</script>

--- a/pages/operaciones/promociones/index.vue
+++ b/pages/operaciones/promociones/index.vue
@@ -80,7 +80,16 @@
                   <span class="font-medium text-text-primary">{{ rowValue(item) }}</span>
                   · {{ rowSchedule(item) }}
                 </p>
-                <p class="text-xs text-text-tertiary mt-0.5 truncate">{{ rowScope(item) }}</p>
+                <button
+                  v-if="isScopeClickable(item)"
+                  type="button"
+                  class="text-xs text-left text-primary hover:underline truncate max-w-full min-h-[44px]"
+                  :aria-label="`Ver alcance de ${item.name}`"
+                  @click="openScopePopover(item)"
+                >
+                  {{ rowScope(item) }}
+                </button>
+                <p v-else class="text-xs text-text-tertiary mt-0.5 truncate">{{ rowScope(item) }}</p>
               </div>
               <div class="flex flex-col items-end gap-1.5 flex-shrink-0">
                 <UiStatusBadge
@@ -125,7 +134,16 @@
           </template>
 
           <template #cell-scope="{ item }">
-            <span class="text-sm text-text-secondary">{{ item ? rowScope(item) : '' }}</span>
+            <button
+              v-if="item && isScopeClickable(item)"
+              type="button"
+              class="text-sm text-left text-primary hover:underline min-h-[44px]"
+              :aria-label="`Ver alcance de ${item.name}`"
+              @click="openScopePopover(item)"
+            >
+              {{ rowScope(item) }}
+            </button>
+            <span v-else-if="item" class="text-sm text-text-secondary">{{ rowScope(item) }}</span>
           </template>
 
           <template #cell-status="{ item }">
@@ -160,6 +178,13 @@
       :promotion-id="panelPromotionId"
       @saved="onPanelSaved"
       @deleted="onPanelSaved"
+    />
+
+    <PromocionesPromotionScopePopover
+      v-model="scopePopoverOpen"
+      :promotion-id="scopePopoverPromo?.id ?? null"
+      :promotion-name="scopePopoverPromo?.name ?? ''"
+      :scope-type="scopePopoverPromo?.scope_type ?? ''"
     />
   </div>
 </template>
@@ -205,6 +230,8 @@ const cache = useQueryCache()
 
 const showPanel = ref(false)
 const panelPromotionId = ref<string | null>(null)
+const scopePopoverOpen = ref(false)
+const scopePopoverPromo = ref<PromotionRow | null>(null)
 
 const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
 const statusFilter = ref<'' | 'active' | 'inactive'>('')
@@ -293,6 +320,17 @@ const rowScope = (item: PromotionRow) => {
     productCount,
     countOnlyThreshold: 5,
   })
+}
+
+function isScopeClickable(item: PromotionRow): boolean {
+  if (item.scope_type === 'all_products') return false
+  const { categoryCount, productCount } = scopeLabelsFor(item)
+  return categoryCount > 0 || productCount > 0
+}
+
+function openScopePopover(item: PromotionRow) {
+  scopePopoverPromo.value = item
+  scopePopoverOpen.value = true
 }
 
 // Full-page loader only on first fetch; refetches show matrix in header (optimistic).

--- a/utils/promotionPreview.ts
+++ b/utils/promotionPreview.ts
@@ -94,6 +94,19 @@ export type ScopeLabelCounts = {
   countOnlyThreshold?: number
 }
 
+export function formatScopeTypeLabel(scopeType: string): string {
+  switch (scopeType) {
+    case 'categories':
+      return 'Categorías'
+    case 'products':
+      return 'Productos'
+    case 'all_products':
+      return 'Todos los productos'
+    default:
+      return scopeType
+  }
+}
+
 export function formatScopeLabel(
   scopeType: string,
   categoryNames: string[],


### PR DESCRIPTION
## Summary
- Alcance cells are clickable when a promo has product/category scope items
- Opens responsive modal (desktop) / bottom sheet (mobile) with on-demand scope fetch
- Search filters within scope; pagination when total exceeds 50 items

Closes #999

## Test plan
- [ ] `/operaciones/promociones` — click Alcance on a scoped promo opens panel
- [ ] Search narrows list; pagination appears for large scopes
- [ ] Esc closes panel; loading/error/empty states render correctly
- [ ] Requires api-warolabs scope endpoint PR merged/deployed

## wr-context
See `.wr/999.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)