### PR TITLE
fix(promociones): allow selecting resale products in promotion scope picker

### DIFF
--- a/.wr/1034.yaml
+++ b/.wr/1034.yaml
@@ -1,0 +1,29 @@
+issue: 1034
+title: "fix(promociones): allow selecting resale products in promotion scope picker"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1034-promo-resale-picker
+
+paths:
+  - composables/useProductSearch.ts
+  - components/ui/ProductSearchInput.vue
+  - components/promociones/PromocionPanel.vue
+
+ac:
+  - Resale products searchable when creating/editing promo scope
+  - Default product search unchanged (includeAllTypes opt-in)
+  - Menu/POS product lists unaffected
+
+out_of_scope:
+  - API filter changes
+  - POS/checkout promo application
+
+hints:
+  entry: "PromocionPanel UiProductSearchInput include-all-types"
+  pattern: "pages/menu/productos/index.vue params.include_all_types"
+  tests: "manual — /operaciones/promociones create + edit"
+
+skip:
+  audits: [ux, color, typography]

--- a/components/promociones/PromocionPanel.vue
+++ b/components/promociones/PromocionPanel.vue
@@ -178,6 +178,7 @@
               <UiProductSearchInput
                 input-id="promo-product-search"
                 placeholder="Buscar producto…"
+                include-all-types
                 :exclude-ids="selectedProducts.map((p) => p.id)"
                 @select="onProductSelect"
               />

--- a/components/ui/ProductSearchInput.vue
+++ b/components/ui/ProductSearchInput.vue
@@ -61,6 +61,8 @@ interface Props {
   placeholder?: string
   inputId?: string
   excludeIds?: string[]
+  /** Include resale products in search results (promotions scope picker). */
+  includeAllTypes?: boolean
 }
 
 interface Emits {
@@ -71,6 +73,7 @@ const props = withDefaults(defineProps<Props>(), {
   placeholder: 'Buscar producto…',
   inputId: 'product-search-input',
   excludeIds: () => [],
+  includeAllTypes: false,
 })
 
 const emit = defineEmits<Emits>()
@@ -78,7 +81,9 @@ const emit = defineEmits<Emits>()
 const searchTerm = ref('')
 const showResults = ref(false)
 
-const { query, results, loading } = useProductSearch()
+const { query, results, loading } = useProductSearch({
+  includeAllTypes: props.includeAllTypes,
+})
 
 const excludeSet = computed(() => new Set(props.excludeIds))
 

--- a/composables/useProductSearch.ts
+++ b/composables/useProductSearch.ts
@@ -11,7 +11,12 @@ export interface ProductRow {
   name: string
 }
 
-export const useProductSearch = () => {
+export interface UseProductSearchOptions {
+  /** Include resale products (API default excludes them unless include_all_types=true). */
+  includeAllTypes?: boolean
+}
+
+export const useProductSearch = (options: UseProductSearchOptions = {}) => {
   const results = ref<ProductRow[]>([])
   const loading = ref(false)
   const error = ref<Error | null>(null)
@@ -21,10 +26,18 @@ export const useProductSearch = () => {
     loading.value = true
     error.value = null
     try {
+      const baseQuery: Record<string, string | number | boolean> = {
+        limit: 50,
+        page: 1,
+      }
+      if (q && q.trim().length > 0) {
+        baseQuery.search = q.trim()
+      }
+      if (options.includeAllTypes) {
+        baseQuery.include_all_types = true
+      }
       const res = await $fetch<{ success?: boolean; data?: ProductRow[] }>('/api/menu/products', {
-        query: q && q.trim().length > 0
-          ? { search: q.trim(), limit: 50, page: 1 }
-          : { limit: 50, page: 1 },
+        query: baseQuery,
       })
       const items = Array.isArray(res?.data) ? res.data : []
       results.value = items.map((p) => ({ id: p.id, name: p.name }))


### PR DESCRIPTION
## Summary
- Add opt-in `includeAllTypes` to `useProductSearch` / `ProductSearchInput`
- Enable it on the promotions scope picker so resale products appear in search
- Default search behavior unchanged for other consumers

Closes #1034

## Test plan
- [ ] `/operaciones/promociones` → Nueva → alcance Productos → search resale product → select
- [ ] Edit existing promo → add another resale product via picker
- [ ] Confirm menu product list filters unchanged

## wr-context
See `.wr/1034.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)