### PR TITLE
feat(menu): searchable product multi-select for modifier groups

### DIFF
--- a/.wr/1052.yaml
+++ b/.wr/1052.yaml
@@ -1,0 +1,25 @@
+issue: 1052
+title: "feat(menu): searchable product multi-select for modifier groups"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1052-product-multi-select
+
+paths:
+  - components/ui/ProductMultiSelect.vue
+  - pages/menu/modificadores/crear.vue
+  - pages/menu/modificadores/[id].vue
+
+ac:
+  - UiProductMultiSelect — search + chips + bulk modal (>15)
+  - modificadores crear/edit — no checkbox scroll list; no limit 250 prefetch
+  - Edit hydrates chips from group.products
+  - validateForm unchanged semantics
+
+out_of_scope:
+  - PromocionPanel refactor to use ProductMultiSelect
+
+hints:
+  reuse: "UiProductSearchInput, PromocionesPromotionScopePickerModal, formatScopeLabel"
+  tests: none

--- a/components/ui/ProductMultiSelect.vue
+++ b/components/ui/ProductMultiSelect.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="space-y-2">
+    <UiProductSearchInput
+      :input-id="inputId"
+      :placeholder="placeholder"
+      :include-all-types="includeAllTypes"
+      :exclude-ids="modelValue.map((p) => p.id)"
+      @select="onSelect"
+    />
+
+    <ul v-if="showChips" class="flex flex-wrap gap-2" role="list">
+      <li
+        v-for="product in modelValue"
+        :key="product.id"
+        class="text-xs bg-primary/10 text-primary px-2 py-1 rounded-full flex items-center gap-1"
+      >
+        <span class="max-w-[14rem] truncate">{{ product.name }}</span>
+        <button
+          type="button"
+          class="hover:opacity-70 min-h-[24px] min-w-[24px] flex items-center justify-center"
+          :aria-label="`Quitar ${product.name}`"
+          @click="removeProduct(product.id)"
+        >
+          ×
+        </button>
+      </li>
+    </ul>
+
+    <div v-else-if="showBulkSummary" class="flex flex-wrap items-center gap-2">
+      <p class="text-sm text-text-secondary">{{ summaryText }}</p>
+      <button
+        type="button"
+        class="text-sm text-primary font-medium min-h-[44px] px-1"
+        @click="pickerOpen = true"
+      >
+        Ver / editar lista
+      </button>
+    </div>
+
+    <p class="text-xs text-text-tertiary">
+      <template v-if="modelValue.length === 0">
+        Busca y agrega productos uno a uno
+      </template>
+      <template v-else>
+        {{ modelValue.length }} producto(s) seleccionado(s)
+      </template>
+    </p>
+
+    <PromocionesPromotionScopePickerModal
+      v-model="pickerOpen"
+      :products="modelValue"
+      @remove="removeProduct"
+      @clear-all="clearAll"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ProductRow } from '~/composables/useProductSearch'
+import { formatScopeLabel } from '~/utils/promotionPreview'
+
+export interface ProductSelection {
+  id: string
+  name: string
+}
+
+const CHIP_THRESHOLD = 15
+
+const props = withDefaults(defineProps<{
+  modelValue: ProductSelection[]
+  inputId?: string
+  placeholder?: string
+  includeAllTypes?: boolean
+  chipThreshold?: number
+}>(), {
+  inputId: 'product-multi-select',
+  placeholder: 'Buscar producto…',
+  includeAllTypes: true,
+  chipThreshold: CHIP_THRESHOLD,
+})
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: ProductSelection[]): void
+}>()
+
+const pickerOpen = ref(false)
+
+const showChips = computed(
+  () => props.modelValue.length > 0 && props.modelValue.length <= props.chipThreshold,
+)
+const showBulkSummary = computed(() => props.modelValue.length > props.chipThreshold)
+
+const summaryText = computed(() =>
+  formatScopeLabel(
+    'products',
+    [],
+    props.modelValue.map((p) => p.name),
+    { productCount: props.modelValue.length, countOnlyThreshold: props.chipThreshold },
+  ),
+)
+
+function onSelect(product: ProductRow) {
+  if (props.modelValue.some((p) => p.id === product.id)) return
+  emit('update:modelValue', [...props.modelValue, { id: product.id, name: product.name }])
+}
+
+function removeProduct(id: string) {
+  emit('update:modelValue', props.modelValue.filter((p) => p.id !== id))
+}
+
+function clearAll() {
+  emit('update:modelValue', [])
+  pickerOpen.value = false
+}
+</script>

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -18,42 +18,13 @@
           <UiFormSection title="Datos del grupo">
             <div class="space-y-4">
               <div>
-                <label class="block text-sm font-medium text-text-primary mb-1">
-                  Productos * <span class="text-text-tertiary font-normal">(selecciona uno o más)</span>
+                <label :for="productSearchInputId" class="block text-sm font-medium text-text-primary mb-1">
+                  Productos *
                 </label>
-                <div class="input-base max-h-60 overflow-y-auto p-3">
-                  <div v-if="loadingProducts" class="flex items-center justify-center py-8">
-                    <div class="inline-flex items-center gap-2 text-text-secondary">
-                      <UiLoadingDots size="10px" />
-                      <span class="text-sm">Cargando productos...</span>
-                    </div>
-                  </div>
-                  <div v-else-if="products.length === 0" class="text-center py-4 text-text-secondary text-sm">
-                    No hay productos disponibles
-                  </div>
-                  <div v-else class="space-y-2">
-                    <label
-                      v-for="product in products"
-                      :key="product.id"
-                      class="flex items-center gap-3 p-2 rounded-lg hover:bg-surface-secondary cursor-pointer transition-colors"
-                      :class="{ 'bg-primary/5 border border-primary/20': form.product_ids.includes(product.id) }"
-                    >
-                      <input
-                        v-model="form.product_ids"
-                        type="checkbox"
-                        :value="product.id"
-                        class="w-4 h-4 text-primary border-border rounded focus:ring-primary"
-                      />
-                      <span class="text-sm text-text-primary">{{ product.name }}</span>
-                      <span v-if="product.category?.name" class="text-xs text-text-secondary ml-auto">
-                        {{ product.category.name }}
-                      </span>
-                    </label>
-                  </div>
-                </div>
-                <p class="text-xs text-text-tertiary mt-1">
-                  {{ form.product_ids.length }} producto(s) seleccionado(s)
-                </p>
+                <UiProductMultiSelect
+                  v-model="selectedProducts"
+                  :input-id="productSearchInputId"
+                />
               </div>
 
               <div>
@@ -388,6 +359,8 @@ const { currentTenant } = useTenantReactive()
 
 const isSubmitting = ref(false)
 const submitError = ref('')
+const productSearchInputId = 'modifier-edit-product-search'
+const selectedProducts = ref<{ id: string; name: string }[]>([])
 
 const form = ref({
   product_ids: [] as string[],
@@ -418,18 +391,6 @@ const { data: groupData, pending: isLoadingGroup, refresh: refreshGroup } = useA
   () => $fetch(`/api/menu/modifier-groups/${groupId}`),
   {
     server: false
-  }
-)
-
-const { data: productsData, pending: loadingProducts } = useAsyncData(
-  `products-${currentTenant.value?.id || 'default'}`,
-  () => $fetch('/api/menu/products', {
-    query: { limit: 250 }
-  }),
-  {
-    server: false,
-    watch: [currentTenant],
-    default: () => ({ data: [] })
   }
 )
 
@@ -527,11 +488,11 @@ async function onInlineProductCreated(product: Record<string, unknown>) {
   })
 }
 
-const products = computed(() => productsData.value?.data || [])
+const isLoadingData = computed(() => isLoadingGroup.value)
 
-const isLoadingData = computed(() => {
-  return isLoadingGroup.value || !productsData.value
-})
+watch(selectedProducts, (list) => {
+  form.value.product_ids = list.map((p) => p.id)
+}, { deep: true })
 
 watch(groupData, (data) => {
   if (data?.data) {
@@ -568,6 +529,10 @@ watch(groupData, (data) => {
       }),
       tenant_id: currentTenant.value?.id || ''
     }
+    selectedProducts.value = (group.products || []).map((p: any) => ({
+      id: p.id,
+      name: p.name,
+    }))
   }
 }, { immediate: true })
 
@@ -577,17 +542,12 @@ watch(availableIngredients, (list) => {
   }
 })
 
-function getProductName(productId: string) {
-  const product = products.value.find((p: any) => p.id === productId)
-  return product?.name || ''
-}
-
 function getSelectedProductsText() {
-  if (form.value.product_ids.length === 0) return 'Ninguno'
-  if (form.value.product_ids.length === 1) {
-    return getProductName(form.value.product_ids[0])
+  if (selectedProducts.value.length === 0) return 'Ninguno'
+  if (selectedProducts.value.length === 1) {
+    return selectedProducts.value[0].name
   }
-  return `${form.value.product_ids.length} productos`
+  return `${selectedProducts.value.length} productos`
 }
 
 function addModifier() {
@@ -612,7 +572,7 @@ function removeModifier(index: number) {
 function validateForm(): boolean {
   submitError.value = ''
 
-  if (form.value.product_ids.length === 0) {
+  if (selectedProducts.value.length === 0) {
     submitError.value = 'Selecciona al menos un producto.'
     return false
   }

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -8,53 +8,20 @@
       indicator="matrix"
     />
 
-    <div v-if="isLoadingData" class="flex items-center justify-center min-h-[400px]">
-      <CommonsTheCustomLoader size="large" />
-    </div>
-
-    <div v-else class="space-y-6">
+    <div class="space-y-6">
       <form @submit.prevent="submitGroup" class="grid grid-cols-1 xl:grid-cols-3 gap-6 xl:gap-8">
         <div class="xl:col-span-2 space-y-6">
           <div class="bg-surface border-2 border-border rounded-xl shadow-sm divide-y divide-border overflow-hidden">
             <UiFormSection title="Datos del grupo">
               <div class="space-y-4">
                 <div>
-                  <label class="block text-sm font-medium text-text-primary mb-1">
+                  <label :for="productSearchInputId" class="block text-sm font-medium text-text-primary mb-1">
                     Productos *
                   </label>
-                  <div class="border border-border rounded-lg p-3 max-h-60 overflow-y-auto bg-surface">
-                    <div v-if="loadingProducts" class="flex items-center justify-center py-8">
-                      <div class="inline-flex items-center gap-2 text-text-secondary">
-                        <UiLoadingDots size="10px" />
-                        <span class="text-sm">Cargando productos...</span>
-                      </div>
-                    </div>
-                    <div v-else-if="products.length === 0" class="text-center py-4 text-text-secondary text-sm">
-                      No hay productos disponibles
-                    </div>
-                    <div v-else class="space-y-2">
-                      <label
-                        v-for="product in products"
-                        :key="product.id"
-                        class="flex items-center gap-3 p-2 rounded-lg hover:bg-surface-secondary cursor-pointer transition-colors"
-                        :class="{ 'bg-primary/5 border border-primary/20': form.product_ids.includes(product.id) }"
-                      >
-                        <input
-                          type="checkbox"
-                          :value="product.id"
-                          v-model="form.product_ids"
-                          class="w-4 h-4 text-primary border-border rounded focus:ring-primary"
-                        />
-                        <span class="text-sm text-text-primary">{{ product.name }}</span>
-                        <span v-if="product.category?.name" class="text-xs text-text-secondary ml-auto">
-                          {{ product.category.name }}
-                        </span>
-                      </label>
-                    </div>
-                  </div>
-                  <p class="text-xs text-text-tertiary mt-1">
-                    {{ form.product_ids.length }} producto(s) seleccionado(s)
-                  </p>
+                  <UiProductMultiSelect
+                    v-model="selectedProducts"
+                    :input-id="productSearchInputId"
+                  />
                 </div>
 
                 <div>
@@ -326,7 +293,7 @@
 
               <div class="flex justify-between text-sm">
                 <span class="text-text-secondary">Productos:</span>
-                <span class="font-semibold text-text-primary">{{ form.product_ids.length }}</span>
+                <span class="font-semibold text-text-primary">{{ selectedProducts.length }}</span>
               </div>
 
               <div class="flex justify-between text-sm">
@@ -391,7 +358,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 
 definePageMeta({
@@ -406,6 +373,8 @@ const { currentTenant } = useTenantReactive()
 const isSubmitting = ref(false)
 const submitError = ref<string | null>(null)
 const nameError = ref('')
+const productSearchInputId = 'modifier-create-product-search'
+const selectedProducts = ref<{ id: string; name: string }[]>([])
 
 const form = ref({
   product_ids: [] as string[],
@@ -428,23 +397,9 @@ const form = ref({
   tenant_id: currentTenant.value?.id || ''
 })
 
-const { data: productsData, pending: loadingProducts } = useAsyncData(
-  `products-${currentTenant.value?.id || 'default'}`,
-  () => $fetch('/api/menu/products', {
-    query: { limit: 250 }
-  }),
-  {
-    server: false,
-    watch: [currentTenant],
-    default: () => ({ data: [] })
-  }
-)
-
-const products = computed(() => productsData.value?.data || [])
-
-const isLoadingData = computed(() => {
-  return !productsData.value
-})
+watch(selectedProducts, (list) => {
+  form.value.product_ids = list.map((p) => p.id)
+}, { deep: true })
 
 function addModifier() {
   form.value.modifiers.push({
@@ -541,7 +496,7 @@ async function validateForm(): Promise<boolean> {
   submitError.value = null
   nameError.value = ''
 
-  if (form.value.product_ids.length === 0) {
+  if (selectedProducts.value.length === 0) {
     submitError.value = 'Selecciona al menos un producto.'
     return false
   }


### PR DESCRIPTION
## Summary

- New `UiProductMultiSelect`: search input, removable chips, bulk modal when >15 selections
- `modificadores/crear` and `[id]` use it instead of `max-h-60` checkbox scroll lists
- No upfront fetch of 250 products; debounced `/api/menu/products?search=`

Closes #1052

## Test plan

- [ ] `/menu/modificadores/crear` — search product, add chip, remove with ×, create group
- [ ] `/menu/modificadores/[id]` — existing linked products show as chips on load
- [ ] Select 16+ products — summary + "Ver / editar lista" modal works

## wr-context

See `.wr/1052.yaml` on this branch.

Made with [Cursor](https://cursor.com)