### PR TITLE
feat(pos): align client promo preview with server conflict rules

### DIFF
--- a/.wr/1015.yaml
+++ b/.wr/1015.yaml
@@ -1,0 +1,35 @@
+issue: 1015
+title: "feat(pos): align client promo preview with server conflict rules"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1015-client-promo-parity
+extends_epic: 1010
+depends_on: 1012
+
+paths:
+  - utils/promoProductMatch.ts
+  - utils/promoProductMatch.test.ts
+  - components/pos/CartPanel.vue
+  - pages/pos/checkout.vue
+  - composables/useActivePromotions.ts
+
+ac:
+  - pickBestPromotionForProduct mirrors api _pick_best_promotion_for_line (type blocks + scope rank + name tie-break)
+  - Orden Actual badges/savings and checkout clientPromoSavings fallback match tax-preview winner when API omits line savings
+  - node:test parity cases for BOGO vs percent vs fixed on same SKU
+
+out_of_scope:
+  - tenant settings UI for promo_type_block_map
+  - overlap advisory on save (#1014)
+  - pages/pos/producto/[id].vue and pages/pos/index.vue (default block map when map not passed)
+
+hints:
+  entry: pickBestPromotionForProduct — utils/promoProductMatch.ts
+  pattern: filterTypeBlockedCandidates + scopeSpecificityRank from promotions_service.py:1111-1180
+  wire_block_map: useActivePromotions reads cached restaurant-context promo_type_block_map
+  tests: node --test utils/promoProductMatch.test.ts
+
+skip:
+  audits: [ux, color, typography, python-compat, db]

--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -357,7 +357,7 @@ import {
   promoBadgeForProduct,
 } from '~/utils/promoProductMatch'
 
-const { activePromos } = useActivePromotions()
+const { activePromos, promoPickOptions } = useActivePromotions()
 
 const { singular: tableSingular } = useTableLabel()
 const tableSingularLower = computed(() => tableSingular.value.toLowerCase())
@@ -489,7 +489,7 @@ const posStore = usePOSStore()
 const { isDeleting } = storeToRefs(posStore)
 
 function linePromoBadge(productId: string, categoryId?: string | null) {
-  return promoBadgeForProduct(activePromos.value, productId, categoryId)
+  return promoBadgeForProduct(activePromos.value, productId, categoryId, promoPickOptions.value)
 }
 
 function categoryForProduct(productId: string): string | null {
@@ -513,6 +513,7 @@ function cartLinePromoSavings(item: CartItem): number {
     item.product.id,
     { subtotal: gross, quantity: item.quantity },
     categoryForProduct(item.product.id),
+    promoPickOptions.value,
   )
 }
 
@@ -526,6 +527,7 @@ function tabLinePromoSavings(item: TabItem): number {
     item.productId,
     { subtotal: item.subtotal, quantity: item.quantity },
     categoryId,
+    promoPickOptions.value,
   )
 }
 

--- a/composables/useActivePromotions.ts
+++ b/composables/useActivePromotions.ts
@@ -2,19 +2,13 @@ import { computed, onUnmounted, ref, watch, type ComputedRef, type Ref } from 'v
 import { $fetch } from 'ofetch'
 import type { PromotionScheduleRow } from '~/utils/promotionPreview'
 import { BOGOTA_TZ } from '~/utils/bogotaDate'
+import {
+  normalizePromoTypeBlockMap,
+  type ActivePromotionRow,
+  type PromoTypeBlockMap,
+} from '~/utils/promoProductMatch'
 
-export interface ActivePromotionRow {
-  id: string
-  name: string
-  promo_type: string
-  scope_type: string
-  schedules: PromotionScheduleRow[]
-  is_currently_active?: boolean
-  category_ids?: string[]
-  product_ids?: string[]
-  value_json?: Record<string, unknown>
-  priority?: number
-}
+export type { ActivePromotionRow }
 
 const MIN_REFETCH_MS = 30_000
 const MAX_REFETCH_MS = 5 * 60_000
@@ -106,7 +100,20 @@ export function useActivePromotions(options?: {
     staleTime: 30_000,
   })
 
+  const { data: restaurantContextData } = useQuery({
+    key: () => ['pos', 'restaurant-context', currentTenant.value?.id],
+    query: () => $fetch<{ success: boolean; data: { promo_type_block_map?: PromoTypeBlockMap } }>(
+      '/api/pos/restaurant-context',
+    ),
+    enabled: () => !!currentTenant.value && (options?.enabled?.value ?? true),
+    staleTime: 30_000,
+  })
+
   const activePromos = computed(() => data.value?.data ?? [])
+  const promoTypeBlockMap = computed(() =>
+    normalizePromoTypeBlockMap(restaurantContextData.value?.data?.promo_type_block_map),
+  )
+  const promoPickOptions = computed(() => ({ promoTypeBlockMap: promoTypeBlockMap.value }))
   const hasActivePromos = computed(() => activePromos.value.length > 0)
 
   const activePromoHint = computed(() => {
@@ -150,5 +157,7 @@ export function useActivePromotions(options?: {
     activePromoHint,
     activePromosStatus: asyncStatus,
     refetchActivePromos: refetch,
+    promoTypeBlockMap,
+    promoPickOptions,
   }
 }

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -49,7 +49,7 @@ function invalidateCheckoutPromoPreview() {
   }
 }
 
-const { activePromos, hasActivePromos, activePromoHint } = useActivePromotions({
+const { activePromos, hasActivePromos, activePromoHint, promoPickOptions } = useActivePromotions({
   onActivePromosChanged: invalidateCheckoutPromoPreview,
 })
 
@@ -451,6 +451,7 @@ const clientPromoSavings = computed(() => {
       productId,
       { subtotal: checkoutLineGross(item), quantity: item.quantity },
       checkoutLineCategoryId(item),
+      promoPickOptions.value,
     )
   }
   return total
@@ -1129,6 +1130,7 @@ const getLinePromoSavings = (item: any): number => {
     productId,
     { subtotal: checkoutLineGross(item), quantity: item.quantity },
     checkoutLineCategoryId(item),
+    promoPickOptions.value,
   )
 }
 

--- a/utils/promoProductMatch.test.ts
+++ b/utils/promoProductMatch.test.ts
@@ -1,0 +1,128 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type { ActivePromotionRow } from './promoProductMatch.ts'
+import {
+  computeLinePromoSavings,
+  linePromoSavingsForProduct,
+  pickBestPromotionForProduct,
+} from './promoProductMatch.ts'
+
+const productId = 'product-1'
+const categoryId = 'category-1'
+
+function promo(
+  overrides: Partial<ActivePromotionRow> & Pick<ActivePromotionRow, 'promo_type' | 'value_json'>,
+): ActivePromotionRow {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    name: overrides.name ?? 'Test promo',
+    promo_type: overrides.promo_type,
+    scope_type: overrides.scope_type ?? 'all_products',
+    schedules: overrides.schedules ?? [],
+    value_json: overrides.value_json,
+    priority: overrides.priority ?? 10,
+    category_ids: overrides.category_ids,
+    product_ids: overrides.product_ids,
+  }
+}
+
+describe('pickBestPromotionForProduct', () => {
+  it('bogo blocks percent and fixed at equal priority', () => {
+    const bogo = promo({
+      name: 'BOGO deal',
+      promo_type: 'bogo',
+      value_json: { buy_qty: 1, get_qty: 1 },
+      priority: 10,
+    })
+    const percent = promo({
+      name: 'Percent deal',
+      promo_type: 'percent_off',
+      value_json: { percent: 30 },
+      priority: 10,
+    })
+    const fixed = promo({
+      name: 'Fixed deal',
+      promo_type: 'fixed_off',
+      value_json: { amount_cop: 5000 },
+      priority: 10,
+    })
+
+    const winner = pickBestPromotionForProduct([percent, fixed, bogo], productId)
+    assert.equal(winner?.name, 'BOGO deal')
+  })
+
+  it('higher priority percent wins over bogo block', () => {
+    const bogo = promo({
+      name: 'BOGO',
+      promo_type: 'bogo',
+      value_json: { buy_qty: 1, get_qty: 1 },
+      priority: 0,
+    })
+    const percent = promo({
+      name: 'VIP percent',
+      promo_type: 'percent_off',
+      value_json: { percent: 30 },
+      priority: 20,
+    })
+
+    const winner = pickBestPromotionForProduct([bogo, percent], productId)
+    assert.equal(winner?.name, 'VIP percent')
+  })
+
+  it('product scope beats category at equal priority', () => {
+    const categoryPromo = promo({
+      id: 'category-promo',
+      name: 'Category wide',
+      promo_type: 'percent_off',
+      value_json: { percent: 50 },
+      scope_type: 'categories',
+      priority: 10,
+      category_ids: [categoryId],
+    })
+    const productPromo = promo({
+      id: 'product-promo',
+      name: 'Product specific',
+      promo_type: 'percent_off',
+      value_json: { percent: 10 },
+      scope_type: 'products',
+      priority: 10,
+      product_ids: [productId],
+    })
+
+    const winner = pickBestPromotionForProduct(
+      [categoryPromo, productPromo],
+      productId,
+      categoryId,
+    )
+    assert.equal(winner?.name, 'Product specific')
+  })
+})
+
+describe('linePromoSavingsForProduct', () => {
+  it('uses blocked winner savings for BOGO vs percent on same SKU', () => {
+    const bogo = promo({
+      name: 'BOGO',
+      promo_type: 'bogo',
+      value_json: { buy_qty: 1, get_qty: 1 },
+      priority: 5,
+    })
+    const percent = promo({
+      name: 'Half off',
+      promo_type: 'percent_off',
+      value_json: { percent: 50 },
+      priority: 5,
+    })
+
+    const savings = linePromoSavingsForProduct(
+      [bogo, percent],
+      productId,
+      { subtotal: 20000, quantity: 2 },
+    )
+    assert.equal(savings, 10000)
+    assert.equal(
+      computeLinePromoSavings({ subtotal: 20000, quantity: 2 }, percent),
+      10000,
+    )
+    assert.equal(pickBestPromotionForProduct([bogo, percent], productId)?.name, 'BOGO')
+  })
+})

--- a/utils/promoProductMatch.ts
+++ b/utils/promoProductMatch.ts
@@ -1,9 +1,56 @@
-import type { ActivePromotionRow } from '~/composables/useActivePromotions'
-import { formatPromoValue } from '~/utils/promotionPreview'
+import type { PromotionScheduleRow } from './promotionPreview.ts'
+import { formatPromoValue } from './promotionPreview.ts'
+
+export interface ActivePromotionRow {
+  id: string
+  name: string
+  promo_type: string
+  scope_type: string
+  schedules: PromotionScheduleRow[]
+  is_currently_active?: boolean
+  category_ids?: string[]
+  product_ids?: string[]
+  value_json?: Record<string, unknown>
+  priority?: number
+}
 
 export type PromoBadgeDisplay = {
   label: string
   title?: string
+}
+
+export type PromoTypeBlockMap = Record<string, string[]>
+
+export type PromoPickOptions = {
+  promoTypeBlockMap?: PromoTypeBlockMap | null
+}
+
+const VALID_PROMO_TYPES = new Set(['percent_off', 'fixed_off', 'bogo'])
+
+/** Client mirror of api promotions_service.DEFAULT_PROMO_TYPE_BLOCK_MAP. */
+export const DEFAULT_PROMO_TYPE_BLOCK_MAP: PromoTypeBlockMap = {
+  bogo: ['percent_off', 'fixed_off'],
+}
+
+/** Client mirror of api promotions_service.normalize_promo_type_block_map. */
+export function normalizePromoTypeBlockMap(
+  raw?: PromoTypeBlockMap | null,
+): PromoTypeBlockMap {
+  if (!raw || Object.keys(raw).length === 0) {
+    return { ...DEFAULT_PROMO_TYPE_BLOCK_MAP }
+  }
+  const normalized: PromoTypeBlockMap = {}
+  for (const [winner, blocked] of Object.entries(raw)) {
+    if (!VALID_PROMO_TYPES.has(winner)) continue
+    if (!Array.isArray(blocked)) continue
+    const cleaned = blocked.filter(
+      (promoType) => typeof promoType === 'string' && VALID_PROMO_TYPES.has(promoType),
+    )
+    if (cleaned.length > 0) normalized[winner] = cleaned
+  }
+  return Object.keys(normalized).length > 0
+    ? normalized
+    : { ...DEFAULT_PROMO_TYPE_BLOCK_MAP }
 }
 
 function toIdSet(ids: Set<string> | readonly string[]): Set<string> {
@@ -42,32 +89,89 @@ export function promosMatchingProduct(
   )
 }
 
-/** Highest priority wins; tie-break by name (matches server _pick_best_promotion_for_line). */
+function scopeSpecificityRank(scopeType: string): number {
+  if (scopeType === 'products') return 2
+  if (scopeType === 'categories') return 1
+  return 0
+}
+
+function promoRankKey(promo: ActivePromotionRow): [number, number, string] {
+  return [
+    promo.priority ?? 0,
+    scopeSpecificityRank(promo.scope_type),
+    promo.name ?? '',
+  ]
+}
+
+function promoBlockRankKey(promo: ActivePromotionRow): [number, number] {
+  return [promo.priority ?? 0, scopeSpecificityRank(promo.scope_type)]
+}
+
+/** Client mirror of api promotions_service._filter_type_blocked_candidates. */
+export function filterTypeBlockedCandidates(
+  matches: ActivePromotionRow[],
+  typeBlockMap: PromoTypeBlockMap,
+): ActivePromotionRow[] {
+  if (matches.length === 0) return []
+  const eligible: ActivePromotionRow[] = []
+  for (const candidate of matches) {
+    const candidateType = candidate.promo_type ?? ''
+    const candidateRank = promoBlockRankKey(candidate)
+    let blocked = false
+    for (const other of matches) {
+      if (other === candidate) continue
+      const blockedTypes = typeBlockMap[other.promo_type ?? ''] ?? []
+      if (!blockedTypes.includes(candidateType)) continue
+      const otherRank = promoBlockRankKey(other)
+      if (otherRank[0] > candidateRank[0] || otherRank[1] > candidateRank[1]) {
+        blocked = true
+        break
+      }
+      if (otherRank[0] === candidateRank[0] && otherRank[1] === candidateRank[1]) {
+        blocked = true
+        break
+      }
+    }
+    if (!blocked) eligible.push(candidate)
+  }
+  return eligible
+}
+
+function comparePromoRank(a: ActivePromotionRow, b: ActivePromotionRow): number {
+  const [aPriority, aScope, aName] = promoRankKey(a)
+  const [bPriority, bScope, bName] = promoRankKey(b)
+  if (aPriority !== bPriority) return aPriority - bPriority
+  if (aScope !== bScope) return aScope - bScope
+  return aName.localeCompare(bName)
+}
+
+/** Client mirror of api promotions_service._pick_best_promotion_for_line. */
 export function pickBestPromotionForProduct(
   promos: ActivePromotionRow[],
   productId: string,
   categoryId?: string | null,
+  options?: PromoPickOptions,
 ): ActivePromotionRow | null {
   const matches = promosMatchingProduct(promos, productId, categoryId)
   if (matches.length === 0) return null
-  return matches.reduce((best, promo) => {
-    const bestPriority = best.priority ?? 0
-    const promoPriority = promo.priority ?? 0
-    if (promoPriority > bestPriority) return promo
-    if (promoPriority < bestPriority) return best
-    return (promo.name ?? '') >= (best.name ?? '') ? promo : best
-  })
+  const blockMap = normalizePromoTypeBlockMap(options?.promoTypeBlockMap)
+  const eligible = filterTypeBlockedCandidates(matches, blockMap)
+  if (eligible.length === 0) return null
+  return eligible.reduce((best, promo) =>
+    comparePromoRank(promo, best) >= 0 ? promo : best,
+  )
 }
 
 export function promoBadgeForProduct(
   promos: ActivePromotionRow[],
   productId: string,
   categoryId?: string | null,
+  options?: PromoPickOptions,
 ): PromoBadgeDisplay | null {
   const matches = promosMatchingProduct(promos, productId, categoryId)
   if (matches.length === 0) return null
 
-  const best = pickBestPromotionForProduct(promos, productId, categoryId)
+  const best = pickBestPromotionForProduct(promos, productId, categoryId, options)
   if (!best) return null
 
   const valueLabel = formatPromoValue(best.promo_type, best.value_json)
@@ -133,8 +237,9 @@ export function linePromoSavingsForProduct(
   productId: string,
   line: LinePromoInput,
   categoryId?: string | null,
+  options?: PromoPickOptions,
 ): number {
-  const promo = pickBestPromotionForProduct(promos, productId, categoryId)
+  const promo = pickBestPromotionForProduct(promos, productId, categoryId, options)
   if (!promo) return 0
   return computeLinePromoSavings(line, promo)
 }


### PR DESCRIPTION
## Summary
- Port server `_pick_best_promotion_for_line` rules (type blocks, scope specificity, name tie-break) into `promoProductMatch.ts`.
- Load tenant `promo_type_block_map` from cached restaurant-context via `useActivePromotions` and thread into CartPanel + checkout client fallback paths.
- Add node:test parity cases mirroring API BOGO/percent/fixed and scope-priority scenarios.

Closes #1015

## Test plan
- [ ] `node --experimental-strip-types --test utils/promoProductMatch.test.ts` (4 passing)
- [ ] POS: add SKU with overlapping BOGO + percent promos — Orden Actual badge/savings match tax-preview total
- [ ] Checkout: when API omits line savings, client fallback shows same winner as charged amount

## wr-context
See `.wr/1015.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)