### PR TITLE
feat(admin): Customer create, wallet recharge, and WaRo rewards catalog

### DIFF
--- a/components/analitica/CreateCustomerModal.vue
+++ b/components/analitica/CreateCustomerModal.vue
@@ -1,0 +1,135 @@
+<template>
+  <UiModal v-model="open" title="Nuevo cliente">
+    <div class="px-6 py-5 space-y-4">
+      <div class="flex flex-col gap-1.5">
+        <label for="create-phone" class="text-sm font-medium text-text-primary">
+          Teléfono <span class="text-red-600">*</span>
+        </label>
+        <input
+          id="create-phone"
+          v-model="form.phone_number"
+          type="tel"
+          placeholder="3001234567"
+          class="h-10 px-3 text-sm border-2 border-border rounded-lg bg-background text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+          :disabled="isSaving"
+        />
+      </div>
+      <div class="flex flex-col gap-1.5">
+        <label for="create-name" class="text-sm font-medium text-text-primary">Nombre</label>
+        <input
+          id="create-name"
+          v-model="form.name"
+          type="text"
+          placeholder="Nombre completo"
+          class="h-10 px-3 text-sm border-2 border-border rounded-lg bg-background text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+          :disabled="isSaving"
+        />
+      </div>
+      <div class="flex flex-col gap-1.5">
+        <label for="create-email" class="text-sm font-medium text-text-primary">Correo</label>
+        <input
+          id="create-email"
+          v-model="form.email"
+          type="email"
+          placeholder="cliente@email.com"
+          class="h-10 px-3 text-sm border-2 border-border rounded-lg bg-background text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+          :disabled="isSaving"
+        />
+      </div>
+      <p v-if="apiError" role="alert" class="text-sm text-red-600">{{ apiError }}</p>
+    </div>
+    <template #footer>
+      <div class="flex items-center justify-end gap-3 px-6 py-4">
+        <button
+          type="button"
+          @click="open = false"
+          class="min-h-[44px] px-4 text-sm font-medium text-text-secondary border-2 border-border rounded-lg hover:bg-surface-secondary"
+        >
+          Cancelar
+        </button>
+        <button
+          type="button"
+          :disabled="isSaving || !canSubmit"
+          @click="handleSubmit"
+          class="min-h-[44px] px-5 text-sm font-semibold rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          <UiLoadingDots v-if="isSaving" size="9px" />
+          <span v-else>Crear cliente</span>
+        </button>
+      </div>
+    </template>
+  </UiModal>
+</template>
+
+<script setup lang="ts">
+import { reactive, computed, watch, ref } from 'vue'
+
+interface CreatedCustomer {
+  id: string
+  name: string
+  phone_number: string | null
+}
+
+interface Props {
+  modelValue: boolean
+}
+
+interface Emits {
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'created', customer: CreatedCustomer): void
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<Emits>()
+
+const open = computed({
+  get: () => props.modelValue,
+  set: (v) => emit('update:modelValue', v),
+})
+
+const form = reactive({ phone_number: '', name: '', email: '' })
+const isSaving = ref(false)
+const apiError = ref<string | null>(null)
+
+watch(() => props.modelValue, (v) => {
+  if (v) {
+    form.phone_number = ''
+    form.name = ''
+    form.email = ''
+    apiError.value = null
+  }
+})
+
+const canSubmit = computed(() => form.phone_number.trim().length >= 7)
+
+const handleSubmit = async () => {
+  if (!canSubmit.value || isSaving.value) return
+  isSaving.value = true
+  apiError.value = null
+  try {
+    const response = await $fetch<{
+      success: boolean
+      data: { id: string; name: string; phone_number: string | null }
+    }>('/api/customers/search-or-create', {
+      method: 'POST',
+      body: {
+        phone_number: form.phone_number.trim(),
+        name: form.name.trim() || null,
+        email: form.email.trim() || null,
+      },
+    })
+    if (response.success) {
+      emit('created', {
+        id: response.data.id,
+        name: response.data.name,
+        phone_number: response.data.phone_number,
+      })
+      open.value = false
+    }
+  } catch (e: any) {
+    apiError.value = e?.data?.detail || e?.message || 'Error al crear el cliente'
+  } finally {
+    isSaving.value = false
+  }
+}
+</script>

--- a/components/analitica/WalletRechargeModal.vue
+++ b/components/analitica/WalletRechargeModal.vue
@@ -1,0 +1,170 @@
+<template>
+  <UiModal v-model="open" title="Recargar billetera">
+    <div class="px-6 py-5 space-y-5">
+      <div class="flex items-center justify-between gap-4">
+        <div class="min-w-0">
+          <p class="text-sm text-text-secondary font-medium">Cliente</p>
+          <p class="text-base font-semibold text-text-primary truncate">{{ customerName }}</p>
+        </div>
+        <div class="text-right flex-shrink-0">
+          <p class="text-sm text-text-secondary font-medium">Saldo actual</p>
+          <p class="text-base font-semibold text-primary">{{ formatCurrency(currentBalance) }}</p>
+        </div>
+      </div>
+
+      <hr class="border-border" />
+
+      <div class="flex flex-col gap-1.5">
+        <label for="wallet-amount" class="text-sm font-medium text-text-primary">Monto (COP)</label>
+        <input
+          id="wallet-amount"
+          v-model.number="amount"
+          type="number"
+          min="1"
+          step="1000"
+          placeholder="50000"
+          class="h-10 px-3 text-sm border-2 border-border rounded-lg bg-background focus:outline-none focus:ring-2 focus:ring-primary/20"
+          :class="{ 'border-red-400': !!validationError }"
+        />
+        <p v-if="validationError" role="alert" class="text-sm text-red-600">{{ validationError }}</p>
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <label for="wallet-payment" class="text-sm font-medium text-text-primary">Forma de pago</label>
+        <select
+          id="wallet-payment"
+          v-model="paymentMethod"
+          class="h-10 px-3 text-sm border-2 border-border rounded-lg bg-background focus:outline-none focus:ring-2 focus:ring-primary/20"
+        >
+          <option v-for="opt in paymentOptions" :key="opt.value" :value="opt.value">
+            {{ opt.label }}
+          </option>
+        </select>
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <label for="wallet-notes" class="text-sm font-medium text-text-primary">
+          Nota <span class="text-text-secondary font-normal">(opcional)</span>
+        </label>
+        <textarea
+          id="wallet-notes"
+          v-model="notes"
+          rows="2"
+          placeholder="Ej. Recarga en efectivo..."
+          class="px-3 py-2 text-sm border-2 border-border rounded-lg bg-background resize-none focus:outline-none focus:ring-2 focus:ring-primary/20"
+        />
+      </div>
+
+      <p v-if="apiError" role="alert" class="text-sm text-red-600">{{ apiError }}</p>
+    </div>
+    <template #footer>
+      <div class="flex items-center justify-end gap-3 px-6 py-4">
+        <button
+          type="button"
+          @click="open = false"
+          class="min-h-[44px] px-4 text-sm font-medium text-text-secondary border-2 border-border rounded-lg"
+        >
+          Cancelar
+        </button>
+        <button
+          type="button"
+          :disabled="isRecharging || !!validationError || !amount"
+          @click="handleSubmit"
+          class="min-h-[44px] px-5 text-sm font-semibold rounded-lg bg-primary text-primary-foreground disabled:opacity-50"
+        >
+          <UiLoadingDots v-if="isRecharging" size="9px" />
+          <span v-else>Registrar recarga</span>
+        </button>
+      </div>
+    </template>
+  </UiModal>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+
+interface PaymentOption {
+  value: string
+  label: string
+}
+
+interface Props {
+  modelValue: boolean
+  customerId: string
+  customerName: string
+  currentBalance: number
+  paymentOptions: PaymentOption[]
+  recharge: (amount_cop: number, payment_method: string, notes?: string) => Promise<unknown>
+  isRecharging: boolean
+  rechargeError: string | null
+}
+
+interface Emits {
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'recharged'): void
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<Emits>()
+
+const { show: showToast } = useToast()
+
+const open = computed({
+  get: () => props.modelValue,
+  set: (v) => emit('update:modelValue', v),
+})
+
+const amount = ref<number | null>(null)
+const paymentMethod = ref('cash')
+const notes = ref('')
+const localError = ref<string | null>(null)
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    minimumFractionDigits: 0,
+  }).format(value || 0)
+
+watch(() => props.modelValue, (v) => {
+  if (v) {
+    amount.value = null
+    notes.value = ''
+    localError.value = null
+    if (props.paymentOptions.length) {
+      paymentMethod.value = props.paymentOptions[0].value
+    }
+  }
+})
+
+watch(
+  () => props.paymentOptions,
+  (opts) => {
+    if (opts.length && !opts.some((o) => o.value === paymentMethod.value)) {
+      paymentMethod.value = opts[0].value
+    }
+  },
+  { immediate: true }
+)
+
+const validationError = computed(() => {
+  if (!amount.value || amount.value <= 0) return null
+  if (!Number.isFinite(amount.value)) return 'Monto inválido'
+  return null
+})
+
+const apiError = computed(() => localError.value || props.rechargeError)
+
+const handleSubmit = async () => {
+  if (!amount.value || amount.value <= 0 || validationError.value) return
+  localError.value = null
+  try {
+    await props.recharge(amount.value, paymentMethod.value, notes.value.trim() || undefined)
+    showToast('Recarga registrada correctamente', 'success')
+    emit('recharged')
+    open.value = false
+  } catch (e: any) {
+    localError.value = e?.data?.detail || e?.message || 'Error al registrar la recarga'
+  }
+}
+</script>

--- a/components/puntos/RedemptionConfigSection.vue
+++ b/components/puntos/RedemptionConfigSection.vue
@@ -1,0 +1,129 @@
+<template>
+  <div class="bg-surface border border-border rounded-lg overflow-hidden">
+    <div class="px-4 py-3 border-b border-border">
+      <h3 class="text-sm font-bold text-text-primary uppercase tracking-wider">Canje B1 — conversión Waros</h3>
+      <p class="text-xs text-text-secondary mt-0.5">Cuántos Waros equivalen a pesos en checkout</p>
+    </div>
+
+    <div v-if="isLoading" class="flex justify-center py-10">
+      <CommonsTheCustomLoader size="medium" />
+    </div>
+
+    <form v-else class="px-4 py-4 space-y-4" @submit.prevent="handleSubmit">
+      <label class="flex items-center justify-between gap-4 cursor-pointer">
+        <span class="text-sm font-medium text-text-primary">Canje habilitado</span>
+        <button
+          type="button"
+          role="switch"
+          :aria-checked="form.redemption_enabled"
+          @click="form.redemption_enabled = !form.redemption_enabled"
+          :class="[
+            'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
+            form.redemption_enabled ? 'bg-primary' : 'bg-slate-300',
+          ]"
+        >
+          <span
+            :class="[
+              'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
+              form.redemption_enabled ? 'translate-x-6' : 'translate-x-1',
+            ]"
+          />
+        </button>
+      </label>
+
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <div class="flex flex-col gap-1.5">
+          <label for="waros-per-1000" class="text-xs font-medium text-text-secondary">
+            Waros por cada $1.000 COP
+          </label>
+          <input
+            id="waros-per-1000"
+            v-model.number="form.waros_per_1000_cop"
+            type="number"
+            min="1"
+            class="h-10 px-3 text-sm border border-border rounded-lg bg-background"
+          />
+        </div>
+        <div class="flex flex-col gap-1.5">
+          <label for="max-redeem-pct" class="text-xs font-medium text-text-secondary">
+            Máx. % del pedido canjeable
+          </label>
+          <input
+            id="max-redeem-pct"
+            v-model.number="form.max_redeem_percent_per_order"
+            type="number"
+            min="0"
+            max="100"
+            step="1"
+            class="h-10 px-3 text-sm border border-border rounded-lg bg-background"
+          />
+        </div>
+        <div class="flex flex-col gap-1.5">
+          <label for="min-waros" class="text-xs font-medium text-text-secondary">
+            Mínimo Waros para canjear
+          </label>
+          <input
+            id="min-waros"
+            v-model.number="form.min_waros_to_redeem"
+            type="number"
+            min="1"
+            class="h-10 px-3 text-sm border border-border rounded-lg bg-background"
+          />
+        </div>
+      </div>
+
+      <p v-if="saveError" role="alert" class="text-sm text-red-600">{{ saveError }}</p>
+
+      <div class="flex justify-end">
+        <button
+          type="submit"
+          :disabled="isSaving"
+          class="min-h-[44px] px-5 text-sm font-semibold rounded-lg bg-primary text-primary-foreground disabled:opacity-50"
+        >
+          <UiLoadingDots v-if="isSaving" size="9px" />
+          <span v-else>Guardar configuración</span>
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, watch } from 'vue'
+
+const { show: showToast } = useToast()
+const { config, isLoading, saveConfig, isSaving, saveError } = useRedemptionConfig()
+
+const form = reactive({
+  redemption_enabled: false,
+  waros_per_1000_cop: 100,
+  max_redeem_percent_per_order: 50,
+  min_waros_to_redeem: 1,
+})
+
+watch(
+  config,
+  (c) => {
+    if (!c) return
+    form.redemption_enabled = c.redemption_enabled
+    form.waros_per_1000_cop = c.waros_per_1000_cop
+    form.max_redeem_percent_per_order = c.max_redeem_percent_per_order
+    form.min_waros_to_redeem = c.min_waros_to_redeem
+  },
+  { immediate: true }
+)
+
+const handleSubmit = async () => {
+  try {
+    await saveConfig({
+      redemption_enabled: form.redemption_enabled,
+      waros_per_1000_cop: form.waros_per_1000_cop,
+      max_redeem_percent_per_order: form.max_redeem_percent_per_order,
+      min_waros_to_redeem: form.min_waros_to_redeem,
+    })
+    showToast('Configuración de canje guardada', 'success')
+  } catch {
+    showToast(saveError.value || 'Error al guardar', 'error')
+  }
+}
+</script>

--- a/components/puntos/WaroRewardModal.vue
+++ b/components/puntos/WaroRewardModal.vue
@@ -1,0 +1,221 @@
+<template>
+  <UiModal v-model="open" :title="isEdit ? 'Editar recompensa' : 'Nueva recompensa'">
+    <div class="px-6 py-5 space-y-4">
+      <div class="flex flex-col gap-1.5">
+        <label for="reward-name" class="text-sm font-medium text-text-primary">Nombre</label>
+        <input
+          id="reward-name"
+          v-model="form.name"
+          type="text"
+          placeholder="Ej. Café gratis"
+          class="h-10 px-3 text-sm border-2 border-border rounded-lg bg-background focus:outline-none focus:ring-2 focus:ring-primary/20"
+          :disabled="isSaving"
+        />
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <label for="reward-type" class="text-sm font-medium text-text-primary">Tipo</label>
+        <select
+          id="reward-type"
+          v-model="form.reward_type"
+          class="h-10 px-3 text-sm border-2 border-border rounded-lg bg-background"
+          :disabled="isSaving || isEdit"
+        >
+          <option value="fixed_cop_off">Descuento fijo (COP)</option>
+          <option value="free_product">Producto gratis</option>
+        </select>
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        <label for="reward-cost" class="text-sm font-medium text-text-primary">Costo en Waros</label>
+        <input
+          id="reward-cost"
+          v-model.number="form.waros_cost"
+          type="number"
+          min="1"
+          step="1"
+          class="h-10 px-3 text-sm border-2 border-border rounded-lg bg-background"
+          :disabled="isSaving"
+        />
+      </div>
+
+      <div v-if="form.reward_type === 'fixed_cop_off'" class="flex flex-col gap-1.5">
+        <label for="reward-cop" class="text-sm font-medium text-text-primary">Descuento (COP)</label>
+        <input
+          id="reward-cop"
+          v-model.number="form.fixed_cop_off"
+          type="number"
+          min="1"
+          step="1000"
+          class="h-10 px-3 text-sm border-2 border-border rounded-lg bg-background"
+          :disabled="isSaving"
+        />
+      </div>
+
+      <div v-else class="flex flex-col gap-1.5">
+        <label class="text-sm font-medium text-text-primary">Producto</label>
+        <UiProductSearchInput
+          v-if="!selectedProduct"
+          placeholder="Buscar producto del menú..."
+          @select="onProductSelect"
+        />
+        <div
+          v-else
+          class="flex items-center justify-between gap-2 px-3 py-2 border border-border rounded-lg bg-surface-secondary"
+        >
+          <span class="text-sm font-medium text-text-primary truncate">{{ selectedProduct.name }}</span>
+          <button
+            type="button"
+            class="text-xs text-text-secondary hover:text-text-primary"
+            @click="clearProduct"
+          >
+            Cambiar
+          </button>
+        </div>
+      </div>
+
+      <label class="flex items-center gap-2 cursor-pointer">
+        <input
+          v-model="form.is_active"
+          type="checkbox"
+          class="rounded border-border text-primary focus:ring-primary"
+          :disabled="isSaving"
+        />
+        <span class="text-sm text-text-primary">Recompensa activa</span>
+      </label>
+
+      <p v-if="apiError" role="alert" class="text-sm text-red-600">{{ apiError }}</p>
+    </div>
+    <template #footer>
+      <div class="flex items-center justify-end gap-3 px-6 py-4">
+        <button
+          type="button"
+          @click="open = false"
+          class="min-h-[44px] px-4 text-sm font-medium border-2 border-border rounded-lg"
+        >
+          Cancelar
+        </button>
+        <button
+          type="button"
+          :disabled="isSaving || !canSubmit"
+          @click="handleSubmit"
+          class="min-h-[44px] px-5 text-sm font-semibold rounded-lg bg-primary text-primary-foreground disabled:opacity-50"
+        >
+          <UiLoadingDots v-if="isSaving" size="9px" />
+          <span v-else>{{ isEdit ? 'Guardar' : 'Crear' }}</span>
+        </button>
+      </div>
+    </template>
+  </UiModal>
+</template>
+
+<script setup lang="ts">
+import { reactive, computed, watch, ref } from 'vue'
+import type { WaroReward, WaroRewardType } from '~/composables/useWaroRewards'
+import type { ProductRow } from '~/composables/useProductSearch'
+
+interface Props {
+  modelValue: boolean
+  reward?: WaroReward | null
+  isSaving: boolean
+}
+
+interface Emits {
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'save', payload: {
+    name: string
+    reward_type: WaroRewardType
+    waros_cost: number
+    fixed_cop_off?: number | null
+    product_id?: string | null
+    is_active: boolean
+  }): void
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<Emits>()
+
+const open = computed({
+  get: () => props.modelValue,
+  set: (v) => emit('update:modelValue', v),
+})
+
+const isEdit = computed(() => !!props.reward?.id)
+const apiError = ref<string | null>(null)
+const selectedProduct = ref<ProductRow | null>(null)
+
+const form = reactive({
+  name: '',
+  reward_type: 'fixed_cop_off' as WaroRewardType,
+  waros_cost: 100,
+  fixed_cop_off: 5000 as number | null,
+  is_active: true,
+})
+
+watch(() => props.modelValue, async (v) => {
+  if (!v) return
+  apiError.value = null
+  if (props.reward) {
+    form.name = props.reward.name
+    form.reward_type = props.reward.reward_type
+    form.waros_cost = props.reward.waros_cost
+    form.fixed_cop_off = props.reward.fixed_cop_off
+    form.is_active = props.reward.is_active
+    if (props.reward.product_id) {
+      try {
+        const res = await $fetch<{ data?: { name?: string } }>(
+          `/api/menu/products/${props.reward.product_id}`
+        )
+        selectedProduct.value = {
+          id: props.reward.product_id,
+          name: res.data?.name || 'Producto',
+        }
+      } catch {
+        selectedProduct.value = {
+          id: props.reward.product_id,
+          name: 'Producto',
+        }
+      }
+    } else {
+      selectedProduct.value = null
+    }
+  } else {
+    form.name = ''
+    form.reward_type = 'fixed_cop_off'
+    form.waros_cost = 100
+    form.fixed_cop_off = 5000
+    form.is_active = true
+    selectedProduct.value = null
+  }
+})
+
+const onProductSelect = (product: ProductRow) => {
+  selectedProduct.value = product
+}
+
+const clearProduct = () => {
+  selectedProduct.value = null
+}
+
+const canSubmit = computed(() => {
+  if (!form.name.trim() || form.waros_cost < 1) return false
+  if (form.reward_type === 'fixed_cop_off') {
+    return !!form.fixed_cop_off && form.fixed_cop_off > 0
+  }
+  return !!selectedProduct.value?.id
+})
+
+const handleSubmit = () => {
+  if (!canSubmit.value) return
+  emit('save', {
+    name: form.name.trim(),
+    reward_type: form.reward_type,
+    waros_cost: form.waros_cost,
+    fixed_cop_off:
+      form.reward_type === 'fixed_cop_off' ? form.fixed_cop_off : null,
+    product_id:
+      form.reward_type === 'free_product' ? selectedProduct.value?.id ?? null : null,
+    is_active: form.is_active,
+  })
+}
+</script>

--- a/components/puntos/WaroRewardsSection.vue
+++ b/components/puntos/WaroRewardsSection.vue
@@ -1,0 +1,141 @@
+<template>
+  <div class="bg-surface border border-border rounded-lg overflow-hidden">
+    <div class="px-4 py-3 border-b border-border flex items-center justify-between gap-3">
+      <div>
+        <h3 class="text-sm font-bold text-text-primary uppercase tracking-wider">Recompensas WaRos</h3>
+        <p class="text-xs text-text-secondary mt-0.5">Catálogo B2 — canje en checkout (POS)</p>
+      </div>
+      <button
+        type="button"
+        @click="openCreate"
+        class="min-h-[44px] px-4 text-sm font-semibold rounded-lg bg-primary text-primary-foreground hover:bg-primary/90"
+      >
+        + Nueva
+      </button>
+    </div>
+
+    <div v-if="isLoading" class="flex justify-center py-10">
+      <CommonsTheCustomLoader size="medium" />
+    </div>
+
+    <div v-else-if="!rewards.length" class="px-4 py-10 text-center text-sm text-text-secondary">
+      No hay recompensas configuradas
+    </div>
+
+    <div v-else class="divide-y divide-border">
+      <div
+        v-for="reward in rewards"
+        :key="reward.id"
+        class="px-4 py-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3"
+      >
+        <div class="min-w-0">
+          <div class="flex items-center gap-2 flex-wrap">
+            <p class="text-sm font-semibold text-text-primary">{{ reward.name }}</p>
+            <span
+              :class="[
+                'text-xs px-2 py-0.5 rounded-full font-medium',
+                reward.is_active ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600',
+              ]"
+            >
+              {{ reward.is_active ? 'Activa' : 'Inactiva' }}
+            </span>
+          </div>
+          <p class="text-xs text-text-secondary mt-1">
+            {{ typeLabel(reward.reward_type) }}
+            · {{ reward.waros_cost.toLocaleString('es-CO') }} Waros
+            <template v-if="reward.reward_type === 'fixed_cop_off' && reward.fixed_cop_off">
+              · {{ formatCurrency(reward.fixed_cop_off) }} descuento
+            </template>
+          </p>
+        </div>
+        <div class="flex items-center gap-2 flex-shrink-0">
+          <button
+            type="button"
+            @click="openEdit(reward)"
+            class="min-h-[36px] px-3 text-xs font-semibold rounded-lg border border-border hover:bg-surface-secondary"
+          >
+            Editar
+          </button>
+          <button
+            type="button"
+            @click="confirmDelete(reward)"
+            class="min-h-[36px] px-3 text-xs font-semibold rounded-lg border border-red-200 text-red-700 hover:bg-red-50"
+          >
+            Eliminar
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <PuntosWaroRewardModal
+      v-model="showModal"
+      :reward="selectedReward"
+      :is-saving="isSaving"
+      @save="handleSave"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { WaroReward } from '~/composables/useWaroRewards'
+
+const { show: showToast } = useToast()
+const {
+  rewards,
+  isLoading,
+  createReward,
+  updateReward,
+  deleteReward,
+  isSaving,
+  apiError,
+} = useWaroRewards()
+
+const showModal = ref(false)
+const selectedReward = ref<WaroReward | null>(null)
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    minimumFractionDigits: 0,
+  }).format(value || 0)
+
+const typeLabel = (type: string) =>
+  type === 'free_product' ? 'Producto gratis' : 'Descuento COP'
+
+const openCreate = () => {
+  selectedReward.value = null
+  showModal.value = true
+}
+
+const openEdit = (reward: WaroReward) => {
+  selectedReward.value = reward
+  showModal.value = true
+}
+
+const handleSave = async (payload: Parameters<typeof createReward>[0]) => {
+  try {
+    if (selectedReward.value) {
+      await updateReward(selectedReward.value.id, payload)
+      showToast('Recompensa actualizada', 'success')
+    } else {
+      await createReward(payload)
+      showToast('Recompensa creada', 'success')
+    }
+    showModal.value = false
+  } catch (e) {
+    showToast(apiError(e), 'error')
+  }
+}
+
+const confirmDelete = async (reward: WaroReward) => {
+  if (!confirm(`¿Eliminar "${reward.name}"?`)) return
+  try {
+    await deleteReward(reward.id)
+    showToast('Recompensa eliminada', 'success')
+  } catch (e) {
+    showToast(apiError(e), 'error')
+  }
+}
+</script>

--- a/composables/useCustomerWallet.ts
+++ b/composables/useCustomerWallet.ts
@@ -1,0 +1,81 @@
+/**
+ * Customer COP wallet — balance, movements, staff recharge.
+ * Proxied: GET/POST /api/customers/{id}/wallet*
+ */
+
+export interface WalletMovement {
+  id: string
+  movement_type: string
+  amount_cop: number
+  balance_after_cop: number
+  payment_method: string | null
+  order_id: string | null
+  notes: string | null
+  created_at: string
+}
+
+export interface CustomerWalletData {
+  customer_id: string
+  balance_cop: number
+  updated_at: string | null
+  movements: WalletMovement[]
+}
+
+export interface WalletResponse {
+  success: boolean
+  data: CustomerWalletData
+}
+
+export const useCustomerWallet = (customerId: Ref<string> | string) => {
+  const idRef = isRef(customerId) ? customerId : ref(customerId)
+  const cache = useQueryCache()
+
+  const { data, status, asyncStatus, error, refetch } = useQuery({
+    key: () => ['customer-wallet', idRef.value],
+    query: () =>
+      $fetch<WalletResponse>(`/api/customers/${idRef.value}/wallet`),
+    enabled: () => !!idRef.value,
+    staleTime: 15_000,
+  })
+
+  const wallet = computed(() => data.value?.data ?? null)
+  const isLoading = computed(() => status.value === 'pending')
+  const isRefreshing = computed(
+    () => asyncStatus.value === 'loading' && data.value != null
+  )
+  const walletError = computed(() => {
+    const e = error.value as any
+    return e?.data?.detail || e?.message || null
+  })
+
+  const rechargeMutation = useMutation({
+    mutation: (vars: {
+      amount_cop: number
+      payment_method: string
+      notes?: string
+    }) =>
+      $fetch<WalletResponse>(`/api/customers/${idRef.value}/wallet/recharge`, {
+        method: 'POST',
+        body: vars,
+      }),
+    onSettled: () =>
+      cache.invalidateQueries({ key: ['customer-wallet', idRef.value] }),
+  })
+
+  const recharge = (amount_cop: number, payment_method: string, notes?: string) =>
+    rechargeMutation.mutateAsync({ amount_cop, payment_method, notes })
+
+  return {
+    wallet,
+    isLoading,
+    isRefreshing,
+    walletError,
+    refetch,
+    recharge,
+    isRecharging: rechargeMutation.isLoading,
+    rechargeError: computed(() => {
+      const e = rechargeMutation.error.value as any
+      return e?.data?.detail || e?.message || null
+    }),
+  }
+}

--- a/composables/useRedemptionConfig.ts
+++ b/composables/useRedemptionConfig.ts
@@ -1,0 +1,71 @@
+/**
+ * B1 redemption conversion settings.
+ * Proxied: GET/PATCH /api/admin/waros/redemption-config
+ */
+
+export interface RedemptionConfig {
+  is_enabled: boolean
+  redemption_enabled: boolean
+  waros_per_1000_cop: number
+  max_redeem_percent_per_order: number
+  min_waros_to_redeem: number
+  earn_on_wallet_payment: boolean
+  earn_base_excludes_waro_redemption: boolean
+}
+
+export type RedemptionConfigPatch = Partial<
+  Pick<
+    RedemptionConfig,
+    | 'redemption_enabled'
+    | 'waros_per_1000_cop'
+    | 'max_redeem_percent_per_order'
+    | 'min_waros_to_redeem'
+  >
+>
+
+export const useRedemptionConfig = () => {
+  const cache = useQueryCache()
+
+  const { data, status, asyncStatus } = useQuery({
+    key: ['waros', 'redemption-config'],
+    query: () =>
+      $fetch<RedemptionConfig>('/api/admin/waros/redemption-config'),
+  })
+
+  const config = computed(() => data.value ?? null)
+  const isLoading = computed(() => status.value === 'pending')
+  const isRefreshing = computed(
+    () => asyncStatus.value === 'loading' && data.value != null
+  )
+
+  const fetchConfig = () =>
+    cache.invalidateQueries({ key: ['waros', 'redemption-config'] })
+
+  const saveMutation = useMutation({
+    mutation: (patch: RedemptionConfigPatch) =>
+      $fetch<RedemptionConfig>('/api/admin/waros/redemption-config', {
+        method: 'PATCH',
+        body: patch,
+      }),
+    onSettled: () =>
+      cache.invalidateQueries({ key: ['waros', 'redemption-config'] }),
+  })
+
+  const saveConfig = (patch: RedemptionConfigPatch) =>
+    saveMutation.mutateAsync(patch)
+
+  const saveError = computed(() => {
+    const e = saveMutation.error.value as any
+    return e?.data?.detail || e?.message || null
+  })
+
+  return {
+    config,
+    isLoading,
+    isRefreshing,
+    fetchConfig,
+    saveConfig,
+    isSaving: saveMutation.isLoading,
+    saveError,
+  }
+}

--- a/composables/useWaroRewards.ts
+++ b/composables/useWaroRewards.ts
@@ -1,0 +1,92 @@
+/**
+ * WaRo rewards catalog CRUD (B2).
+ * Proxied: /api/admin/waros/rewards
+ */
+
+export type WaroRewardType = 'free_product' | 'fixed_cop_off'
+
+export interface WaroReward {
+  id: string
+  name: string
+  reward_type: WaroRewardType
+  waros_cost: number
+  fixed_cop_off: number | null
+  product_id: string | null
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface WaroRewardsResponse {
+  rewards: WaroReward[]
+}
+
+export interface WaroRewardPayload {
+  name: string
+  reward_type: WaroRewardType
+  waros_cost: number
+  fixed_cop_off?: number | null
+  product_id?: string | null
+  is_active?: boolean
+}
+
+export const useWaroRewards = () => {
+  const cache = useQueryCache()
+
+  const { data, status, asyncStatus } = useQuery({
+    key: ['waros', 'rewards'],
+    query: () => $fetch<WaroRewardsResponse>('/api/admin/waros/rewards'),
+  })
+
+  const rewards = computed(() => data.value?.rewards ?? [])
+  const isLoading = computed(() => status.value === 'pending')
+  const isRefreshing = computed(
+    () => asyncStatus.value === 'loading' && data.value != null
+  )
+
+  const fetchRewards = () =>
+    cache.invalidateQueries({ key: ['waros', 'rewards'] })
+
+  const createMutation = useMutation({
+    mutation: (payload: WaroRewardPayload) =>
+      $fetch('/api/admin/waros/rewards', { method: 'POST', body: payload }),
+    onSettled: () => cache.invalidateQueries({ key: ['waros', 'rewards'] }),
+  })
+
+  const updateMutation = useMutation({
+    mutation: (vars: { id: string; payload: Partial<WaroRewardPayload> }) =>
+      $fetch(`/api/admin/waros/rewards/${vars.id}`, {
+        method: 'PUT',
+        body: vars.payload,
+      }),
+    onSettled: () => cache.invalidateQueries({ key: ['waros', 'rewards'] }),
+  })
+
+  const deleteMutation = useMutation({
+    mutation: (id: string) =>
+      $fetch(`/api/admin/waros/rewards/${id}`, { method: 'DELETE' }),
+    onSettled: () => cache.invalidateQueries({ key: ['waros', 'rewards'] }),
+  })
+
+  const apiError = (e: unknown) => {
+    const err = e as any
+    return err?.data?.detail || err?.message || 'Error al procesar la operación'
+  }
+
+  return {
+    rewards,
+    isLoading,
+    isRefreshing,
+    fetchRewards,
+    createReward: (payload: WaroRewardPayload) =>
+      createMutation.mutateAsync(payload),
+    updateReward: (id: string, payload: Partial<WaroRewardPayload>) =>
+      updateMutation.mutateAsync({ id, payload }),
+    deleteReward: (id: string) => deleteMutation.mutateAsync(id),
+    isSaving:
+      createMutation.isLoading ||
+      updateMutation.isLoading ||
+      deleteMutation.isLoading,
+    apiError,
+  }
+}

--- a/pages/analitica/clientes/[id].vue
+++ b/pages/analitica/clientes/[id].vue
@@ -219,6 +219,51 @@ const saveEdit = async () => {
 const showWarosModal = ref(false)
 const showManualPanel = ref(false)
 
+// ── Wallet COP ────────────────────────────────────────────────────────────
+const showWalletRechargeModal = ref(false)
+const {
+  wallet,
+  isLoading: isLoadingWallet,
+  recharge,
+  isRecharging,
+  rechargeError,
+  refetch: refetchWallet,
+} = useCustomerWallet(customerId)
+
+const walletBalance = computed(() => wallet.value?.balance_cop ?? 0)
+const walletMovements = computed(() => wallet.value?.movements ?? [])
+
+const walletPaymentOptions = computed(() => {
+  const slugs = new Set(['credit', 'customer_wallet'])
+  const opts: { value: string; label: string }[] = []
+  for (const group of paymentGroups.value) {
+    for (const method of group.methods ?? []) {
+      const slug = (method as any).slug || group.slug
+      if (slugs.has(slug)) continue
+      opts.push({ value: slug, label: method.name || group.name })
+    }
+  }
+  if (!opts.length) {
+    opts.push(
+      { value: 'cash', label: 'Efectivo' },
+      { value: 'card', label: 'Tarjeta' },
+      { value: 'digital', label: 'Digital' },
+    )
+  }
+  return opts
+})
+
+const walletMovementLabel = (type: string) => {
+  if (type === 'recharge') return 'Recarga'
+  if (type === 'redeem') return 'Uso en pedido'
+  if (type === 'refund') return 'Devolución'
+  return type
+}
+
+const onWalletRecharged = async () => {
+  await refetchWallet()
+}
+
 // Waros data comes from the main apiData response (no separate call)
 const warosSummary = computed(() => (apiData.value as any)?.waros_summary ?? null)
 const isLoadingWaros = computed(() => isLoading.value)
@@ -529,6 +574,45 @@ onUnmounted(() => {
             </div>
           </div>
         </div>
+
+        <!-- Wallet COP section -->
+        <div class="border-t border-border px-5 py-4">
+          <div class="flex items-center justify-between gap-4">
+            <div>
+              <p class="text-xs text-text-secondary uppercase tracking-wider font-medium mb-0.5">Billetera COP</p>
+              <p v-if="isLoadingWallet" class="text-sm font-semibold text-text-secondary">Cargando...</p>
+              <p v-else class="text-sm font-semibold text-primary">{{ formatCurrency(walletBalance) }}</p>
+            </div>
+            <button
+              type="button"
+              aria-label="Recargar billetera del cliente"
+              @click="showWalletRechargeModal = true"
+              class="min-h-[44px] px-4 text-sm font-semibold rounded-lg border-2 border-primary/30 text-primary bg-primary/5 hover:bg-primary/10 transition-colors"
+            >
+              + Recargar
+            </button>
+          </div>
+          <div v-if="walletMovements.length" class="mt-3 space-y-2 max-h-40 overflow-y-auto">
+            <div
+              v-for="mov in walletMovements.slice(0, 5)"
+              :key="mov.id"
+              class="flex items-center justify-between gap-3 text-sm py-1.5 border-b border-border/50 last:border-0"
+            >
+              <div class="min-w-0">
+                <p class="text-text-primary font-medium">{{ walletMovementLabel(mov.movement_type) }}</p>
+                <p class="text-xs text-text-secondary">{{ formatDate(mov.created_at) }}</p>
+              </div>
+              <span
+                :class="[
+                  'font-semibold flex-shrink-0',
+                  mov.amount_cop >= 0 ? 'text-green-700' : 'text-red-600',
+                ]"
+              >
+                {{ mov.amount_cop >= 0 ? '+' : '' }}{{ formatCurrency(Math.abs(mov.amount_cop)) }}
+              </span>
+            </div>
+          </div>
+        </div>
       </div>
 
       <!-- Stats -->
@@ -824,6 +908,19 @@ onUnmounted(() => {
       :customer-name="customer.name"
       :current-balance="warosBalance"
       @assigned="onWarosAssigned"
+    />
+
+    <AnaliticaWalletRechargeModal
+      v-if="customer"
+      v-model="showWalletRechargeModal"
+      :customer-id="customerId"
+      :customer-name="customer.name"
+      :current-balance="walletBalance"
+      :payment-options="walletPaymentOptions"
+      :recharge="recharge"
+      :is-recharging="isRecharging"
+      :recharge-error="rechargeError"
+      @recharged="onWalletRecharged"
     />
 
     <!-- Slide-over: asignaciones manuales -->

--- a/pages/analitica/clientes/index.vue
+++ b/pages/analitica/clientes/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
+import { useRouter } from 'vue-router';
 import { useDebounceFn } from '@vueuse/core'
 import { es } from 'date-fns/locale';
 import { format as fnsFormat, formatDistanceToNow } from 'date-fns';
@@ -243,8 +244,21 @@ onUnmounted(() => {
         >
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
         </button>
+        <button
+          type="button"
+          @click="showCreateModal = true"
+          class="h-10 px-4 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 transition-colors flex-shrink-0 whitespace-nowrap"
+          aria-label="Crear nuevo cliente"
+        >
+          + Nuevo cliente
+        </button>
       </div>
     </ClientOnly>
+
+    <AnaliticaCreateCustomerModal
+      v-model="showCreateModal"
+      @created="onCustomerCreated"
+    />
 
     <!-- Loading -->
     <div v-if="isLoading" class="flex items-center justify-center min-h-[400px]">

--- a/pages/analitica/puntos.vue
+++ b/pages/analitica/puntos.vue
@@ -135,6 +135,10 @@ onUnmounted(() => {
         />
       </div>
 
+      <!-- Redemption + rewards admin -->
+      <PuntosRedemptionConfigSection />
+      <PuntosWaroRewardsSection />
+
       <!-- Empty state -->
       <div
         v-if="rules.length === 0"


### PR DESCRIPTION
## Summary
- Add **Nuevo cliente** flow on `/analitica/clientes` (search-or-create, phone required)
- Add **Wallet COP** card on customer detail: balance, recharge modal, recent movements
- Extend `/analitica/puntos` with **B1 redemption config** and **WaRo rewards** CRUD (B2 catalog)
- Three composables wire existing proxied API routes from api-warolabs#369/#370

## Test plan
- [ ] `/analitica/clientes` — click **Nuevo cliente**, create with phone → lands on detail page
- [ ] `/analitica/clientes/:id` — wallet balance loads; recharge with payment method + note; movements update
- [ ] `/analitica/puntos` — toggle redemption config, save B1 fields; create/edit/delete reward (fixed_cop_off + free_product)
- [ ] Verify API errors show `detail` message (e.g. duplicate phone, invalid amount)
- [ ] Confirm cajero/admin can access; no customer-facing routes added

Closes #1062

Made with [Cursor](https://cursor.com)