### PR TITLE
fix(forms): add parseLocaleDecimal utility and DecimalInput component

### DIFF
--- a/components/ui/DecimalInput.vue
+++ b/components/ui/DecimalInput.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+/**
+ * Locale-safe decimal input — avoids HTML5 `type="number"` step validation.
+ * Use in purchase/quantity forms (see epic #1074). Batch migrations: pass `precision` 1|2|3.
+ */
+import {
+  parseLocaleDecimal,
+  roundToPrecision,
+  type DecimalPrecision,
+} from '~/utils/parseLocaleDecimal'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue?: number | null
+    /** Decimal places applied on blur (default 2 = former step="0.01"). */
+    precision?: DecimalPrecision
+    min?: number
+    max?: number
+    placeholder?: string
+    disabled?: boolean
+    required?: boolean
+    id?: string
+    class?: string
+  }>(),
+  {
+    modelValue: null,
+    precision: 2,
+  },
+)
+
+const emit = defineEmits<{
+  'update:modelValue': [value: number | null]
+}>()
+
+const inputRef = ref<HTMLInputElement>()
+const displayValue = ref('')
+
+function formatModelForDisplay(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return ''
+  return String(value)
+}
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    if (document.activeElement === inputRef.value) return
+    displayValue.value = formatModelForDisplay(value ?? null)
+  },
+  { immediate: true },
+)
+
+function sanitizeTyping(raw: string): string {
+  return raw.replace(/[^\d.,-]/g, '')
+}
+
+function onInput(event: Event) {
+  const target = event.target as HTMLInputElement
+  displayValue.value = sanitizeTyping(target.value)
+}
+
+function commitValue() {
+  const parsed = parseLocaleDecimal(displayValue.value)
+  if (parsed === null) {
+    emit('update:modelValue', null)
+    displayValue.value = ''
+    return
+  }
+
+  let rounded = roundToPrecision(parsed, props.precision)
+  if (props.min !== undefined && rounded < props.min) rounded = props.min
+  if (props.max !== undefined && rounded > props.max) rounded = props.max
+
+  emit('update:modelValue', rounded)
+  displayValue.value = formatModelForDisplay(rounded)
+}
+
+function onBlur() {
+  commitValue()
+}
+
+defineExpose({
+  focus: () => inputRef.value?.focus(),
+  blur: () => inputRef.value?.blur(),
+})
+</script>
+
+<template>
+  <input
+    ref="inputRef"
+    :id="id"
+    type="text"
+    inputmode="decimal"
+    :value="displayValue"
+    :placeholder="placeholder"
+    :disabled="disabled"
+    :required="required"
+    :class="['input-base', props.class]"
+    @input="onInput"
+    @blur="onBlur"
+  />
+</template>

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -672,6 +672,7 @@ import { useBilling } from '@/composables/useBilling'
 import { useScanQuotaQuery } from '~/composables/queries/useScanQuota'
 import { usePaymentMethods } from '~/composables/usePaymentMethods'
 import { usePaymentLabel } from '~/composables/usePaymentLabel'
+import { parseLocaleDecimal } from '~/utils/parseLocaleDecimal'
 
 const formatPurchaseDate = (date: Date) => fnsFormat(date, 'dd/MM/yy', { locale: es })
 
@@ -1279,10 +1280,10 @@ const handleScanFileSelect = async (event: Event) => {
           const item: PurchaseItem = {
             ingredient_id: matchedId,
             searchTerm: ingredientName,
-            purchase_quantity: ocrItem.cantidad || 1,
+            purchase_quantity: parseLocaleDecimal(ocrItem.cantidad) ?? 1,
             purchase_unit: '',
-            unit_cost: ocrItem.precio_unitario || 0,
-            total_cost: ocrItem.total || 0,
+            unit_cost: parseLocaleDecimal(ocrItem.precio_unitario) ?? 0,
+            total_cost: parseLocaleDecimal(ocrItem.total) ?? 0,
             notes: '',
             suggested_price: null,
             item_type: 'food',

--- a/utils/parseLocaleDecimal.test.ts
+++ b/utils/parseLocaleDecimal.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseLocaleDecimal, roundToPrecision } from './parseLocaleDecimal.ts'
+
+describe('parseLocaleDecimal', () => {
+  it('parses comma decimal', () => {
+    assert.equal(parseLocaleDecimal('1,50'), 1.5)
+  })
+
+  it('parses dot decimal', () => {
+    assert.equal(parseLocaleDecimal('12.345'), 12.345)
+  })
+
+  it('parses es-CO thousands and comma decimal', () => {
+    assert.equal(parseLocaleDecimal('1.234,56'), 1234.56)
+  })
+
+  it('parses en-US thousands and dot decimal', () => {
+    assert.equal(parseLocaleDecimal('1,234.56'), 1234.56)
+  })
+
+  it('strips whitespace and currency symbol', () => {
+    assert.equal(parseLocaleDecimal('  $ 2,5 '), 2.5)
+  })
+
+  it('passes through finite numbers', () => {
+    assert.equal(parseLocaleDecimal(3.14), 3.14)
+  })
+
+  it('returns null for invalid input', () => {
+    assert.equal(parseLocaleDecimal(''), null)
+    assert.equal(parseLocaleDecimal('abc'), null)
+    assert.equal(parseLocaleDecimal(null), null)
+    assert.equal(parseLocaleDecimal(Number.NaN), null)
+  })
+})
+
+describe('roundToPrecision', () => {
+  it('rounds to 2 decimals', () => {
+    assert.equal(roundToPrecision(1.2345, 2), 1.23)
+  })
+
+  it('rounds to 3 decimals', () => {
+    assert.equal(roundToPrecision(1.23456, 3), 1.235)
+  })
+
+  it('rounds to 1 decimal', () => {
+    assert.equal(roundToPrecision(1.25, 1), 1.3)
+  })
+})

--- a/utils/parseLocaleDecimal.ts
+++ b/utils/parseLocaleDecimal.ts
@@ -1,0 +1,47 @@
+/** Decimal precision used by {@link DecimalInput} and purchase forms. */
+export type DecimalPrecision = 1 | 2 | 3
+
+/**
+ * Parse a locale-formatted decimal (es-CO comma or dot separators).
+ * Returns `null` for empty or invalid input.
+ *
+ * Examples: `"1,50"` → 1.5, `"1.234,56"` → 1234.56, `"12.345"` → 12.345
+ */
+export function parseLocaleDecimal(value: string | number | null | undefined): number | null {
+  if (value === null || value === undefined) return null
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null
+  }
+
+  const trimmed = String(value).trim()
+  if (!trimmed) return null
+
+  let normalized = trimmed.replace(/[$\s\u00A0]/g, '')
+
+  const hasComma = normalized.includes(',')
+  const hasDot = normalized.includes('.')
+
+  if (hasComma && hasDot) {
+    const lastComma = normalized.lastIndexOf(',')
+    const lastDot = normalized.lastIndexOf('.')
+    if (lastComma > lastDot) {
+      // es-CO thousands with dot, decimal comma: 1.234,56
+      normalized = normalized.replace(/\./g, '').replace(',', '.')
+    } else {
+      // en-US thousands with comma: 1,234.56
+      normalized = normalized.replace(/,/g, '')
+    }
+  } else if (hasComma) {
+    normalized = normalized.replace(',', '.')
+  }
+
+  const parsed = Number(normalized)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+/** Round to fixed decimal places (matches DB / field precision). */
+export function roundToPrecision(value: number, precision: DecimalPrecision): number {
+  const factor = 10 ** precision
+  return Math.round(value * factor) / factor
+}


### PR DESCRIPTION
## Summary

Batch 1 of epic #1074 — shared decimal parsing foundation for purchase/quantity forms.

- Add `parseLocaleDecimal` + `roundToPrecision` utilities (comma/dot, es-CO thousands)
- Add `UiDecimalInput` component (`type="text"`, `inputmode="decimal"`, configurable precision)
- Normalize OCR `cantidad` / `precio_unitario` / `total` in compra directa create flow

Closes #1075

## Test plan

- [x] `node --test utils/parseLocaleDecimal.test.ts` — 10/10 pass
- [ ] `/abastecimiento/compras-directas/crear` — Leer factura con IA; verify OCR items populate with comma decimals (e.g. `1,50`)
- [ ] Confirm `UiDecimalInput` is available for batch 2 migrations (not wired to item row yet — intentional)

## Files

| File | Change |
|------|--------|
| `utils/parseLocaleDecimal.ts` | New parse + round helpers |
| `utils/parseLocaleDecimal.test.ts` | Unit tests |
| `components/ui/DecimalInput.vue` | Shared input component |
| `pages/abastecimiento/compras-directas/crear.vue` | OCR mapping only |

## Epic

Part of #1074 — batches 2–5 will migrate consumer forms to `UiDecimalInput`.

Made with [Cursor](https://cursor.com)