### PR TITLE
fix(menu): station creation 404 from product create page

### DIFF
--- a/.wr/1036.yaml
+++ b/.wr/1036.yaml
@@ -1,0 +1,27 @@
+issue: 1036
+title: "fix(menu): station creation 404 from product create page"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1036-station-create-404
+
+paths:
+  - components/cocina/StationPanel.vue
+
+ac:
+  - POST station from /menu/productos/crear succeeds
+  - Same API path as operaciones/comandas
+  - Cache invalidation unchanged
+
+out_of_scope:
+  - Backend stations router
+  - KDS token flows
+
+hints:
+  entry: "StationPanel submit() POST path"
+  pattern: "pages/operaciones/comandas.vue /api/api/stations"
+  tests: "manual — crear estación desde productos/crear"
+
+skip:
+  audits: [ux, color, typography]

--- a/components/cocina/StationPanel.vue
+++ b/components/cocina/StationPanel.vue
@@ -270,7 +270,7 @@ async function submit() {
   loading.value = true
   errorMsg.value = null
   try {
-    const res = await $fetch<{ success: boolean; data: Station }>('/api/stations', {
+    const res = await $fetch<{ success: boolean; data: Station }>('/api/api/stations', {
       method: 'POST',
       body: {
         name: trimmedName,


### PR DESCRIPTION
## Summary
- Fix `StationPanel` POST path from `/api/stations` to `/api/api/stations`
- Restores kitchen station creation from `/menu/productos/crear`

Closes #1036

## Test plan
- [ ] `/menu/productos/crear` → Nueva estación → Crear → success
- [ ] Station appears in inherited station / comandas list
- [ ] Comandas station CRUD unchanged

## wr-context
See `.wr/1036.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)