### PR TITLE
feat(menu): modificadores single-page form UX (crear + edit)

### DIFF
--- a/.wr/1047.yaml
+++ b/.wr/1047.yaml
@@ -1,0 +1,25 @@
+issue: 1047
+title: "feat(menu): modificadores single-page form UX (crear + edit)"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1047-modificadores-single-page
+parent_epic: 1045
+
+paths:
+  - pages/menu/modificadores/crear.vue
+  - pages/menu/modificadores/[id].vue
+
+ac:
+  - crear.vue — no wizard; UiFormSection Datos del grupo + Opciones; sticky Resumen
+  - [id].vue — no edit wizard; same shell; validateForm + inline submitError
+  - Microcopy sentence-case; API payloads unchanged
+
+out_of_scope:
+  - modificadores/index.vue
+  - API changes
+
+hints:
+  pattern: "mirror recetas/crear + recetas/[id]"
+  tests: none

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full">
+  <div>
     <UiSubmitBusyOverlay
       :busy="isSubmitting"
       label="Actualizando grupo de modificadores..."
@@ -8,170 +8,29 @@
       indicator="matrix"
     />
 
-    <!-- Loading State -->
     <div v-if="isLoadingData" class="flex items-center justify-center min-h-[400px]">
       <CommonsTheCustomLoader size="large" />
     </div>
 
-    <!-- Main Content -->
-    <div v-else class="flex w-full flex-col">
-      <!-- Header Card -->
-      <div class="bg-surface border-2 border-border rounded-lg mb-4 sm:mb-6">
-        <div class="p-4 sm:p-6">
-          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
-            <!-- Group Name -->
-            <div class="flex items-center space-x-2 sm:space-x-3">
-              <div class="bg-background p-2 sm:p-3 rounded-lg border border-border flex-shrink-0">
-                <svg class="w-6 h-6 sm:w-8 sm:h-8 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
-                </svg>
-              </div>
-              <div class="space-y-1">
-                <p class="text-xs font-medium text-text-secondary uppercase tracking-wide">Editar Grupo</p>
-                <p class="text-lg font-semibold text-text-primary">{{ form.name || 'Sin nombre' }}</p>
-              </div>
-            </div>
-
-            <!-- Products -->
-            <div class="flex items-center space-x-2 sm:space-x-3">
-              <div class="bg-background p-2 sm:p-3 rounded-lg border border-border flex-shrink-0">
-                <svg class="w-6 h-6 sm:w-8 sm:h-8 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-                </svg>
-              </div>
-              <div class="space-y-1">
-                <p class="text-xs font-medium text-text-secondary uppercase tracking-wide">Productos</p>
-                <p class="text-sm sm:text-lg font-semibold text-text-primary">{{ getSelectedProductsText() }}</p>
-              </div>
-            </div>
-
-            <!-- Type Badge -->
-            <div class="flex items-center space-x-2 sm:space-x-3">
-              <div class="bg-background p-2 sm:p-3 rounded-lg border border-border flex-shrink-0">
-                <svg class="w-6 h-6 sm:w-8 sm:h-8 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-              </div>
-              <div class="space-y-1">
-                <p class="text-xs font-medium text-text-secondary uppercase tracking-wide">Tipo</p>
-                <div class="pt-1">
-                  <UiStatusBadge
-                    :value="form.is_required ? 'Obligatorio' : 'Opcional'"
-                    format="text"
-                    :variant="form.is_required ? 'warning' : 'secondary'"
-                    size="lg"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Progress Steps -->
-      <div class="bg-surface border-border border rounded-lg mb-4 sm:mb-6">
-        <div class="p-3 sm:p-6">
-          <div class="flex items-center justify-between">
-            <!-- Step 1 -->
-            <div class="flex items-center flex-1">
-              <div
-                class="flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full transition-colors border-2 flex-shrink-0"
-                :class="{
-                  'bg-primary text-primary-foreground border-primary': currentStep === 1,
-                  'bg-secondary text-secondary-foreground border-secondary': currentStep > 1,
-                  'border-border text-text-secondary bg-transparent': currentStep < 1
-                }"
-              >
-                <svg v-if="currentStep > 1" class="w-4 h-4 sm:w-6 sm:h-6" fill="currentColor" viewBox="0 0 20 20">
-                  <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
-                </svg>
-                <span v-else class="font-semibold text-sm sm:text-base">1</span>
-              </div>
-              <div class="ml-1 sm:ml-3 flex-1 min-w-0">
-                <p class="text-xs sm:text-sm font-medium truncate" :class="currentStep >= 1 ? 'text-text-primary' : 'text-text-secondary'">
-                  <span class="hidden sm:inline">Información del Grupo</span>
-                  <span class="sm:hidden">Info</span>
-                </p>
-                <p class="text-xs text-text-secondary hidden sm:block">Configuración básica</p>
-              </div>
-              <div class="flex-1 h-0.5 sm:h-1 mx-1 sm:mx-4" :class="currentStep > 1 ? 'bg-secondary' : 'bg-border'"></div>
-            </div>
-
-            <!-- Step 2 -->
-            <div class="flex items-center flex-1">
-              <div
-                class="flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full transition-colors border-2 flex-shrink-0"
-                :class="{
-                  'bg-primary text-primary-foreground border-primary': currentStep === 2,
-                  'bg-secondary text-secondary-foreground border-secondary': currentStep > 2,
-                  'border-border text-text-secondary bg-transparent': currentStep < 2
-                }"
-              >
-                <svg v-if="currentStep > 2" class="w-4 h-4 sm:w-6 sm:h-6" fill="currentColor" viewBox="0 0 20 20">
-                  <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
-                </svg>
-                <span v-else class="font-semibold text-sm sm:text-base">2</span>
-              </div>
-              <div class="ml-1 sm:ml-3 flex-1 min-w-0">
-                <p class="text-xs sm:text-sm font-medium truncate" :class="currentStep >= 2 ? 'text-text-primary' : 'text-text-secondary'">
-                  Modificadores
-                </p>
-                <p class="text-xs text-text-secondary hidden sm:block">Opciones disponibles</p>
-              </div>
-              <div class="flex-1 h-0.5 sm:h-1 mx-1 sm:mx-4" :class="currentStep > 2 ? 'bg-secondary' : 'bg-border'"></div>
-            </div>
-
-            <!-- Step 3 -->
-            <div class="flex items-center">
-              <div
-                class="flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full transition-colors border-2 flex-shrink-0"
-                :class="{
-                  'bg-primary text-primary-foreground border-primary': currentStep === 3,
-                  'bg-secondary text-secondary-foreground border-secondary': currentStep > 3,
-                  'border-border text-text-secondary bg-transparent': currentStep < 3
-                }"
-              >
-                <span class="font-semibold text-sm sm:text-base">3</span>
-              </div>
-              <div class="ml-1 sm:ml-3 min-w-0">
-                <p class="text-xs sm:text-sm font-medium truncate" :class="currentStep >= 3 ? 'text-text-primary' : 'text-text-secondary'">
-                  <span class="hidden sm:inline">Revisión</span>
-                  <span class="sm:hidden">Revisar</span>
-                </p>
-                <p class="text-xs text-text-secondary hidden sm:block">Verificar y actualizar</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Form Content -->
-      <form @submit.prevent="handleNext">
-        <!-- Step 1: Información del Grupo -->
-        <Transition name="fade" mode="out-in">
-        <div v-if="currentStep === 1" key="step-1" class="bg-surface border-border border rounded-lg">
-          <div class="p-4 sm:p-6">
-            <h3 class="text-base sm:text-lg font-semibold text-text-primary mb-4 sm:mb-6">Información del Grupo</h3>
-
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6">
-              <!-- Products Selection (Multi-select) -->
-              <div class="md:col-span-2">
-                <label class="block text-sm font-medium text-text-primary mb-2">
-                  Productos * <span class="text-text-secondary font-normal">(selecciona uno o más)</span>
+    <form v-else @submit.prevent="handleSubmit" class="grid grid-cols-1 xl:grid-cols-3 gap-6 xl:gap-8">
+      <div class="xl:col-span-2 space-y-6">
+        <div class="bg-surface border-2 border-border rounded-xl shadow-sm divide-y divide-border overflow-hidden">
+          <UiFormSection title="Datos del grupo">
+            <div class="space-y-4">
+              <div>
+                <label class="block text-sm font-medium text-text-primary mb-1">
+                  Productos * <span class="text-text-tertiary font-normal">(selecciona uno o más)</span>
                 </label>
-                <div class="border border-border rounded-lg p-3 max-h-60 overflow-y-auto bg-surface">
-                  <!-- Loading state -->
+                <div class="input-base max-h-60 overflow-y-auto p-3">
                   <div v-if="loadingProducts" class="flex items-center justify-center py-8">
-                    <div class="flex flex-col items-center gap-2">
-                      <div class="w-6 h-6 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>
-                      <span class="text-sm text-text-secondary">Cargando productos...</span>
+                    <div class="inline-flex items-center gap-2 text-text-secondary">
+                      <UiLoadingDots size="10px" />
+                      <span class="text-sm">Cargando productos...</span>
                     </div>
                   </div>
-                  <!-- Empty state -->
                   <div v-else-if="products.length === 0" class="text-center py-4 text-text-secondary text-sm">
                     No hay productos disponibles
                   </div>
-                  <!-- Products list -->
                   <div v-else class="space-y-2">
                     <label
                       v-for="product in products"
@@ -180,9 +39,9 @@
                       :class="{ 'bg-primary/5 border border-primary/20': form.product_ids.includes(product.id) }"
                     >
                       <input
+                        v-model="form.product_ids"
                         type="checkbox"
                         :value="product.id"
-                        v-model="form.product_ids"
                         class="w-4 h-4 text-primary border-border rounded focus:ring-primary"
                       />
                       <span class="text-sm text-text-primary">{{ product.name }}</span>
@@ -192,442 +51,310 @@
                     </label>
                   </div>
                 </div>
-                <p class="text-xs text-text-secondary mt-1">
+                <p class="text-xs text-text-tertiary mt-1">
                   {{ form.product_ids.length }} producto(s) seleccionado(s)
                 </p>
               </div>
 
-              <!-- Group Name -->
-              <div class="md:col-span-2">
-                <label class="block text-sm font-medium text-text-primary mb-2">
-                  Nombre del Grupo *
+              <div>
+                <label class="block text-sm font-medium text-text-primary mb-1">
+                  Nombre del grupo *
                 </label>
                 <input
-                  type="text"
                   v-model="form.name"
-                  placeholder="Ej: Extras, Tamaño, Sin..."
-                  class="w-full px-4 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-text-primary"
+                  type="text"
                   required
+                  class="input-base w-full px-4 py-2"
+                  placeholder="Ej. Extras, Tamaño, Sin..."
                 />
               </div>
 
-              <!-- Min Qty -->
-              <div>
-                <label class="block text-sm font-medium text-text-primary mb-2">
-                  Selección Mínima *
-                </label>
-                <input
-                  type="number"
-                  v-model.number="form.min_qty"
-                  placeholder="0"
-                  min="0"
-                  class="w-full px-4 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-text-primary"
-                  required
-                />
-                <p class="text-xs text-text-secondary mt-1">Cantidad mínima de opciones a seleccionar</p>
-              </div>
-
-              <!-- Max Qty -->
-              <div>
-                <label class="block text-sm font-medium text-text-primary mb-2">
-                  Selección Máxima *
-                </label>
-                <input
-                  type="number"
-                  v-model.number="form.max_qty"
-                  placeholder="1"
-                  min="1"
-                  class="w-full px-4 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-text-primary"
-                  required
-                />
-                <p class="text-xs text-text-secondary mt-1">Cantidad máxima de opciones a seleccionar</p>
-              </div>
-
-              <!-- Sort Order -->
-              <div>
-                <label class="block text-sm font-medium text-text-primary mb-2">
-                  Orden de Visualización
-                </label>
-                <input
-                  type="number"
-                  v-model.number="form.sort_order"
-                  placeholder="0"
-                  min="0"
-                  class="w-full px-4 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-text-primary"
-                />
-                <p class="text-xs text-text-secondary mt-1">Menor número aparece primero</p>
-              </div>
-
-              <!-- Is Required -->
-              <div class="flex items-start">
-                <div class="flex items-center h-full pt-8">
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <label class="block text-sm font-medium text-text-primary mb-1">
+                    Selección mínima *
+                  </label>
                   <input
-                    type="checkbox"
-                    v-model="form.is_required"
-                    id="is_required"
-                    class="w-5 h-5 text-primary border-border rounded focus:ring-primary"
+                    v-model.number="form.min_qty"
+                    type="number"
+                    required
+                    min="0"
+                    placeholder="0"
+                    class="input-base w-full px-4 py-2"
                   />
-                  <label for="is_required" class="ml-3">
-                    <span class="text-sm font-medium text-text-primary block">Es Obligatorio</span>
-                    <span class="text-xs text-text-secondary">El cliente debe seleccionar al menos una opción</span>
+                  <p class="text-xs text-text-tertiary mt-1">Cantidad mínima de opciones a seleccionar</p>
+                </div>
+
+                <div>
+                  <label class="block text-sm font-medium text-text-primary mb-1">
+                    Selección máxima *
                   </label>
+                  <input
+                    v-model.number="form.max_qty"
+                    type="number"
+                    required
+                    min="1"
+                    placeholder="1"
+                    class="input-base w-full px-4 py-2"
+                  />
+                  <p class="text-xs text-text-tertiary mt-1">Cantidad máxima de opciones a seleccionar</p>
+                </div>
+              </div>
+
+              <div>
+                <label class="block text-sm font-medium text-text-primary mb-1">
+                  Orden de visualización
+                </label>
+                <input
+                  v-model.number="form.sort_order"
+                  type="number"
+                  min="0"
+                  placeholder="0"
+                  class="input-base w-full px-4 py-2"
+                />
+                <p class="text-xs text-text-tertiary mt-1">Menor número aparece primero</p>
+              </div>
+
+              <div class="flex items-start gap-3">
+                <input
+                  v-model="form.is_required"
+                  type="checkbox"
+                  id="is_required"
+                  class="h-4 w-4 mt-0.5 text-primary focus:ring-primary border-border rounded"
+                />
+                <div>
+                  <label for="is_required" class="text-sm font-medium text-text-primary cursor-pointer">
+                    Es obligatorio
+                  </label>
+                  <p class="text-xs text-text-tertiary mt-0.5">
+                    El cliente debe seleccionar al menos una opción
+                  </p>
                 </div>
               </div>
             </div>
-          </div>
-        </div>
+          </UiFormSection>
 
-        <!-- Step 2: Modificadores -->
-        <div v-else-if="currentStep === 2" key="step-2" class="bg-surface border border-border rounded-lg">
-          <MenuCatalogInlineCreateBusyOverlay
-            :busy="inlineCatalogBusy"
-            :label="inlineCatalogBusyLabel"
-            :hint="inlineCatalogBusyHint"
-          >
-          <div class="p-4 sm:p-6">
-            <MenuIngredientProductHint class="mb-4" />
-            <div class="flex justify-between items-center mb-4 sm:mb-6">
-              <h3 class="text-base sm:text-lg font-semibold text-text-primary">Modificadores</h3>
-              <button
+          <UiFormSection title="Opciones">
+            <template #actions>
+              <UiButton
                 type="button"
+                variant="outline"
+                size="sm"
                 @click="addModifier"
-                class="btn-secondary px-3 sm:px-4 py-2 rounded-lg text-sm"
               >
-                + Agregar Modificador
-              </button>
-            </div>
+                + Agregar
+              </UiButton>
+            </template>
 
-            <!-- Empty State -->
-            <div v-if="form.modifiers.length === 0" class="text-center py-12 text-text-secondary">
-              <svg class="w-16 h-16 mx-auto mb-4 text-titan-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
-              </svg>
-              <p class="text-base font-medium mb-1">No hay modificadores agregados</p>
-              <p class="text-sm">Agrega opciones que los clientes puedan seleccionar</p>
-            </div>
+            <MenuCatalogInlineCreateBusyOverlay
+              :busy="inlineCatalogBusy"
+              :label="inlineCatalogBusyLabel"
+              :hint="inlineCatalogBusyHint"
+            >
+              <MenuIngredientProductHint class="mb-4" />
 
-            <!-- Modifiers List -->
-            <div class="space-y-4">
-              <div
-                v-for="(modifier, index) in form.modifiers"
-                :key="index"
-                class="border border-border rounded-lg p-4 bg-background"
-              >
-                <div class="grid grid-cols-1 md:grid-cols-12 gap-3 mb-3">
-                  <!-- Ingredient Selector -->
-                  <div class="md:col-span-4">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
-                    <UiIngredientSearchInput
-                      :initialValue="modifier.ingredient_name || ''"
-                      :allow-create="true"
-                      @select="(ing) => selectIngredient(modifier, ing)"
-                      @create="(name) => openCustomIngModal(name, index)"
-                    />
-                    <!-- Show ingredient cost for reference -->
-                    <p v-if="modifier.ingredient_id" class="text-xs text-text-secondary mt-1">
-                      Costo: {{ formatCurrency(getIngredientById(modifier.ingredient_id)?.costo_unitario || 0) }}/{{ getIngredientById(modifier.ingredient_id)?.unit }}
-                    </p>
-                  </div>
-
-                  <!-- Quantity -->
-                  <div class="md:col-span-1">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad</label>
-                    <input
-                      type="number"
-                      v-model.number="modifier.ingredient_quantity"
-                      placeholder="50"
-                      min="0.01"
-                      step="any"
-                      class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary"
-                    />
-                  </div>
-
-                  <!-- Unit -->
-                  <div class="md:col-span-2">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Unidad</label>
-                    <select
-                      v-model="modifier.ingredient_unit"
-                      class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary bg-surface"
-                    >
-                      <option
-                        v-for="opt in getIngredientUnitOptions(modifier.ingredient_id)"
-                        :key="opt.value"
-                        :value="opt.value"
-                      >{{ opt.label }}</option>
-                    </select>
-                    <span v-if="modifier.ingredient_id && loadingUnits.has(modifier.ingredient_id)" class="flex items-center gap-1 text-xs text-text-secondary mt-0.5">
-                      <svg class="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
-                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
-                      </svg>
-                      Cargando...
-                    </span>
-                  </div>
-
-                  <!-- Price -->
-                  <div class="md:col-span-2">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Precio Venta</label>
-                    <div class="relative">
-                      <span class="absolute left-3 top-1/2 transform -translate-y-1/2 text-text-secondary text-sm">$</span>
-                      <input
-                        type="number"
-                        v-model.number="modifier.price"
-                        placeholder="0"
-                        step="100"
-                        class="w-full pl-8 pr-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary"
-                      />
-                    </div>
-                  </div>
-
-                  <!-- Max Limit -->
-                  <div class="md:col-span-2">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Máx</label>
-                    <input
-                      type="number"
-                      v-model.number="modifier.max_limit"
-                      placeholder="1"
-                      min="1"
-                      class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary"
-                    />
-                  </div>
-
-                  <!-- Sort Order -->
-                  <div class="md:col-span-1">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Orden</label>
-                    <input
-                      type="number"
-                      v-model.number="modifier.sort_order"
-                      placeholder="0"
-                      min="0"
-                      class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary"
-                    />
-                  </div>
-
-                  <!-- Delete Button -->
-                  <div class="md:col-span-1 flex items-end">
-                    <button
-                      type="button"
-                      @click="removeModifier(index)"
-                      class="w-full md:w-auto px-3 py-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-                    >
-                      <svg class="w-5 h-5 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-
-                <!-- Checkboxes -->
-                <div class="flex flex-wrap gap-4 text-sm">
-                  <label class="flex items-center gap-2 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      v-model="modifier.is_default"
-                      class="w-4 h-4 text-primary border-border rounded focus:ring-primary"
-                    />
-                    <span class="text-text-primary">Predeterminado</span>
-                  </label>
-
-                  <label class="flex items-center gap-2 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      v-model="modifier.is_available"
-                      class="w-4 h-4 text-primary border-border rounded focus:ring-primary"
-                    />
-                    <span class="text-text-primary">Disponible</span>
-                  </label>
-                </div>
+              <div v-if="form.modifiers.length === 0" class="text-center py-10 text-text-secondary border border-dashed border-border rounded-lg">
+                <Icon name="heroicons:tag" class="h-12 w-12 mx-auto mb-3 text-text-tertiary/50" />
+                <p class="text-sm font-medium mb-0.5">Sin opciones en el grupo</p>
+                <p class="text-xs text-text-tertiary">Agrega modificadores que los clientes puedan seleccionar</p>
               </div>
-            </div>
-          </div>
-          </MenuCatalogInlineCreateBusyOverlay>
-        </div>
 
-        <!-- Step 3: Review -->
-        <div v-else-if="currentStep === 3" key="step-3" class="bg-surface border border-border rounded-lg">
-          <!-- Header -->
-          <div class="border-b border-border p-4 sm:p-6 md:p-8">
-            <div class="flex flex-col sm:flex-row justify-between items-start gap-4">
-              <div>
-                <h1 class="text-xl sm:text-2xl md:text-3xl font-bold text-text-primary mb-2">EDITAR GRUPO DE MODIFICADORES</h1>
-                <p class="text-xs sm:text-sm text-text-secondary">Resumen de los cambios a realizar</p>
-              </div>
-            </div>
-          </div>
-
-          <!-- Group Info -->
-          <div class="px-4 sm:px-6 md:px-8 py-4 sm:py-6 border-b border-border">
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6 md:gap-8">
-              <div>
-                <p class="text-xs font-semibold text-text-secondary uppercase tracking-wide mb-2">Grupo</p>
-                <p class="text-lg font-bold text-text-primary">{{ form.name }}</p>
-                <div class="mt-2">
-                  <p class="text-xs font-semibold text-text-secondary uppercase tracking-wide mb-1">Productos asociados:</p>
-                  <div class="flex flex-wrap gap-1">
-                    <span
-                      v-for="name in getSelectedProductNames()"
-                      :key="name"
-                      class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary"
-                    >
-                      {{ name }}
-                    </span>
-                  </div>
-                </div>
-              </div>
-              <div>
-                <p class="text-xs font-semibold text-text-secondary uppercase tracking-wide mb-2">Configuración</p>
-                <div class="space-y-1">
-                  <p class="text-sm text-text-primary">Selección: {{ form.min_qty }} - {{ form.max_qty }} opciones</p>
-                  <div class="flex gap-2 mt-3">
-                    <UiStatusBadge
-                      :value="form.is_required ? 'Obligatorio' : 'Opcional'"
-                      format="text"
-                      :variant="form.is_required ? 'warning' : 'secondary'"
-                      size="sm"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Modifiers Table -->
-          <div class="px-4 sm:px-6 md:px-8 py-4 sm:py-6">
-            <p class="text-xs font-semibold text-text-secondary uppercase tracking-wide mb-4">
-              Modificadores ({{ form.modifiers.length }})
-            </p>
-
-            <!-- Mobile: Cards View -->
-            <div class="md:hidden space-y-3">
-              <div
-                v-for="(modifier, index) in form.modifiers"
-                :key="index"
-                class="border border-border rounded-lg p-3 bg-background"
-              >
-                <div class="mb-2">
-                  <p class="font-medium text-text-primary text-sm">{{ modifier.name }}</p>
-                  <div class="flex gap-2 mt-2">
-                    <UiStatusBadge
-                      v-if="modifier.is_default"
-                      value="Predeterminado"
-                      format="text"
-                      variant="default"
-                      size="sm"
-                    />
-                    <UiStatusBadge
-                      :value="modifier.is_available ? 'Disponible' : 'No disponible'"
-                      format="text"
-                      :variant="modifier.is_available ? 'success' : 'destructive'"
-                      size="sm"
-                    />
-                  </div>
-                </div>
-                <div class="grid grid-cols-2 gap-3 mt-3 pt-3 border-t border-border">
-                  <div>
-                    <p class="text-xs text-text-secondary mb-1">Precio</p>
-                    <p class="text-sm text-text-primary font-semibold">
-                      {{ formatCurrency(modifier.price) }}
-                    </p>
-                  </div>
-                  <div>
-                    <p class="text-xs text-text-secondary mb-1">Máx cantidad</p>
-                    <p class="text-sm text-text-primary font-semibold">
-                      {{ modifier.max_limit }}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Desktop: Table View -->
-            <table class="w-full hidden md:table">
-              <thead>
-                <tr class="border-b border-border">
-                  <th class="text-left py-3 text-xs font-semibold text-text-secondary uppercase tracking-wide">
-                    Modificador
-                  </th>
-                  <th class="text-right py-3 text-xs font-semibold text-text-secondary uppercase tracking-wide">
-                    Precio
-                  </th>
-                  <th class="text-center py-3 text-xs font-semibold text-text-secondary uppercase tracking-wide">
-                    Máx
-                  </th>
-                  <th class="text-center py-3 text-xs font-semibold text-text-secondary uppercase tracking-wide">
-                    Estado
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr
+              <div v-else class="space-y-3">
+                <div
                   v-for="(modifier, index) in form.modifiers"
                   :key="index"
-                  class="border-b border-border"
+                  class="border border-border rounded-lg p-3 sm:p-4 bg-background"
                 >
-                  <td class="py-4">
-                    <div class="flex items-center gap-2">
-                      <p class="font-medium text-text-primary">{{ modifier.name }}</p>
-                      <UiStatusBadge
-                        v-if="modifier.is_default"
-                        value="Predeterminado"
-                        format="text"
-                        variant="default"
-                        size="sm"
+                  <div class="grid grid-cols-1 md:grid-cols-12 gap-3 mb-3">
+                    <div class="md:col-span-4">
+                      <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
+                      <UiIngredientSearchInput
+                        :initialValue="modifier.ingredient_name || ''"
+                        :allow-create="true"
+                        @select="(ing) => selectIngredient(modifier, ing)"
+                        @create="(name) => openCustomIngModal(name, index)"
+                      />
+                      <p v-if="modifier.ingredient_id" class="text-xs text-text-secondary mt-1">
+                        Costo: {{ formatCurrency(getIngredientById(modifier.ingredient_id)?.costo_unitario || 0) }}/{{ getIngredientById(modifier.ingredient_id)?.unit }}
+                      </p>
+                    </div>
+
+                    <div class="md:col-span-1">
+                      <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad</label>
+                      <input
+                        v-model.number="modifier.ingredient_quantity"
+                        type="number"
+                        min="0.01"
+                        step="any"
+                        placeholder="50"
+                        class="input-base w-full px-3 py-2 text-sm"
                       />
                     </div>
-                  </td>
-                  <td class="text-right py-4 text-text-primary font-semibold">
-                    {{ formatCurrency(modifier.price) }}
-                  </td>
-                  <td class="text-center py-4 text-text-primary">
-                    {{ modifier.max_limit }}
-                  </td>
-                  <td class="text-center py-4">
-                    <UiStatusBadge
-                      :value="modifier.is_available ? 'Disponible' : 'No disponible'"
-                      format="text"
-                      :variant="modifier.is_available ? 'success' : 'destructive'"
-                      size="sm"
-                    />
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+
+                    <div class="md:col-span-2">
+                      <label class="block text-xs font-medium text-text-secondary mb-1">Unidad</label>
+                      <div class="relative">
+                        <select
+                          v-model="modifier.ingredient_unit"
+                          :disabled="modifier.ingredient_id && loadingUnits.has(modifier.ingredient_id)"
+                          class="input-base w-full py-2 pr-3 text-sm disabled:opacity-50"
+                          :class="modifier.ingredient_id && loadingUnits.has(modifier.ingredient_id) ? 'pl-7' : 'pl-3'"
+                        >
+                          <option
+                            v-for="opt in getIngredientUnitOptions(modifier.ingredient_id)"
+                            :key="opt.value"
+                            :value="opt.value"
+                          >{{ opt.label }}</option>
+                        </select>
+                        <span v-if="modifier.ingredient_id && loadingUnits.has(modifier.ingredient_id)" class="absolute left-2 top-2.5 pointer-events-none text-text-secondary">
+                          <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
+                          </svg>
+                        </span>
+                      </div>
+                    </div>
+
+                    <div class="md:col-span-2">
+                      <label class="block text-xs font-medium text-text-secondary mb-1">Precio venta</label>
+                      <div class="relative">
+                        <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary text-sm">$</span>
+                        <input
+                          v-model.number="modifier.price"
+                          type="number"
+                          step="100"
+                          placeholder="0"
+                          class="input-base w-full pl-8 pr-3 py-2 text-sm"
+                        />
+                      </div>
+                    </div>
+
+                    <div class="md:col-span-1">
+                      <label class="block text-xs font-medium text-text-secondary mb-1">Máx</label>
+                      <input
+                        v-model.number="modifier.max_limit"
+                        type="number"
+                        min="1"
+                        placeholder="1"
+                        class="input-base w-full px-3 py-2 text-sm"
+                      />
+                    </div>
+
+                    <div class="md:col-span-1">
+                      <label class="block text-xs font-medium text-text-secondary mb-1">Orden</label>
+                      <input
+                        v-model.number="modifier.sort_order"
+                        type="number"
+                        min="0"
+                        placeholder="0"
+                        class="input-base w-full px-3 py-2 text-sm"
+                      />
+                    </div>
+
+                    <div class="md:col-span-1">
+                      <label class="block text-xs font-medium text-text-secondary mb-1 invisible select-none" aria-hidden="true">&nbsp;</label>
+                      <button
+                        type="button"
+                        @click="removeModifier(index)"
+                        class="flex items-center justify-center w-full h-[38px] text-destructive hover:bg-destructive/5 rounded-lg transition-colors"
+                        title="Eliminar opción"
+                      >
+                        <Icon name="heroicons:trash" class="h-5 w-5" />
+                      </button>
+                    </div>
+                  </div>
+
+                  <div class="flex flex-wrap gap-4 text-sm">
+                    <label class="flex items-center gap-2 cursor-pointer">
+                      <input
+                        v-model="modifier.is_default"
+                        type="checkbox"
+                        class="w-4 h-4 text-primary border-border rounded focus:ring-primary"
+                      />
+                      <span class="text-text-primary">Predeterminado</span>
+                    </label>
+
+                    <label class="flex items-center gap-2 cursor-pointer">
+                      <input
+                        v-model="modifier.is_available"
+                        type="checkbox"
+                        class="w-4 h-4 text-primary border-border rounded focus:ring-primary"
+                      />
+                      <span class="text-text-primary">Disponible</span>
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </MenuCatalogInlineCreateBusyOverlay>
+          </UiFormSection>
+        </div>
+      </div>
+
+      <div class="xl:col-span-1 space-y-6">
+        <div class="bg-surface border-2 border-border rounded-xl p-6 shadow-sm sticky top-6">
+          <h3 class="text-lg font-semibold text-text-primary mb-4">Resumen</h3>
+
+          <div class="space-y-3">
+            <div class="flex justify-between text-sm gap-2">
+              <span class="text-text-secondary">Grupo:</span>
+              <span class="font-semibold text-text-primary text-right truncate">{{ form.name || '—' }}</span>
+            </div>
+
+            <div class="flex justify-between text-sm">
+              <span class="text-text-secondary">Productos:</span>
+              <span class="font-semibold text-text-primary">{{ getSelectedProductsText() }}</span>
+            </div>
+
+            <div class="flex justify-between text-sm">
+              <span class="text-text-secondary">Opciones:</span>
+              <span class="font-semibold text-text-primary">{{ form.modifiers.length }}</span>
+            </div>
+
+            <div class="flex justify-between text-sm">
+              <span class="text-text-secondary">Selección:</span>
+              <span class="font-semibold text-text-primary">{{ form.min_qty }} – {{ form.max_qty }}</span>
+            </div>
+
+            <div class="flex justify-between text-sm items-center gap-2">
+              <span class="text-text-secondary">Tipo:</span>
+              <UiStatusBadge
+                :value="form.is_required ? 'Obligatorio' : 'Opcional'"
+                format="text"
+                :variant="form.is_required ? 'warning' : 'secondary'"
+                size="sm"
+              />
+            </div>
+          </div>
+
+          <div class="mt-6 pt-6 border-t border-border space-y-3">
+            <p v-if="submitError" role="alert" class="text-sm text-destructive">{{ submitError }}</p>
+
+            <UiButton
+              type="submit"
+              variant="default"
+              size="lg"
+              class="w-full"
+              :disabled="isSubmitting"
+            >
+              <Icon v-if="!isSubmitting" name="heroicons:check" class="h-5 w-5 mr-2" />
+              <Icon v-else name="heroicons:arrow-path" class="h-5 w-5 mr-2 animate-spin" />
+              {{ isSubmitting ? 'Guardando...' : 'Guardar grupo' }}
+            </UiButton>
+
+            <UiButton
+              type="button"
+              variant="outline"
+              size="default"
+              class="w-full"
+              :disabled="isSubmitting"
+              @click="cancel"
+            >
+              Cancelar
+            </UiButton>
           </div>
         </div>
-        </Transition>
-
-        <!-- Navigation Buttons -->
-        <div class="flex justify-between mt-4 sm:mt-6 gap-3">
-          <button
-            v-if="currentStep > 1"
-            type="button"
-            @click="previousStep"
-            class="btn-secondary px-4 sm:px-6 py-2 sm:py-3 rounded-lg font-medium"
-          >
-            ← Anterior
-          </button>
-          <div v-else></div>
-
-          <button
-            v-if="currentStep < 3"
-            type="submit"
-            :disabled="!canProceed"
-            class="btn-primary px-4 sm:px-6 py-2 sm:py-3 rounded-lg font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Siguiente →
-          </button>
-          <button
-            v-else
-            type="button"
-            @click="submitGroup"
-            :disabled="isSubmitting"
-            class="btn-primary px-4 sm:px-6 py-2 sm:py-3 rounded-lg font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Actualizar Grupo
-          </button>
-        </div>
-      </form>
-    </div>
+      </div>
+    </form>
 
     <MenuInlineCatalogCreateShell
       ref="inlineCreateShell"
@@ -659,11 +386,9 @@ const toast = useToast()
 const cache = useQueryCache()
 const { currentTenant } = useTenantReactive()
 
-// State
-const currentStep = ref(1)
 const isSubmitting = ref(false)
+const submitError = ref('')
 
-// Form data
 const form = ref({
   product_ids: [] as string[],
   name: '',
@@ -686,7 +411,6 @@ const form = ref({
   tenant_id: currentTenant.value?.id || ''
 })
 
-// Fetch existing modifier group
 const groupId = route.params.id as string
 
 const { data: groupData, pending: isLoadingGroup, refresh: refreshGroup } = useAsyncData(
@@ -697,7 +421,6 @@ const { data: groupData, pending: isLoadingGroup, refresh: refreshGroup } = useA
   }
 )
 
-// Fetch products
 const { data: productsData, pending: loadingProducts } = useAsyncData(
   `products-${currentTenant.value?.id || 'default'}`,
   () => $fetch('/api/menu/products', {
@@ -712,7 +435,6 @@ const { data: productsData, pending: loadingProducts } = useAsyncData(
 
 const { availableIngredients } = useMenuIngredientsQuery()
 
-// Ingredient cache and purchase units
 const ingredientCache = ref<Record<string, any>>({})
 const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 const loadingUnits = ref<Set<string>>(new Set())
@@ -805,24 +527,12 @@ async function onInlineProductCreated(product: Record<string, unknown>) {
   })
 }
 
-// Computed
 const products = computed(() => productsData.value?.data || [])
 
 const isLoadingData = computed(() => {
   return isLoadingGroup.value || !productsData.value
 })
 
-const canProceed = computed(() => {
-  if (currentStep.value === 1) {
-    return form.value.product_ids.length > 0 && form.value.name && form.value.max_qty >= form.value.min_qty
-  }
-  if (currentStep.value === 2) {
-    return form.value.modifiers.length > 0 && form.value.modifiers.every(m => m.name)
-  }
-  return true
-})
-
-// Load existing data into form
 watch(groupData, (data) => {
   if (data?.data) {
     const group = data.data
@@ -867,22 +577,17 @@ watch(availableIngredients, (list) => {
   }
 })
 
-// Methods
 function getProductName(productId: string) {
   const product = products.value.find((p: any) => p.id === productId)
   return product?.name || ''
 }
 
 function getSelectedProductsText() {
-  if (form.value.product_ids.length === 0) return 'Seleccionar'
+  if (form.value.product_ids.length === 0) return 'Ninguno'
   if (form.value.product_ids.length === 1) {
     return getProductName(form.value.product_ids[0])
   }
   return `${form.value.product_ids.length} productos`
-}
-
-function getSelectedProductNames() {
-  return form.value.product_ids.map(id => getProductName(id)).filter(Boolean)
 }
 
 function addModifier() {
@@ -904,22 +609,44 @@ function removeModifier(index: number) {
   form.value.modifiers.splice(index, 1)
 }
 
-function handleNext() {
-  if (canProceed.value && currentStep.value < 3) {
-    currentStep.value++
+function validateForm(): boolean {
+  submitError.value = ''
+
+  if (form.value.product_ids.length === 0) {
+    submitError.value = 'Selecciona al menos un producto.'
+    return false
   }
+
+  if (!form.value.name.trim()) {
+    submitError.value = 'El nombre del grupo es obligatorio.'
+    return false
+  }
+
+  if (form.value.max_qty < form.value.min_qty) {
+    submitError.value = 'La selección máxima debe ser mayor o igual a la mínima.'
+    return false
+  }
+
+  if (form.value.modifiers.length === 0) {
+    submitError.value = 'Agrega al menos una opción al grupo.'
+    return false
+  }
+
+  const missingIngredient = form.value.modifiers.some(m => !m.ingredient_id)
+  if (missingIngredient) {
+    submitError.value = 'Todas las opciones deben tener un ingrediente o reventa.'
+    return false
+  }
+
+  return true
 }
 
-function previousStep() {
-  if (currentStep.value > 1) {
-    currentStep.value--
-  }
-}
-
-async function submitGroup() {
+async function handleSubmit() {
   if (isSubmitting.value) return
+  if (!validateForm()) return
 
   isSubmitting.value = true
+  submitError.value = ''
 
   try {
     form.value.tenant_id = currentTenant.value?.id || ''
@@ -934,10 +661,14 @@ async function submitGroup() {
     toast.success('Grupo de modificadores actualizado correctamente', { title: 'Guardado' })
   } catch (error: any) {
     console.error('Error updating modifier group:', error)
-    alert(`Error al actualizar el grupo: ${error.message || 'Por favor intenta de nuevo.'}`)
+    submitError.value = error.data?.detail || error.message || 'Error al actualizar. Intenta de nuevo.'
   } finally {
     isSubmitting.value = false
   }
+}
+
+function cancel() {
+  router.push('/menu/modificadores')
 }
 
 function formatCurrency(value: number) {
@@ -951,13 +682,7 @@ function formatCurrency(value: number) {
 </script>
 
 <style scoped>
-.fade-enter-active,
-.fade-leave-active {
-  transition: opacity 0.2s ease;
-}
-
-.fade-enter-from,
-.fade-leave-to {
-  opacity: 0;
+.input-base {
+  @apply border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-text-primary bg-surface;
 }
 </style>

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full">
+  <div>
     <UiSubmitBusyOverlay
       :busy="isSubmitting"
       label="Creando grupo de modificadores..."
@@ -8,667 +8,374 @@
       indicator="matrix"
     />
 
-    <!-- Loading State -->
     <div v-if="isLoadingData" class="flex items-center justify-center min-h-[400px]">
-      <div class="inline-flex items-center gap-2 text-text-secondary">
-        <UiLoadingDots size="12px" />
-        <span class="text-sm">Cargando datos...</span>
-      </div>
+      <CommonsTheCustomLoader size="large" />
     </div>
 
-    <!-- Main Content -->
-    <div v-else class="flex w-full flex-col">
-      <!-- Header Card -->
-      <div class="bg-surface border-2 border-border rounded-lg mb-4 sm:mb-6">
-        <div class="p-4 sm:p-6">
-          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
-            <!-- Group Name -->
-            <div class="flex items-center space-x-2 sm:space-x-3">
-              <div class="bg-background p-2 sm:p-3 rounded-lg border border-border flex-shrink-0">
-                <svg class="w-6 h-6 sm:w-8 sm:h-8 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
-                </svg>
-              </div>
-              <div class="space-y-1">
-                <p class="text-xs font-medium text-text-secondary uppercase tracking-wide">Nuevo Grupo</p>
-                <p class="text-lg font-semibold text-text-primary">{{ form.name || 'Sin nombre' }}</p>
-              </div>
-            </div>
-
-            <!-- Products -->
-            <div class="flex items-center space-x-2 sm:space-x-3">
-              <div class="bg-background p-2 sm:p-3 rounded-lg border border-border flex-shrink-0">
-                <svg class="w-6 h-6 sm:w-8 sm:h-8 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-                </svg>
-              </div>
-              <div class="space-y-1">
-                <p class="text-xs font-medium text-text-secondary uppercase tracking-wide">Productos</p>
-                <p class="text-sm sm:text-lg font-semibold text-text-primary">{{ getSelectedProductsText() }}</p>
-              </div>
-            </div>
-
-            <!-- Type Badge -->
-            <div class="flex items-center space-x-2 sm:space-x-3">
-              <div class="bg-background p-2 sm:p-3 rounded-lg border border-border flex-shrink-0">
-                <svg class="w-6 h-6 sm:w-8 sm:h-8 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-              </div>
-              <div class="space-y-1">
-                <p class="text-xs font-medium text-text-secondary uppercase tracking-wide">Tipo</p>
-                <div class="pt-1">
-                  <UiStatusBadge
-                    :value="form.is_required ? 'Obligatorio' : 'Opcional'"
-                    format="text"
-                    :variant="form.is_required ? 'warning' : 'secondary'"
-                    size="lg"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Progress Steps -->
-      <div class="bg-surface border-border border rounded-lg mb-4 sm:mb-6">
-        <div class="p-3 sm:p-6">
-          <div class="flex items-center justify-between">
-            <!-- Step 1 -->
-            <div class="flex items-center flex-1">
-              <div
-                class="flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full transition-colors border-2 flex-shrink-0"
-                :class="{
-                  'bg-primary text-primary-foreground border-primary': currentStep === 1,
-                  'bg-secondary text-secondary-foreground border-secondary': currentStep > 1,
-                  'border-border text-text-secondary bg-transparent': currentStep < 1
-                }"
-              >
-                <svg v-if="currentStep > 1" class="w-4 h-4 sm:w-6 sm:h-6" fill="currentColor" viewBox="0 0 20 20">
-                  <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
-                </svg>
-                <span v-else class="font-semibold text-sm sm:text-base">1</span>
-              </div>
-              <div class="ml-1 sm:ml-3 flex-1 min-w-0">
-                <p class="text-xs sm:text-sm font-medium truncate" :class="currentStep >= 1 ? 'text-text-primary' : 'text-text-secondary'">
-                  <span class="hidden sm:inline">Información del Grupo</span>
-                  <span class="sm:hidden">Info</span>
-                </p>
-                <p class="text-xs text-text-secondary hidden sm:block">Configuración básica</p>
-              </div>
-              <div class="flex-1 h-0.5 sm:h-1 mx-1 sm:mx-4" :class="currentStep > 1 ? 'bg-secondary' : 'bg-border'"></div>
-            </div>
-
-            <!-- Step 2 -->
-            <div class="flex items-center flex-1">
-              <div
-                class="flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full transition-colors border-2 flex-shrink-0"
-                :class="{
-                  'bg-primary text-primary-foreground border-primary': currentStep === 2,
-                  'bg-secondary text-secondary-foreground border-secondary': currentStep > 2,
-                  'border-border text-text-secondary bg-transparent': currentStep < 2
-                }"
-              >
-                <svg v-if="currentStep > 2" class="w-4 h-4 sm:w-6 sm:h-6" fill="currentColor" viewBox="0 0 20 20">
-                  <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
-                </svg>
-                <span v-else class="font-semibold text-sm sm:text-base">2</span>
-              </div>
-              <div class="ml-1 sm:ml-3 flex-1 min-w-0">
-                <p class="text-xs sm:text-sm font-medium truncate" :class="currentStep >= 2 ? 'text-text-primary' : 'text-text-secondary'">
-                  Modificadores
-                </p>
-                <p class="text-xs text-text-secondary hidden sm:block">Opciones disponibles</p>
-              </div>
-              <div class="flex-1 h-0.5 sm:h-1 mx-1 sm:mx-4" :class="currentStep > 2 ? 'bg-secondary' : 'bg-border'"></div>
-            </div>
-
-            <!-- Step 3 -->
-            <div class="flex items-center">
-              <div
-                class="flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full transition-colors border-2 flex-shrink-0"
-                :class="{
-                  'bg-primary text-primary-foreground border-primary': currentStep === 3,
-                  'bg-secondary text-secondary-foreground border-secondary': currentStep > 3,
-                  'border-border text-text-secondary bg-transparent': currentStep < 3
-                }"
-              >
-                <span class="font-semibold text-sm sm:text-base">3</span>
-              </div>
-              <div class="ml-1 sm:ml-3 min-w-0">
-                <p class="text-xs sm:text-sm font-medium truncate" :class="currentStep >= 3 ? 'text-text-primary' : 'text-text-secondary'">
-                  <span class="hidden sm:inline">Revisión</span>
-                  <span class="sm:hidden">Revisar</span>
-                </p>
-                <p class="text-xs text-text-secondary hidden sm:block">Verificar y crear</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Form Content -->
-      <form @submit.prevent="handleNext">
-        <!-- Step 1: Información del Grupo -->
-        <Transition name="fade" mode="out-in">
-        <div v-if="currentStep === 1" key="step-1" class="bg-surface border-border border rounded-lg">
-          <div class="p-4 sm:p-6">
-            <h3 class="text-base sm:text-lg font-semibold text-text-primary mb-4 sm:mb-6">Información del Grupo</h3>
-
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6">
-              <!-- Products Selection (Multi-select) -->
-              <div class="md:col-span-2">
-                <label class="block text-sm font-medium text-text-primary mb-2">
-                  Productos * <span class="text-text-secondary font-normal">(selecciona uno o más)</span>
-                </label>
-                <div class="border border-border rounded-lg p-3 max-h-60 overflow-y-auto bg-surface">
-                  <!-- Loading state -->
-                  <div v-if="loadingProducts" class="flex items-center justify-center py-8">
-                    <div class="inline-flex items-center gap-2 text-text-secondary">
-                      <UiLoadingDots size="10px" />
-                      <span class="text-sm">Cargando productos...</span>
+    <div v-else class="space-y-6">
+      <form @submit.prevent="submitGroup" class="grid grid-cols-1 xl:grid-cols-3 gap-6 xl:gap-8">
+        <div class="xl:col-span-2 space-y-6">
+          <div class="bg-surface border-2 border-border rounded-xl shadow-sm divide-y divide-border overflow-hidden">
+            <UiFormSection title="Datos del grupo">
+              <div class="space-y-4">
+                <div>
+                  <label class="block text-sm font-medium text-text-primary mb-1">
+                    Productos *
+                  </label>
+                  <div class="border border-border rounded-lg p-3 max-h-60 overflow-y-auto bg-surface">
+                    <div v-if="loadingProducts" class="flex items-center justify-center py-8">
+                      <div class="inline-flex items-center gap-2 text-text-secondary">
+                        <UiLoadingDots size="10px" />
+                        <span class="text-sm">Cargando productos...</span>
+                      </div>
+                    </div>
+                    <div v-else-if="products.length === 0" class="text-center py-4 text-text-secondary text-sm">
+                      No hay productos disponibles
+                    </div>
+                    <div v-else class="space-y-2">
+                      <label
+                        v-for="product in products"
+                        :key="product.id"
+                        class="flex items-center gap-3 p-2 rounded-lg hover:bg-surface-secondary cursor-pointer transition-colors"
+                        :class="{ 'bg-primary/5 border border-primary/20': form.product_ids.includes(product.id) }"
+                      >
+                        <input
+                          type="checkbox"
+                          :value="product.id"
+                          v-model="form.product_ids"
+                          class="w-4 h-4 text-primary border-border rounded focus:ring-primary"
+                        />
+                        <span class="text-sm text-text-primary">{{ product.name }}</span>
+                        <span v-if="product.category?.name" class="text-xs text-text-secondary ml-auto">
+                          {{ product.category.name }}
+                        </span>
+                      </label>
                     </div>
                   </div>
-                  <!-- Empty state -->
-                  <div v-else-if="products.length === 0" class="text-center py-4 text-text-secondary text-sm">
-                    No hay productos disponibles
-                  </div>
-                  <!-- Products list -->
-                  <div v-else class="space-y-2">
-                    <label
-                      v-for="product in products"
-                      :key="product.id"
-                      class="flex items-center gap-3 p-2 rounded-lg hover:bg-surface-secondary cursor-pointer transition-colors"
-                      :class="{ 'bg-primary/5 border border-primary/20': form.product_ids.includes(product.id) }"
-                    >
-                      <input
-                        type="checkbox"
-                        :value="product.id"
-                        v-model="form.product_ids"
-                        class="w-4 h-4 text-primary border-border rounded focus:ring-primary"
-                      />
-                      <span class="text-sm text-text-primary">{{ product.name }}</span>
-                      <span v-if="product.category?.name" class="text-xs text-text-secondary ml-auto">
-                        {{ product.category.name }}
-                      </span>
+                  <p class="text-xs text-text-tertiary mt-1">
+                    {{ form.product_ids.length }} producto(s) seleccionado(s)
+                  </p>
+                </div>
+
+                <div>
+                  <label class="block text-sm font-medium text-text-primary mb-1">
+                    Nombre *
+                  </label>
+                  <input
+                    type="text"
+                    v-model="form.name"
+                    placeholder="Ej. extras, tamaño, sin..."
+                    class="input-base w-full px-4 py-2"
+                    :class="nameError ? 'border-destructive focus:ring-destructive' : ''"
+                    required
+                    @input="nameError = ''"
+                  />
+                  <p v-if="nameError" role="alert" class="text-xs text-destructive mt-1 flex items-center gap-1">
+                    <svg class="w-3.5 h-3.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+                    {{ nameError }}
+                  </p>
+                </div>
+
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <div>
+                    <label class="block text-sm font-medium text-text-primary mb-1">
+                      Selección mínima *
                     </label>
+                    <input
+                      type="number"
+                      v-model.number="form.min_qty"
+                      placeholder="0"
+                      min="0"
+                      class="input-base w-full px-4 py-2"
+                      required
+                    />
+                    <p class="text-xs text-text-tertiary mt-1">Mínimo de opciones a elegir</p>
+                  </div>
+
+                  <div>
+                    <label class="block text-sm font-medium text-text-primary mb-1">
+                      Selección máxima *
+                    </label>
+                    <input
+                      type="number"
+                      v-model.number="form.max_qty"
+                      placeholder="1"
+                      min="1"
+                      class="input-base w-full px-4 py-2"
+                      required
+                    />
+                    <p class="text-xs text-text-tertiary mt-1">Máximo de opciones a elegir</p>
                   </div>
                 </div>
-                <p class="text-xs text-text-secondary mt-1">
-                  {{ form.product_ids.length }} producto(s) seleccionado(s)
-                </p>
-              </div>
 
-              <!-- Group Name -->
-              <div class="md:col-span-2">
-                <label class="block text-sm font-medium text-text-primary mb-2">
-                  Nombre del Grupo *
-                </label>
-                <input
-                  type="text"
-                  v-model="form.name"
-                  placeholder="Ej: Extras, Tamaño, Sin..."
-                  class="w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-text-primary"
-                  :class="nameError ? 'border-destructive focus:ring-destructive' : 'border-border'"
-                  required
-                  @input="nameError = ''"
-                />
-                <p v-if="nameError" role="alert" class="text-xs text-destructive mt-1 flex items-center gap-1">
-                  <svg class="w-3.5 h-3.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
-                  {{ nameError }}
-                </p>
-              </div>
+                <div>
+                  <label class="block text-sm font-medium text-text-primary mb-1">
+                    Orden de visualización <span class="text-text-tertiary font-normal">(opcional)</span>
+                  </label>
+                  <input
+                    type="number"
+                    v-model.number="form.sort_order"
+                    placeholder="0"
+                    min="0"
+                    class="input-base w-full px-4 py-2"
+                  />
+                  <p class="text-xs text-text-tertiary mt-1">Menor número aparece primero</p>
+                </div>
 
-              <!-- Min Qty -->
-              <div>
-                <label class="block text-sm font-medium text-text-primary mb-2">
-                  Selección Mínima *
-                </label>
-                <input
-                  type="number"
-                  v-model.number="form.min_qty"
-                  placeholder="0"
-                  min="0"
-                  class="w-full px-4 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-text-primary"
-                  required
-                />
-                <p class="text-xs text-text-secondary mt-1">Cantidad mínima de opciones a seleccionar</p>
-              </div>
-
-              <!-- Max Qty -->
-              <div>
-                <label class="block text-sm font-medium text-text-primary mb-2">
-                  Selección Máxima *
-                </label>
-                <input
-                  type="number"
-                  v-model.number="form.max_qty"
-                  placeholder="1"
-                  min="1"
-                  class="w-full px-4 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-text-primary"
-                  required
-                />
-                <p class="text-xs text-text-secondary mt-1">Cantidad máxima de opciones a seleccionar</p>
-              </div>
-
-              <!-- Sort Order -->
-              <div>
-                <label class="block text-sm font-medium text-text-primary mb-2">
-                  Orden de Visualización
-                </label>
-                <input
-                  type="number"
-                  v-model.number="form.sort_order"
-                  placeholder="0"
-                  min="0"
-                  class="w-full px-4 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-text-primary"
-                />
-                <p class="text-xs text-text-secondary mt-1">Menor número aparece primero</p>
-              </div>
-
-              <!-- Is Required -->
-              <div class="flex items-start">
-                <div class="flex items-center h-full pt-8">
+                <div class="flex items-start gap-3">
                   <input
                     type="checkbox"
                     v-model="form.is_required"
                     id="is_required"
-                    class="w-5 h-5 text-primary border-border rounded focus:ring-primary"
+                    class="h-4 w-4 mt-0.5 text-primary focus:ring-primary border-border rounded"
                   />
-                  <label for="is_required" class="ml-3">
-                    <span class="text-sm font-medium text-text-primary block">Es Obligatorio</span>
-                    <span class="text-xs text-text-secondary">El cliente debe seleccionar al menos una opción</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Step 2: Modificadores -->
-        <div v-else-if="currentStep === 2" key="step-2" class="bg-surface border border-border rounded-lg">
-          <MenuCatalogInlineCreateBusyOverlay
-            :busy="inlineCatalogBusy"
-            :label="inlineCatalogBusyLabel"
-            :hint="inlineCatalogBusyHint"
-          >
-          <div class="p-4 sm:p-6">
-            <MenuIngredientProductHint class="mb-4" />
-            <div class="flex justify-between items-center mb-4 sm:mb-6">
-              <h3 class="text-base sm:text-lg font-semibold text-text-primary">Modificadores</h3>
-              <button
-                type="button"
-                @click="addModifier"
-                class="btn-secondary px-3 sm:px-4 py-2 rounded-lg text-sm"
-              >
-                + Agregar Modificador
-              </button>
-            </div>
-
-            <!-- Empty State -->
-            <div v-if="form.modifiers.length === 0" class="text-center py-12 text-text-secondary">
-              <svg class="w-16 h-16 mx-auto mb-4 text-titan-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
-              </svg>
-              <p class="text-base font-medium mb-1">No hay modificadores agregados</p>
-              <p class="text-sm">Agrega opciones que los clientes puedan seleccionar</p>
-            </div>
-
-            <!-- Modifiers List -->
-            <div class="space-y-4">
-              <div
-                v-for="(modifier, index) in form.modifiers"
-                :key="index"
-                class="border border-border rounded-lg p-4 bg-background"
-              >
-                <div class="grid grid-cols-1 md:grid-cols-12 gap-3 mb-3">
-                  <!-- Ingredient Selector -->
-                  <div class="md:col-span-4">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
-                    <UiIngredientSearchInput
-                      :allow-create="true"
-                      @select="(ing) => selectIngredient(modifier, ing)"
-                      @create="(name) => openCustomIngModal(name, index)"
-                    />
-                    <!-- Show ingredient cost for reference -->
-                    <p v-if="modifier.ingredient_id" class="text-xs text-text-secondary mt-1">
-                      Costo: {{ formatCurrency(getIngredientById(modifier.ingredient_id)?.costo_unitario || 0) }}/{{ getIngredientById(modifier.ingredient_id)?.unit }}
+                  <div>
+                    <label for="is_required" class="text-sm font-medium text-text-primary cursor-pointer">
+                      Obligatorio
+                    </label>
+                    <p class="text-xs text-text-tertiary mt-0.5">
+                      El cliente debe seleccionar al menos una opción
                     </p>
                   </div>
-
-                  <!-- Quantity -->
-                  <div class="md:col-span-1">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad</label>
-                    <input
-                      type="number"
-                      v-model.number="modifier.ingredient_quantity"
-                      placeholder="50"
-                      min="0.01"
-                      step="any"
-                      class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary"
-                    />
-                  </div>
-
-                  <!-- Unit -->
-                  <div class="md:col-span-2">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Unidad</label>
-                    <select
-                      v-model="modifier.ingredient_unit"
-                      class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary bg-surface"
-                    >
-                      <option
-                        v-for="opt in getIngredientUnitOptions(modifier.ingredient_id)"
-                        :key="opt.value"
-                        :value="opt.value"
-                      >{{ opt.label }}</option>
-                    </select>
-                    <span v-if="modifier.ingredient_id && loadingUnits.has(modifier.ingredient_id)" class="flex items-center gap-1 text-xs text-text-secondary mt-0.5">
-                      <svg class="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
-                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
-                      </svg>
-                      Cargando...
-                    </span>
-                  </div>
-
-                  <!-- Price -->
-                  <div class="md:col-span-2">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Precio Venta</label>
-                    <div class="relative">
-                      <span class="absolute left-3 top-1/2 transform -translate-y-1/2 text-text-secondary text-sm">$</span>
-                      <input
-                        type="number"
-                        v-model.number="modifier.price"
-                        placeholder="0"
-                        step="100"
-                        class="w-full pl-8 pr-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary"
-                      />
-                    </div>
-                  </div>
-
-                  <!-- Max Limit -->
-                  <div class="md:col-span-1">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Máx</label>
-                    <input
-                      type="number"
-                      v-model.number="modifier.max_limit"
-                      placeholder="1"
-                      min="1"
-                      class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary"
-                    />
-                  </div>
-
-                  <!-- Sort Order -->
-                  <div class="md:col-span-1">
-                    <label class="block text-xs font-medium text-text-secondary mb-1">Orden</label>
-                    <input
-                      type="number"
-                      v-model.number="modifier.sort_order"
-                      placeholder="0"
-                      min="0"
-                      class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary"
-                    />
-                  </div>
-
-                  <!-- Delete Button -->
-                  <div class="md:col-span-1 flex items-end">
-                    <button
-                      type="button"
-                      @click="removeModifier(index)"
-                      class="w-full md:w-auto px-3 py-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-                    >
-                      <svg class="w-5 h-5 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-
-                <!-- Checkboxes -->
-                <div class="flex flex-wrap gap-4 text-sm">
-                  <label class="flex items-center gap-2 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      v-model="modifier.is_default"
-                      class="w-4 h-4 text-primary border-border rounded focus:ring-primary"
-                    />
-                    <span class="text-text-primary">Predeterminado</span>
-                  </label>
-
-                  <label class="flex items-center gap-2 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      v-model="modifier.is_available"
-                      class="w-4 h-4 text-primary border-border rounded focus:ring-primary"
-                    />
-                    <span class="text-text-primary">Disponible</span>
-                  </label>
                 </div>
               </div>
-            </div>
-          </div>
-          </MenuCatalogInlineCreateBusyOverlay>
-        </div>
+            </UiFormSection>
 
-        <!-- Step 3: Review -->
-        <div v-else-if="currentStep === 3" key="step-3">
-          <!-- Header compacto -->
-          <div class="bg-surface border border-border rounded-lg px-4 sm:px-6 py-3 mb-3 flex items-center justify-between">
-            <div>
-              <p class="text-xs text-text-secondary uppercase tracking-wide font-semibold">Nuevo Grupo · Resumen</p>
-              <p class="text-base font-bold text-text-primary">{{ form.name }}</p>
-            </div>
-            <p class="text-xs text-text-secondary">{{ new Date().toLocaleDateString('es-CO', { day:'2-digit', month:'short', year:'numeric' }) }}</p>
-          </div>
+            <UiFormSection title="Opciones">
+              <template #actions>
+                <button
+                  type="button"
+                  @click="addModifier"
+                  class="btn-secondary px-3 py-1.5 rounded-lg text-sm"
+                >
+                  + Agregar
+                </button>
+              </template>
 
-          <!-- Layout dos columnas -->
-          <div class="flex flex-col lg:flex-row gap-4 items-start">
+              <MenuCatalogInlineCreateBusyOverlay
+                :busy="inlineCatalogBusy"
+                :label="inlineCatalogBusyLabel"
+                :hint="inlineCatalogBusyHint"
+              >
+                <MenuIngredientProductHint class="mb-4" />
 
-            <!-- Columna izquierda: modificadores -->
-            <div class="w-full lg:flex-1 space-y-4">
-              <div class="bg-surface border border-border rounded-lg p-4">
-                <p class="text-xs font-semibold text-text-secondary uppercase tracking-wide mb-3">
-                  Modificadores ({{ form.modifiers.length }})
-                </p>
+                <div v-if="form.modifiers.length === 0" class="text-center py-10 text-text-secondary border border-dashed border-border rounded-lg">
+                  <svg class="w-12 h-12 mx-auto mb-3 text-text-tertiary/50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+                  </svg>
+                  <p class="text-sm font-medium mb-0.5">Sin opciones agregadas</p>
+                  <p class="text-xs text-text-tertiary">Agrega modificadores que el cliente pueda elegir</p>
+                </div>
 
-                <!-- Mobile: Cards View -->
-                <div class="md:hidden space-y-3">
+                <div v-else class="space-y-3">
                   <div
                     v-for="(modifier, index) in form.modifiers"
                     :key="index"
-                    class="border border-border rounded-lg p-3 bg-background"
+                    class="border border-border rounded-lg p-3 sm:p-4 bg-background"
                   >
-                    <div class="mb-2">
-                      <p class="font-medium text-text-primary text-sm">{{ modifier.name }}</p>
-                      <p v-if="modifier.ingredient_quantity" class="text-xs text-text-secondary">
-                        {{ modifier.ingredient_quantity }} {{ modifier.ingredient_unit }}
-                      </p>
-                      <div class="flex gap-2 mt-2">
-                        <UiStatusBadge
-                          v-if="modifier.is_default"
-                          value="Predeterminado"
-                          format="text"
-                          variant="default"
-                          size="sm"
+                    <div class="grid grid-cols-1 md:grid-cols-12 gap-3 mb-3">
+                      <div class="md:col-span-4">
+                        <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
+                        <UiIngredientSearchInput
+                          :allow-create="true"
+                          @select="(ing) => selectIngredient(modifier, ing)"
+                          @create="(name) => openCustomIngModal(name, index)"
                         />
-                        <UiStatusBadge
-                          :value="modifier.is_available ? 'Disponible' : 'No disponible'"
-                          format="text"
-                          :variant="modifier.is_available ? 'success' : 'destructive'"
-                          size="sm"
-                        />
+                        <p v-if="modifier.ingredient_id" class="text-xs text-text-secondary mt-1">
+                          Costo: {{ formatCurrency(getIngredientById(modifier.ingredient_id)?.costo_unitario || 0) }}/{{ getIngredientById(modifier.ingredient_id)?.unit }}
+                        </p>
                       </div>
-                    </div>
-                    <div class="grid grid-cols-2 gap-3 mt-3 pt-3 border-t border-border">
-                      <div>
-                        <p class="text-xs text-text-secondary mb-1">Precio</p>
-                        <p class="text-sm text-text-primary font-semibold">{{ formatCurrency(modifier.price) }}</p>
-                      </div>
-                      <div>
-                        <p class="text-xs text-text-secondary mb-1">Máx cantidad</p>
-                        <p class="text-sm text-text-primary font-semibold">{{ modifier.max_limit }}</p>
-                      </div>
-                    </div>
-                  </div>
-                </div>
 
-                <!-- Desktop: Table View -->
-                <table class="w-full hidden md:table">
-                  <thead>
-                    <tr class="border-b border-border">
-                      <th class="text-left py-3 text-xs font-semibold text-text-secondary uppercase tracking-wide">Modificador</th>
-                      <th class="text-center py-3 text-xs font-semibold text-text-secondary uppercase tracking-wide">Cantidad</th>
-                      <th class="text-right py-3 text-xs font-semibold text-text-secondary uppercase tracking-wide">Precio</th>
-                      <th class="text-center py-3 text-xs font-semibold text-text-secondary uppercase tracking-wide">Máx</th>
-                      <th class="text-center py-3 text-xs font-semibold text-text-secondary uppercase tracking-wide">Estado</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr
-                      v-for="(modifier, index) in form.modifiers"
-                      :key="index"
-                      class="border-b border-border"
-                    >
-                      <td class="py-4">
-                        <div class="flex items-center gap-2">
-                          <p class="font-medium text-text-primary">{{ modifier.name }}</p>
-                          <UiStatusBadge
-                            v-if="modifier.is_default"
-                            value="Predeterminado"
-                            format="text"
-                            variant="default"
-                            size="sm"
+                      <div class="md:col-span-1">
+                        <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad</label>
+                        <input
+                          type="number"
+                          v-model.number="modifier.ingredient_quantity"
+                          placeholder="50"
+                          min="0.01"
+                          step="any"
+                          class="input-base w-full px-3 py-2 text-sm"
+                        />
+                      </div>
+
+                      <div class="md:col-span-2">
+                        <label class="block text-xs font-medium text-text-secondary mb-1">Unidad</label>
+                        <div class="relative">
+                          <select
+                            v-model="modifier.ingredient_unit"
+                            :disabled="modifier.ingredient_id && loadingUnits.has(modifier.ingredient_id)"
+                            class="input-base w-full py-2 pr-3 text-sm disabled:opacity-50"
+                            :class="modifier.ingredient_id && loadingUnits.has(modifier.ingredient_id) ? 'pl-7' : 'pl-3'"
+                          >
+                            <option
+                              v-for="opt in getIngredientUnitOptions(modifier.ingredient_id)"
+                              :key="opt.value"
+                              :value="opt.value"
+                            >{{ opt.label }}</option>
+                          </select>
+                          <span v-if="modifier.ingredient_id && loadingUnits.has(modifier.ingredient_id)" class="absolute left-2 top-2.5 pointer-events-none text-text-secondary">
+                            <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+                              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
+                            </svg>
+                          </span>
+                        </div>
+                      </div>
+
+                      <div class="md:col-span-2">
+                        <label class="block text-xs font-medium text-text-secondary mb-1">Precio venta</label>
+                        <div class="relative">
+                          <span class="absolute left-3 top-1/2 transform -translate-y-1/2 text-text-secondary text-sm">$</span>
+                          <input
+                            type="number"
+                            v-model.number="modifier.price"
+                            placeholder="0"
+                            step="100"
+                            class="input-base w-full pl-8 pr-3 py-2 text-sm"
                           />
                         </div>
-                      </td>
-                      <td class="text-center py-4 text-text-primary">
-                        <span v-if="modifier.ingredient_quantity">{{ modifier.ingredient_quantity }} {{ modifier.ingredient_unit }}</span>
-                        <span v-else class="text-text-secondary">-</span>
-                      </td>
-                      <td class="text-right py-4 text-text-primary font-semibold">{{ formatCurrency(modifier.price) }}</td>
-                      <td class="text-center py-4 text-text-primary">{{ modifier.max_limit }}</td>
-                      <td class="text-center py-4">
-                        <UiStatusBadge
-                          :value="modifier.is_available ? 'Disponible' : 'No disponible'"
-                          format="text"
-                          :variant="modifier.is_available ? 'success' : 'destructive'"
-                          size="sm"
+                      </div>
+
+                      <div class="md:col-span-1">
+                        <label class="block text-xs font-medium text-text-secondary mb-1">Máx</label>
+                        <input
+                          type="number"
+                          v-model.number="modifier.max_limit"
+                          placeholder="1"
+                          min="1"
+                          class="input-base w-full px-3 py-2 text-sm"
                         />
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-            </div>
+                      </div>
 
-            <!-- Columna derecha: configuración del grupo -->
-            <div class="w-full lg:w-72 xl:w-80 space-y-4 lg:sticky lg:top-4">
+                      <div class="md:col-span-1">
+                        <label class="block text-xs font-medium text-text-secondary mb-1">Orden</label>
+                        <input
+                          type="number"
+                          v-model.number="modifier.sort_order"
+                          placeholder="0"
+                          min="0"
+                          class="input-base w-full px-3 py-2 text-sm"
+                        />
+                      </div>
 
-              <!-- Grupo -->
-              <div class="bg-surface border border-border rounded-lg p-4">
-                <p class="text-xs font-semibold text-text-secondary uppercase tracking-wide mb-3">Grupo</p>
-                <div class="space-y-2">
-                  <div class="flex justify-between items-center">
-                    <span class="text-sm text-text-secondary">Tipo</span>
-                    <UiStatusBadge
-                      :value="form.is_required ? 'Obligatorio' : 'Opcional'"
-                      format="text"
-                      :variant="form.is_required ? 'warning' : 'secondary'"
-                      size="sm"
-                    />
-                  </div>
-                  <div class="flex justify-between items-center">
-                    <span class="text-sm text-text-secondary">Selección</span>
-                    <span class="text-sm font-semibold text-text-primary">{{ form.min_qty }} – {{ form.max_qty }} opciones</span>
+                      <div class="md:col-span-1">
+                        <label class="block text-xs font-medium text-text-secondary mb-1 invisible select-none" aria-hidden="true">&nbsp;</label>
+                        <button
+                          type="button"
+                          @click="removeModifier(index)"
+                          class="flex items-center justify-center w-full h-[38px] text-destructive hover:bg-destructive/5 rounded-lg transition-colors"
+                          title="Eliminar opción"
+                        >
+                          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+
+                    <div class="flex flex-wrap gap-4 text-sm">
+                      <label class="flex items-center gap-2 cursor-pointer">
+                        <input
+                          type="checkbox"
+                          v-model="modifier.is_default"
+                          class="w-4 h-4 text-primary border-border rounded focus:ring-primary"
+                        />
+                        <span class="text-text-primary">Predeterminado</span>
+                      </label>
+
+                      <label class="flex items-center gap-2 cursor-pointer">
+                        <input
+                          type="checkbox"
+                          v-model="modifier.is_available"
+                          class="w-4 h-4 text-primary border-border rounded focus:ring-primary"
+                        />
+                        <span class="text-text-primary">Disponible</span>
+                      </label>
+                    </div>
                   </div>
                 </div>
-                <div class="mt-3 pt-3 border-t border-border">
-                  <p class="text-xs text-text-secondary mb-2">Productos asociados</p>
-                  <div class="flex flex-wrap gap-1">
-                    <span
-                      v-for="name in getSelectedProductNames()"
-                      :key="name"
-                      class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary"
-                    >
-                      {{ name }}
-                    </span>
-                  </div>
-                </div>
-              </div>
-
-              <!-- Resumen -->
-              <div class="bg-surface border border-border rounded-lg p-4">
-                <p class="text-xs font-semibold text-text-secondary uppercase tracking-wide mb-3">Resumen</p>
-                <div class="space-y-2">
-                  <div class="flex justify-between items-center">
-                    <span class="text-sm text-text-secondary">Total modificadores</span>
-                    <span class="text-sm font-bold text-text-primary">{{ form.modifiers.length }}</span>
-                  </div>
-                  <div class="flex justify-between items-center">
-                    <span class="text-sm text-text-secondary">Con ingrediente</span>
-                    <span class="text-sm font-semibold text-text-primary">{{ form.modifiers.filter(m => m.ingredient_id).length }}</span>
-                  </div>
-                  <div class="flex justify-between items-center">
-                    <span class="text-sm text-text-secondary">Con costo adicional</span>
-                    <span class="text-sm font-semibold text-text-primary">{{ form.modifiers.filter(m => m.price > 0).length }}</span>
-                  </div>
-                </div>
-              </div>
-            </div>
+              </MenuCatalogInlineCreateBusyOverlay>
+            </UiFormSection>
           </div>
         </div>
-        </Transition>
-      </form>
 
-      <!-- Navigation Buttons -->
-      <div class="bg-surface border-t border-border shadow-lg mt-6">
-        <div class="px-4 sm:px-6 md:px-8 py-3 sm:py-4">
-          <div class="flex justify-between items-center gap-3">
-            <button
-              v-if="currentStep > 1"
-              type="button"
-              @click="previousStep"
-              class="btn-secondary px-4 sm:px-6 py-2 rounded-lg text-sm sm:text-base"
-            >
-              <span class="hidden sm:inline">← Anterior</span>
-              <span class="sm:hidden">←</span>
-            </button>
-            <NuxtLink
-              v-else
-              to="/menu/modificadores"
-              class="btn-secondary px-4 sm:px-6 py-2 rounded-lg text-sm sm:text-base"
-            >
-              Cancelar
-            </NuxtLink>
+        <div class="xl:col-span-1 space-y-6">
+          <div class="bg-surface border-2 border-border rounded-xl p-6 shadow-sm sticky top-6">
+            <h3 class="text-lg font-semibold text-text-primary mb-4">Resumen</h3>
 
-            <button
-              v-if="currentStep < 3"
-              type="button"
-              @click="handleNext"
-              :disabled="!canProceed"
-              class="btn-primary px-4 sm:px-6 py-2 rounded-lg transition-opacity text-sm sm:text-base"
-              :class="{ 'opacity-50 cursor-not-allowed': !canProceed }"
-            >
-              <span class="hidden sm:inline">Siguiente →</span>
-              <span class="sm:hidden">→</span>
-            </button>
-            <div v-else class="flex flex-col items-end gap-2">
-              <p v-if="submitError" role="alert" class="text-sm text-destructive">{{ submitError }}</p>
-              <button
-                type="button"
-                @click="submitGroup"
+            <div class="space-y-3">
+              <div class="flex justify-between text-sm gap-2">
+                <span class="text-text-secondary">Nombre:</span>
+                <span class="font-semibold text-text-primary text-right truncate">{{ form.name || '—' }}</span>
+              </div>
+
+              <div class="flex justify-between text-sm items-center gap-2">
+                <span class="text-text-secondary">Tipo:</span>
+                <UiStatusBadge
+                  :value="form.is_required ? 'Obligatorio' : 'Opcional'"
+                  format="text"
+                  :variant="form.is_required ? 'warning' : 'secondary'"
+                  size="sm"
+                />
+              </div>
+
+              <div class="flex justify-between text-sm">
+                <span class="text-text-secondary">Selección:</span>
+                <span class="font-semibold text-text-primary">{{ form.min_qty }} – {{ form.max_qty }} opciones</span>
+              </div>
+
+              <div class="flex justify-between text-sm">
+                <span class="text-text-secondary">Productos:</span>
+                <span class="font-semibold text-text-primary">{{ form.product_ids.length }}</span>
+              </div>
+
+              <div class="flex justify-between text-sm">
+                <span class="text-text-secondary">Total opciones:</span>
+                <span class="font-semibold text-text-primary">{{ form.modifiers.length }}</span>
+              </div>
+
+              <div class="flex justify-between text-sm">
+                <span class="text-text-secondary">Con ingrediente:</span>
+                <span class="font-semibold text-text-primary">{{ form.modifiers.filter(m => m.ingredient_id).length }}</span>
+              </div>
+
+              <div class="flex justify-between text-sm">
+                <span class="text-text-secondary">Con costo adicional:</span>
+                <span class="font-semibold text-text-primary">{{ form.modifiers.filter(m => m.price > 0).length }}</span>
+              </div>
+            </div>
+
+            <div class="mt-6 pt-6 border-t border-border space-y-3">
+              <p v-if="submitError" role="alert" class="text-sm text-destructive flex items-center gap-1">
+                <svg class="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
+                {{ submitError }}
+              </p>
+              <UiButton
+                type="submit"
+                variant="default"
+                size="lg"
+                class="w-full"
                 :disabled="isSubmitting"
-                class="btn-primary px-4 sm:px-6 py-2 rounded-lg transition-opacity text-sm sm:text-base"
-                :class="{ 'opacity-50 cursor-not-allowed': isSubmitting }"
               >
-                <span class="hidden sm:inline">{{ isSubmitting ? 'Creando...' : 'Crear Grupo' }}</span>
-                <span class="sm:hidden">{{ isSubmitting ? '...' : 'Crear' }}</span>
-              </button>
+                <Icon v-if="!isSubmitting" name="heroicons:check" class="h-5 w-5 mr-2" />
+                <Icon v-else name="heroicons:arrow-path" class="h-5 w-5 mr-2 animate-spin" />
+                {{ isSubmitting ? 'Creando...' : 'Crear grupo' }}
+              </UiButton>
+
+              <UiButton
+                type="button"
+                variant="outline"
+                size="default"
+                class="w-full"
+                :disabled="isSubmitting"
+                @click="router.push('/menu/modificadores')"
+              >
+                Cancelar
+              </UiButton>
             </div>
           </div>
         </div>
-      </div>
+      </form>
     </div>
 
     <MenuInlineCatalogCreateShell
@@ -696,13 +403,10 @@ useHead({ title: 'Crear Modificador' })
 const router = useRouter()
 const { currentTenant } = useTenantReactive()
 
-// State
-const currentStep = ref(1)
 const isSubmitting = ref(false)
 const submitError = ref<string | null>(null)
 const nameError = ref('')
 
-// Form data
 const form = ref({
   product_ids: [] as string[],
   name: '',
@@ -724,7 +428,6 @@ const form = ref({
   tenant_id: currentTenant.value?.id || ''
 })
 
-// Fetch products
 const { data: productsData, pending: loadingProducts } = useAsyncData(
   `products-${currentTenant.value?.id || 'default'}`,
   () => $fetch('/api/menu/products', {
@@ -737,40 +440,11 @@ const { data: productsData, pending: loadingProducts } = useAsyncData(
   }
 )
 
-// Computed
 const products = computed(() => productsData.value?.data || [])
 
 const isLoadingData = computed(() => {
   return !productsData.value
 })
-
-const canProceed = computed(() => {
-  if (currentStep.value === 1) {
-    return form.value.product_ids.length > 0 && form.value.name && form.value.max_qty >= form.value.min_qty
-  }
-  if (currentStep.value === 2) {
-    return form.value.modifiers.length > 0 && form.value.modifiers.every(m => m.ingredient_id && m.name)
-  }
-  return true
-})
-
-// Methods
-function getProductName(productId: string) {
-  const product = products.value.find((p: any) => p.id === productId)
-  return product?.name || ''
-}
-
-function getSelectedProductsText() {
-  if (form.value.product_ids.length === 0) return 'Seleccionar'
-  if (form.value.product_ids.length === 1) {
-    return getProductName(form.value.product_ids[0])
-  }
-  return `${form.value.product_ids.length} productos`
-}
-
-function getSelectedProductNames() {
-  return form.value.product_ids.map(id => getProductName(id)).filter(Boolean)
-}
 
 function addModifier() {
   form.value.modifiers.push({
@@ -786,7 +460,6 @@ function addModifier() {
   })
 }
 
-// Ingredient cache and purchase units
 const ingredientCache = ref<Record<string, any>>({})
 const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 const loadingUnits = ref<Set<string>>(new Set())
@@ -864,26 +537,50 @@ function removeModifier(index: number) {
   form.value.modifiers.splice(index, 1)
 }
 
-async function handleNext() {
-  if (!canProceed.value || currentStep.value >= 3) return
-  if (currentStep.value === 1) {
-    const res = await $fetch<{ available: boolean }>(`/api/menu/check-name?entity=modifier-groups&name=${encodeURIComponent(form.value.name.trim())}`)
-    if (!res.available) {
-      nameError.value = 'Ya existe un grupo de modificadores con ese nombre.'
-      return
-    }
-  }
-  currentStep.value++
-}
+async function validateForm(): Promise<boolean> {
+  submitError.value = null
+  nameError.value = ''
 
-function previousStep() {
-  if (currentStep.value > 1) {
-    currentStep.value--
+  if (form.value.product_ids.length === 0) {
+    submitError.value = 'Selecciona al menos un producto.'
+    return false
   }
+
+  if (!form.value.name.trim()) {
+    nameError.value = 'El nombre es obligatorio.'
+    return false
+  }
+
+  if (form.value.max_qty < form.value.min_qty) {
+    submitError.value = 'La selección máxima debe ser mayor o igual a la mínima.'
+    return false
+  }
+
+  const res = await $fetch<{ available: boolean }>(
+    `/api/menu/check-name?entity=modifier-groups&name=${encodeURIComponent(form.value.name.trim())}`,
+  )
+  if (!res.available) {
+    nameError.value = 'Ya existe un grupo de modificadores con ese nombre.'
+    return false
+  }
+
+  if (form.value.modifiers.length === 0) {
+    submitError.value = 'Agrega al menos un modificador al grupo.'
+    return false
+  }
+
+  const invalidModifiers = form.value.modifiers.some(m => !m.ingredient_id || !m.name)
+  if (invalidModifiers) {
+    submitError.value = 'Completa todos los modificadores con ingrediente o reventa.'
+    return false
+  }
+
+  return true
 }
 
 async function submitGroup() {
   if (isSubmitting.value) return
+  if (!(await validateForm())) return
 
   isSubmitting.value = true
   submitError.value = null
@@ -917,13 +614,7 @@ function formatCurrency(value: number) {
 </script>
 
 <style scoped>
-.fade-enter-active,
-.fade-leave-active {
-  transition: opacity 0.2s ease;
-}
-
-.fade-enter-from,
-.fade-leave-to {
-  opacity: 0;
+.input-base {
+  @apply border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-text-primary bg-surface;
 }
 </style>


### PR DESCRIPTION
## Summary

- Remove 3-step wizards on `/menu/modificadores/crear` and `/menu/modificadores/[id]`
- Single-screen layout: **Datos del grupo** + **Opciones** sections with sticky **Resumen** sidebar
- Inline `validateForm()` on submit; edit page uses `submitError` instead of `alert()`

Part of epic #1045 · Closes #1047

## Test plan

- [ ] `/menu/modificadores/crear` — create group with products + 2 options; no wizard steps
- [ ] `/menu/modificadores/[id]` — edit existing group; save without step navigation
- [ ] Inline ingredient/product create still works from option rows

## wr-context

See `.wr/1047.yaml` on this branch.

Made with [Cursor](https://cursor.com)