### PR TITLE
fix(ui): teleport SubmitBusyOverlay to body for true fullscreen

### DIFF
--- a/components/ui/SubmitBusyOverlay.vue
+++ b/components/ui/SubmitBusyOverlay.vue
@@ -37,61 +37,64 @@ const hintId = computed(() => props.hint ? `${labelId.value}-hint` : undefined)
 </script>
 
 <template>
-  <Transition
-    enter-active-class="transition-opacity duration-200"
-    enter-from-class="opacity-0"
-    enter-to-class="opacity-100"
-    leave-active-class="transition-opacity duration-150"
-    leave-from-class="opacity-100"
-    leave-to-class="opacity-0"
-  >
-    <div
-      v-if="busy"
-      :class="[overlayPositionClass, 'submit-busy-overlay flex items-center justify-center p-4 sm:p-6']"
-      aria-live="polite"
-      :aria-busy="busy"
+  <!-- Teleport avoids broken fixed positioning inside .page-layout (transform animation). -->
+  <Teleport to="body" :disabled="!fullscreen">
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-150"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
     >
       <div
-        :class="[panelClass, 'relative w-full max-w-lg overflow-hidden rounded-[28px] border px-6 py-7 shadow-2xl backdrop-blur-2xl sm:px-8']"
-        role="status"
-        :aria-labelledby="labelId"
-        :aria-describedby="hintId"
+        v-if="busy"
+        :class="[overlayPositionClass, 'submit-busy-overlay flex items-center justify-center p-4 sm:p-6']"
+        aria-live="polite"
+        :aria-busy="busy"
       >
-        <div class="relative flex flex-col items-center gap-5 text-center">
-          <div
-            class="inline-flex items-center gap-2 rounded-full border border-crocus-200 bg-crocus-100/90 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-crocus-700"
-          >
-            Submit busy
-          </div>
-
-          <CommonsTheCustomLoader
-            v-if="indicator === 'matrix'"
-            size="large"
-            :show-phrase="false"
-          />
-
-          <div
-            v-else
-            class="h-10 w-10 rounded-full border-[3px] border-primary border-t-transparent animate-spin"
-            aria-hidden="true"
-          />
-
-          <div class="space-y-1.5">
-            <p :id="labelId" class="text-lg font-semibold text-text-primary sm:text-xl">
-              {{ label }}
-            </p>
-            <p
-              v-if="hint"
-              :id="hintId"
-              class="mx-auto max-w-md text-sm leading-relaxed text-text-secondary"
+        <div
+          :class="[panelClass, 'relative w-full max-w-lg overflow-hidden rounded-[28px] border px-6 py-7 shadow-2xl backdrop-blur-2xl sm:px-8']"
+          role="status"
+          :aria-labelledby="labelId"
+          :aria-describedby="hintId"
+        >
+          <div class="relative flex flex-col items-center gap-5 text-center">
+            <div
+              class="inline-flex items-center gap-2 rounded-full border border-crocus-200 bg-crocus-100/90 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-crocus-700"
             >
-              {{ hint }}
-            </p>
+              Submit busy
+            </div>
+
+            <CommonsTheCustomLoader
+              v-if="indicator === 'matrix'"
+              size="large"
+              :show-phrase="false"
+            />
+
+            <div
+              v-else
+              class="h-10 w-10 rounded-full border-[3px] border-primary border-t-transparent animate-spin"
+              aria-hidden="true"
+            />
+
+            <div class="space-y-1.5">
+              <p :id="labelId" class="text-lg font-semibold text-text-primary sm:text-xl">
+                {{ label }}
+              </p>
+              <p
+                v-if="hint"
+                :id="hintId"
+                class="mx-auto max-w-md text-sm leading-relaxed text-text-secondary"
+              >
+                {{ hint }}
+              </p>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </Transition>
+    </Transition>
+  </Teleport>
 </template>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- Teleports `UiSubmitBusyOverlay` to `document.body` when `fullscreen` (default).
- Fixes loading overlay appearing at the top of long forms (e.g. compra directa crear) instead of covering the viewport.

## Test plan
- [ ] Open `/abastecimiento/compras-directas/crear`, scroll to bottom, submit — overlay visible without scrolling up
- [ ] Create product still shows overlay centered on screen

Made with [Cursor](https://cursor.com)