### PR TITLE
feat(pos): product card badge when active promotion applies

### DIFF
--- a/.wr/1001.yaml
+++ b/.wr/1001.yaml
@@ -1,0 +1,35 @@
+issue: 1001
+title: "feat(pos): product card badge when active promotion applies"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1001-pos-promo-badge
+
+paths:
+  - composables/useActivePromotions.ts
+  - utils/promoProductMatch.ts
+  - components/pos/ProductCard.vue
+  - pages/pos/index.vue
+
+ac:
+  - Product cards show badge when active promo matches scope
+  - Scope rules mirror checkout (all_products, categories, products; highest priority)
+  - only_current fetch gates schedule — no badge outside window
+  - Badge truncates on mobile with optional tooltip for name/other promos
+  - ActivePromotionRow includes scope IDs + value_json
+  - Client product_in_scope helper in promoProductMatch.ts
+
+out_of_scope:
+  - Checkout receipt/resumen changes
+  - New promotion types
+  - API changes
+  - PromocionPanel invalidation (already exists)
+
+hints:
+  entry: "pages/pos/index.vue — PosProductCard grid"
+  pattern: "checkout.vue:2039-2044 — emerald promo pill; promotions_service.py:91-105 product_in_scope"
+  tests: "none — front-only; manual verify on /pos"
+
+skip:
+  audits: [ux, color, typography]

--- a/components/pos/ProductCard.vue
+++ b/components/pos/ProductCard.vue
@@ -7,7 +7,14 @@
     @click="$emit('select', product)"
   >
     <!-- Product icon: real image when uploaded, emoji as fallback (#465) -->
-    <div :style="iconSlotStyle" class="w-full aspect-[3/2] border border-border/30 rounded-2xl shadow-sm flex items-center justify-center mb-1.5 md:mb-3 select-none flex-shrink-0 overflow-hidden">
+    <div :style="iconSlotStyle" class="relative w-full aspect-[3/2] border border-border/30 rounded-2xl shadow-sm flex items-center justify-center mb-1.5 md:mb-3 select-none flex-shrink-0 overflow-hidden">
+      <span
+        v-if="promoBadge"
+        class="absolute top-1 left-1 right-1 z-10 max-w-full text-[9px] md:text-[10px] bg-emerald-500/90 text-white px-1.5 py-0.5 rounded-full font-semibold truncate text-center shadow-sm pointer-events-none"
+        :title="promoBadge.title || promoBadge.label"
+      >
+        {{ promoBadge.label }}
+      </span>
       <img
         v-if="product.image_url && product.image_url.startsWith('http')"
         :src="product.image_url"
@@ -45,8 +52,14 @@ interface Product {
   available: boolean
 }
 
+interface PromoBadge {
+  label: string
+  title?: string
+}
+
 interface Props {
   product: Product
+  promoBadge?: PromoBadge | null
 }
 
 interface Emits {

--- a/composables/useActivePromotions.ts
+++ b/composables/useActivePromotions.ts
@@ -10,6 +10,10 @@ export interface ActivePromotionRow {
   scope_type: string
   schedules: PromotionScheduleRow[]
   is_currently_active?: boolean
+  category_ids?: string[]
+  product_ids?: string[]
+  value_json?: Record<string, unknown>
+  priority?: number
 }
 
 const MIN_REFETCH_MS = 30_000

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -13,6 +13,7 @@ import {
   parseFireTableResponse,
   printComandaTickets,
 } from '~/composables/useComandaPrint'
+import { promoBadgeForProduct } from '~/utils/promoProductMatch'
 
 definePageMeta({
   layout: 'dashboard',
@@ -32,7 +33,7 @@ const toast = useToast()
 const posStore = usePOSStore()
 const { tabItems: storeTabItems, tabTotal: storeTabTotal, activeTableSession } = storeToRefs(posStore)
 
-const { hasActivePromos, activePromoHint } = useActivePromotions()
+const { activePromos, hasActivePromos, activePromoHint } = useActivePromotions()
 
 // Clear session at setup time (before first render) so showFloorPlan is correct immediately.
 // If navigating from a POS sub-page (checkout, producto), posNavigation flag preserves the session.
@@ -950,11 +951,23 @@ const products = computed(() => {
     name: p.name,
     price: p.price,
     category: p.category_name || p.category?.name || 'Sin categoría',
+    category_id: p.category_id ?? null,
     image: '🍽️',
     image_url: p.image_url || null,
     available: p.is_available,
     is_resale: p.is_resale || false
   }))
+})
+
+const promoBadgesByProductId = computed(() => {
+  const map = new Map<string, ReturnType<typeof promoBadgeForProduct>>()
+  const promos = activePromos.value
+  if (promos.length === 0) return map
+  for (const product of products.value) {
+    const badge = promoBadgeForProduct(promos, product.id, product.category_id)
+    if (badge) map.set(product.id, badge)
+  }
+  return map
 })
 
 const categories = computed(() => {
@@ -1539,6 +1552,7 @@ onUnmounted(() => {
               v-for="product in filteredProducts"
               :key="product.id"
               :product="product"
+              :promo-badge="promoBadgesByProductId.get(product.id) ?? null"
               @select="selectProduct"
             />
           </div>

--- a/utils/promoProductMatch.ts
+++ b/utils/promoProductMatch.ts
@@ -1,0 +1,86 @@
+import type { ActivePromotionRow } from '~/composables/useActivePromotions'
+import { formatPromoValue } from '~/utils/promotionPreview'
+
+export type PromoBadgeDisplay = {
+  label: string
+  title?: string
+}
+
+function toIdSet(ids: Set<string> | readonly string[]): Set<string> {
+  return ids instanceof Set ? ids : new Set(ids)
+}
+
+/** Client mirror of api promotions_service.product_in_scope. */
+export function productInScope(
+  scopeType: string,
+  categoryIds: Set<string> | readonly string[],
+  productIds: Set<string> | readonly string[],
+  productId: string,
+  categoryId?: string | null,
+): boolean {
+  if (scopeType === 'all_products') return true
+  if (scopeType === 'products') return toIdSet(productIds).has(productId)
+  if (scopeType === 'categories') {
+    return categoryId != null && toIdSet(categoryIds).has(categoryId)
+  }
+  return false
+}
+
+export function promosMatchingProduct(
+  promos: ActivePromotionRow[],
+  productId: string,
+  categoryId?: string | null,
+): ActivePromotionRow[] {
+  return promos.filter((promo) =>
+    productInScope(
+      promo.scope_type,
+      promo.category_ids ?? [],
+      promo.product_ids ?? [],
+      productId,
+      categoryId,
+    ),
+  )
+}
+
+/** Highest priority wins; tie-break by name (matches server _pick_best_promotion_for_line). */
+export function pickBestPromotionForProduct(
+  promos: ActivePromotionRow[],
+  productId: string,
+  categoryId?: string | null,
+): ActivePromotionRow | null {
+  const matches = promosMatchingProduct(promos, productId, categoryId)
+  if (matches.length === 0) return null
+  return matches.reduce((best, promo) => {
+    const bestPriority = best.priority ?? 0
+    const promoPriority = promo.priority ?? 0
+    if (promoPriority > bestPriority) return promo
+    if (promoPriority < bestPriority) return best
+    return (promo.name ?? '') >= (best.name ?? '') ? promo : best
+  })
+}
+
+export function promoBadgeForProduct(
+  promos: ActivePromotionRow[],
+  productId: string,
+  categoryId?: string | null,
+): PromoBadgeDisplay | null {
+  const matches = promosMatchingProduct(promos, productId, categoryId)
+  if (matches.length === 0) return null
+
+  const best = pickBestPromotionForProduct(promos, productId, categoryId)
+  if (!best) return null
+
+  const valueLabel = formatPromoValue(best.promo_type, best.value_json)
+  const label = valueLabel && valueLabel !== '—' ? valueLabel : best.name
+
+  let title = best.name
+  if (matches.length > 1) {
+    const others = matches
+      .filter((p) => p.id !== best.id)
+      .map((p) => p.name)
+      .filter(Boolean)
+    if (others.length > 0) title = `${best.name} (+ ${others.join(', ')})`
+  }
+
+  return { label, title }
+}


### PR DESCRIPTION
## Summary
- Extend `ActivePromotionRow` with scope IDs, `value_json`, and `priority` from the active promos API
- Add `promoProductMatch.ts` mirroring server `product_in_scope` + priority pick for badge labels
- Show truncated promo badge on `PosProductCard` when a schedule-current promotion applies

Closes #1001

## Test plan
- [ ] Open `/pos` with an active promotion scoped to all products — all cards show badge
- [ ] Create category-scoped promo — only products in that category show badge
- [ ] Create product-scoped promo — only matching products show badge
- [ ] Promo outside schedule window — no badge (only_current filter)
- [ ] Two promos on same product — higher priority badge shown; tooltip lists others
- [ ] Save promotion in admin — POS badges refresh via existing cache invalidation

## wr-context
See `.wr/1001.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)