### PR TITLE
fix(equipo): migrate salary forms to UiDecimalInput

### DIFF
--- a/components/team/SalaryConfigModal.vue
+++ b/components/team/SalaryConfigModal.vue
@@ -51,13 +51,12 @@
           <div>
             <label class="block text-sm font-medium text-text-primary mb-2">Multiplicador</label>
             <div class="flex items-center gap-3">
-              <input
-                v-model.number="form.multiplier"
-                type="number"
-                step="0.1"
-                min="0.5"
-                max="10"
-                class="input-base w-24 px-3 py-2 text-center font-semibold"
+              <UiDecimalInput
+                v-model="form.multiplier"
+                :precision="1"
+                :min="0.5"
+                :max="10"
+                class="w-24 px-3 py-2 text-center font-semibold"
               />
               <span class="text-text-secondary">x SMMLV</span>
             </div>
@@ -81,12 +80,11 @@
           <label class="block text-sm font-medium text-text-primary mb-2">Monto Mensual</label>
           <div class="relative">
             <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
-            <input
-              v-model.number="form.fixed_amount"
-              type="number"
-              min="0"
-              step="1000"
-              class="input-base w-full pl-7 pr-3 py-2 font-semibold"
+            <UiDecimalInput
+              v-model="form.fixed_amount"
+              :min="0"
+              :precision="2"
+              class="w-full pl-7 pr-3 py-2 font-semibold"
               placeholder="0"
             />
           </div>

--- a/pages/equipo/salarios/[id]/configurar.vue
+++ b/pages/equipo/salarios/[id]/configurar.vue
@@ -110,12 +110,11 @@
               </label>
               <div class="relative">
                 <span class="absolute left-5 top-1/2 -translate-y-1/2 text-crocus-600 font-bold text-xl">$</span>
-                <input
-                  v-model.number="form.daily_rate"
-                  type="number"
-                  min="0"
-                  step="any"
-                  class="input-base w-full pl-10 pr-5 py-3 text-xl font-bold rounded-xl focus:ring-2 focus:ring-crocus-500"
+                <UiDecimalInput
+                  v-model="form.daily_rate"
+                  :min="0"
+                  :precision="2"
+                  class="w-full pl-10 pr-5 py-3 text-xl font-bold rounded-xl focus:ring-2 focus:ring-crocus-500"
                   placeholder="0"
                 />
               </div>
@@ -282,13 +281,12 @@
                   Multiplicador *
                 </label>
                 <div class="flex items-center gap-4">
-                  <input
-                    v-model.number="form.multiplier"
-                    type="number"
-                    step="0.1"
-                    min="0.5"
-                    max="10"
-                    class="input-base w-40 px-5 py-3 text-center text-xl font-bold rounded-xl focus:ring-2 focus:ring-crocus-500"
+                  <UiDecimalInput
+                    v-model="form.multiplier"
+                    :precision="1"
+                    :min="0.5"
+                    :max="10"
+                    class="w-40 px-5 py-3 text-center text-xl font-bold rounded-xl focus:ring-2 focus:ring-crocus-500"
                     placeholder="1.0"
                   />
                   <span class="text-text-secondary font-medium">× SMMLV</span>
@@ -332,12 +330,11 @@
                 </label>
                 <div class="relative">
                   <span class="absolute left-5 top-1/2 -translate-y-1/2 text-crocus-600 font-bold text-xl">$</span>
-                  <input
-                    v-model.number="form.fixed_amount"
-                    type="number"
-                    min="0"
-                    step="any"
-                    class="input-base w-full pl-10 pr-5 py-3 text-xl font-bold rounded-xl focus:ring-2 focus:ring-crocus-500"
+                  <UiDecimalInput
+                    v-model="form.fixed_amount"
+                    :min="0"
+                    :precision="2"
+                    class="w-full pl-10 pr-5 py-3 text-xl font-bold rounded-xl focus:ring-2 focus:ring-crocus-500"
                     placeholder="0"
                   />
                 </div>
@@ -377,12 +374,11 @@
                 </label>
                 <div class="relative">
                   <span class="absolute left-5 top-1/2 -translate-y-1/2 text-crocus-600 font-bold text-xl">$</span>
-                  <input
-                    v-model.number="form.hourly_rate"
-                    type="number"
-                    min="0"
-                    step="any"
-                    class="input-base w-full pl-10 pr-5 py-3 text-xl font-bold rounded-xl focus:ring-2 focus:ring-crocus-500"
+                  <UiDecimalInput
+                    v-model="form.hourly_rate"
+                    :min="0"
+                    :precision="2"
+                    class="w-full pl-10 pr-5 py-3 text-xl font-bold rounded-xl focus:ring-2 focus:ring-crocus-500"
                     placeholder="0"
                   />
                 </div>

--- a/pages/equipo/salarios/[id]/index.vue
+++ b/pages/equipo/salarios/[id]/index.vue
@@ -523,12 +523,11 @@ watch(employeeData, (data) => {
                 </label>
                 <div class="relative">
                   <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
-                  <input
-                    type="number"
-                    v-model.number="editForm.dailyRate"
-                    step="any"
-                    min="0"
-                    class="input-base w-full pl-8 pr-4 py-2.5"
+                  <UiDecimalInput
+                    v-model="editForm.dailyRate"
+                    :min="0"
+                    :precision="2"
+                    class="w-full pl-8 pr-4 py-2.5"
                   />
                 </div>
               </div>
@@ -555,12 +554,11 @@ watch(employeeData, (data) => {
                   <label class="block text-sm font-medium text-text-primary mb-2">
                     Multiplicador SMMLV *
                   </label>
-                  <input
-                    type="number"
-                    v-model.number="editForm.minimumWageMultiplier"
-                    step="0.1"
-                    min="0.5"
-                    class="input-base w-full px-4 py-2"
+                  <UiDecimalInput
+                    v-model="editForm.minimumWageMultiplier"
+                    :precision="1"
+                    :min="0.5"
+                    class="w-full px-4 py-2"
                   />
                 </div>
 
@@ -571,12 +569,11 @@ watch(employeeData, (data) => {
                   </label>
                   <div class="relative">
                     <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
-                    <input
-                      type="number"
-                      v-model.number="editForm.fixedAmount"
-                      step="any"
-                      min="0"
-                      class="input-base w-full pl-8 pr-4 py-2"
+                    <UiDecimalInput
+                      v-model="editForm.fixedAmount"
+                      :min="0"
+                      :precision="2"
+                      class="w-full pl-8 pr-4 py-2"
                     />
                   </div>
                 </div>
@@ -588,12 +585,11 @@ watch(employeeData, (data) => {
                   </label>
                   <div class="relative">
                     <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
-                    <input
-                      type="number"
-                      v-model.number="editForm.hourlyRate"
-                      step="any"
-                      min="0"
-                      class="input-base w-full pl-8 pr-4 py-2"
+                    <UiDecimalInput
+                      v-model="editForm.hourlyRate"
+                      :min="0"
+                      :precision="2"
+                      class="w-full pl-8 pr-4 py-2"
                     />
                   </div>
                 </div>

--- a/pages/equipo/salarios/[id]/pago.vue
+++ b/pages/equipo/salarios/[id]/pago.vue
@@ -105,12 +105,11 @@
               </div>
               <div v-else class="relative">
                 <span class="absolute left-4 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
-                <input
-                  v-model.number="form.payment_amount"
-                  type="number"
-                  min="0"
-                  step="any"
-                  class="input-base w-full pl-8 pr-4 py-2 text-lg font-semibold"
+                <UiDecimalInput
+                  v-model="form.payment_amount"
+                  :min="0"
+                  :precision="2"
+                  class="w-full pl-8 pr-4 py-2 text-lg font-semibold"
                   placeholder="0"
                 />
               </div>
@@ -183,25 +182,23 @@
               <div class="grid grid-cols-2 gap-3">
                 <div>
                   <label class="text-xs text-indigo-800 block mb-1">ARL % (clase riesgo)</label>
-                  <input
-                    v-model.number="form.arl_rate_pct"
-                    type="number"
-                    min="0"
-                    max="7"
-                    step="0.001"
-                    class="input-base w-full px-3 py-1.5 text-sm"
+                  <UiDecimalInput
+                    v-model="form.arl_rate_pct"
+                    :min="0"
+                    :max="7"
+                    :precision="3"
+                    class="w-full px-3 py-1.5 text-sm"
                     placeholder="0.522"
                   />
                 </div>
                 <div>
                   <label class="text-xs text-indigo-800 block mb-1">Caja Compensación %</label>
-                  <input
-                    v-model.number="form.caja_rate_pct"
-                    type="number"
-                    min="0"
-                    max="4"
-                    step="0.1"
-                    class="input-base w-full px-3 py-1.5 text-sm"
+                  <UiDecimalInput
+                    v-model="form.caja_rate_pct"
+                    :min="0"
+                    :max="4"
+                    :precision="1"
+                    class="w-full px-3 py-1.5 text-sm"
                     placeholder="4"
                   />
                 </div>


### PR DESCRIPTION
## Summary

Migrates equipo/nómina salary configuration and payment forms to `UiDecimalInput` (epic #1074, batch 5).

- `SalaryConfigModal.vue` — SMMLV multiplier + fixed monthly amount
- `configurar.vue` — daily rate, multiplier, fixed/hourly amounts
- `index.vue` — inline edit salary fields
- `pago.vue` — payment amount, ARL % (3dp), Caja % (1dp)

Closes #1079

## Test plan

- [ ] `/equipo/salarios/:id/configurar` — set multiplier `1.25`, fixed salary with decimals; save without browser "valor no válido"
- [ ] `/equipo/salarios/:id` — edit employee inline: multiplier, fixed/hourly/daily amounts
- [ ] `SalaryConfigModal` from team list — multiplier quick-picks still work
- [ ] `/equipo/salarios/:id/pago` — enter payment amount, ARL `0.522`, Caja `4`; submit form
- [ ] Day-count fields (`step=1`) unchanged on pago page


Made with [Cursor](https://cursor.com)