### PR TITLE
feat(promotions): overlap advisory on promo save

### DIFF
--- a/.wr/1014.yaml
+++ b/.wr/1014.yaml
@@ -1,0 +1,22 @@
+issue: 1014
+title: "feat(promotions): overlap advisory on promo create/edit (warn only)"
+repo: both
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-1014-promo-overlap-advisory
+
+paths:
+  - api_warocol.com/app/services/promotions_service.py
+  - api_warocol.com/app/models/tenant_promotion.py
+  - front_nuxt/components/promociones/PromocionPanel.vue
+  - api_warocol.com/tests/test_promotions_crud.py
+
+ac:
+  - Overlap detector on API; front warning panel + ack gate on requires_acknowledgment
+  - overlap_acknowledged on create/update body
+
+hints:
+  tests: "pytest api_warocol.com/tests/test_promotions_crud.py -v -k overlap"
+
+epic: 1010

--- a/components/promociones/PromocionPanel.vue
+++ b/components/promociones/PromocionPanel.vue
@@ -80,6 +80,37 @@
               <p v-for="(err, i) in validationErrors" :key="i">{{ err }}</p>
             </div>
 
+            <div
+              v-if="overlapWarnings.length"
+              role="status"
+              class="text-sm text-amber-900 bg-amber-50 border border-amber-200 rounded-xl px-3 py-3 space-y-2"
+            >
+              <p class="font-medium">
+                {{ requiresAcknowledgment
+                  ? 'Esta promoción se superpone con otras activas (misma prioridad). Confirma o sube la prioridad para guardar.'
+                  : 'Esta promoción se superpone con otras activas:' }}
+              </p>
+              <ul class="list-disc pl-4 space-y-1">
+                <li v-for="w in overlapWarnings" :key="w.promotion_id">
+                  <span class="font-medium">{{ w.promotion_name }}</span>
+                  — prioridad {{ w.priority }},
+                  {{ w.shared_product_count }} producto(s) en común
+                  <span v-if="w.risk === 'high'" class="text-amber-700">(conflicto de prioridad)</span>
+                </li>
+              </ul>
+              <label
+                v-if="requiresAcknowledgment"
+                class="flex items-start gap-2 pt-1 cursor-pointer"
+              >
+                <input
+                  v-model="overlapAcknowledged"
+                  type="checkbox"
+                  class="mt-0.5 rounded border-amber-400 text-primary focus:ring-primary/30"
+                />
+                <span>Entiendo que en checkout gana la promoción de mayor prioridad (empate por nombre).</span>
+              </label>
+            </div>
+
             <div class="flex flex-col gap-1.5">
               <label for="promo-name" class="text-sm font-medium text-text-primary">
                 Nombre <span class="text-destructive">*</span>
@@ -371,6 +402,21 @@ import {
 const PRODUCT_CHIP_THRESHOLD = 15
 import { bogotaDateAtNoon, combineBogotaDateAndTimeISO } from '~/utils/bogotaDate'
 
+interface OverlapWarning {
+  promotion_id: string
+  promotion_name: string
+  priority: number
+  shared_product_count: number
+  risk: 'high' | 'medium'
+}
+
+interface PromotionSaveResponse {
+  success: boolean
+  data?: unknown
+  overlap_warnings?: OverlapWarning[]
+  requires_acknowledgment?: boolean
+}
+
 interface Props {
   modelValue: boolean
   promotionId?: string | null
@@ -457,6 +503,9 @@ const selectedCategories = ref<CategoryRow[]>([])
 const selectedProducts = ref<{ id: string; name: string }[]>([])
 const scopePickerOpen = ref(false)
 const validationErrors = ref<string[]>([])
+const overlapWarnings = ref<OverlapWarning[]>([])
+const requiresAcknowledgment = ref(false)
+const overlapAcknowledged = ref(false)
 const isSaving = ref(false)
 const loadError = ref(false)
 const loadingPromotion = ref(false)
@@ -478,6 +527,9 @@ function resetForm() {
   selectedProducts.value = []
   scopePickerOpen.value = false
   validationErrors.value = []
+  overlapWarnings.value = []
+  requiresAcknowledgment.value = false
+  overlapAcknowledged.value = false
   loadError.value = false
 }
 
@@ -668,6 +720,7 @@ function buildPayload() {
     ends_at,
     priority: Math.min(32767, Math.max(0, Math.round(Number(form.priority) || 0))),
     stackable: false,
+    overlap_acknowledged: overlapAcknowledged.value,
   }
 }
 
@@ -711,16 +764,30 @@ async function invalidatePromotionCaches() {
 
 async function onSubmit() {
   if (!validate()) return
+  if (requiresAcknowledgment.value && !overlapAcknowledged.value && Number(form.priority) === 0) {
+    validationErrors.value = ['Marca la casilla de confirmación o sube la prioridad por encima de 0.']
+    return
+  }
   isSaving.value = true
+  validationErrors.value = []
   try {
     const body = buildPayload()
+    let res: PromotionSaveResponse
     if (!isEdit.value) {
-      await $fetch('/api/api/promotions', { method: 'POST', body })
-      toast.add({ title: 'Promoción creada', color: 'success' })
+      res = await $fetch<PromotionSaveResponse>('/api/api/promotions', { method: 'POST', body })
     } else {
-      await $fetch(`/api/api/promotions/${props.promotionId}`, { method: 'PATCH', body })
-      toast.add({ title: 'Promoción actualizada', color: 'success' })
+      res = await $fetch<PromotionSaveResponse>(`/api/api/promotions/${props.promotionId}`, { method: 'PATCH', body })
     }
+    overlapWarnings.value = res.overlap_warnings ?? []
+    requiresAcknowledgment.value = Boolean(res.requires_acknowledgment)
+    if (requiresAcknowledgment.value) {
+      overlapAcknowledged.value = false
+      return
+    }
+    toast.add({
+      title: isEdit.value ? 'Promoción actualizada' : 'Promoción creada',
+      color: 'success',
+    })
     await invalidatePromotionCaches()
     close()
     emit('saved')
@@ -750,8 +817,18 @@ async function onDelete() {
 
 function close() {
   scopePickerOpen.value = false
+  overlapWarnings.value = []
+  requiresAcknowledgment.value = false
+  overlapAcknowledged.value = false
   emit('update:modelValue', false)
 }
+
+watch(() => form.priority, (value) => {
+  if (Number(value) > 0) {
+    requiresAcknowledgment.value = false
+    overlapAcknowledged.value = false
+  }
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- Show overlap warning panel when API returns `overlap_warnings` on create/update.
- Gate high-risk saves behind acknowledgment checkbox or priority > 0 when `requires_acknowledgment` is true.

Requires companion API PR (uno0uno/api-warolabs).

Closes #1014

## Test plan
- [ ] Create overlapping promos — warning panel lists conflicts + product count
- [ ] Priority-0 tie blocks save until ack or priority bump
- [ ] Save succeeds after acknowledgment

## wr-context
See `.wr/1014.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)