### PR TITLE
feat(promotions): editable priority field in admin promo form

### DIFF
--- a/.wr/1013.yaml
+++ b/.wr/1013.yaml
@@ -1,0 +1,38 @@
+issue: 1013
+title: "feat(promotions): editable priority field in admin promo form"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1013-promo-priority-ui
+epic: 1010
+
+paths:
+  - components/promociones/PromocionPanel.vue
+  - pages/operaciones/promociones/index.vue
+
+ac:
+  - Create/edit promo sends user-defined priority (0–32767) to API
+  - Form explains higher priority wins when multiple promos match the same line at checkout
+  - Promos list shows priority column or badge when >0
+  - Existing promos remain valid (default 0)
+
+out_of_scope:
+  - Overlap detector UI (batch #1014)
+  - Evaluator/type rules changes (batch #1012)
+  - stackable field UI (keep hardcoded false in payload)
+  - API/backend changes (priority already on PromotionCreate/Update/Response)
+
+hints:
+  entry: "PromocionPanel.vue buildPayload() — replace hardcoded priority: 0"
+  pattern: "PromocionPanel.vue:268-290 — reuse bordered card + label/help text layout near active toggle"
+  list: "index.vue columns + PromotionRow — add priority; badge/column only when item.priority > 0"
+  load: "loadPromotion() — map p.priority ?? 0 into form; resetForm default 0"
+  validate: "clamp 0–32767 in validate() or input min/max (matches tenant_promotion.py:68,105)"
+  api: "POST/PATCH /api/api/promotions — priority already accepted; list GET returns priority on each row"
+  tests: "manual — create promo priority 10, verify list badge and PATCH round-trip"
+
+skip:
+  audits: [ux, color, typography]
+
+delta_from_epic: "#1010 Research findings — _pick_best_promotion_for_line uses priority DESC then name; admin always saved priority 0"

--- a/components/promociones/PromocionPanel.vue
+++ b/components/promociones/PromocionPanel.vue
@@ -265,6 +265,24 @@
               </div>
             </div>
 
+            <div class="rounded-xl border border-border px-4 py-3 bg-surface-secondary/30">
+              <div class="flex flex-col gap-1.5">
+                <label for="promo-priority" class="text-sm font-medium text-text-primary">Prioridad</label>
+                <input
+                  id="promo-priority"
+                  v-model.number="form.priority"
+                  type="number"
+                  min="0"
+                  max="32767"
+                  step="1"
+                  :class="inputClass"
+                />
+                <p class="text-xs text-text-tertiary leading-snug">
+                  Si varias promociones aplican a la misma línea en checkout, gana la de mayor prioridad (0 = normal).
+                </p>
+              </div>
+            </div>
+
             <div class="flex items-center justify-between rounded-xl border border-border px-4 py-3 bg-surface-secondary/30">
               <div class="flex flex-col gap-0.5">
                 <span class="text-sm font-medium text-text-primary">Promoción activa</span>
@@ -430,6 +448,7 @@ const form = reactive({
   scope_type: 'all_products' as 'all_products' | 'categories' | 'products',
   schedules: [defaultSchedule()] as ScheduleFormRow[],
   is_active: true,
+  priority: 0,
   startsAtDate: '',
   endsAtDate: '',
 })
@@ -452,6 +471,7 @@ function resetForm() {
   form.scope_type = 'all_products'
   form.schedules = [defaultSchedule()]
   form.is_active = true
+  form.priority = 0
   form.startsAtDate = ''
   form.endsAtDate = ''
   selectedCategories.value = []
@@ -480,6 +500,7 @@ async function loadPromotion(id: string) {
     form.promo_type = p.promo_type
     form.scope_type = p.scope_type
     form.is_active = p.is_active
+    form.priority = Number(p.priority ?? 0)
     if (p.promo_type === 'percent_off') form.percent = Number(p.value_json?.percent ?? 10)
     if (p.promo_type === 'fixed_off') form.amountCop = Number(p.value_json?.amount_cop ?? 0)
     if (p.promo_type === 'bogo') {
@@ -645,7 +666,7 @@ function buildPayload() {
     is_active: form.is_active,
     starts_at,
     ends_at,
-    priority: 0,
+    priority: Math.min(32767, Math.max(0, Math.round(Number(form.priority) || 0))),
     stackable: false,
   }
 }
@@ -653,6 +674,10 @@ function buildPayload() {
 function validate(): boolean {
   const errors: string[] = []
   if (!form.name.trim()) errors.push('El nombre es obligatorio.')
+  const priority = Number(form.priority)
+  if (!Number.isFinite(priority) || priority < 0 || priority > 32767 || !Number.isInteger(priority)) {
+    errors.push('La prioridad debe ser un entero entre 0 y 32767.')
+  }
   if (form.scope_type === 'categories' && !selectedCategories.value.length) {
     errors.push('Selecciona al menos una categoría.')
   }

--- a/pages/operaciones/promociones/index.vue
+++ b/pages/operaciones/promociones/index.vue
@@ -106,6 +106,13 @@
                     variant="secondary"
                     size="sm"
                   />
+                  <UiStatusBadge
+                    v-if="(item.priority ?? 0) > 0"
+                    :value="`Prioridad ${item.priority}`"
+                    format="text"
+                    variant="warning"
+                    size="sm"
+                  />
                 </div>
                 <p class="text-xs text-text-secondary mt-0.5">
                   <span class="font-medium text-text-primary">{{ rowValue(item) }}</span>
@@ -187,6 +194,17 @@
             />
           </template>
 
+          <template #cell-priority="{ item }">
+            <UiStatusBadge
+              v-if="item && (item.priority ?? 0) > 0"
+              :value="String(item.priority)"
+              format="text"
+              variant="warning"
+              size="sm"
+            />
+            <span v-else-if="item" class="text-sm text-text-tertiary">—</span>
+          </template>
+
           <template #cell-actions="{ item }">
             <div v-if="item" class="flex items-center justify-end gap-0.5">
               <button
@@ -242,6 +260,7 @@ interface PromotionRow {
   name: string
   promo_type: string
   scope_type: string
+  priority?: number
   value_json?: Record<string, unknown>
   is_active: boolean
   is_currently_active?: boolean | null
@@ -328,6 +347,7 @@ const columns: Column[] = [
   { key: 'schedule', title: 'Horario', sortable: false },
   { key: 'scope', title: 'Alcance', sortable: false },
   { key: 'status', title: 'Estado', sortable: false },
+  { key: 'priority', title: 'Prioridad', sortable: false },
   { key: 'actions', title: '', align: 'right' as const },
 ]
 


### PR DESCRIPTION
## Summary
- Add editable priority field (0–32767) to `PromocionPanel` with checkout conflict guidance.
- Send user-defined priority on create/edit instead of hardcoded `0`.
- Show priority column (badge when >0) in the promos list and mobile cards.

Closes #1013

## Test plan
- [ ] Create promo with priority 10 — verify PATCH round-trip on edit
- [ ] Create promo with priority 0 — list shows em dash, no badge on mobile
- [ ] Edit existing promo — priority loads from API and saves correctly
- [ ] Invalid priority (negative or >32767) shows validation error

## wr-context
See `.wr/1013.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)