### PR TITLE
feat(menu): recetas single-page form UX (crear + edit)

### DIFF
--- a/.wr/1046.yaml
+++ b/.wr/1046.yaml
@@ -1,0 +1,33 @@
+# Machine contract — issue #1046
+issue: 1046
+title: "feat(menu): recetas single-page form UX (crear + edit)"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1046-recetas-single-page
+parent_epic: 1045
+
+paths:
+  - pages/menu/recetas/crear.vue
+  - pages/menu/recetas/[id].vue
+
+ac:
+  - crear.vue — no wizard; grid xl:grid-cols-3; UiFormSection Datos + Ingredientes; sticky Resumen sidebar
+  - crear.vue — validateForm at submit (name, duplicate check, ingredients, duplicates)
+  - [id].vue — divide-y UiFormSection card; Resumen sidebar; sentence-case microcopy
+  - [id].vue — submitError inline instead of alert for validation errors
+  - API payloads unchanged
+
+out_of_scope:
+  - modificadores (batch #1047)
+  - recetas/index.vue
+  - API changes
+
+hints:
+  entry: "pages/menu/recetas/crear.vue — mirror productos/crear.vue"
+  pattern: "UiFormSection + sticky Resumen sidebar"
+  depends_on: "#1043 FormSection.vue (branch wr-1043 or merged main)"
+
+skip:
+  audits: [ux, color, typography]

--- a/pages/menu/recetas/[id].vue
+++ b/pages/menu/recetas/[id].vue
@@ -84,10 +84,10 @@
                 <div
                   v-for="(ingredient, index) in form.ingredients"
                   :key="index"
-                  class="flex items-start gap-3 p-4 bg-background rounded-lg border border-border"
+                  class="border border-border rounded-lg p-3 sm:p-4 bg-background"
                 >
-                  <div class="flex-1 grid grid-cols-1 md:grid-cols-12 gap-3">
-                    <div class="md:col-span-5">
+                  <div class="grid grid-cols-1 md:grid-cols-12 gap-3">
+                    <div class="md:col-span-4">
                       <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
                       <UiIngredientSearchInput
                         :initialValue="ingredient.ingredient_name"
@@ -110,7 +110,7 @@
                       />
                     </div>
 
-                    <div class="md:col-span-3">
+                    <div class="md:col-span-2">
                       <label class="block text-xs font-medium text-text-secondary mb-1">Unidad</label>
                       <div class="relative">
                         <select
@@ -134,36 +134,40 @@
                       </div>
                     </div>
 
-                    <div class="md:col-span-1 flex items-end">
-                      <label class="flex items-center gap-2 cursor-pointer">
+                    <div class="md:col-span-2">
+                      <label class="block text-xs font-medium text-text-secondary mb-1">Requerido</label>
+                      <label class="flex items-center gap-2 h-[38px] cursor-pointer">
                         <input
                           v-model="ingredient.is_required"
                           type="checkbox"
                           class="h-4 w-4 text-primary border-border rounded focus:ring-primary"
                         />
-                        <span class="text-xs font-medium text-text-primary whitespace-nowrap">Requerido</span>
+                        <span class="text-xs font-medium text-text-primary">Sí</span>
                       </label>
                     </div>
 
-                    <div class="md:col-span-12">
-                      <label class="block text-xs font-medium text-text-secondary mb-1">Notas <span class="font-normal">(opcional)</span></label>
-                      <input
-                        v-model="ingredient.notes"
-                        type="text"
-                        class="input-base w-full px-3 py-2 text-sm"
-                        placeholder="Ej. mozzarella de búfala"
-                      />
+                    <div class="md:col-span-1">
+                      <label class="block text-xs font-medium text-text-secondary mb-1 invisible select-none" aria-hidden="true">&nbsp;</label>
+                      <button
+                        type="button"
+                        @click="removeIngredient(index)"
+                        class="flex items-center justify-center w-full h-[38px] text-destructive hover:bg-destructive/5 rounded-lg transition-colors"
+                        title="Eliminar línea"
+                      >
+                        <Icon name="heroicons:trash" class="h-5 w-5" />
+                      </button>
                     </div>
                   </div>
 
-                  <button
-                    type="button"
-                    @click="removeIngredient(index)"
-                    class="px-3 py-2 text-destructive hover:bg-destructive/5 rounded-lg transition-colors flex-shrink-0"
-                    title="Eliminar línea"
-                  >
-                    <Icon name="heroicons:trash" class="h-5 w-5" />
-                  </button>
+                  <div class="mt-3">
+                    <label class="block text-xs font-medium text-text-secondary mb-1">Notas <span class="font-normal">(opcional)</span></label>
+                    <input
+                      v-model="ingredient.notes"
+                      type="text"
+                      class="input-base w-full px-3 py-2 text-sm"
+                      placeholder="Ej. mozzarella de búfala"
+                    />
+                  </div>
                 </div>
               </div>
             </MenuCatalogInlineCreateBusyOverlay>

--- a/pages/menu/recetas/[id].vue
+++ b/pages/menu/recetas/[id].vue
@@ -1,47 +1,42 @@
 <template>
   <div>
-    <!-- Loading State -->
     <div v-if="isPageLoading" class="flex items-center justify-center min-h-[400px]">
       <CommonsTheCustomLoader size="large" />
     </div>
 
-    <!-- Error State -->
     <CommonsTheErrorState v-else-if="fetchError || !recipeData" />
 
     <form v-else @submit.prevent="handleSubmit" class="grid grid-cols-1 xl:grid-cols-3 gap-6 xl:gap-8">
-      <!-- Left Column: Form Content -->
       <div class="xl:col-span-2 space-y-6">
-        <div class="bg-surface border-2 border-border rounded-xl p-6 md:p-8 shadow-sm">
-          <!-- Información Básica -->
-          <div>
-            <h3 class="text-lg font-semibold text-text-primary mb-6">Información General</h3>
-            <div class="grid grid-cols-1 gap-6">
+        <div class="bg-surface border-2 border-border rounded-xl shadow-sm divide-y divide-border overflow-hidden">
+          <UiFormSection title="Datos de la receta">
+            <div class="space-y-4">
               <div>
-                <label class="block text-sm font-medium text-text-primary mb-2">
-                  Nombre del Tipo Base *
+                <label class="block text-sm font-medium text-text-primary mb-1">
+                  Nombre *
                 </label>
                 <input
                   v-model="form.name"
                   type="text"
                   required
                   class="input-base w-full px-4 py-2"
-                  placeholder="Ej: Pizza Italiana Clásica"
+                  placeholder="Ej. pizza italiana clásica"
                 />
               </div>
 
               <div>
-                <label class="block text-sm font-medium text-text-primary mb-2">
-                  Descripción
+                <label class="block text-sm font-medium text-text-primary mb-1">
+                  Descripción <span class="text-text-tertiary font-normal">(opcional)</span>
                 </label>
                 <textarea
                   v-model="form.description"
                   rows="3"
-                  class="input-base w-full px-4 py-2"
-                  placeholder="Describe la receta base..."
-                ></textarea>
+                  class="input-base w-full px-4 py-2 resize-y min-h-[5.5rem]"
+                  placeholder="Breve descripción de la receta base"
+                />
               </div>
 
-              <div class="flex items-start space-x-3">
+              <div class="flex items-start gap-3">
                 <input
                   v-model="form.is_active"
                   type="checkbox"
@@ -52,24 +47,16 @@
                   <label for="is_active" class="text-sm font-medium text-text-primary cursor-pointer">
                     Receta activa
                   </label>
-                  <p class="text-xs text-text-secondary mt-1">
-                    Las recetas activas pueden ser asignadas a nuevos productos
+                  <p class="text-xs text-text-tertiary mt-0.5">
+                    Disponible para asignar a productos nuevos
                   </p>
                 </div>
               </div>
             </div>
-          </div>
+          </UiFormSection>
 
-          <!-- Ingredientes -->
-          <MenuCatalogInlineCreateBusyOverlay
-            class="mt-8 block"
-            :busy="inlineCatalogBusy"
-            :label="inlineCatalogBusyLabel"
-            :hint="inlineCatalogBusyHint"
-          >
-            <MenuIngredientProductHint class="mb-4" />
-            <div class="flex justify-between items-center mb-6">
-              <h3 class="text-lg font-semibold text-text-primary">Ingredientes y reventa de la receta</h3>
+          <UiFormSection title="Ingredientes">
+            <template #actions>
               <UiButton
                 type="button"
                 variant="outline"
@@ -78,176 +65,177 @@
               >
                 + Agregar
               </UiButton>
-            </div>
+            </template>
 
-            <!-- Empty State -->
-            <div v-if="form.ingredients.length === 0" class="text-center py-12 text-text-secondary border border-border rounded-lg">
-              <Icon name="heroicons:cube" class="h-16 w-16 mx-auto mb-4 text-titan-300" />
-              <p class="text-base font-medium mb-1">No hay líneas en la receta</p>
-              <p class="text-sm">Agrega ingredientes o productos de reventa que componen esta receta base</p>
-            </div>
+            <MenuCatalogInlineCreateBusyOverlay
+              :busy="inlineCatalogBusy"
+              :label="inlineCatalogBusyLabel"
+              :hint="inlineCatalogBusyHint"
+            >
+              <MenuIngredientProductHint class="mb-4" />
 
-            <!-- Lista de ingredientes -->
-            <div class="space-y-3 mb-4">
-              <div
-                v-for="(ingredient, index) in form.ingredients"
-                :key="index"
-                class="flex items-start gap-3 p-4 bg-surface-secondary rounded-lg border border-border"
-              >
-                <div class="flex-1 grid grid-cols-1 md:grid-cols-12 gap-3">
-                  <!-- Ingrediente -->
-                  <div class="md:col-span-5">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
-                    <UiIngredientSearchInput
-                      :initialValue="ingredient.ingredient_name"
-                      :allow-create="true"
-                      @select="(ing) => selectIngredient(ing, index)"
-                      @create="(name) => openCustomIngModal(name, index)"
-                    />
-                  </div>
+              <div v-if="form.ingredients.length === 0" class="text-center py-10 text-text-secondary border border-dashed border-border rounded-lg">
+                <Icon name="heroicons:cube" class="h-12 w-12 mx-auto mb-3 text-text-tertiary/50" />
+                <p class="text-sm font-medium mb-0.5">Sin líneas en la receta</p>
+                <p class="text-xs text-text-tertiary">Agrega ingredientes o productos de reventa</p>
+              </div>
 
-                  <!-- Cantidad -->
-                  <div class="md:col-span-3">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad *</label>
-                    <input
-                      v-model.number="ingredient.base_quantity"
-                      type="number"
-                      required
-                      min="0.01"
-                      step="any"
-                      class="input-base w-full px-3 py-2 text-sm"
-                      placeholder="0"
-                    />
-                  </div>
+              <div v-else class="space-y-3">
+                <div
+                  v-for="(ingredient, index) in form.ingredients"
+                  :key="index"
+                  class="flex items-start gap-3 p-4 bg-background rounded-lg border border-border"
+                >
+                  <div class="flex-1 grid grid-cols-1 md:grid-cols-12 gap-3">
+                    <div class="md:col-span-5">
+                      <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
+                      <UiIngredientSearchInput
+                        :initialValue="ingredient.ingredient_name"
+                        :allow-create="true"
+                        @select="(ing) => selectIngredient(ing, index)"
+                        @create="(name) => openCustomIngModal(name, index)"
+                      />
+                    </div>
 
-                  <!-- Unidad -->
-                  <div class="md:col-span-3">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Unidad</label>
-                    <div class="relative">
-                      <select
-                        v-model="ingredient.unit"
-                        :disabled="loadingUnits.has(ingredient.ingredient_id)"
-                        class="input-base w-full py-2 pr-3 text-sm disabled:opacity-50"
-                        :class="loadingUnits.has(ingredient.ingredient_id) ? 'pl-7' : 'pl-3'"
-                      >
-                        <option
-                          v-for="opt in getIngredientUnitOptions(ingredient.ingredient_id)"
-                          :key="opt.value"
-                          :value="opt.value"
-                        >{{ opt.label }}</option>
-                      </select>
-                      <span v-if="loadingUnits.has(ingredient.ingredient_id)" class="absolute left-2 top-2.5 pointer-events-none text-text-secondary">
-                        <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
-                        </svg>
-                      </span>
+                    <div class="md:col-span-3">
+                      <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad *</label>
+                      <input
+                        v-model.number="ingredient.base_quantity"
+                        type="number"
+                        required
+                        min="0.01"
+                        step="any"
+                        class="input-base w-full px-3 py-2 text-sm"
+                        placeholder="0"
+                      />
+                    </div>
+
+                    <div class="md:col-span-3">
+                      <label class="block text-xs font-medium text-text-secondary mb-1">Unidad</label>
+                      <div class="relative">
+                        <select
+                          v-model="ingredient.unit"
+                          :disabled="loadingUnits.has(ingredient.ingredient_id)"
+                          class="input-base w-full py-2 pr-3 text-sm disabled:opacity-50"
+                          :class="loadingUnits.has(ingredient.ingredient_id) ? 'pl-7' : 'pl-3'"
+                        >
+                          <option
+                            v-for="opt in getIngredientUnitOptions(ingredient.ingredient_id)"
+                            :key="opt.value"
+                            :value="opt.value"
+                          >{{ opt.label }}</option>
+                        </select>
+                        <span v-if="loadingUnits.has(ingredient.ingredient_id)" class="absolute left-2 top-2.5 pointer-events-none text-text-secondary">
+                          <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
+                          </svg>
+                        </span>
+                      </div>
+                    </div>
+
+                    <div class="md:col-span-1 flex items-end">
+                      <label class="flex items-center gap-2 cursor-pointer">
+                        <input
+                          v-model="ingredient.is_required"
+                          type="checkbox"
+                          class="h-4 w-4 text-primary border-border rounded focus:ring-primary"
+                        />
+                        <span class="text-xs font-medium text-text-primary whitespace-nowrap">Requerido</span>
+                      </label>
+                    </div>
+
+                    <div class="md:col-span-12">
+                      <label class="block text-xs font-medium text-text-secondary mb-1">Notas <span class="font-normal">(opcional)</span></label>
+                      <input
+                        v-model="ingredient.notes"
+                        type="text"
+                        class="input-base w-full px-3 py-2 text-sm"
+                        placeholder="Ej. mozzarella de búfala"
+                      />
                     </div>
                   </div>
 
-                  <!-- Requerido -->
-                  <div class="md:col-span-1 flex items-end">
-                    <label class="flex items-center gap-2 cursor-pointer">
-                      <input
-                        type="checkbox"
-                        v-model="ingredient.is_required"
-                        class="h-4 w-4 text-primary border-border rounded focus:ring-primary"
-                      />
-                      <span class="text-xs font-medium text-text-primary whitespace-nowrap">Requerido</span>
-                    </label>
-                  </div>
-
-                  <!-- Notas -->
-                  <div class="md:col-span-12">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Notas (opcional)</label>
-                    <input
-                      v-model="ingredient.notes"
-                      type="text"
-                      class="input-base w-full px-3 py-2 text-sm"
-                      placeholder="Ej: Usar mozzarella de búfala, temperatura ambiente..."
-                    />
-                  </div>
+                  <button
+                    type="button"
+                    @click="removeIngredient(index)"
+                    class="px-3 py-2 text-destructive hover:bg-destructive/5 rounded-lg transition-colors flex-shrink-0"
+                    title="Eliminar línea"
+                  >
+                    <Icon name="heroicons:trash" class="h-5 w-5" />
+                  </button>
                 </div>
-
-                <!-- Delete Button -->
-                <button
-                  type="button"
-                  @click="removeIngredient(index)"
-                  class="px-3 py-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors flex-shrink-0"
-                  title="Eliminar ingrediente"
-                >
-                  <Icon name="heroicons:trash" class="h-5 w-5" />
-                </button>
               </div>
-            </div>
-          </MenuCatalogInlineCreateBusyOverlay>
+            </MenuCatalogInlineCreateBusyOverlay>
+          </UiFormSection>
         </div>
       </div>
 
-      <!-- Right Column: Actions Card -->
-      <div class="xl:col-span-1">
-        <div class="bg-surface border-2 border-border rounded-xl p-6 shadow-sm sticky top-6 space-y-4">
-          <h3 class="text-lg font-semibold text-text-primary mb-4">Acciones</h3>
+      <div class="xl:col-span-1 space-y-6">
+        <div class="bg-surface border-2 border-border rounded-xl p-6 shadow-sm sticky top-6">
+          <h3 class="text-lg font-semibold text-text-primary mb-4">Resumen</h3>
 
-          <UiButton
-            type="submit"
-            variant="default"
-            size="lg"
-            class="w-full"
-            :disabled="isSubmitting"
-          >
-            <Icon v-if="!isSubmitting" name="heroicons:check" class="h-5 w-5 mr-2" />
-            <Icon v-else name="heroicons:arrow-path" class="h-5 w-5 mr-2 animate-spin" />
-            {{ isSubmitting ? 'Guardando...' : 'Actualizar Receta' }}
-          </UiButton>
-
-          <UiButton
-            type="button"
-            variant="outline"
-            size="default"
-            class="w-full"
-            @click="cancel"
-            :disabled="isSubmitting"
-          >
-            Cancelar
-          </UiButton>
-
-          <UiButton
-            type="button"
-            variant="destructive"
-            size="default"
-            class="w-full"
-            @click="deleteRecipe"
-            :disabled="isSubmitting"
-          >
-            <Icon name="heroicons:trash" class="h-5 w-5 mr-2" />
-            Eliminar Receta
-          </UiButton>
-
-          <!-- Info Card -->
-          <div class="mt-6 p-4 bg-background rounded-lg border border-border">
-            <h4 class="text-sm font-semibold text-text-primary mb-3">Información</h4>
-            <div class="space-y-2 text-xs text-text-secondary">
-              <div class="flex justify-between">
-                <span>Total Ingredientes:</span>
-                <span class="font-semibold text-text-primary">{{ form.ingredients.length }}</span>
-              </div>
-              <div class="flex justify-between">
-                <span>Ingredientes Requeridos:</span>
-                <span class="font-semibold text-text-primary">
-                  {{ form.ingredients.filter(i => i.is_required).length }}
-                </span>
-              </div>
-              <div class="flex justify-between items-center">
-                <span>Estado:</span>
-                <UiStatusBadge
-                  :value="form.is_active ? 'Activa' : 'Inactiva'"
-                  format="text"
-                  :variant="form.is_active ? 'success' : 'secondary'"
-                  size="sm"
-                />
-              </div>
+          <div class="space-y-3">
+            <div class="flex justify-between text-sm">
+              <span class="text-text-secondary">Ingredientes:</span>
+              <span class="font-semibold text-text-primary">{{ form.ingredients.length }}</span>
             </div>
+
+            <div class="flex justify-between text-sm">
+              <span class="text-text-secondary">Requeridos:</span>
+              <span class="font-semibold text-text-primary">
+                {{ form.ingredients.filter(i => i.is_required).length }}
+              </span>
+            </div>
+
+            <div class="flex justify-between text-sm items-center gap-2">
+              <span class="text-text-secondary">Estado:</span>
+              <UiStatusBadge
+                :value="form.is_active ? 'Activa' : 'Inactiva'"
+                format="text"
+                :variant="form.is_active ? 'success' : 'secondary'"
+                size="sm"
+              />
+            </div>
+          </div>
+
+          <div class="mt-6 pt-6 border-t border-border space-y-3">
+            <p v-if="submitError" role="alert" class="text-sm text-destructive">{{ submitError }}</p>
+
+            <UiButton
+              type="submit"
+              variant="default"
+              size="lg"
+              class="w-full"
+              :disabled="isSubmitting"
+            >
+              <Icon v-if="!isSubmitting" name="heroicons:check" class="h-5 w-5 mr-2" />
+              <Icon v-else name="heroicons:arrow-path" class="h-5 w-5 mr-2 animate-spin" />
+              {{ isSubmitting ? 'Guardando...' : 'Guardar receta' }}
+            </UiButton>
+
+            <UiButton
+              type="button"
+              variant="outline"
+              size="default"
+              class="w-full"
+              :disabled="isSubmitting"
+              @click="cancel"
+            >
+              Cancelar
+            </UiButton>
+
+            <UiButton
+              type="button"
+              variant="destructive"
+              size="default"
+              class="w-full"
+              :disabled="isSubmitting"
+              @click="deleteRecipe"
+            >
+              <Icon name="heroicons:trash" class="h-5 w-5 mr-2" />
+              Eliminar receta
+            </UiButton>
           </div>
         </div>
       </div>
@@ -268,11 +256,9 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useQueryCache } from '@pinia/colada'
-import { useTenantReactive } from '@/composables/useTenantReactive'
 import { useMenuIngredientsQuery } from '@/composables/queries/useMenuIngredients'
 
 definePageMeta({
-  // layout: 'dashboard' - Inherited from parent menu.vue
   pageTransition: {
     name: 'fade',
     mode: 'out-in'
@@ -291,12 +277,9 @@ const route = useRoute()
 const router = useRouter()
 const toast = useToast()
 const cache = useQueryCache()
-const { currentTenant } = useTenantReactive()
 
-// Get recipe base ID from route
 const recipeId = route.params.id as string
 
-// Fetch recipe base data from backend
 const { data: recipeData, pending: isLoading, error: fetchError, refresh } = useAsyncData(
   `recipe-base-${recipeId}`,
   () => $fetch(`/api/menu/recipe-bases/${recipeId}`),
@@ -310,13 +293,8 @@ const isPageLoading = computed(() => isLoading.value)
 
 const { availableIngredients } = useMenuIngredientsQuery()
 
-// Ingredient cache: populated from API response on load or when user selects via UiIngredientSearchInput
 const ingredientCache = ref<Record<string, any>>({})
-
-// Purchase units cache for dynamic unit options
 const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
-
-// Tracks which ingredient IDs are currently fetching purchase units
 const loadingUnits = ref<Set<string>>(new Set())
 
 const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient, mergeIngredientUnitFields, rehydrateIngredientCaches } = useIngredientUnitOptions()
@@ -403,7 +381,6 @@ async function onInlineProductCreated(product: Record<string, unknown>) {
   })
 }
 
-// Form state
 const form = ref({
   name: '',
   description: '',
@@ -419,8 +396,8 @@ const form = ref({
 })
 
 const isSubmitting = ref(false)
+const submitError = ref('')
 
-// Watch recipe data and populate form
 watch(recipeData, (data) => {
   if (data?.data) {
     const recipe = data.data
@@ -452,7 +429,6 @@ watch(availableIngredients, (list) => {
   }
 })
 
-// Methods
 const addIngredient = () => {
   form.value.ingredients.push({
     ingredient_id: '',
@@ -470,22 +446,21 @@ const removeIngredient = (index: number) => {
 
 const handleSubmit = async () => {
   if (isSubmitting.value) return
+  submitError.value = ''
 
-  // Validate quantities > 0
   const hasZeroQuantity = form.value.ingredients.some(ing => !ing.base_quantity || ing.base_quantity <= 0)
   if (hasZeroQuantity) {
-    alert('Error: Todos los ingredientes deben tener una cantidad mayor a 0.')
+    submitError.value = 'Todos los ingredientes deben tener cantidad mayor a 0.'
     return
   }
 
-  // Validate no duplicate ingredients
   const ingredientIds = form.value.ingredients
     .map(ing => ing.ingredient_id)
-    .filter(id => id !== '') // Ignore empty selections
+    .filter(id => id !== '')
 
   const uniqueIds = new Set(ingredientIds)
   if (ingredientIds.length !== uniqueIds.size) {
-    alert('Error: No puedes agregar el mismo ingrediente más de una vez en la misma receta.')
+    submitError.value = 'No puedes agregar el mismo ingrediente más de una vez.'
     return
   }
 
@@ -507,14 +482,13 @@ const handleSubmit = async () => {
     toast.success('Receta actualizada correctamente', { title: 'Guardado' })
   } catch (error: any) {
     console.error('Error updating recipe base:', error)
-    alert(`Error al actualizar la receta: ${error.data?.detail || error.message || 'Por favor intenta de nuevo.'}`)
+    submitError.value = error.data?.detail || error.message || 'Error al actualizar. Intenta de nuevo.'
   } finally {
     isSubmitting.value = false
   }
 }
 
 const cancel = () => {
-  // clearNuxtData()
   router.push('/menu/recetas')
 }
 
@@ -530,11 +504,10 @@ const deleteRecipe = async () => {
       method: 'DELETE'
     })
 
-    // clearNuxtData()
     await router.push('/menu/recetas')
   } catch (error: any) {
     console.error('Error deleting recipe base:', error)
-    alert(`Error al eliminar la receta: ${error.data?.detail || error.message || 'Por favor intenta de nuevo.'}`)
+    submitError.value = error.data?.detail || error.message || 'Error al eliminar. Intenta de nuevo.'
   } finally {
     isSubmitting.value = false
   }

--- a/pages/menu/recetas/crear.vue
+++ b/pages/menu/recetas/crear.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full">
+  <div>
     <UiSubmitBusyOverlay
       :busy="isSubmitting"
       label="Creando receta base..."
@@ -8,512 +8,254 @@
       indicator="matrix"
     />
 
-    <!-- Loading State -->
     <div v-if="isLoadingData" class="flex items-center justify-center min-h-[400px]">
       <CommonsTheCustomLoader size="large" />
     </div>
 
-    <!-- Main Content -->
-    <div v-else class="flex w-full flex-col">
-      <!-- Recipe Base Information Card -->
-      <div class="bg-surface border-2 border-border rounded-lg mb-4 sm:mb-6">
-        <div class="p-4 sm:p-6">
-          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
-            <!-- Recipe Base Name -->
-            <div class="flex items-center space-x-2 sm:space-x-3">
-              <div class="bg-background p-2 sm:p-3 rounded-lg border border-border flex-shrink-0">
-                <svg class="w-6 h-6 sm:w-8 sm:h-8 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                </svg>
-              </div>
-              <div class="space-y-1">
-                <p class="text-xs font-medium text-text-secondary uppercase tracking-wide">
-                  Nueva Receta Base
-                </p>
-                <p class="text-lg font-semibold text-text-primary">
-                  {{ form.name || 'Sin nombre' }}
-                </p>
-              </div>
-            </div>
-
-            <!-- Ingredients Count -->
-            <div class="flex items-center space-x-2 sm:space-x-3">
-              <div class="bg-background p-2 sm:p-3 rounded-lg border border-border flex-shrink-0">
-                <svg class="w-6 h-6 sm:w-8 sm:h-8 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-                </svg>
-              </div>
-              <div class="space-y-1">
-                <p class="text-xs font-medium text-text-secondary uppercase tracking-wide">
-                  Ingredientes
-                </p>
-                <p class="text-sm sm:text-lg font-semibold text-text-primary">
-                  {{ form.ingredients.length }} ingrediente{{ form.ingredients.length !== 1 ? 's' : '' }}
-                </p>
-              </div>
-            </div>
-
-            <!-- Status Badge -->
-            <div class="flex items-center space-x-2 sm:space-x-3">
-              <div class="bg-background p-2 sm:p-3 rounded-lg border border-border flex-shrink-0">
-                <svg class="w-6 h-6 sm:w-8 sm:h-8 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-              </div>
-              <div class="space-y-1">
-                <p class="text-xs font-medium text-text-secondary uppercase tracking-wide">
-                  Estado
-                </p>
-                <div class="pt-1">
-                  <UiStatusBadge
-                    :value="form.is_active ? 'Activa' : 'Inactiva'"
-                    format="text"
-                    :variant="form.is_active ? 'success' : 'secondary'"
-                    size="lg"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Progress Steps -->
-      <div class="bg-surface border-border border rounded-lg mb-4 sm:mb-6">
-        <div class="p-3 sm:p-6">
-          <div class="flex items-center justify-between">
-            <!-- Step 1 -->
-            <div class="flex items-center flex-1">
-              <div
-                class="flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full transition-colors border-2 flex-shrink-0"
-                :class="{
-                  'bg-primary text-primary-foreground border-primary': currentStep === 1,
-                  'bg-secondary text-secondary-foreground border-secondary': currentStep > 1,
-                  'border-border text-text-secondary bg-transparent': currentStep < 1
-                }"
-              >
-                <svg v-if="currentStep > 1" class="w-4 h-4 sm:w-6 sm:h-6" fill="currentColor" viewBox="0 0 20 20">
-                  <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
-                </svg>
-                <span v-else class="font-semibold text-sm sm:text-base">1</span>
-              </div>
-              <div class="ml-1 sm:ml-3 flex-1 min-w-0">
-                <p class="text-xs sm:text-sm font-medium truncate" :class="currentStep >= 1 ? 'text-text-primary' : 'text-text-secondary'">
-                  <span class="hidden sm:inline">Información General</span>
-                  <span class="sm:hidden">Info</span>
-                </p>
-                <p class="text-xs text-text-secondary hidden sm:block">Datos básicos de la receta</p>
-              </div>
-              <div class="flex-1 h-0.5 sm:h-1 mx-1 sm:mx-4" :class="currentStep > 1 ? 'bg-secondary' : 'bg-border'"></div>
-            </div>
-
-            <!-- Step 2 -->
-            <div class="flex items-center flex-1">
-              <div
-                class="flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full transition-colors border-2 flex-shrink-0"
-                :class="{
-                  'bg-primary text-primary-foreground border-primary': currentStep === 2,
-                  'bg-secondary text-secondary-foreground border-secondary': currentStep > 2,
-                  'border-border text-text-secondary bg-transparent': currentStep < 2
-                }"
-              >
-                <svg v-if="currentStep > 2" class="w-4 h-4 sm:w-6 sm:h-6" fill="currentColor" viewBox="0 0 20 20">
-                  <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
-                </svg>
-                <span v-else class="font-semibold text-sm sm:text-base">2</span>
-              </div>
-              <div class="ml-1 sm:ml-3 flex-1 min-w-0">
-                <p class="text-xs sm:text-sm font-medium truncate" :class="currentStep >= 2 ? 'text-text-primary' : 'text-text-secondary'">
-                  Ingredientes
-                </p>
-                <p class="text-xs text-text-secondary hidden sm:block">Composición de la receta</p>
-              </div>
-              <div class="flex-1 h-0.5 sm:h-1 mx-1 sm:mx-4" :class="currentStep > 2 ? 'bg-secondary' : 'bg-border'"></div>
-            </div>
-
-            <!-- Step 3 -->
-            <div class="flex items-center">
-              <div
-                class="flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full transition-colors border-2 flex-shrink-0"
-                :class="{
-                  'bg-primary text-primary-foreground border-primary': currentStep === 3,
-                  'bg-secondary text-secondary-foreground border-secondary': currentStep > 3,
-                  'border-border text-text-secondary bg-transparent': currentStep < 3
-                }"
-              >
-                <span class="font-semibold text-sm sm:text-base">3</span>
-              </div>
-              <div class="ml-1 sm:ml-3 min-w-0">
-                <p class="text-xs sm:text-sm font-medium truncate" :class="currentStep >= 3 ? 'text-text-primary' : 'text-text-secondary'">
-                  <span class="hidden sm:inline">Revisión y Confirmación</span>
-                  <span class="sm:hidden">Revisar</span>
-                </p>
-                <p class="text-xs text-text-secondary hidden sm:block">Verificar y crear</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Form Content -->
-      <form @submit.prevent="handleNext">
-        <!-- Step 1: Información General -->
-        <Transition name="fade" mode="out-in">
-        <div v-if="currentStep === 1" key="step-1" class="bg-surface border-border border rounded-lg">
-          <div class="p-4 sm:p-6">
-            <h3 class="text-base sm:text-lg font-semibold text-text-primary mb-4 sm:mb-6">Información General</h3>
-
-            <div class="grid grid-cols-1 gap-4 sm:gap-6">
-              <!-- Recipe Base Name -->
-              <div>
-                <label class="block text-sm font-medium text-text-primary mb-2">
-                  Nombre del Tipo Base *
-                </label>
-                <input
-                  type="text"
-                  v-model="form.name"
-                  placeholder="Ej: Pizza Italiana Clásica, Hamburguesa Premium, Arepa Tradicional"
-                  class="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-text-primary"
-                  :class="nameError ? 'border-destructive focus:ring-destructive' : 'border-border'"
-                  required
-                  @input="nameError = ''"
-                />
-                <p v-if="nameError" class="text-xs text-destructive mt-1 flex items-center gap-1">
-                  <svg class="w-3.5 h-3.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
-                  {{ nameError }}
-                </p>
-                <p v-else class="text-xs text-text-secondary mt-1">Este será el nombre de la receta base que podrás asignar a múltiples productos</p>
-              </div>
-
-              <!-- Description -->
-              <div>
-                <label class="block text-sm font-medium text-text-primary mb-2">
-                  Descripción
-                </label>
-                <textarea
-                  v-model="form.description"
-                  placeholder="Describe la receta base, sus características principales..."
-                  rows="3"
-                  class="w-full px-4 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-text-primary resize-none"
-                />
-              </div>
-
-              <!-- Active Status -->
-              <div class="flex items-start space-x-3">
-                <input
-                  v-model="form.is_active"
-                  type="checkbox"
-                  id="is_active"
-                  class="h-4 w-4 mt-0.5 text-primary focus:ring-primary border-border rounded"
-                />
+    <div v-else class="space-y-6">
+      <form @submit.prevent="submitRecipe" class="grid grid-cols-1 xl:grid-cols-3 gap-6 xl:gap-8">
+        <div class="xl:col-span-2 space-y-6">
+          <div class="bg-surface border-2 border-border rounded-xl shadow-sm divide-y divide-border overflow-hidden">
+            <UiFormSection title="Datos de la receta">
+              <div class="space-y-4">
                 <div>
-                  <label for="is_active" class="text-sm font-medium text-text-primary cursor-pointer">
-                    Receta activa
+                  <label class="block text-sm font-medium text-text-primary mb-1">
+                    Nombre *
                   </label>
-                  <p class="text-xs text-text-secondary mt-1">
-                    Las recetas activas pueden ser asignadas a nuevos productos
+                  <input
+                    v-model="form.name"
+                    type="text"
+                    required
+                    class="input-base w-full px-4 py-2"
+                    :class="nameError ? 'border-destructive focus:ring-destructive' : ''"
+                    placeholder="Ej. pizza italiana clásica"
+                    @input="nameError = ''"
+                  />
+                  <p v-if="nameError" role="alert" class="text-xs text-destructive mt-1 flex items-center gap-1">
+                    <svg class="w-3.5 h-3.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+                    {{ nameError }}
                   </p>
                 </div>
-              </div>
-            </div>
-          </div>
-        </div>
 
-        <!-- Step 2: Ingredientes -->
-        <div v-else-if="currentStep === 2" key="step-2" class="bg-surface border border-border rounded-lg">
-          <MenuCatalogInlineCreateBusyOverlay
-            :busy="inlineCatalogBusy"
-            :label="inlineCatalogBusyLabel"
-            :hint="inlineCatalogBusyHint"
-          >
-          <div class="p-4 sm:p-6">
-            <MenuIngredientProductHint class="mb-4" />
-            <div class="flex justify-between items-center mb-4 sm:mb-6">
-              <h3 class="text-base sm:text-lg font-semibold text-text-primary">Ingredientes y reventa de la receta</h3>
-              <button
-                type="button"
-                @click="addIngredient"
-                class="btn-secondary px-3 sm:px-4 py-2 rounded-lg text-sm"
-              >
-                + Agregar
-              </button>
-            </div>
-
-            <!-- Duplicate ingredient error -->
-            <div v-if="duplicateIngredientError" class="mb-4 flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-              <svg class="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
-              {{ duplicateIngredientError }}
-            </div>
-
-            <!-- Empty State -->
-            <div v-if="form.ingredients.length === 0" class="text-center py-12 text-text-secondary">
-              <svg class="w-16 h-16 mx-auto mb-4 text-titan-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-              </svg>
-              <p class="text-base font-medium mb-1">No hay líneas en la receta</p>
-              <p class="text-sm">Agrega ingredientes o productos de reventa que componen esta receta base</p>
-            </div>
-
-            <!-- Ingredients List -->
-            <div v-else class="space-y-3">
-              <div
-                v-for="(ingredient, index) in form.ingredients"
-                :key="index"
-                class="border border-border rounded-lg p-3 sm:p-4 bg-background"
-              >
-                <div class="grid grid-cols-1 md:grid-cols-12 gap-3">
-                  <!-- Ingredient -->
-                  <div class="md:col-span-4">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
-                    <UiIngredientSearchInput
-                      :allow-create="true"
-                      @select="(ing) => selectIngredient(ing, index)"
-                      @create="(name) => openCustomIngModal(name, index)"
-                    />
-                  </div>
-
-                  <!-- Quantity -->
-                  <div class="md:col-span-3">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad *</label>
-                    <input
-                      type="number"
-                      v-model.number="ingredient.base_quantity"
-                      placeholder="0"
-                      min="0.01"
-                      step="any"
-                      class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary"
-                      required
-                    />
-                  </div>
-
-                  <!-- Unit -->
-                  <div class="md:col-span-2">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Unidad</label>
-                    <div class="relative">
-                      <select
-                        v-model="ingredient.unit"
-                        :disabled="loadingUnits.has(ingredient.ingredient_id)"
-                        class="w-full py-2 pr-3 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary bg-surface disabled:opacity-50"
-                        :class="loadingUnits.has(ingredient.ingredient_id) ? 'pl-7' : 'pl-3'"
-                      >
-                        <option
-                          v-for="opt in getIngredientUnitOptions(ingredient.ingredient_id)"
-                          :key="opt.value"
-                          :value="opt.value"
-                        >
-                          {{ opt.label }}
-                        </option>
-                      </select>
-                      <span v-if="loadingUnits.has(ingredient.ingredient_id)" class="absolute left-2 top-2.5 pointer-events-none text-text-secondary">
-                        <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
-                        </svg>
-                      </span>
-                    </div>
-                  </div>
-
-                  <!-- Required Checkbox -->
-                  <div class="md:col-span-2 flex items-end">
-                    <label class="flex items-center gap-2 cursor-pointer">
-                      <input
-                        type="checkbox"
-                        v-model="ingredient.is_required"
-                        class="h-4 w-4 text-primary border-border rounded focus:ring-primary"
-                      />
-                      <span class="text-xs font-medium text-text-primary">Requerido</span>
-                    </label>
-                  </div>
-
-                  <!-- Delete Button -->
-                  <div class="md:col-span-1 flex items-end">
-                    <button
-                      type="button"
-                      @click="removeIngredient(index)"
-                      class="w-full md:w-auto px-3 py-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-                    >
-                      <svg class="w-5 h-5 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                      </svg>
-                    </button>
-                  </div>
+                <div>
+                  <label class="block text-sm font-medium text-text-primary mb-1">
+                    Descripción <span class="text-text-tertiary font-normal">(opcional)</span>
+                  </label>
+                  <textarea
+                    v-model="form.description"
+                    rows="3"
+                    class="input-base w-full px-4 py-2 resize-y min-h-[5.5rem]"
+                    placeholder="Breve descripción de la receta base"
+                  />
                 </div>
 
-                <!-- Notes for this ingredient -->
-                <div class="mt-3">
-                  <label class="block text-xs font-medium text-text-secondary mb-1">Notas (opcional)</label>
+                <div class="flex items-start gap-3">
                   <input
-                    type="text"
-                    v-model="ingredient.notes"
-                    placeholder="Ej: Usar mozzarella de búfala, temperatura ambiente..."
-                    class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary"
+                    v-model="form.is_active"
+                    type="checkbox"
+                    id="is_active"
+                    class="h-4 w-4 mt-0.5 text-primary focus:ring-primary border-border rounded"
                   />
-                </div>
-              </div>
-
-              </div>
-          </div>
-          </MenuCatalogInlineCreateBusyOverlay>
-        </div>
-
-        <!-- Step 3: Review -->
-        <div v-else-if="currentStep === 3" key="step-3" class="bg-surface border border-border rounded-lg">
-          <!-- Header -->
-          <div class="border-b border-border p-4 sm:p-6 md:p-8">
-            <div class="flex flex-col sm:flex-row justify-between items-start gap-4">
-              <div>
-                <h1 class="text-xl sm:text-2xl md:text-3xl font-bold text-text-primary mb-2">NUEVA RECETA BASE</h1>
-                <p class="text-xs sm:text-sm text-text-secondary">Resumen de la receta base a crear</p>
-              </div>
-              <UiStatusBadge
-                :value="form.is_active ? 'Activa' : 'Inactiva'"
-                format="text"
-                :variant="form.is_active ? 'success' : 'secondary'"
-                size="lg"
-              />
-            </div>
-          </div>
-
-          <!-- Recipe Base Info -->
-          <div class="px-4 sm:px-6 md:px-8 py-4 sm:py-6 border-b border-border">
-            <div class="grid grid-cols-1 gap-4 sm:gap-6">
-              <div>
-                <p class="text-xs font-semibold text-text-secondary uppercase tracking-wide mb-2">Tipo Base</p>
-                <p class="text-lg font-bold text-text-primary">{{ form.name }}</p>
-                <p v-if="form.description" class="text-sm text-text-secondary mt-2">{{ form.description }}</p>
-              </div>
-            </div>
-          </div>
-
-          <!-- Recipe Information -->
-          <div class="px-4 sm:px-6 md:px-8 py-4 sm:py-6 border-b border-border bg-background/50">
-            <p class="text-xs font-semibold text-text-secondary uppercase tracking-wide mb-3 sm:mb-4">
-              Información de la Receta
-            </p>
-            <div class="grid grid-cols-2 md:grid-cols-2 gap-4 sm:gap-6">
-              <div>
-                <p class="text-sm text-text-secondary mb-1">Total Ingredientes</p>
-                <p class="text-lg font-bold text-text-primary">{{ form.ingredients.length }}</p>
-              </div>
-              <div>
-                <p class="text-sm text-text-secondary mb-1">Ingredientes Requeridos</p>
-                <p class="text-lg font-bold text-text-primary">
-                  {{ form.ingredients.filter(i => i.is_required).length }}
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <!-- Ingredients Table -->
-          <div class="px-4 sm:px-6 md:px-8 py-4 sm:py-6">
-            <p class="text-xs font-semibold text-text-secondary uppercase tracking-wide mb-4">
-              Composición de la Receta Base
-            </p>
-
-            <!-- Mobile: Cards View -->
-            <div class="md:hidden space-y-3">
-              <div
-                v-for="(ingredient, index) in form.ingredients"
-                :key="index"
-                class="border border-border rounded-lg p-3 bg-background"
-              >
-                <div class="flex justify-between items-start mb-2">
-                  <p class="font-medium text-text-primary text-sm">{{ getIngredientName(ingredient.ingredient_id) }}</p>
-                  <UiStatusBadge
-                    :value="ingredient.is_required ? 'Requerido' : 'Opcional'"
-                    format="text"
-                    :variant="ingredient.is_required ? 'success' : 'secondary'"
-                    size="sm"
-                  />
-                </div>
-                <p v-if="ingredient.notes" class="text-xs text-text-secondary mb-2">{{ ingredient.notes }}</p>
-                <div class="grid grid-cols-1 gap-3 pt-2 border-t border-border">
                   <div>
-                    <p class="text-xs text-text-secondary mb-1">Cantidad</p>
-                    <p class="text-sm text-text-primary font-semibold">
-                      {{ ingredient.base_quantity }} {{ ingredient.unit }}
+                    <label for="is_active" class="text-sm font-medium text-text-primary cursor-pointer">
+                      Receta activa
+                    </label>
+                    <p class="text-xs text-text-tertiary mt-0.5">
+                      Disponible para asignar a productos nuevos
                     </p>
                   </div>
                 </div>
               </div>
-            </div>
+            </UiFormSection>
 
-            <!-- Desktop: Table View -->
-            <table class="w-full hidden md:table">
-              <thead>
-                <tr class="border-b border-border">
-                  <th class="text-left py-3 text-xs font-semibold text-text-secondary uppercase tracking-wide">
-                    Ingrediente
-                  </th>
-                  <th class="text-center py-3 text-xs font-semibold text-text-secondary uppercase tracking-wide">
-                    Estado
-                  </th>
-                  <th class="text-right py-3 text-xs font-semibold text-text-secondary uppercase tracking-wide">
-                    Cantidad
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr
-                  v-for="(ingredient, index) in form.ingredients"
-                  :key="index"
-                  class="border-b border-border"
+            <UiFormSection title="Ingredientes">
+              <template #actions>
+                <button
+                  type="button"
+                  @click="addIngredient"
+                  class="btn-secondary px-3 py-1.5 rounded-lg text-sm"
                 >
-                  <td class="py-4">
-                    <p class="font-medium text-text-primary">{{ getIngredientName(ingredient.ingredient_id) }}</p>
-                    <p v-if="ingredient.notes" class="text-xs text-text-secondary mt-1">{{ ingredient.notes }}</p>
-                  </td>
-                  <td class="text-center py-4">
-                    <UiStatusBadge
-                      :value="ingredient.is_required ? 'Requerido' : 'Opcional'"
-                      format="text"
-                      :variant="ingredient.is_required ? 'success' : 'secondary'"
-                      size="sm"
-                    />
-                  </td>
-                  <td class="text-right py-4 text-text-primary font-semibold">
-                    {{ ingredient.base_quantity }} {{ ingredient.unit }}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                  + Agregar
+                </button>
+              </template>
+
+              <MenuCatalogInlineCreateBusyOverlay
+                :busy="inlineCatalogBusy"
+                :label="inlineCatalogBusyLabel"
+                :hint="inlineCatalogBusyHint"
+              >
+                <MenuIngredientProductHint class="mb-4" />
+
+                <div v-if="duplicateIngredientError" class="mb-4 flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                  <svg class="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+                  {{ duplicateIngredientError }}
+                </div>
+
+                <div v-if="form.ingredients.length === 0" class="text-center py-10 text-text-secondary border border-dashed border-border rounded-lg">
+                  <svg class="w-12 h-12 mx-auto mb-3 text-text-tertiary/50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+                  </svg>
+                  <p class="text-sm font-medium mb-0.5">Sin líneas en la receta</p>
+                  <p class="text-xs text-text-tertiary">Agrega ingredientes o productos de reventa</p>
+                </div>
+
+                <div v-else class="space-y-3">
+                  <div
+                    v-for="(ingredient, index) in form.ingredients"
+                    :key="index"
+                    class="border border-border rounded-lg p-3 sm:p-4 bg-background"
+                  >
+                    <div class="grid grid-cols-1 md:grid-cols-12 gap-3">
+                      <div class="md:col-span-4">
+                        <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
+                        <UiIngredientSearchInput
+                          :allow-create="true"
+                          @select="(ing) => selectIngredient(ing, index)"
+                          @create="(name) => openCustomIngModal(name, index)"
+                        />
+                      </div>
+
+                      <div class="md:col-span-3">
+                        <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad *</label>
+                        <input
+                          v-model.number="ingredient.base_quantity"
+                          type="number"
+                          placeholder="0"
+                          min="0.01"
+                          step="any"
+                          class="input-base w-full px-3 py-2 text-sm"
+                          required
+                        />
+                      </div>
+
+                      <div class="md:col-span-2">
+                        <label class="block text-xs font-medium text-text-secondary mb-1">Unidad</label>
+                        <div class="relative">
+                          <select
+                            v-model="ingredient.unit"
+                            :disabled="loadingUnits.has(ingredient.ingredient_id)"
+                            class="input-base w-full py-2 pr-3 text-sm disabled:opacity-50"
+                            :class="loadingUnits.has(ingredient.ingredient_id) ? 'pl-7' : 'pl-3'"
+                          >
+                            <option
+                              v-for="opt in getIngredientUnitOptions(ingredient.ingredient_id)"
+                              :key="opt.value"
+                              :value="opt.value"
+                            >
+                              {{ opt.label }}
+                            </option>
+                          </select>
+                          <span v-if="loadingUnits.has(ingredient.ingredient_id)" class="absolute left-2 top-2.5 pointer-events-none text-text-secondary">
+                            <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+                              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
+                            </svg>
+                          </span>
+                        </div>
+                      </div>
+
+                      <div class="md:col-span-2 flex items-end">
+                        <label class="flex items-center gap-2 cursor-pointer">
+                          <input
+                            v-model="ingredient.is_required"
+                            type="checkbox"
+                            class="h-4 w-4 text-primary border-border rounded focus:ring-primary"
+                          />
+                          <span class="text-xs font-medium text-text-primary">Requerido</span>
+                        </label>
+                      </div>
+
+                      <div class="md:col-span-1 flex items-end">
+                        <button
+                          type="button"
+                          @click="removeIngredient(index)"
+                          class="w-full md:w-auto px-3 py-2 text-destructive hover:bg-destructive/5 rounded-lg transition-colors"
+                          title="Eliminar línea"
+                        >
+                          <svg class="w-5 h-5 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+
+                    <div class="mt-3">
+                      <label class="block text-xs font-medium text-text-secondary mb-1">Notas <span class="font-normal">(opcional)</span></label>
+                      <input
+                        v-model="ingredient.notes"
+                        type="text"
+                        placeholder="Ej. mozzarella de búfala"
+                        class="input-base w-full px-3 py-2 text-sm"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </MenuCatalogInlineCreateBusyOverlay>
+            </UiFormSection>
           </div>
         </div>
-        </Transition>
 
-        <!-- Navigation Buttons -->
-        <div class="flex justify-between mt-4 sm:mt-6 gap-3">
-          <button
-            v-if="currentStep > 1"
-            type="button"
-            @click="previousStep"
-            class="btn-secondary px-4 sm:px-6 py-2 sm:py-3 rounded-lg font-medium"
-          >
-            ← Anterior
-          </button>
-          <div v-else></div>
+        <div class="xl:col-span-1 space-y-6">
+          <div class="bg-surface border-2 border-border rounded-xl p-6 shadow-sm sticky top-6">
+            <h3 class="text-lg font-semibold text-text-primary mb-4">Resumen</h3>
 
-          <button
-            v-if="currentStep < 3"
-            type="submit"
-            :disabled="!canProceed"
-            class="btn-primary px-4 sm:px-6 py-2 sm:py-3 rounded-lg font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Siguiente →
-          </button>
-          <div v-else class="flex flex-col items-end gap-2">
-            <p v-if="submitError" class="text-sm text-destructive flex items-center gap-1">
-              <svg class="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
-              {{ submitError }}
-            </p>
-            <button
-              type="button"
-              @click="submitRecipe"
-              :disabled="isSubmitting"
-              class="btn-primary px-4 sm:px-6 py-2 sm:py-3 rounded-lg font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              Crear Receta Base
-            </button>
+            <div class="space-y-3">
+              <div class="flex justify-between text-sm gap-2">
+                <span class="text-text-secondary">Nombre:</span>
+                <span class="font-semibold text-text-primary text-right truncate">{{ form.name || '—' }}</span>
+              </div>
+
+              <div class="flex justify-between text-sm">
+                <span class="text-text-secondary">Ingredientes:</span>
+                <span class="font-semibold text-text-primary">{{ form.ingredients.length }}</span>
+              </div>
+
+              <div class="flex justify-between text-sm">
+                <span class="text-text-secondary">Requeridos:</span>
+                <span class="font-semibold text-text-primary">
+                  {{ form.ingredients.filter(i => i.is_required).length }}
+                </span>
+              </div>
+
+              <div class="flex justify-between text-sm items-center gap-2">
+                <span class="text-text-secondary">Estado:</span>
+                <UiStatusBadge
+                  :value="form.is_active ? 'Activa' : 'Inactiva'"
+                  format="text"
+                  :variant="form.is_active ? 'success' : 'secondary'"
+                  size="sm"
+                />
+              </div>
+            </div>
+
+            <div class="mt-6 pt-6 border-t border-border space-y-3">
+              <p v-if="submitError" role="alert" class="text-sm text-destructive flex items-center gap-1">
+                <svg class="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+                {{ submitError }}
+              </p>
+              <UiButton
+                type="submit"
+                variant="default"
+                size="lg"
+                class="w-full"
+                :disabled="isSubmitting"
+              >
+                <Icon v-if="!isSubmitting" name="heroicons:check" class="h-5 w-5 mr-2" />
+                <Icon v-else name="heroicons:arrow-path" class="h-5 w-5 mr-2 animate-spin" />
+                {{ isSubmitting ? 'Creando...' : 'Crear receta' }}
+              </UiButton>
+
+              <UiButton
+                type="button"
+                variant="outline"
+                size="default"
+                class="w-full"
+                :disabled="isSubmitting"
+                @click="router.push('/menu/recetas')"
+              >
+                Cancelar
+              </UiButton>
+            </div>
           </div>
         </div>
       </form>
@@ -532,7 +274,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 
 definePageMeta({
@@ -544,14 +286,11 @@ useHead({ title: 'Crear Receta' })
 const router = useRouter()
 const { currentTenant } = useTenantReactive()
 
-// State
-const currentStep = ref(1)
 const isSubmitting = ref(false)
 const nameError = ref('')
 const duplicateIngredientError = ref('')
 const submitError = ref('')
 
-// Form data
 const form = ref({
   name: '',
   description: '',
@@ -566,13 +305,8 @@ const form = ref({
   tenant_id: currentTenant.value?.id || ''
 })
 
-// Ingredient cache: populated when user selects via UiIngredientSearchInput
 const ingredientCache = ref<Record<string, any>>({})
-
-// Purchase units cache per ingredient
 const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
-
-// Tracks which ingredient IDs are currently fetching their purchase units
 const loadingUnits = ref<Set<string>>(new Set())
 
 const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient } = useIngredientUnitOptions()
@@ -644,22 +378,6 @@ async function onInlineProductCreated(product: Record<string, unknown>) {
 
 const isLoadingData = ref(false)
 
-const canProceed = computed(() => {
-  if (currentStep.value === 1) {
-    return form.value.name.trim().length > 0
-  }
-  if (currentStep.value === 2) {
-    return form.value.ingredients.length > 0 &&
-           form.value.ingredients.every(i => i.ingredient_id && i.base_quantity > 0)
-  }
-  return true
-})
-
-// Methods
-function getIngredientName(ingredientId: string) {
-  return ingredientCache.value[ingredientId]?.name || 'Ingrediente desconocido'
-}
-
 function addIngredient() {
   form.value.ingredients.push({
     ingredient_id: '',
@@ -674,41 +392,53 @@ function removeIngredient(index: number) {
   form.value.ingredients.splice(index, 1)
 }
 
-async function handleNext() {
-  if (!canProceed.value || currentStep.value >= 3) return
-  if (currentStep.value === 1) {
-    const res = await $fetch<{ available: boolean }>(`/api/menu/check-name?entity=recipe-bases&name=${encodeURIComponent(form.value.name.trim())}`)
-    if (!res.available) {
-      nameError.value = 'Ya existe una receta base con ese nombre.'
-      return
-    }
-  }
-  currentStep.value++
-  window.scrollTo({ top: 0, behavior: 'smooth' })
-}
+async function validateForm(): Promise<boolean> {
+  submitError.value = ''
+  nameError.value = ''
+  duplicateIngredientError.value = ''
 
-function previousStep() {
-  if (currentStep.value > 1) {
-    currentStep.value--
-    window.scrollTo({ top: 0, behavior: 'smooth' })
+  if (!form.value.name.trim()) {
+    nameError.value = 'El nombre es obligatorio.'
+    return false
   }
+
+  const res = await $fetch<{ available: boolean }>(
+    `/api/menu/check-name?entity=recipe-bases&name=${encodeURIComponent(form.value.name.trim())}`,
+  )
+  if (!res.available) {
+    nameError.value = 'Ya existe una receta base con ese nombre.'
+    return false
+  }
+
+  if (form.value.ingredients.length === 0) {
+    submitError.value = 'Agrega al menos un ingrediente a la receta.'
+    return false
+  }
+
+  const invalid = form.value.ingredients.some(
+    i => !i.ingredient_id || !i.base_quantity || i.base_quantity <= 0,
+  )
+  if (invalid) {
+    submitError.value = 'Completa todos los ingredientes con cantidad mayor a 0.'
+    return false
+  }
+
+  const ingredientIds = form.value.ingredients
+    .map(ing => ing.ingredient_id)
+    .filter(id => id !== '')
+
+  const uniqueIds = new Set(ingredientIds)
+  if (ingredientIds.length !== uniqueIds.size) {
+    duplicateIngredientError.value = 'No puedes agregar el mismo ingrediente más de una vez.'
+    return false
+  }
+
+  return true
 }
 
 async function submitRecipe() {
   if (isSubmitting.value) return
-
-  // Validate no duplicate ingredients
-  const ingredientIds = form.value.ingredients
-    .map(ing => ing.ingredient_id)
-    .filter(id => id !== '') // Ignore empty selections
-
-  const uniqueIds = new Set(ingredientIds)
-  if (ingredientIds.length !== uniqueIds.size) {
-    duplicateIngredientError.value = 'No puedes agregar el mismo ingrediente más de una vez en la misma receta.'
-    currentStep.value = 2
-    return
-  }
-  duplicateIngredientError.value = ''
+  if (!(await validateForm())) return
 
   isSubmitting.value = true
   submitError.value = ''
@@ -716,8 +446,7 @@ async function submitRecipe() {
   try {
     form.value.tenant_id = currentTenant.value?.id || ''
 
-    // Create the base recipe type and its ingredients
-    const response = await $fetch('/api/menu/recipe-bases', {
+    await $fetch('/api/menu/recipe-bases', {
       method: 'POST',
       body: {
         name: form.value.name,
@@ -740,8 +469,6 @@ async function submitRecipe() {
     const detail = error.data?.detail || error.message || 'Error inesperado. Por favor intenta de nuevo.'
     if (error.status === 400 && typeof detail === 'string' && detail.toLowerCase().includes('nombre')) {
       nameError.value = detail
-      currentStep.value = 1
-      window.scrollTo({ top: 0, behavior: 'smooth' })
     } else {
       submitError.value = typeof detail === 'string' ? detail : 'Error inesperado. Por favor intenta de nuevo.'
     }
@@ -752,13 +479,7 @@ async function submitRecipe() {
 </script>
 
 <style scoped>
-.fade-enter-active,
-.fade-leave-active {
-  transition: opacity 0.2s ease;
-}
-
-.fade-enter-from,
-.fade-leave-to {
-  opacity: 0;
+.input-base {
+  @apply border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-text-primary bg-surface;
 }
 </style>

--- a/pages/menu/recetas/crear.vue
+++ b/pages/menu/recetas/crear.vue
@@ -154,25 +154,27 @@
                         </div>
                       </div>
 
-                      <div class="md:col-span-2 flex items-end">
-                        <label class="flex items-center gap-2 cursor-pointer">
+                      <div class="md:col-span-2">
+                        <label class="block text-xs font-medium text-text-secondary mb-1">Requerido</label>
+                        <label class="flex items-center gap-2 h-[38px] cursor-pointer">
                           <input
                             v-model="ingredient.is_required"
                             type="checkbox"
                             class="h-4 w-4 text-primary border-border rounded focus:ring-primary"
                           />
-                          <span class="text-xs font-medium text-text-primary">Requerido</span>
+                          <span class="text-xs font-medium text-text-primary">Sí</span>
                         </label>
                       </div>
 
-                      <div class="md:col-span-1 flex items-end">
+                      <div class="md:col-span-1">
+                        <label class="block text-xs font-medium text-text-secondary mb-1 invisible select-none" aria-hidden="true">&nbsp;</label>
                         <button
                           type="button"
                           @click="removeIngredient(index)"
-                          class="w-full md:w-auto px-3 py-2 text-destructive hover:bg-destructive/5 rounded-lg transition-colors"
+                          class="flex items-center justify-center w-full h-[38px] text-destructive hover:bg-destructive/5 rounded-lg transition-colors"
                           title="Eliminar línea"
                         >
-                          <svg class="w-5 h-5 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                           </svg>
                         </button>


### PR DESCRIPTION
## Summary

- Remove the 3-step wizard on `/menu/recetas/crear` — all fields and ingredients on one screen with sticky **Resumen** sidebar
- Migrate `/menu/recetas/[id]` to `UiFormSection` + divide-y card layout matching product edit
- Sentence-case microcopy (Nombre *, Descripción opcional); inline validation on submit instead of step navigation

**Stacks on:** #1044 (`wr-1043-single-page-create`) for `FormSection.vue` — merge #1044 first, then this PR.

Part of epic #1045 · Closes #1046

## Test plan

- [ ] `/menu/recetas/crear` — create recipe with 2+ ingredients; no Atrás/Siguiente
- [ ] `/menu/recetas/crear` — duplicate name shows inline error
- [ ] `/menu/recetas/[id]` — edit name, add/remove ingredient, save
- [ ] `/menu/recetas/[id]` — delete recipe (confirm dialog)
- [ ] Inline catalog create (ingredient/product) still works from ingredient rows


Made with [Cursor](https://cursor.com)