### PR TITLE
fix(pos): align cart promo totals and BOGO display clarity

### DIFF
--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -108,8 +108,8 @@
           }"
           :order-number="idx + 1"
           :show-fulfillment-status="comandasEnabled"
-          :promo-label="linePromoBadge(item.productId, item.categoryId)?.label ?? null"
-          :promo-title="linePromoBadge(item.productId, item.categoryId)?.title ?? null"
+          :promo-label="linePromoBadgeWhenSaving(item.productId, item.categoryId, tabLinePromoSavings(item))?.label ?? null"
+          :promo-title="linePromoBadgeWhenSaving(item.productId, item.categoryId, tabLinePromoSavings(item))?.title ?? null"
           :promo-savings="tabLinePromoSavings(item)"
           :gross-total="item.subtotal"
           :class="[
@@ -144,8 +144,8 @@
         :key="index"
         :item="item"
         :order-number="tabItems.length + index + 1"
-        :promo-label="linePromoBadge(item.product.id, categoryForProduct(item.product.id))?.label ?? null"
-        :promo-title="linePromoBadge(item.product.id, categoryForProduct(item.product.id))?.title ?? null"
+        :promo-label="linePromoBadgeWhenSaving(item.product.id, categoryForProduct(item.product.id), cartLinePromoSavings(item))?.label ?? null"
+        :promo-title="linePromoBadgeWhenSaving(item.product.id, categoryForProduct(item.product.id), cartLinePromoSavings(item))?.title ?? null"
         :promo-savings="cartLinePromoSavings(item)"
         @edit="$emit('edit-item', index, item.product.id)"
         @remove="$emit('remove-item', index)"
@@ -365,12 +365,7 @@
 <script setup lang="ts">
 import { usePOSStore } from '~/stores/usePOSStore'
 import { storeToRefs } from 'pinia'
-import {
-  linePromoSavingsForProduct,
-  promoBadgeForProduct,
-} from '~/utils/promoProductMatch'
-
-const { activePromos, promoPickOptions } = useActivePromotions()
+import { usePosOrderPromoTotals } from '~/composables/usePosOrderPromoTotals'
 
 const { singular: tableSingular } = useTableLabel()
 const tableSingularLower = computed(() => tableSingular.value.toLowerCase())
@@ -501,66 +496,21 @@ const emit = defineEmits<Emits>()
 const posStore = usePOSStore()
 const { isDeleting } = storeToRefs(posStore)
 
-function linePromoBadge(productId: string, categoryId?: string | null) {
-  return promoBadgeForProduct(activePromos.value, productId, categoryId, promoPickOptions.value)
-}
-
 function categoryForProduct(productId: string): string | null {
   return posStore.getProduct(productId)?.category_id ?? null
 }
 
-function cartLineGross(item: CartItem): number {
-  const basePrice = Number(item.product.price) || 0
-  const modifiersPrice = (item.modifiers ?? []).reduce(
-    (sum, mod) => sum + Number(mod.price) * (mod.quantity ?? 1),
-    0,
-  )
-  return (basePrice + modifiersPrice) * Number(item.quantity)
-}
-
-function cartLinePromoSavings(item: CartItem): number {
-  if (item.promo_opt_out) return 0
-  const gross = cartLineGross(item)
-  return linePromoSavingsForProduct(
-    activePromos.value,
-    item.product.id,
-    { subtotal: gross, quantity: item.quantity },
-    categoryForProduct(item.product.id),
-    promoPickOptions.value,
-  )
-}
-
-function tabLinePromoSavings(item: TabItem): number {
-  if (item.promoOptOut) return 0
-  const fromApi = Number(item.promoSavings) || 0
-  if (fromApi > 0) return fromApi
-  const categoryId = item.categoryId ?? categoryForProduct(item.productId)
-  return linePromoSavingsForProduct(
-    activePromos.value,
-    item.productId,
-    { subtotal: item.subtotal, quantity: item.quantity },
-    categoryId,
-    promoPickOptions.value,
-  )
-}
-
-const grossOrderTotal = computed(() =>
-  props.mesaMode ? props.tabTotal + props.total : props.total,
-)
-
-const orderPromoSavings = computed(() => {
-  let savings = 0
-  for (const item of props.tabItems ?? []) {
-    savings += tabLinePromoSavings(item)
-  }
-  for (const item of props.items) {
-    savings += cartLinePromoSavings(item)
-  }
-  return savings
-})
-
-const netOrderTotal = computed(() =>
-  Math.max(0, grossOrderTotal.value - orderPromoSavings.value),
+const {
+  cartLinePromoSavings,
+  tabLinePromoSavings,
+  linePromoBadgeWhenSaving,
+  orderPromoSavings,
+  grossOrderTotal,
+  netOrderTotal,
+} = usePosOrderPromoTotals(
+  () => props.items,
+  () => props.tabItems ?? [],
+  () => (props.mesaMode ? props.tabTotal + props.total : props.total),
 )
 
 // Issue warocol.com#708 — mesa tab lines live outside posStore.cart; count both buckets.

--- a/components/promociones/PromocionPanel.vue
+++ b/components/promociones/PromocionPanel.vue
@@ -145,6 +145,9 @@
                 <label for="promo-get" class="text-sm font-medium text-text-primary">Lleva gratis</label>
                 <input id="promo-get" v-model.number="form.getQty" type="number" min="1" :class="inputClass" />
               </div>
+              <p class="col-span-2 text-xs text-text-tertiary">
+                Ej. 3×2: Compra 2, Lleva gratis 1 (mín. 3 en carrito). Para 6×5: Compra 5, Lleva gratis 1.
+              </p>
             </div>
 
             <div class="flex flex-col gap-1.5">

--- a/composables/usePosOrderPromoTotals.ts
+++ b/composables/usePosOrderPromoTotals.ts
@@ -1,0 +1,121 @@
+import {
+  linePromoSavingsForProduct,
+  promoBadgeForProduct,
+  type PromoBadgeDisplay,
+} from '~/utils/promoProductMatch'
+
+export type PosPromoCartItem = {
+  product: {
+    id: string
+    price: number
+  }
+  modifiers: Array<{ price: number; quantity?: number }>
+  quantity: number
+  promo_opt_out?: boolean
+}
+
+export type PosPromoTabItem = {
+  productId: string
+  categoryId?: string | null
+  quantity: number
+  subtotal: number
+  promoSavings?: number
+  promoOptOut?: boolean
+  modifiers?: Array<{ price: number; quantity?: number }>
+}
+
+/** Shared POS cart/tab promo savings — keeps CartPanel and mobile bar in sync (#1094). */
+export function usePosOrderPromoTotals(
+  getCartItems: () => PosPromoCartItem[],
+  getTabItems: () => PosPromoTabItem[],
+  getGrossTotal: () => number,
+) {
+  const posStore = usePOSStore()
+  const { activePromos, promoPickOptions } = useActivePromotions()
+
+  function categoryForProduct(productId: string): string | null {
+    return posStore.getProduct(productId)?.category_id ?? null
+  }
+
+  function cartLineGross(item: PosPromoCartItem): number {
+    const basePrice = Number(item.product.price) || 0
+    const modifiersPrice = (item.modifiers ?? []).reduce(
+      (sum, mod) => sum + Number(mod.price) * (mod.quantity ?? 1),
+      0,
+    )
+    return (basePrice + modifiersPrice) * Number(item.quantity)
+  }
+
+  function cartLinePromoSavings(item: PosPromoCartItem): number {
+    if (item.promo_opt_out) return 0
+    return linePromoSavingsForProduct(
+      activePromos.value,
+      item.product.id,
+      { subtotal: cartLineGross(item), quantity: item.quantity },
+      categoryForProduct(item.product.id),
+      promoPickOptions.value,
+    )
+  }
+
+  function tabLinePromoSavings(item: PosPromoTabItem): number {
+    if (item.promoOptOut) return 0
+    const fromApi = Number(item.promoSavings) || 0
+    if (fromApi > 0) return fromApi
+    const categoryId = item.categoryId ?? categoryForProduct(item.productId)
+    return linePromoSavingsForProduct(
+      activePromos.value,
+      item.productId,
+      { subtotal: item.subtotal, quantity: item.quantity },
+      categoryId,
+      promoPickOptions.value,
+    )
+  }
+
+  function linePromoBadge(
+    productId: string,
+    categoryId?: string | null,
+  ): PromoBadgeDisplay | null {
+    return promoBadgeForProduct(
+      activePromos.value,
+      productId,
+      categoryId,
+      promoPickOptions.value,
+    )
+  }
+
+  /** Hide cart-line badge when qty rules yield zero savings (scope-only badge stays on catalog). */
+  function linePromoBadgeWhenSaving(
+    productId: string,
+    categoryId: string | null | undefined,
+    savings: number,
+  ): PromoBadgeDisplay | null {
+    if (savings <= 0) return null
+    return linePromoBadge(productId, categoryId)
+  }
+
+  const orderPromoSavings = computed(() => {
+    let savings = 0
+    for (const item of getTabItems()) {
+      savings += tabLinePromoSavings(item)
+    }
+    for (const item of getCartItems()) {
+      savings += cartLinePromoSavings(item)
+    }
+    return savings
+  })
+
+  const grossOrderTotal = computed(() => getGrossTotal())
+
+  const netOrderTotal = computed(() =>
+    Math.max(0, grossOrderTotal.value - orderPromoSavings.value),
+  )
+
+  return {
+    cartLinePromoSavings,
+    tabLinePromoSavings,
+    linePromoBadgeWhenSaving,
+    orderPromoSavings,
+    grossOrderTotal,
+    netOrderTotal,
+  }
+}

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -14,6 +14,7 @@ import {
   printComandaTickets,
 } from '~/composables/useComandaPrint'
 import { promoBadgeForProduct } from '~/utils/promoProductMatch'
+import { usePosOrderPromoTotals } from '~/composables/usePosOrderPromoTotals'
 
 definePageMeta({
   layout: 'dashboard',
@@ -1030,6 +1031,15 @@ const filteredProducts = computed(() => {
 // Use store for cart data
 const cartTotal = computed(() => posStore.cartTotal)
 
+const { netOrderTotal: mobileCartNetTotal } = usePosOrderPromoTotals(
+  () => posStore.cart,
+  () => storeTabItems.value,
+  () =>
+    isKitchenServiceMode.value
+      ? (storeTabTotal.value ?? 0) + cartTotal.value
+      : cartTotal.value,
+)
+
 // warocol.com#1032 — fixed cart bar + bottom sheet on mobile/tablet (< lg)
 const showMobileCartSheet = ref(false)
 const mobileCartItemCount = computed(() =>
@@ -1037,11 +1047,7 @@ const mobileCartItemCount = computed(() =>
     ? storeTabItems.value.length + posStore.cart.length
     : posStore.cart.length,
 )
-const mobileCartDisplayTotal = computed(() =>
-  isKitchenServiceMode.value
-    ? (storeTabTotal.value ?? 0) + cartTotal.value
-    : cartTotal.value,
-)
+const mobileCartDisplayTotal = computed(() => mobileCartNetTotal.value)
 const mobileCartFormattedTotal = computed(() => formatCurrencyPOS(mobileCartDisplayTotal.value))
 
 const { setMobileCart, setOpenCartHandler, clearMobileCart } = usePosMobileCart()

--- a/utils/promoProductMatch.test.ts
+++ b/utils/promoProductMatch.test.ts
@@ -2,9 +2,11 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import type { ActivePromotionRow } from './promoProductMatch.ts'
 import {
+  bogoMinQuantity,
   computeLinePromoSavings,
   linePromoSavingsForProduct,
   pickBestPromotionForProduct,
+  promoBadgeForProduct,
 } from './promoProductMatch.ts'
 
 const productId = 'product-1'
@@ -124,5 +126,29 @@ describe('linePromoSavingsForProduct', () => {
       10000,
     )
     assert.equal(pickBestPromotionForProduct([bogo, percent], productId)?.name, 'BOGO')
+  })
+})
+
+describe('bogoMinQuantity', () => {
+  it('returns paid plus free units for bundle threshold', () => {
+    assert.equal(bogoMinQuantity({ buy_qty: 2, get_qty: 1 }), 3)
+    assert.equal(bogoMinQuantity({ buy_qty: 6, get_qty: 5 }), 11)
+    assert.equal(bogoMinQuantity({ buy_qty: 5, get_qty: 1 }), 6)
+  })
+})
+
+describe('promoBadgeForProduct', () => {
+  it('includes BOGO minimum quantity in title', () => {
+    const badge = promoBadgeForProduct(
+      [
+        promo({
+          name: 'Pizza promo',
+          promo_type: 'bogo',
+          value_json: { buy_qty: 5, get_qty: 1 },
+        }),
+      ],
+      productId,
+    )
+    assert.match(badge?.title ?? '', /mín\. 6 ud\./)
   })
 })

--- a/utils/promoProductMatch.ts
+++ b/utils/promoProductMatch.ts
@@ -146,6 +146,14 @@ function comparePromoRank(a: ActivePromotionRow, b: ActivePromotionRow): number 
 }
 
 /** Client mirror of api promotions_service._pick_best_promotion_for_line. */
+/** Minimum cart quantity before BOGO savings apply (buy paid + get free units). */
+export function bogoMinQuantity(valueJson?: Record<string, unknown> | null): number {
+  const buy = Number(valueJson?.buy_qty) || 0
+  const get = Number(valueJson?.get_qty) || 0
+  if (buy < 1 || get < 1) return 0
+  return buy + get
+}
+
 export function pickBestPromotionForProduct(
   promos: ActivePromotionRow[],
   productId: string,
@@ -178,12 +186,16 @@ export function promoBadgeForProduct(
   const label = valueLabel && valueLabel !== '—' ? valueLabel : best.name
 
   let title = best.name
+  if (best.promo_type === 'bogo') {
+    const minQty = bogoMinQuantity(best.value_json)
+    if (minQty > 0) title = `${best.name} (mín. ${minQty} ud.)`
+  }
   if (matches.length > 1) {
     const others = matches
       .filter((p) => p.id !== best.id)
       .map((p) => p.name)
       .filter(Boolean)
-    if (others.length > 0) title = `${best.name} (+ ${others.join(', ')})`
+    if (others.length > 0) title = `${title} (+ ${others.join(', ')})`
   }
 
   return { label, title }

--- a/utils/promotionPreview.ts
+++ b/utils/promotionPreview.ts
@@ -80,7 +80,8 @@ export function formatPromoValue(
       const buy = Number(v.buy_qty)
       const get = Number(v.get_qty)
       if (!Number.isFinite(buy) || !Number.isFinite(get)) return '—'
-      return `Compra ${buy} · lleva ${get}`
+      if (buy < 1 || get < 1) return '—'
+      return `Compra ${buy} · ${get} gratis (mín. ${buy + get})`
     }
     default:
       return '—'


### PR DESCRIPTION
## Summary

- Extract shared `usePosOrderPromoTotals` so desktop cart footer and mobile cart bar show the same **net** total after line promos.
- Hide cart-line promo badges when quantity rules produce zero savings (avoids badge + full-price mismatch on mesa/counter lines).
- Clarify BOGO copy: label shows free units + minimum bundle size; admin form hints how to configure 6×5 (Compra 5, Lleva gratis 1).

Closes #1094

## Test plan

- [ ] `bun test utils/promoProductMatch.test.ts`
- [ ] POS mesa: line with BOGO below min qty shows no badge; at/above min shows badge + net line total
- [ ] Mobile cart bar total matches desktop Orden Actual net total when promos apply
- [ ] Catalog cards still show promo badge with BOGO min qty in tooltip

## wr-context

See issue #1094 ship-context comment (`wr-context` label).

Made with [Cursor](https://cursor.com)