### PR TITLE
feat(pos): checkout wallet payment and WaRo redemption (#1063)

### DIFF
--- a/components/pos/WaroRewardPickerModal.vue
+++ b/components/pos/WaroRewardPickerModal.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import type { WaroReward } from '~/composables/useWaroRewards'
+
+const props = defineProps<{
+  modelValue: boolean
+  warosBalance: number
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+  select: [reward: WaroReward]
+}>()
+
+const { rewards, isLoading, fetchRewards } = useWaroRewards()
+
+const activeRewards = computed(() =>
+  rewards.value.filter(r => r.is_active),
+)
+
+watch(
+  () => props.modelValue,
+  (open) => {
+    if (open) fetchRewards()
+  },
+)
+
+function close() {
+  emit('update:modelValue', false)
+}
+
+function pick(reward: WaroReward) {
+  if (props.warosBalance < reward.waros_cost) return
+  emit('select', reward)
+  close()
+}
+
+function rewardSubtitle(reward: WaroReward) {
+  if (reward.reward_type === 'fixed_cop_off' && reward.fixed_cop_off) {
+    return `-${formatCurrency(reward.fixed_cop_off)} · ${reward.waros_cost.toLocaleString('es-CO')} pts`
+  }
+  return `Producto gratis · ${reward.waros_cost.toLocaleString('es-CO')} pts`
+}
+</script>
+
+<template>
+  <Transition name="sheet">
+    <div
+      v-if="modelValue"
+      class="fixed inset-0 z-[70] flex items-end md:items-center justify-center md:p-4 bg-black/50"
+      @click.self="close"
+    >
+      <div
+        class="bottom-sheet-panel bg-surface w-full md:max-w-md border border-border flex flex-col rounded-t-2xl md:rounded-2xl shadow-2xl max-h-[85vh]"
+        @click.stop
+      >
+        <div class="p-5 border-b border-border flex items-center justify-between">
+          <div>
+            <h2 class="text-lg font-bold text-text-primary">Canjear recompensa</h2>
+            <p class="text-sm text-text-secondary mt-0.5">
+              Saldo: {{ warosBalance.toLocaleString('es-CO') }} pts
+            </p>
+          </div>
+          <button
+            type="button"
+            aria-label="Cerrar"
+            class="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-xl text-text-secondary hover:bg-surface-secondary"
+            @click="close"
+          >
+            <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div class="flex-1 overflow-y-auto p-4">
+          <div v-if="isLoading" class="space-y-3">
+            <div v-for="i in 3" :key="i" class="h-16 rounded-xl bg-surface-secondary animate-pulse" />
+          </div>
+          <div v-else-if="activeRewards.length === 0" class="py-8 text-center text-text-secondary text-sm">
+            No hay recompensas activas configuradas.
+          </div>
+          <ul v-else class="space-y-2">
+            <li v-for="reward in activeRewards" :key="reward.id">
+              <button
+                type="button"
+                class="w-full text-left p-4 rounded-xl border transition-colors min-h-[44px]"
+                :class="warosBalance >= reward.waros_cost
+                  ? 'border-border hover:border-amber-400 hover:bg-amber-50/50'
+                  : 'border-border opacity-50 cursor-not-allowed'"
+                :disabled="warosBalance < reward.waros_cost"
+                @click="pick(reward)"
+              >
+                <p class="font-semibold text-text-primary">{{ reward.name }}</p>
+                <p class="text-xs text-text-secondary mt-0.5">{{ rewardSubtitle(reward) }}</p>
+              </button>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>

--- a/composables/useWaroRedemptionPreview.ts
+++ b/composables/useWaroRedemptionPreview.ts
@@ -1,0 +1,129 @@
+/**
+ * Debounced WaRo redemption preview for POS checkout (B1/B2/B3).
+ * Proxied: GET /api/admin/waros/preview-redemption
+ */
+
+export interface PromoLineForRedemption {
+  id: string
+  product_id: string
+  category_id?: string | null
+  quantity: number
+  subtotal: number
+  promo_opt_out?: boolean
+}
+
+export interface WaroRedemptionPreview {
+  redemption_enabled: boolean
+  subtotal_after_promos: number
+  manual_discount_amount: number
+  base_after_manual: number
+  base_canje: number
+  b1_waros: number
+  b1_cop: number
+  b1_cop_raw: number
+  b2_waros: number
+  reward_fixed_off: number
+  reward_type: string | null
+  reward_name: string | null
+  waro_reward_id: string | null
+  total_waro_discount_cop: number
+  total_waros_cost: number
+  max_redeem_percent: number
+  max_b1_cop_cap: number
+  wallet_balance: number
+  total_after_redemption: number
+}
+
+export interface WaroRedemptionPreviewParams {
+  lines: PromoLineForRedemption[]
+  customerId?: string | null
+  manualDiscountAmount?: number
+  discountType?: 'percent' | 'fixed' | null
+  discountValue?: number | null
+  warosToRedeem?: number
+  waroRewardId?: string | null
+}
+
+export const useWaroRedemptionPreview = () => {
+  const preview = ref<WaroRedemptionPreview | null>(null)
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let requestSeq = 0
+
+  const resetPreview = () => {
+    preview.value = null
+    error.value = null
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  const fetchPreview = async (params: WaroRedemptionPreviewParams) => {
+    if (!params.lines.length) {
+      resetPreview()
+      return null
+    }
+
+    const seq = ++requestSeq
+    isLoading.value = true
+    error.value = null
+
+    try {
+      const query: Record<string, string> = {
+        lines: JSON.stringify(params.lines),
+      }
+      if (params.customerId) query.customer_id = params.customerId
+      if (params.manualDiscountAmount != null && params.manualDiscountAmount > 0) {
+        query.manual_discount_amount = String(params.manualDiscountAmount)
+      }
+      if (params.discountType && params.discountValue != null && params.discountValue > 0) {
+        query.discount_type = params.discountType
+        query.discount_value = String(params.discountValue)
+      }
+      if (params.warosToRedeem != null && params.warosToRedeem > 0) {
+        query.waros_to_redeem = String(params.warosToRedeem)
+      }
+      if (params.waroRewardId) query.waro_reward_id = params.waroRewardId
+
+      const qs = new URLSearchParams(query).toString()
+      const data = await $fetch<WaroRedemptionPreview>(
+        `/api/admin/waros/preview-redemption?${qs}`,
+      )
+      if (seq !== requestSeq) return null
+      preview.value = data
+      return data
+    } catch (e: any) {
+      if (seq !== requestSeq) return null
+      preview.value = null
+      const detail = e?.data?.detail
+      error.value = Array.isArray(detail)
+        ? detail.map((d: any) => d.msg ?? JSON.stringify(d)).join('; ')
+        : detail || e?.data?.message || e?.message || 'Error al calcular canje WaRo'
+      return null
+    } finally {
+      if (seq === requestSeq) isLoading.value = false
+    }
+  }
+
+  const schedulePreview = (params: WaroRedemptionPreviewParams, delayMs = 400) => {
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => {
+      void fetchPreview(params)
+    }, delayMs)
+  }
+
+  onUnmounted(() => {
+    if (timer) clearTimeout(timer)
+  })
+
+  return {
+    preview,
+    isLoading,
+    error,
+    fetchPreview,
+    schedulePreview,
+    resetPreview,
+  }
+}

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -7,7 +7,9 @@ import QRCode from 'qrcode'
 import { usePOSStore, type TabItem } from '~/stores/usePOSStore'
 import { clearTableQrPaymentIntent, readTableQrPaymentIntent } from '~/composables/useTableSessionSync'
 import { useAddressStore, type AddressCreate } from '~/stores/address'
-import { PAYMENT_DEFAULTS, type PosPaymentGroup, type PosPaymentMethod } from '~/utils/paymentDefaults'
+import { PAYMENT_DEFAULTS, WALLET_PAYMENT_SLUG, type PosPaymentGroup, type PosPaymentMethod } from '~/utils/paymentDefaults'
+import type { WaroReward } from '~/composables/useWaroRewards'
+import type { PromoLineForRedemption } from '~/composables/useWaroRedemptionPreview'
 import DeliveryAddressPicker from '~/components/pos/checkout/DeliveryAddressPicker.vue'
 import DeliveryAddressForm from '~/components/pos/checkout/DeliveryAddressForm.vue'
 import { displayTableCode } from '~/composables/useTableDisplayCode'
@@ -496,7 +498,18 @@ const discountAmount = computed(() => {
   }
   return Math.min(Math.round(val), Math.round(subtotalAfterPromos.value))
 })
-const discountedTotal = computed(() => subtotalAfterPromos.value - discountAmount.value)
+const {
+  preview: waroPreview,
+  isLoading: isLoadingWaroPreview,
+  error: waroPreviewError,
+  schedulePreview,
+  resetPreview: resetWaroPreview,
+} = useWaroRedemptionPreview()
+const waroDiscountCop = computed(() => Number(waroPreview.value?.total_waro_discount_cop) || 0)
+const combinedDiscountForTax = computed(() => discountAmount.value + waroDiscountCop.value)
+const discountedTotal = computed(() =>
+  Math.max(0, subtotalAfterPromos.value - discountAmount.value - waroDiscountCop.value),
+)
 // warocol.com#639 — final amount charged to the customer when tipping is enabled.
 // total_amount on orders never includes tip (tax-base invariant from migration 079);
 // charged_amount = total_amount + tip_amount lives at the payment layer only.
@@ -522,13 +535,14 @@ const {
   staleTime: 5_000,  // short — running_total changes when items are added
 })
 
-// POS tax preview — only when in counter/bar mode. discountAmount is part of
-// the key so a discount change re-fetches automatically.
+// POS tax preview — manual + WaRo discounts are folded into discount_amount (#1063).
 const { data: posTaxPreviewData } = useQuery({
-  key: () => ['pos', 'cart', posStore.cartId ?? null, 'tax-preview', discountAmount.value, promoOptOutSignature.value],
+  key: () => ['pos', 'cart', posStore.cartId ?? null, 'tax-preview', combinedDiscountForTax.value, promoOptOutSignature.value],
   query: () => {
     const params = new URLSearchParams()
-    if (discountAmount.value > 0) params.set('discount_amount', String(discountAmount.value))
+    if (combinedDiscountForTax.value > 0) {
+      params.set('discount_amount', String(combinedDiscountForTax.value))
+    }
     const qs = params.toString() ? `?${params.toString()}` : ''
     return $fetch<{
       standard_tax: number
@@ -758,6 +772,7 @@ const addSplitPayment = async () => {
               : {}),
             ...checkoutServedByBody.value,
             ...checkoutTipBody.value,
+            ...checkoutWaroBody.value,
           }
         }) as any
         paidTotal = response.data.paid_total ?? amountToCharge
@@ -805,6 +820,7 @@ const addSplitPayment = async () => {
               : {}),
             ...checkoutServedByBody.value,
             ...checkoutTipBody.value,
+            ...checkoutWaroBody.value,
           }
         }) as any
         paidTotal = response.data.paid_total ?? amountToCharge
@@ -953,12 +969,123 @@ const confirmVoidPayment = async () => {
   }
 }
 
-// Waros
+// Waros + wallet (#1063)
 const { summary: warosSummary, isLoadingSummary: isLoadingWaros, fetchSummary: fetchWarosSummary, resetSummary } = useWarosCliente()
 const { estimatedWaros, isLoadingEstimate, systemEnabled: warosSystemEnabled, fetchEstimate, resetEstimate } = useWarosEstimate()
 const showWarosModal = ref(false)
+const showWaroRewardPicker = ref(false)
+const warosToRedeemInput = ref('')
+const selectedWaroReward = ref<WaroReward | null>(null)
 const warosBalance = computed(() => warosSummary.value?.current_balance ?? 0)
 const isAnonymousCustomer = computed(() => selectedCustomer.value?.phone_number === '0000000000')
+const customerIdRef = computed(() => selectedCustomer.value?.id ?? '')
+const { wallet: customerWallet, isLoading: isLoadingWallet, refetch: refetchWallet } =
+  useCustomerWallet(customerIdRef)
+const walletBalanceCop = computed(() => customerWallet.value?.balance_cop ?? 0)
+const { config: redemptionConfig } = useRedemptionConfig()
+
+const warosToRedeem = computed(() => {
+  const n = parseInt(warosToRedeemInput.value, 10)
+  return Number.isFinite(n) && n > 0 ? n : 0
+})
+const waroRewardLabel = computed(() => {
+  if (selectedWaroReward.value) return selectedWaroReward.value.name
+  return waroPreview.value?.reward_name ?? null
+})
+const waroRedemptionEnabled = computed(
+  () => redemptionConfig.value?.redemption_enabled !== false && warosSystemEnabled.value,
+)
+
+function buildRedemptionPromoLines(): PromoLineForRedemption[] {
+  return cartItems.value
+    .map(item => ({
+      id: String(item.orderItemId ?? item.id ?? ''),
+      product_id: String(item.product?.id ?? ''),
+      category_id: checkoutLineCategoryId(item),
+      quantity: Number(item.quantity) || 1,
+      subtotal: checkoutLineGross(item),
+      promo_opt_out: Boolean(item.promo_opt_out ?? item.promoOptOut),
+    }))
+    .filter(line => line.id && line.product_id)
+}
+
+function refreshWaroPreview() {
+  if (!selectedCustomer.value || isAnonymousCustomer.value) {
+    resetWaroPreview()
+    return
+  }
+  if (!warosToRedeem.value && !selectedWaroReward.value) {
+    resetWaroPreview()
+    return
+  }
+  schedulePreview({
+    lines: buildRedemptionPromoLines(),
+    customerId: selectedCustomer.value.id,
+    manualDiscountAmount: discountAmount.value,
+    discountType: discountEnabled.value ? discountType.value : null,
+    discountValue:
+      discountEnabled.value && discountInput.value
+        ? Number(discountInput.value)
+        : null,
+    warosToRedeem: warosToRedeem.value || undefined,
+    waroRewardId: selectedWaroReward.value?.id ?? null,
+  })
+}
+
+const checkoutWaroBody = computed(() => {
+  const body: Record<string, number | string> = {}
+  if (warosToRedeem.value > 0) body.waros_to_redeem = warosToRedeem.value
+  if (selectedWaroReward.value?.id) body.waro_reward_id = selectedWaroReward.value.id
+  return body
+})
+
+function applyMaxWarosRedeem() {
+  const cap = waroPreview.value?.max_b1_cop_cap
+  const rate = redemptionConfig.value?.waros_per_1000_cop ?? 100
+  if (!cap || cap <= 0 || rate <= 0) return
+  const warosNeeded = Math.floor((cap * 1000) / rate)
+  const reserved = selectedWaroReward.value?.waros_cost ?? 0
+  warosToRedeemInput.value = String(Math.max(0, Math.min(warosNeeded, warosBalance.value - reserved)))
+}
+
+function onWaroRewardPicked(reward: WaroReward) {
+  selectedWaroReward.value = reward
+  refreshWaroPreview()
+}
+
+function clearWaroRedemption() {
+  warosToRedeemInput.value = ''
+  selectedWaroReward.value = null
+  resetWaroPreview()
+}
+
+function isPaymentGroupVisible(group: PosPaymentGroup) {
+  if (group.triggersCartera) {
+    return !!(selectedCustomer.value && !isAnonymousCustomer.value)
+  }
+  if (group.slug === WALLET_PAYMENT_SLUG || group.triggersWallet) {
+    return !!(selectedCustomer.value && !isAnonymousCustomer.value && walletBalanceCop.value > 0)
+  }
+  return true
+}
+
+const isWalletMethod = computed(() => selectedGroup.value?.slug === WALLET_PAYMENT_SLUG)
+
+watch(
+  [
+    () => selectedCustomer.value?.id,
+    discountAmount,
+    () => discountType.value,
+    () => discountInput.value,
+    () => warosToRedeemInput.value,
+    () => selectedWaroReward.value?.id,
+    cartItems,
+    promoOptOutSignature,
+    () => discountEnabled.value,
+  ],
+  () => refreshWaroPreview(),
+  { deep: true },
+)
 
 // Delivery eligibility — allowed for counter and bar (anything that's not a real mesa).
 // Mesa is dine-in by definition; bar is a permanent counter tab used as walk-in/mostrador.
@@ -1029,6 +1156,7 @@ watch(selectedCustomer, async (customer) => {
   // last left them — never auto-open on customer change.
   resetSummary()
   resetEstimate()
+  clearWaroRedemption()
   customerInsights.value = null
   insightsLoading.value = false
   if (!customer || customer.phone_number === '0000000000') return
@@ -1237,6 +1365,7 @@ const processOrder = async () => {
           // it on the first completed order of the session).
           ...checkoutTipBody.value,
           ...checkoutServedByBody.value,
+          ...checkoutWaroBody.value,
         },
       }) as any
 
@@ -1355,6 +1484,7 @@ const processOrder = async () => {
         ...checkoutServedByBody.value,
         // warocol.com#639 — tip capture (server validates against tenant.tip_enabled)
         ...checkoutTipBody.value,
+        ...checkoutWaroBody.value,
       }
     }) as {
       success: boolean
@@ -1442,9 +1572,10 @@ const processOrder = async () => {
   }
 }
 
-const onCustomerIdentified = (customer: { id: string; name: string | null; phone_number: string | null; email: string | null }) => {
+const onCustomerIdentified = async (customer: { id: string; name: string | null; phone_number: string | null; email: string | null }) => {
   selectedCustomer.value = customer
   processingError.value = ''
+  await posStore.setCustomer(customer as any)
 }
 
 // Derived from dynamic groups
@@ -1513,9 +1644,7 @@ const requiresMethodSelection = computed(() =>
 
 // Dynamic grid class based on group count (excluding hidden cartera groups)
 const paymentGridClass = computed(() => {
-  const visibleCount = posPaymentGroups.value.filter(
-    g => !g.triggersCartera || (selectedCustomer.value && !isAnonymousCustomer.value)
-  ).length
+  const visibleCount = posPaymentGroups.value.filter(g => isPaymentGroupVisible(g)).length
   if (visibleCount <= 2) return 'grid-cols-2'
   if (visibleCount === 3) return 'grid-cols-3'
   return 'grid-cols-2 md:grid-cols-4'
@@ -1721,6 +1850,8 @@ type PrefacturaPrintSnapshot = {
   promoBreakdown: PromoBreakdownLine[]
   cartSubtotal: number
   manualDiscountAmount: number
+  waroDiscountCop: number
+  waroRewardName: string | null
 }
 
 const prefacturaPrintSnapshot = ref<PrefacturaPrintSnapshot | null>(null)
@@ -1740,6 +1871,8 @@ const prefacturaPrintData = computed(() => {
     promoBreakdown: displayPromoBreakdown.value,
     cartSubtotal: cartTotal.value,
     manualDiscountAmount: discountAmount.value,
+    waroDiscountCop: waroDiscountCop.value,
+    waroRewardName: waroRewardLabel.value,
   }
 })
 
@@ -1765,6 +1898,8 @@ function capturePrefacturaPrintSnapshot() {
     promoBreakdown: displayPromoBreakdown.value.map(p => ({ ...p })),
     cartSubtotal: cartTotal.value,
     manualDiscountAmount: discountAmount.value,
+    waroDiscountCop: waroDiscountCop.value,
+    waroRewardName: waroRewardLabel.value,
   }
 }
 
@@ -2073,6 +2208,20 @@ onUnmounted(() => {
 // modes. Uses a watcher (not onMounted) because businessProfile is loaded
 // asynchronously by the tenants store and may still be undefined when
 // checkout mounts on a fresh page load.
+watch(
+  () => posStore.currentCustomer,
+  (customer) => {
+    if (!customer || selectedCustomer.value) return
+    selectedCustomer.value = {
+      id: customer.id,
+      name: customer.name ?? null,
+      phone_number: customer.phone_number ?? null,
+      email: customer.email ?? null,
+    }
+  },
+  { immediate: true },
+)
+
 const autoSelectAttempted = ref(false)
 watch(
   () => businessProfile.value,
@@ -2321,7 +2470,7 @@ onUnmounted(() => {
             <label
               v-for="group in posPaymentGroups"
               :key="group.slug"
-              v-show="!group.triggersCartera || (selectedCustomer && !isAnonymousCustomer)"
+              v-show="isPaymentGroupVisible(group)"
               class="cursor-pointer relative"
             >
               <input type="radio" name="payment" :value="group.slug" v-model="selectedPaymentMethod" class="sr-only">
@@ -2800,15 +2949,19 @@ onUnmounted(() => {
                 <span>Subtotal con promoción</span>
                 <span class="font-medium text-text-primary">{{ formatCurrency(subtotalAfterPromos) }}</span>
               </div>
+              <div v-if="discountEnabled && discountAmount > 0" class="flex justify-between text-sm text-primary">
+                <span>Descuento manual</span>
+                <span class="font-medium">- {{ formatCurrency(discountAmount) }}</span>
+              </div>
+              <div v-if="waroDiscountCop > 0" class="flex justify-between text-sm text-amber-700">
+                <span>{{ waroRewardLabel ? `WaRo: ${waroRewardLabel}` : 'Canje WaRo' }}</span>
+                <span class="font-medium">- {{ formatCurrency(waroDiscountCop) }}</span>
+              </div>
               <div class="flex justify-between text-sm text-text-secondary">
                 <span>{{ taxPreview ? taxPreview.standard_tax_label : 'Impuestos (0%)' }}</span>
                 <span class="font-medium text-text-primary">
                   {{ formatCurrency(taxPreview ? (taxPreview.standard_tax + taxPreview.liquor_tax) : 0) }}
                 </span>
-              </div>
-              <div v-if="discountEnabled && discountAmount > 0" class="flex justify-between text-sm text-primary">
-                <span>Descuento</span>
-                <span class="font-medium">- {{ formatCurrency(discountAmount) }}</span>
               </div>
               <div
                 v-if="tipAmount > 0"
@@ -2867,31 +3020,75 @@ onUnmounted(() => {
               <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" />
             </svg>
           </button>
-          <div v-show="activeAccordion === 'waros'" class="border-t border-border px-5 py-4">
-            <!-- Skeleton -->
-            <div v-if="isLoadingWaros" class="grid grid-cols-2 gap-3 mb-3">
-              <div class="animate-pulse bg-surface-secondary rounded-xl p-3 h-14"></div>
-              <div class="animate-pulse bg-surface-secondary rounded-xl p-3 h-14"></div>
+          <div v-show="activeAccordion === 'waros'" class="border-t border-border px-5 py-4 space-y-3">
+            <div v-if="isLoadingWaros" class="grid grid-cols-2 gap-3">
+              <div class="animate-pulse bg-surface-secondary rounded-xl p-3 h-14" />
+              <div class="animate-pulse bg-surface-secondary rounded-xl p-3 h-14" />
             </div>
-            <!-- Data -->
-            <div v-else class="grid grid-cols-2 gap-3 mb-3">
+            <div v-else class="grid grid-cols-2 gap-3">
               <div class="bg-amber-50 rounded-xl p-3">
-                <p class="text-xs text-text-secondary mb-0.5">Balance actual</p>
-                <p class="text-lg font-bold text-amber-700 leading-tight">{{ warosBalance.toLocaleString('es-CO') }}</p>
+                <p class="text-xs text-text-secondary mb-0.5">Balance WaRo</p>
+                <p class="text-lg font-bold text-amber-700 leading-tight tabular-nums">{{ warosBalance.toLocaleString('es-CO') }} pts</p>
               </div>
-              <div class="bg-green-50 rounded-xl p-3">
-                <p class="text-xs text-text-secondary mb-0.5">Ganarías esta compra</p>
-                <p class="text-lg font-bold text-green-700 leading-tight" aria-live="polite">
-                  <span v-if="isLoadingEstimate" class="inline-block h-5 w-16 rounded bg-green-200 animate-pulse"></span>
-                  <span v-else-if="estimatedWaros === null">—</span>
-                  <span v-else>+ {{ estimatedWaros.toLocaleString('es-CO') }}</span>
+              <div class="bg-emerald-50 rounded-xl p-3">
+                <p class="text-xs text-text-secondary mb-0.5">Saldo wallet</p>
+                <p class="text-lg font-bold text-emerald-700 leading-tight tabular-nums">
+                  {{ isLoadingWallet ? '…' : formatCurrency(walletBalanceCop) }}
                 </p>
               </div>
             </div>
+            <div v-if="!isLoadingWaros" class="bg-green-50 rounded-xl p-3">
+              <p class="text-xs text-text-secondary mb-0.5">Ganarías esta compra</p>
+              <p class="text-base font-bold text-green-700 leading-tight" aria-live="polite">
+                <span v-if="isLoadingEstimate" class="inline-block h-5 w-16 rounded bg-green-200 animate-pulse" />
+                <span v-else-if="estimatedWaros === null">—</span>
+                <span v-else>+ {{ estimatedWaros.toLocaleString('es-CO') }} pts</span>
+              </p>
+            </div>
+            <template v-if="waroRedemptionEnabled">
+              <div v-if="selectedWaroReward" class="flex items-center justify-between gap-2 p-3 rounded-xl bg-amber-50 border border-amber-200 text-sm">
+                <span class="font-medium text-amber-900 truncate">{{ selectedWaroReward.name }}</span>
+                <button type="button" class="text-xs text-amber-700 underline min-h-[44px] px-2" @click="selectedWaroReward = null; refreshWaroPreview()">
+                  Quitar
+                </button>
+              </div>
+              <div class="space-y-2">
+                <label class="text-xs font-semibold text-text-secondary uppercase tracking-wide">Canjear puntos</label>
+                <div class="flex gap-2">
+                  <input
+                    v-model="warosToRedeemInput"
+                    type="number"
+                    min="0"
+                    inputmode="numeric"
+                    placeholder="Puntos"
+                    class="input-base flex-1 min-h-[44px] px-3 text-sm tabular-nums"
+                  />
+                  <button
+                    type="button"
+                    class="min-h-[44px] px-3 rounded-lg border border-amber-300 text-amber-800 text-xs font-semibold hover:bg-amber-50"
+                    @click="applyMaxWarosRedeem"
+                  >
+                    Máximo
+                  </button>
+                </div>
+                <p v-if="waroPreview?.b1_cop" class="text-xs text-amber-700 tabular-nums">
+                  ≈ {{ formatCurrency(waroPreview.b1_cop) }} · máx. {{ waroPreview.max_redeem_percent }}%
+                </p>
+              </div>
+              <button
+                type="button"
+                class="w-full min-h-[44px] px-4 py-2.5 text-sm font-semibold border border-amber-300 rounded-lg text-amber-800 hover:bg-amber-50"
+                @click="showWaroRewardPicker = true"
+              >
+                Canjear recompensa
+              </button>
+              <p v-if="waroPreviewError" class="text-xs text-destructive">{{ waroPreviewError }}</p>
+              <p v-if="isLoadingWaroPreview" class="text-xs text-text-tertiary">Calculando canje…</p>
+            </template>
             <button
               type="button"
               @click="showWarosModal = true"
-              class="w-full min-h-[44px] px-4 py-2.5 text-sm font-medium border border-border rounded-lg hover:bg-surface-secondary transition-colors text-text-secondary focus:outline-none focus:ring-2 focus:ring-primary/30"
+              class="w-full min-h-[44px] px-4 py-2.5 text-sm font-medium border border-border rounded-lg hover:bg-surface-secondary transition-colors text-text-secondary"
             >
               Asignar manualmente
             </button>
@@ -3259,15 +3456,19 @@ onUnmounted(() => {
               <span>Subtotal con promoción</span>
               <span class="font-medium text-text-primary">{{ formatCurrency(subtotalAfterPromos) }}</span>
             </div>
+            <div v-if="discountEnabled && discountAmount > 0" class="flex justify-between text-sm text-green-600 dark:text-green-400">
+              <span>Descuento manual</span>
+              <span class="font-medium">- {{ formatCurrency(discountAmount) }}</span>
+            </div>
+            <div v-if="waroDiscountCop > 0" class="flex justify-between text-sm text-amber-700">
+              <span>{{ waroRewardLabel ? `WaRo: ${waroRewardLabel}` : 'Canje WaRo' }}</span>
+              <span class="font-medium">- {{ formatCurrency(waroDiscountCop) }}</span>
+            </div>
             <div class="flex justify-between text-sm text-text-secondary">
               <span>{{ taxPreview ? taxPreview.standard_tax_label : 'Impuestos (0%)' }}</span>
               <span class="font-medium text-text-primary">
                 {{ formatCurrency(taxPreview ? (taxPreview.standard_tax + taxPreview.liquor_tax) : 0) }}
               </span>
-            </div>
-            <div v-if="discountEnabled && discountAmount > 0" class="flex justify-between text-sm text-green-600 dark:text-green-400">
-              <span>Descuento</span>
-              <span class="font-medium">- {{ formatCurrency(discountAmount) }}</span>
             </div>
             <div
               v-if="tipAmount > 0"
@@ -3306,32 +3507,46 @@ onUnmounted(() => {
         v-if="selectedCustomer && !isAnonymousCustomer && warosSystemEnabled"
         class="bg-surface rounded-2xl border border-border overflow-hidden shadow-sm"
       >
-        <div class="px-5 py-4">
-          <h3 class="font-bold text-text-primary text-sm mb-3">Puntos Waros</h3>
-          <div v-if="isLoadingWaros" class="grid grid-cols-2 gap-3 mb-3">
-            <div class="animate-pulse bg-surface-secondary rounded-xl p-3 h-14"></div>
-            <div class="animate-pulse bg-surface-secondary rounded-xl p-3 h-14"></div>
+        <div class="px-5 py-4 space-y-3">
+          <h3 class="font-bold text-text-primary text-sm">Puntos Waros</h3>
+          <div v-if="isLoadingWaros" class="grid grid-cols-2 gap-3">
+            <div class="animate-pulse bg-surface-secondary rounded-xl p-3 h-14" />
+            <div class="animate-pulse bg-surface-secondary rounded-xl p-3 h-14" />
           </div>
-          <div v-else class="grid grid-cols-2 gap-3 mb-3">
+          <div v-else class="grid grid-cols-2 gap-3">
             <div class="bg-amber-50 rounded-xl p-3">
-              <p class="text-xs text-text-secondary mb-0.5">Balance actual</p>
-              <p class="text-lg font-bold text-amber-700 leading-tight">
-                {{ warosBalance.toLocaleString('es-CO') }}
-              </p>
+              <p class="text-xs text-text-secondary mb-0.5">Balance WaRo</p>
+              <p class="text-lg font-bold text-amber-700 leading-tight tabular-nums">{{ warosBalance.toLocaleString('es-CO') }} pts</p>
             </div>
-            <div class="bg-green-50 rounded-xl p-3">
-              <p class="text-xs text-text-secondary mb-0.5">Ganarías esta compra</p>
-              <p class="text-lg font-bold text-green-700 leading-tight" aria-live="polite">
-                <span v-if="isLoadingEstimate" class="inline-block h-5 w-16 rounded bg-green-200 animate-pulse"></span>
-                <span v-else-if="estimatedWaros === null">—</span>
-                <span v-else>+ {{ estimatedWaros.toLocaleString('es-CO') }}</span>
+            <div class="bg-emerald-50 rounded-xl p-3">
+              <p class="text-xs text-text-secondary mb-0.5">Saldo wallet</p>
+              <p class="text-lg font-bold text-emerald-700 leading-tight tabular-nums">
+                {{ isLoadingWallet ? '…' : formatCurrency(walletBalanceCop) }}
               </p>
             </div>
           </div>
+          <template v-if="waroRedemptionEnabled">
+            <div class="flex gap-2">
+              <input
+                v-model="warosToRedeemInput"
+                type="number"
+                min="0"
+                inputmode="numeric"
+                placeholder="Puntos a canjear"
+                class="input-base flex-1 min-h-[44px] px-3 text-sm"
+              />
+              <button type="button" class="min-h-[44px] px-3 rounded-lg border border-amber-300 text-xs font-semibold text-amber-800" @click="applyMaxWarosRedeem">
+                Máximo
+              </button>
+            </div>
+            <button type="button" class="w-full min-h-[44px] border border-amber-300 rounded-lg text-sm font-semibold text-amber-800" @click="showWaroRewardPicker = true">
+              Canjear recompensa
+            </button>
+          </template>
           <button
             type="button"
             @click="showWarosModal = true"
-            class="w-full min-h-[44px] px-4 py-2.5 text-sm font-medium border border-border rounded-lg hover:bg-surface-secondary transition-colors text-text-secondary focus:outline-none focus:ring-2 focus:ring-primary/30"
+            class="w-full min-h-[44px] px-4 py-2.5 text-sm font-medium border border-border rounded-lg hover:bg-surface-secondary text-text-secondary"
           >
             Asignar manualmente
           </button>
@@ -3793,6 +4008,13 @@ onUnmounted(() => {
       </div>
     </Teleport>
 
+    <!-- WaRo reward picker (B2) -->
+    <PosWaroRewardPickerModal
+      v-model="showWaroRewardPicker"
+      :waros-balance="warosBalance"
+      @select="onWaroRewardPicked"
+    />
+
     <!-- Waros Manual Assignment Modal -->
     <PuntosAsignarWarosModal
       v-if="selectedCustomer"
@@ -3884,6 +4106,10 @@ onUnmounted(() => {
     <div v-if="prefacturaPrintData.manualDiscountAmount > 0" class="receipt-item">
       <span>Descuento manual</span>
       <span>-{{ formatCurrency(prefacturaPrintData.manualDiscountAmount) }}</span>
+    </div>
+    <div v-if="prefacturaPrintData.waroDiscountCop > 0" class="receipt-item">
+      <span>{{ prefacturaPrintData.waroRewardName ? `WaRo: ${prefacturaPrintData.waroRewardName}` : 'Canje WaRo' }}</span>
+      <span>-{{ formatCurrency(prefacturaPrintData.waroDiscountCop) }}</span>
     </div>
     <div v-if="taxPreview && taxPreview.standard_tax > 0" class="receipt-item">
       <span>{{ taxPreview.standard_tax_label || 'Impuesto' }}</span>

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -239,6 +239,42 @@ const isMesaMode = computed(
   () => !!posStore.activeTableSession && !posStore.activeTableSession?.isBar,
 )
 
+// Customer identification on POS main screen (#1063)
+const showCustomerModal = ref(false)
+const posCustomerId = computed(() => posStore.currentCustomer?.id ?? '')
+const isAnonymousPosCustomer = computed(
+  () => posStore.currentCustomer?.phone_number === '0000000000',
+)
+const { wallet: posCustomerWallet, isLoading: isLoadingPosWallet, refetch: refetchPosWallet } =
+  useCustomerWallet(posCustomerId)
+const {
+  summary: posWarosSummary,
+  isLoadingSummary: isLoadingPosWaros,
+  fetchSummary: fetchPosWarosSummary,
+  resetSummary: resetPosWarosSummary,
+} = useWarosCliente()
+
+watch(posCustomerId, (id) => {
+  if (!id || isAnonymousPosCustomer.value) {
+    resetPosWarosSummary()
+    return
+  }
+  void fetchPosWarosSummary(id)
+  void refetchPosWallet()
+}, { immediate: true })
+
+const onPosCustomerIdentified = async (customer: {
+  id: string
+  name: string | null
+  phone_number: string | null
+  email: string | null
+}) => {
+  await posStore.setCustomer(customer as any)
+}
+
+const posWarosBalance = computed(() => posWarosSummary.value?.current_balance ?? 0)
+const posWalletBalance = computed(() => posCustomerWallet.value?.balance_cop ?? 0)
+
 // ── Unfired counts — tab vs cart (#807) ───────────────────────────────────
 // Banner uses tab + cart; kitchen send is only via Agregar y enviar (tab/add auto-fires).
 const tabUnfiredCount = computed(() => {
@@ -1520,24 +1556,58 @@ onUnmounted(() => {
 
       <!-- Customer Header (when customer is identified and no mesa mode) -->
       <div v-else-if="posStore.currentCustomer" class="bg-crocus-600/5 border border-crocus-500/25 rounded-xl mb-4 p-4">
-        <div class="flex items-center gap-3">
-          <div class="bg-crocus-600/10 p-3 rounded-xl border border-crocus-500/20 flex-shrink-0">
-            <svg class="w-5 h-5 text-crocus-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-            </svg>
+        <div class="flex items-start justify-between gap-3">
+          <div class="flex items-center gap-3 min-w-0">
+            <div class="bg-crocus-600/10 p-3 rounded-xl border border-crocus-500/20 flex-shrink-0">
+              <svg class="w-5 h-5 text-crocus-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+              </svg>
+            </div>
+            <div class="min-w-0">
+              <p class="text-[10px] font-bold text-crocus-600 uppercase tracking-widest">
+                Cliente Actual
+              </p>
+              <p class="text-base font-bold text-text-primary leading-tight truncate">
+                {{ posStore.currentCustomer.name || 'Sin nombre' }}
+              </p>
+              <p class="text-xs text-text-secondary mt-0.5">
+                📱 {{ posStore.currentCustomer.phone_number }}
+              </p>
+              <div
+                v-if="!isAnonymousPosCustomer"
+                class="flex flex-wrap gap-2 mt-2"
+              >
+                <span class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700 border border-emerald-200">
+                  Wallet: {{ isLoadingPosWallet ? '…' : formatCurrency(posWalletBalance) }}
+                </span>
+                <span class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-amber-50 text-amber-700 border border-amber-200">
+                  WaRos: {{ isLoadingPosWaros ? '…' : posWarosBalance.toLocaleString('es-CO') }} pts
+                </span>
+              </div>
+            </div>
           </div>
-          <div>
-            <p class="text-[10px] font-bold text-crocus-600 uppercase tracking-widest">
-              Cliente Actual
-            </p>
-            <p class="text-base font-bold text-text-primary leading-tight">
-              {{ posStore.currentCustomer.name || 'Sin nombre' }}
-            </p>
-            <p class="text-xs text-text-secondary mt-0.5">
-              📱 {{ posStore.currentCustomer.phone_number }}
-            </p>
-          </div>
+          <button
+            type="button"
+            class="flex-shrink-0 text-xs font-semibold text-crocus-700 hover:text-crocus-800 px-3 py-2 rounded-lg border border-crocus-500/30 hover:bg-crocus-600/10 transition-colors min-h-[44px]"
+            @click="showCustomerModal = true"
+          >
+            Cambiar
+          </button>
         </div>
+      </div>
+
+      <!-- Identify customer CTA (counter/bar, no table session) -->
+      <div v-else class="mb-4">
+        <button
+          type="button"
+          class="w-full flex items-center justify-center gap-2 min-h-[44px] px-4 py-3 rounded-xl border-2 border-dashed border-crocus-500/40 text-crocus-700 font-semibold text-sm hover:bg-crocus-600/5 transition-colors"
+          @click="showCustomerModal = true"
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+          </svg>
+          Identificar cliente
+        </button>
       </div>
 
 
@@ -1762,5 +1832,11 @@ onUnmounted(() => {
       @update:served-by="(id) => posStore.setCartServedBy(id)"
     />
   </UiBottomSheetModal>
+
+  <PosCustomerIdentificationModal
+    v-model="showCustomerModal"
+    @customer-identified="onPosCustomerIdentified"
+    @fiscal-updated="onPosCustomerIdentified"
+  />
 
 </template>

--- a/utils/paymentDefaults.ts
+++ b/utils/paymentDefaults.ts
@@ -4,6 +4,7 @@ import {
   DevicePhoneMobileIcon,
   ClockIcon,
   CurrencyDollarIcon,
+  WalletIcon,
 } from '@heroicons/vue/24/outline'
 
 export interface PosPaymentMethod {
@@ -16,14 +17,19 @@ export interface PosPaymentGroup {
   slug: string
   name: string
   triggersCartera: boolean
+  /** COP prepayment wallet tender (api#369) */
+  triggersWallet?: boolean
   methods: PosPaymentMethod[]
 }
+
+export const WALLET_PAYMENT_SLUG = 'customer_wallet'
 
 export const PAYMENT_DEFAULTS: PosPaymentGroup[] = [
   { id: 'cash',    slug: 'cash',    name: 'Efectivo', triggersCartera: false, methods: [] },
   { id: 'card',    slug: 'card',    name: 'Datáfono', triggersCartera: false, methods: [] },
   { id: 'digital', slug: 'digital', name: 'QR',       triggersCartera: false, methods: [] },
   { id: 'credit',  slug: 'credit',  name: 'Crédito',  triggersCartera: true,  methods: [] },
+  { id: 'customer_wallet', slug: WALLET_PAYMENT_SLUG, name: 'Saldo wallet', triggersCartera: false, triggersWallet: true, methods: [] },
 ]
 
 /** Map a payment group slug to a Heroicon component. Falls back to CurrencyDollarIcon. */
@@ -32,6 +38,7 @@ export const SLUG_ICON_MAP: Record<string, typeof CurrencyDollarIcon> = {
   card:    CreditCardIcon,
   digital: DevicePhoneMobileIcon,
   credit:  ClockIcon,
+  [WALLET_PAYMENT_SLUG]: WalletIcon,
 }
 
 export const SLUG_ICON_FALLBACK = CurrencyDollarIcon


### PR DESCRIPTION
## Summary
- POS index: customer identification modal with Wallet / WaRo badges
- Checkout: seeds customer from `posStore`, debounced `preview-redemption`, B1 points + B2 reward picker, `customer_wallet` tender
- Complete / mesa close payloads include `waros_to_redeem` and `waro_reward_id`; prefactura shows WaRo discount line

Closes #1063

## Test plan
- [ ] POS counter: identify customer → badges show wallet balance + WaRo pts
- [ ] Navigate to checkout → customer pre-selected from POS (no re-pick)
- [ ] B1: enter points / Máximo → summary shows WaRo COP discount before tax
- [ ] B2: **Canjear recompensa** → pick reward → preview line + points cost
- [ ] B3: combine B1 + B2 on same order
- [ ] **Saldo wallet** payment method visible when `balance_cop > 0`; pay full or split remainder
- [ ] Anonymous customer (`0000000000`): no wallet tender, no WaRo redeem UI
- [ ] Prefactura print includes WaRo discount + reward name when applied
- [ ] Mesa close + split first payment send redemption fields to API


Made with [Cursor](https://cursor.com)