### PR TITLE
fix(pos): cart footer total reflects line promo savings

### DIFF
--- a/.wr/1022.yaml
+++ b/.wr/1022.yaml
@@ -1,0 +1,28 @@
+# wr-context — issue #1022
+issue: 1022
+title: "fix(pos): cart footer total reflects line promo savings"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1022-cart-footer-net-total
+
+paths:
+  - components/pos/CartPanel.vue
+
+ac:
+  - Footer Total shows netOrderTotal after line promo savings
+  - When orderPromoSavings > 0, show gross struck through and Descuentos promoción line
+  - Mesa mode sums tab + pending cart via existing orderPromoSavings loop
+  - Manual QA 30% line discount footer matches line net totals
+
+out_of_scope:
+  - Checkout API persistence modifier splitting
+
+hints:
+  entry: "CartPanel.vue footer — netOrderTotal orderPromoSavings grossOrderTotal"
+  pattern: "CartItem.vue:45-56 — line-through gross + net total"
+  tests: "manual POS QA"
+
+skip:
+  audits: [ux, color, typography]

--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -170,10 +170,23 @@
 
     <!-- Cart Footer -->
     <div class="px-4 py-4 border-t border-border space-y-3 bg-surface-secondary/40">
-      <!-- Total -->
+      <!-- Total — net after line promos (#1022) -->
+      <div
+        v-if="orderPromoSavings > 0"
+        class="flex items-center justify-between text-xs"
+      >
+        <span class="font-medium text-text-tertiary">Descuentos promoción</span>
+        <span class="font-semibold text-emerald-700 dark:text-emerald-400 tabular-nums">-{{ formatCurrency(orderPromoSavings) }}</span>
+      </div>
       <div class="flex items-center justify-between">
         <span class="text-xs font-semibold text-text-tertiary uppercase tracking-widest">Total</span>
-        <span class="text-3xl font-black text-text-primary tabular-nums">{{ formatCurrency(mesaMode ? (tabTotal + total) : total) }}</span>
+        <div class="flex flex-col items-end">
+          <span
+            v-if="orderPromoSavings > 0"
+            class="text-sm text-text-tertiary line-through tabular-nums"
+          >{{ formatCurrency(grossOrderTotal) }}</span>
+          <span class="text-3xl font-black text-text-primary tabular-nums">{{ formatCurrency(netOrderTotal) }}</span>
+        </div>
       </div>
 
       <!-- Actions — Mostrador / barra sin comandas -->


### PR DESCRIPTION
## Summary
- Cart footer **Total** now displays `netOrderTotal` (gross minus line promo savings).
- When promos apply, shows a **Descuentos promoción** row and gross subtotal struck through above the net total.
- Mesa mode unchanged in logic: `orderPromoSavings` already sums tab items + pending cart.

Closes #1022

## Test plan
- [ ] POS: add product with 30% line promo → footer total matches sum of line net prices
- [ ] Mesa mode: tab items + pending cart with promos → footer net = gross − savings for both buckets
- [ ] No promos → footer shows single total (no discount row)

## wr-context
See `.wr/1022.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)