### PR TITLE
fix(pos): remove manual Waros assignment from checkout

### DIFF
--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -972,7 +972,6 @@ const confirmVoidPayment = async () => {
 // Waros + wallet (#1063)
 const { summary: warosSummary, isLoadingSummary: isLoadingWaros, fetchSummary: fetchWarosSummary, resetSummary } = useWarosCliente()
 const { estimatedWaros, earnEligible: warosEarnEligible, isLoadingEstimate, systemEnabled: warosSystemEnabled, fetchEstimate, resetEstimate } = useWarosEstimate()
-const showWarosModal = ref(false)
 const showWaroRewardPicker = ref(false)
 const warosToRedeemInput = ref('')
 const selectedWaroReward = ref<WaroReward | null>(null)
@@ -1158,10 +1157,6 @@ watch(selectedPaymentMethod, () => {
   if (discountedTotal.value <= 0) return
   refreshWarosEstimate()
 })
-
-const onWarosAssigned = async (_payload: { newBalance: number }) => {
-  await fetchWarosSummary(selectedCustomer.value!.id)
-}
 
 watch(selectedCustomer, async (customer) => {
   // Reset Waros state on customer change. Accordions stay where the user
@@ -3134,13 +3129,6 @@ onUnmounted(() => {
               <p v-if="waroPreviewError" class="text-xs text-destructive">{{ waroPreviewError }}</p>
               <p v-if="isLoadingWaroPreview" class="text-xs text-text-tertiary">Calculando canje…</p>
             </template>
-            <button
-              type="button"
-              @click="showWarosModal = true"
-              class="w-full min-h-[44px] px-4 py-2.5 text-sm font-medium border border-border rounded-lg hover:bg-surface-secondary transition-colors text-text-secondary"
-            >
-              Asignar manualmente
-            </button>
           </div>
         </div>
 
@@ -3592,13 +3580,6 @@ onUnmounted(() => {
               Canjear recompensa
             </button>
           </template>
-          <button
-            type="button"
-            @click="showWarosModal = true"
-            class="w-full min-h-[44px] px-4 py-2.5 text-sm font-medium border border-border rounded-lg hover:bg-surface-secondary text-text-secondary"
-          >
-            Asignar manualmente
-          </button>
         </div>
       </div>
 
@@ -4062,16 +4043,6 @@ onUnmounted(() => {
       v-model="showWaroRewardPicker"
       :waros-balance="warosBalance"
       @select="onWaroRewardPicked"
-    />
-
-    <!-- Waros Manual Assignment Modal -->
-    <PuntosAsignarWarosModal
-      v-if="selectedCustomer"
-      v-model="showWarosModal"
-      :profile-id="selectedCustomer.id"
-      :customer-name="selectedCustomer.name || selectedCustomer.phone_number || ''"
-      :current-balance="warosBalance"
-      @assigned="onWarosAssigned"
     />
 
   <!-- Issue #535 — Hidden prefactura for printing.


### PR DESCRIPTION
## Summary
- Removed manual Waros assignment entry points from POS checkout (desktop + mobile)
- Removed `PuntosAsignarWarosModal` wiring and related state/handler from checkout
- B1 redemption and B2 reward picker flows unchanged

Closes #1068

## Test plan
- [ ] Open `/pos/checkout` with a customer that has Waros balance
- [ ] Confirm Waros section shows redeem + "Canjear recompensa" but no "Asignar manualmente"
- [ ] Confirm B1 points input and B2 reward picker still work
- [ ] Confirm `/analitica/clientes/[id]` still has "+ Asignar puntos"

## wr-context
See `.wr/1068.yaml` locally (gitignored); issue body is the contract.

Made with [Cursor](https://cursor.com)