### PR TITLE
fix(abastecimiento): clarify invoice scan block vs quota on compra directa

### DIFF
--- a/.wr/1057.yaml
+++ b/.wr/1057.yaml
@@ -1,0 +1,40 @@
+# Machine contract for wr-fast — issue #1057
+issue: 1057
+title: "fix(abastecimiento): Invoice AI scanner unavailable for Waro Colombia tenant"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-1057-invoice-scanner-access
+
+paths:
+  - pages/abastecimiento/compras-directas/crear.vue
+  - ../api_warocol.com/app/services/billing_service.py
+  - ../api_warocol.com/app/config.py
+  - ../api_warocol.com/tests/test_billing_exempt_tenants.py
+
+ac:
+  - Waro Colombia can use Leer factura con IA when exempt from grace downgrades
+  - Root cause documented — past_due Pro → read_only while scan_usage shows free-tier 4/1000
+  - Inline alert when scan blocked despite available quota
+  - OCR hint (photo, not DIAN XML)
+
+out_of_scope:
+  - DIAN XML/ZIP purchase invoice import
+  - Fixing past_due subscription row in DB (ops)
+
+hints:
+  entry: "get_subscription_access — billing_service.py"
+  pattern: "BILLING_EXEMPT_TENANT_IDS env — warocolombia 93b3e582-34fa-44a6-8d0f-bf82a3608727"
+  tests: "pytest tests/test_billing_exempt_tenants.py -v"
+  root_cause: |
+    tenant warocolombia: subscription past_due since 2026-05-26 (~4 days) → read_only.
+    scan_usage row: 4/1000 (free default limit; Pro active limit would be 500).
+    Front isScanBlocked blocks button; quota bar still shows available scans.
+
+skip:
+  audits: [ux, color, typography]
+
+companion:
+  api_repo: uno0uno/api-warolabs
+  api_branch: wr-1057-invoice-scanner-access

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -92,6 +92,7 @@
                     </svg>
                     <UiLoadingDots v-else size="9px" />
                     <span class="hidden sm:inline">{{ isScanning ? currentPhrase : 'Leer factura con IA' }}</span>
+                    <span class="inline sm:hidden">{{ isScanning ? '...' : 'IA' }}</span>
                   </button>
                 </div>
               </template>
@@ -103,6 +104,25 @@
               :scans-remaining="scansRemaining"
               class="mb-3 sm:mb-4"
             />
+
+            <div
+              v-if="isScanBlocked"
+              role="alert"
+              class="mb-3 sm:mb-4 p-3 rounded-lg border border-warning/30 bg-warning/10 text-sm"
+            >
+              <p class="font-medium text-warning">Escaneo IA suspendido por suscripción</p>
+              <p class="text-text-secondary mt-1 text-xs leading-relaxed">
+                {{ accessStatus?.message || 'Tu suscripción requiere atención.' }}
+                La cuota de escaneos (p. ej. {{ quota?.scans_used ?? 0 }} / {{ quota?.scans_limit ?? 0 }}) es independiente: puedes tener escaneos disponibles y aun así estar bloqueado por pago pendiente.
+              </p>
+              <NuxtLink to="/gestion/billing" class="inline-flex items-center gap-1 mt-2 text-xs font-semibold text-primary hover:underline">
+                Ir a Mi plan
+              </NuxtLink>
+            </div>
+
+            <p class="text-xs text-text-secondary mb-3 sm:mb-4">
+              Sube una <strong>foto o imagen</strong> de la factura de compra (OCR). No importa archivos XML/ZIP de factura electrónica DIAN.
+            </p>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4">
               <div class="md:col-span-2">

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="page-layout">
-    <!-- Loading overlay during submit -->
-    <div v-if="isSubmitting" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div class="bg-background rounded-xl p-6 flex flex-col items-center gap-3 shadow-xl">
-        <CommonsTheCustomLoader size="large" />
-        <p class="text-base font-semibold text-text-primary">Registrando compra directa...</p>
-      </div>
-    </div>
+    <UiSubmitBusyOverlay
+      :busy="isSubmitting"
+      label="Registrando compra directa..."
+      hint="Estamos guardando la compra, actualizando inventario y adjuntando documentos."
+      variant="glass"
+      indicator="matrix"
+    />
 
     <!-- Loading State -->
     <div v-if="isLoadingData" class="flex items-center justify-center min-h-[300px]">


### PR DESCRIPTION
## Summary
- Shows a visible alert when IA scan is blocked by subscription (`read_only`/`blocked`) even if quota bar still shows available scans (e.g. 4/1000).
- Adds OCR hint: photo/image only, not DIAN XML/ZIP.
- Labels scan button on mobile (`IA`).

Closes #1057

## Test plan
- [ ] On `/abastecimiento/compras-directas/crear` with `read_only` access, alert explains subscription block vs quota
- [ ] With API exempt env set, **Leer factura con IA** is enabled
- [ ] Mobile shows `IA` label on scan button

## wr-context
See `.wr/1057.yaml` on this branch (LLM contract).

**Requires API PR:** set `BILLING_EXEMPT_TENANT_IDS=93b3e582-34fa-44a6-8d0f-bf82a3608727` in api-warolabs.

Made with [Cursor](https://cursor.com)