### PR TITLE
fix(purchases): migrate decimal inputs in purchase modals, payments, and promociones

### DIFF
--- a/components/payments/PaymentForm.vue
+++ b/components/payments/PaymentForm.vue
@@ -36,9 +36,14 @@
               <label class="block text-sm font-medium text-text-primary mb-2">Monto Pagado *</label>
               <div class="relative">
                 <span class="absolute left-4 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
-                <input v-model.number="formData.payment_amount" type="number" step="0.01" min="0.01" required
+                <UiDecimalInput
+                  v-model="formData.payment_amount"
+                  :min="0.01"
+                  :precision="2"
+                  required
                   class="w-full pl-8 pr-4 py-2.5 bg-background border-2 border-border rounded-lg text-text-primary focus:border-primary transition-colors"
-                  placeholder="0.00" />
+                  placeholder="0.00"
+                />
               </div>
             </div>
 

--- a/components/promociones/PromocionPanel.vue
+++ b/components/promociones/PromocionPanel.vue
@@ -115,25 +115,23 @@
 
             <div v-if="form.promo_type === 'percent_off'" class="flex flex-col gap-1.5">
               <label for="promo-percent" class="text-sm font-medium text-text-primary">Porcentaje</label>
-              <input
+              <UiDecimalInput
                 id="promo-percent"
-                v-model.number="form.percent"
-                type="number"
-                min="0.01"
-                max="100"
-                step="0.01"
+                v-model="form.percent"
+                :min="0.01"
+                :max="100"
+                :precision="2"
                 :class="inputClass"
               />
             </div>
 
             <div v-else-if="form.promo_type === 'fixed_off'" class="flex flex-col gap-1.5">
               <label for="promo-amount" class="text-sm font-medium text-text-primary">Monto (COP)</label>
-              <input
+              <UiDecimalInput
                 id="promo-amount"
-                v-model.number="form.amountCop"
-                type="number"
-                min="1"
-                step="1"
+                v-model="form.amountCop"
+                :min="1"
+                :precision="2"
                 :class="inputClass"
               />
             </div>

--- a/components/purchases/CompletePricesForm.vue
+++ b/components/purchases/CompletePricesForm.vue
@@ -32,15 +32,14 @@
                 Precio sugerido (último registrado)
               </span>
             </div>
-            <input
-              v-model.number="item.unit_cost"
-              type="number"
-              step="0.01"
-              min="0"
+            <UiDecimalInput
+              v-model="item.unit_cost"
+              :min="0"
+              :precision="2"
               required
               class="input-base w-full px-4 py-2"
               placeholder="0.00"
-              @input="calculateItemTotal(index)"
+              @update:model-value="calculateItemTotal(index)"
             />
             <p class="text-xs text-text-secondary mt-1">
               Por {{ item.unit }}
@@ -93,11 +92,10 @@
           <label class="block text-sm font-medium text-text-primary mb-2">
             IVA
           </label>
-          <input
-            v-model.number="taxAmount"
-            type="number"
-            step="0.01"
-            min="0"
+          <UiDecimalInput
+            v-model="taxAmount"
+            :min="0"
+            :precision="2"
             class="input-base w-full px-4 py-2"
             placeholder="0.00"
           />

--- a/components/purchases/CompletePricesModal.vue
+++ b/components/purchases/CompletePricesModal.vue
@@ -60,15 +60,14 @@
                   <label class="block text-sm font-medium text-text-primary mb-2">
                     Precio Unitario *
                   </label>
-                  <input
-                    v-model.number="item.unit_cost"
-                    type="number"
-                    step="0.01"
-                    min="0"
+                  <UiDecimalInput
+                    v-model="item.unit_cost"
+                    :min="0"
+                    :precision="2"
                     required
                     class="input-base w-full px-4 py-2"
                     placeholder="0.00"
-                    @input="calculateItemTotal(index)"
+                    @update:model-value="calculateItemTotal(index)"
                   />
                   <p class="text-xs text-text-secondary mt-1">
                     Por {{ item.unit }}
@@ -121,11 +120,10 @@
                 <label class="block text-sm font-medium text-text-primary mb-2">
                   IVA
                 </label>
-                <input
-                  v-model.number="taxAmount"
-                  type="number"
-                  step="0.01"
-                  min="0"
+                <UiDecimalInput
+                  v-model="taxAmount"
+                  :min="0"
+                  :precision="2"
                   class="input-base w-full px-4 py-2"
                   placeholder="0.00"
                 />

--- a/components/purchases/InvoiceForm.vue
+++ b/components/purchases/InvoiceForm.vue
@@ -60,13 +60,26 @@
       <!-- Invoice Amount -->
       <div>
         <label class="block text-sm font-medium text-text-primary mb-2">Monto de Factura *</label>
-        <input v-model.number="formData.invoice_amount" type="number" step="0.01" min="0.01" required class="w-full px-4 py-2 bg-background border-2 border-border rounded-lg text-text-primary focus:border-primary" placeholder="0.00" />
+        <UiDecimalInput
+          v-model="formData.invoice_amount"
+          :min="0.01"
+          :precision="2"
+          required
+          class="w-full px-4 py-2 bg-background border-2 border-border rounded-lg text-text-primary focus:border-primary"
+          placeholder="0.00"
+        />
       </div>
 
       <!-- Tax Amount -->
       <div>
         <label class="block text-sm font-medium text-text-primary mb-2">IVA</label>
-        <input v-model.number="formData.tax_amount" type="number" step="0.01" min="0" class="w-full px-4 py-2 bg-background border-2 border-border rounded-lg text-text-primary focus:border-primary" placeholder="0.00" />
+        <UiDecimalInput
+          v-model="formData.tax_amount"
+          :min="0"
+          :precision="2"
+          class="w-full px-4 py-2 bg-background border-2 border-border rounded-lg text-text-primary focus:border-primary"
+          placeholder="0.00"
+        />
       </div>
     </div>
 

--- a/components/purchases/InvoicePurchaseModal.vue
+++ b/components/purchases/InvoicePurchaseModal.vue
@@ -88,13 +88,26 @@
             <!-- Invoice Amount -->
             <div>
               <label class="block text-sm font-medium text-text-primary mb-2">Monto de Factura *</label>
-              <input v-model.number="formData.invoice_amount" type="number" step="0.01" min="0.01" required class="w-full px-4 py-2 bg-background border-2 border-border rounded-lg text-text-primary focus:border-primary" placeholder="0.00" />
+              <UiDecimalInput
+                v-model="formData.invoice_amount"
+                :min="0.01"
+                :precision="2"
+                required
+                class="w-full px-4 py-2 bg-background border-2 border-border rounded-lg text-text-primary focus:border-primary"
+                placeholder="0.00"
+              />
             </div>
 
             <!-- Tax Amount -->
             <div>
               <label class="block text-sm font-medium text-text-primary mb-2">IVA</label>
-              <input v-model.number="formData.tax_amount" type="number" step="0.01" min="0" class="w-full px-4 py-2 bg-background border-2 border-border rounded-lg text-text-primary focus:border-primary" placeholder="0.00" />
+              <UiDecimalInput
+                v-model="formData.tax_amount"
+                :min="0"
+                :precision="2"
+                class="w-full px-4 py-2 bg-background border-2 border-border rounded-lg text-text-primary focus:border-primary"
+                placeholder="0.00"
+              />
             </div>
           </div>
 

--- a/components/purchases/ReceiveForm.vue
+++ b/components/purchases/ReceiveForm.vue
@@ -27,12 +27,15 @@
               <label class="block text-xs font-medium text-text-secondary mb-1">
                 Cantidad Recibida *
               </label>
-              <input v-model.number="item.quantity_received" type="number" step="0.001" min="0" required
+              <UiDecimalInput
+                v-model="item.quantity_received"
+                :min="0"
+                :precision="3"
+                required
                 class="w-full px-3 py-2 rounded-lg text-text-primary transition-all border-2"
                 style="background-color: hsl(var(--surface)); border-color: hsl(var(--crocus-600) / 0.3);"
-                @focus="$event.target.style.borderColor = 'hsl(var(--crocus-600))'; $event.target.style.outline = '2px solid hsl(var(--crocus-600) / 0.2)'"
-                @blur="$event.target.style.borderColor = 'hsl(var(--crocus-600) / 0.3)'; $event.target.style.outline = 'none'"
-                :placeholder="item.quantity_ordered.toString()" />
+                :placeholder="item.quantity_ordered.toString()"
+              />
             </div>
 
             <!-- Item Condition -->

--- a/components/purchases/ReceivePurchaseModal.vue
+++ b/components/purchases/ReceivePurchaseModal.vue
@@ -61,12 +61,15 @@
                     <label class="block text-xs font-medium text-text-secondary mb-1">
                       Cantidad Recibida *
                     </label>
-                    <input v-model.number="item.quantity_received" type="number" step="0.001" min="0" required
+                    <UiDecimalInput
+                      v-model="item.quantity_received"
+                      :min="0"
+                      :precision="3"
+                      required
                       class="w-full px-3 py-2 rounded-lg text-text-primary transition-all border-2"
                       style="background-color: hsl(var(--surface)); border-color: hsl(var(--crocus-600) / 0.3);"
-                      @focus="$event.target.style.borderColor = 'hsl(var(--crocus-600))'; $event.target.style.outline = '2px solid hsl(var(--crocus-600) / 0.2)'"
-                      @blur="$event.target.style.borderColor = 'hsl(var(--crocus-600) / 0.3)'; $event.target.style.outline = 'none'"
-                      :placeholder="item.quantity_ordered.toString()" />
+                      :placeholder="item.quantity_ordered.toString()"
+                    />
                   </div>
 
                   <!-- Item Condition -->


### PR DESCRIPTION
## Summary
- Migrates 8 purchase/payment/promo components from native `type="number"` + restrictive `step` to shared `UiDecimalInput`
- Batch 3 of epic #1074 — builds on #1075 (DecimalInput foundation) and #1076 (abastecimiento pattern)
- Receive forms use `precision="3"` for `quantity_received`; CompletePrices* wire `@update:model-value` for line totals

## Test plan
- [ ] Open Complete Prices modal — enter unit price with comma or extra decimals; no browser “valor no válido” tooltip; line total updates on blur
- [ ] Register invoice modal — enter invoice amount and IVA with manual decimal entry
- [ ] Receive purchase modal — enter quantity with 3 decimal places (e.g. 1.125)
- [ ] Payment form — enter amount with `$` prefix visible; accepts comma/dot decimals
- [ ] Promociones panel — percent and fixed COP discount fields accept decimal entry

Closes #1077

Made with [Cursor](https://cursor.com)