### PR TITLE
chore(pos): checkout customer/cart debug logs

### DIFF
--- a/components/pos/CustomerIdentificationModal.vue
+++ b/components/pos/CustomerIdentificationModal.vue
@@ -436,6 +436,7 @@
 import { ref, computed, watch, nextTick } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
 import { $fetch } from 'ofetch'
+import { posDebugLog, posDebugSerializeError } from '~/utils/posDebugLog'
 
 type FiscalIdType = 'CC' | 'NIT' | 'CE' | 'PA' | 'TI' | ''
 
@@ -701,6 +702,10 @@ const handleCreate = async () => {
   if (!canSubmitCreate.value) return
   isCreating.value = true
   createError.value = ''
+  posDebugLog('customer-modal', 'handleCreate:start', {
+    phone: createForm.value.phone_number,
+    wantsInvoice: wantsInvoice.value,
+  })
   try {
     const fiscalPayload = wantsInvoice.value ? {
       fiscal_id_type: createForm.value.fiscal_id_type || null,
@@ -719,11 +724,21 @@ const handleCreate = async () => {
       }
     })
     if (response.success) {
+      posDebugLog('customer-modal', 'handleCreate:ok', {
+        customerId: response.data.id,
+        phone: response.data.phone_number,
+      })
       emit('customer-identified', toSelected(response.data))
       emit('update:modelValue', false)
+    } else {
+      posDebugLog('customer-modal', 'handleCreate:unexpected-response', { success: response.success })
     }
   } catch (e: any) {
     createError.value = e.data?.message || e.message || 'Error al guardar el cliente'
+    posDebugLog('customer-modal', 'handleCreate:failed', {
+      createError: createError.value,
+      ...posDebugSerializeError(e),
+    })
   } finally {
     isCreating.value = false
   }

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -15,6 +15,7 @@ import DeliveryAddressForm from '~/components/pos/checkout/DeliveryAddressForm.v
 import { displayTableCode } from '~/composables/useTableDisplayCode'
 import { formatPromoTypeLabel } from '~/utils/promotionPreview'
 import { linePromoSavingsForProduct } from '~/utils/promoProductMatch'
+import { posDebugLog, posDebugSerializeError } from '~/utils/posDebugLog'
 
 interface TopProduct {
   name: string
@@ -1695,6 +1696,17 @@ const processOrder = async () => {
 }
 
 const onCustomerIdentified = async (customer: { id: string; name: string | null; phone_number: string | null; email: string | null }) => {
+  posDebugLog('checkout', 'onCustomerIdentified:start', {
+    customerId: customer.id,
+    phone: customer.phone_number,
+    isBar: !!posStore.activeTableSession?.isBar,
+    isKitchenServiceMode: isKitchenServiceMode.value,
+    comandasEnabled: comandasEnabled.value,
+    cartId: posStore.cartId,
+    cartItems: posStore.cart.length,
+    tabItems: storeTabItems.value.length,
+    cartItemsComputed: cartItems.value.length,
+  })
   selectedCustomer.value = customer
   processingError.value = ''
   // Bar / mesa tab / synced counter cart: do not load the new customer's empty backend cart (#1101).
@@ -1702,7 +1714,18 @@ const onCustomerIdentified = async (customer: { id: string; name: string | null;
     !!posStore.activeTableSession?.isBar
     || isKitchenServiceMode.value
     || (!!posStore.cartId && posStore.cart.length > 0)
-  await posStore.setCustomer(customer as any, { preserveCart })
+  posDebugLog('checkout', 'onCustomerIdentified:preserveCart', { preserveCart })
+  try {
+    await posStore.setCustomer(customer as any, { preserveCart })
+    posDebugLog('checkout', 'onCustomerIdentified:done', {
+      cartItems: posStore.cart.length,
+      cartItemsComputed: cartItems.value.length,
+      syncError: syncError.value || null,
+    })
+  } catch (error) {
+    posDebugLog('checkout', 'onCustomerIdentified:failed', posDebugSerializeError(error))
+    throw error
+  }
 }
 
 // Derived from dynamic groups
@@ -2243,6 +2266,10 @@ const isLoadingPaymentMethods = computed(() =>
 const syncCart = async () => {
   // Si no hay items, no hacer nada
   if (posStore.cart.length === 0) {
+    posDebugLog('checkout', 'syncCart:skipped-empty', {
+      isBar: !!posStore.activeTableSession?.isBar,
+      tabItems: storeTabItems.value.length,
+    })
     isSyncingCart.value = false
     return
   }
@@ -2250,13 +2277,18 @@ const syncCart = async () => {
   try {
     isSyncingCart.value = true
     syncError.value = ''
+    posDebugLog('checkout', 'syncCart:start', { cartId: posStore.cartId, items: posStore.cart.length })
 
     const success = await posStore.syncCartBatch()
     if (!success) {
       syncError.value = 'Error al sincronizar el carrito'
+      posDebugLog('checkout', 'syncCart:batch-failed', { cartId: posStore.cartId })
+    } else {
+      posDebugLog('checkout', 'syncCart:ok', { cartId: posStore.cartId })
     }
   } catch (error: any) {
     syncError.value = error.message || 'Error al sincronizar'
+    posDebugLog('checkout', 'syncCart:failed', posDebugSerializeError(error))
   } finally {
     isSyncingCart.value = false
   }
@@ -2324,6 +2356,14 @@ watch(() => selectedCustomer.value?.id, () => {
 // they fire from setup, in parallel with the mount).
 onMounted(async () => {
   setPageSubtitle('Checkout')
+  posDebugLog('checkout', 'mount', {
+    isBar: !!posStore.activeTableSession?.isBar,
+    isKitchenServiceMode: isKitchenServiceMode.value,
+    cartId: posStore.cartId,
+    cartItems: posStore.cart.length,
+    tabItems: storeTabItems.value.length,
+    route: useRoute().path,
+  })
 
   // Siempre regeneramos el carrito backend desde el estado local actual.
   if (posStore.cart.length > 0) {
@@ -2335,7 +2375,27 @@ onMounted(async () => {
   // Cart sync is the only operation that's genuinely sequential (mutation
   // local → backend). All read queries already kicked off from setup.
   await syncCart()
+  posDebugLog('checkout', 'mount:after-syncCart', {
+    cartItems: posStore.cart.length,
+    cartItemsComputed: cartItems.value.length,
+    syncError: syncError.value || null,
+  })
 })
+
+watch(
+  () => cartItems.value.length,
+  (count, prev) => {
+    if (count === 0 && (prev ?? 0) > 0) {
+      posDebugLog('checkout', 'cartItems:became-empty', {
+        isBar: !!posStore.activeTableSession?.isBar,
+        isKitchenServiceMode: isKitchenServiceMode.value,
+        storeCart: posStore.cart.length,
+        tabItems: storeTabItems.value.length,
+        selectedCustomerId: selectedCustomer.value?.id ?? null,
+      })
+    }
+  },
+)
 
 onUnmounted(() => {
   clearRefreshHandler(refreshAll)

--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import type { CartModifier } from '~/stores/online_cart'
+import { posDebugLog, posDebugSerializeError } from '~/utils/posDebugLog'
 
 const modifierLineTotal = (mod: CartModifier) => Number(mod.price) * (mod.quantity ?? 1)
 
@@ -327,21 +328,38 @@ export const usePOSStore = defineStore('pos', () => {
     }
 
     const setCustomer = async (customer: Customer, options?: SetCustomerOptions) => {
+        posDebugLog('pos-store', 'setCustomer', {
+            customerId: customer.id,
+            preserveCart: !!options?.preserveCart,
+            cartItems: cart.value.length,
+            cartId: cartId.value ?? null,
+            isBar: activeTableSession.value?.isBar ?? false,
+            tabItems: tabItems.value.length,
+        })
         currentCustomer.value = customer
-        if (options?.preserveCart) return
+        if (options?.preserveCart) {
+            posDebugLog('pos-store', 'setCustomer:skipped-cart-load', { customerId: customer.id })
+            return
+        }
         if (cart.value.length > 0 && !cartId.value) {
+            posDebugLog('pos-store', 'setCustomer:syncLocalCartToBackend', { customerId: customer.id })
             await syncLocalCartToBackend(customer.id)
         } else {
+            posDebugLog('pos-store', 'setCustomer:loadCartFromBackend', { customerId: customer.id })
             await loadCartFromBackend(customer.id)
         }
     }
 
     // Cargar carrito desde el backend
     const loadCartFromBackend = async (customerId: string) => {
-        if (isSyncing.value) return
+        if (isSyncing.value) {
+            posDebugLog('pos-store', 'loadCartFromBackend:skipped-already-syncing', { customerId })
+            return
+        }
 
         try {
             isSyncing.value = true
+            posDebugLog('pos-store', 'loadCartFromBackend:start', { customerId })
             const response = await $fetch(`/api/pos/cart/${customerId}`) as {
                 success: boolean
                 data: {
@@ -373,8 +391,17 @@ export const usePOSStore = defineStore('pos', () => {
                     is_resale: item.is_resale || false,
                     promo_opt_out: Boolean(item.promo_opt_out),
                 }))
+                posDebugLog('pos-store', 'loadCartFromBackend:ok', {
+                    customerId,
+                    cartId: cartId.value,
+                    itemCount: cart.value.length,
+                })
             }
-        } catch {
+        } catch (error) {
+            posDebugLog('pos-store', 'loadCartFromBackend:failed', {
+                customerId,
+                ...posDebugSerializeError(error),
+            })
             cart.value = []
         } finally {
             isSyncing.value = false

--- a/utils/posDebugLog.ts
+++ b/utils/posDebugLog.ts
@@ -1,0 +1,39 @@
+/**
+ * POS checkout / customer / cart diagnostics.
+ * Enabled when `import.meta.dev` or `localStorage.setItem('waro_pos_debug', '1')`.
+ * Filter DevTools console with: `[pos-debug]`
+ */
+export function isPosDebugEnabled(): boolean {
+  if (import.meta.dev) return true
+  if (import.meta.server) return false
+  try {
+    return localStorage.getItem('waro_pos_debug') === '1'
+  } catch {
+    return false
+  }
+}
+
+function serializeError(error: unknown): Record<string, unknown> {
+  if (error && typeof error === 'object') {
+    const e = error as Record<string, unknown>
+    const data = e.data
+    return {
+      message: e.message ?? String(error),
+      status: e.statusCode ?? e.status,
+      ...(data && typeof data === 'object' ? { data } : {}),
+    }
+  }
+  return { message: String(error) }
+}
+
+export function posDebugLog(
+  scope: string,
+  event: string,
+  payload?: Record<string, unknown>,
+): void {
+  if (!isPosDebugEnabled()) return
+  const line = payload ? { scope, event, ...payload } : { scope, event }
+  console.info('[pos-debug]', line)
+}
+
+export { serializeError as posDebugSerializeError }


### PR DESCRIPTION
## Summary

- Add `utils/posDebugLog.ts` — `[pos-debug]` console lines for POS checkout customer flow
- Log modal create, checkout `onCustomerIdentified`, `setCustomer`, `loadCartFromBackend` (including API errors)

## How to use

DevTools → filter `[pos-debug]`. In production-like local: `localStorage.setItem('waro_pos_debug','1')` + reload.

## Test plan

- [ ] Bar checkout → Nuevo cliente → see `preserveCart: true` and `skipped-cart-load`

Made with [Cursor](https://cursor.com)