### PR TITLE
fix(pos): preserve cart when identifying customer at checkout

### DIFF
--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1697,7 +1697,12 @@ const processOrder = async () => {
 const onCustomerIdentified = async (customer: { id: string; name: string | null; phone_number: string | null; email: string | null }) => {
   selectedCustomer.value = customer
   processingError.value = ''
-  await posStore.setCustomer(customer as any)
+  // Bar / mesa tab / synced counter cart: do not load the new customer's empty backend cart (#1101).
+  const preserveCart =
+    !!posStore.activeTableSession?.isBar
+    || isKitchenServiceMode.value
+    || (!!posStore.cartId && posStore.cart.length > 0)
+  await posStore.setCustomer(customer as any, { preserveCart })
 }
 
 // Derived from dynamic groups

--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -321,8 +321,14 @@ export const usePOSStore = defineStore('pos', () => {
         }
     }
 
-    const setCustomer = async (customer: Customer) => {
+    type SetCustomerOptions = {
+        /** Keep in-memory cart/session — checkout attaches customer at payment (#1101, #1030). */
+        preserveCart?: boolean
+    }
+
+    const setCustomer = async (customer: Customer, options?: SetCustomerOptions) => {
         currentCustomer.value = customer
+        if (options?.preserveCart) return
         if (cart.value.length > 0 && !cartId.value) {
             await syncLocalCartToBackend(customer.id)
         } else {


### PR DESCRIPTION
## Summary

- Add `setCustomer(..., { preserveCart })` so checkout can attach a customer without fetching their (empty) backend cart.
- Use `preserveCart` on bar sessions, kitchen tab checkout, and counter checkout when the cart is already synced.

Closes #1101

## Test plan

- [ ] Bar (comandas off): add items → checkout → Nuevo cliente → save → same lines, customer selected
- [ ] Counter: checkout with items → change/create customer → cart unchanged
- [ ] Mesa/bar with comandas: tab checkout → create customer → tab items remain
- [ ] POS index: identify customer before sale still loads/syncs cart as before

## wr-context

Bar checkout called `loadCartFromBackend(newCustomerId)` and wiped the session cart. API `complete_pos_order` already reassigns `customer_id` on the cart at payment time.

Made with [Cursor](https://cursor.com)