### PR TITLE
fix(menu): lock ingredient type after inline type step

### DIFF
--- a/components/ingredientes/IngredientePropioPanel.vue
+++ b/components/ingredientes/IngredientePropioPanel.vue
@@ -94,8 +94,8 @@
             <p v-if="errors.name" class="text-xs text-destructive">{{ errors.name }}</p>
           </div>
 
-          <!-- CREACIÓN: tipo de ingrediente (bodega — no es reventa de menú) -->
-          <div v-if="!isEdit" class="flex flex-col gap-1.5">
+          <!-- CREACIÓN: selector de tipo (solo si no viene fijado del paso anterior) -->
+          <div v-if="!isEdit && !lockIngredientType" class="flex flex-col gap-1.5">
             <label class="text-sm font-medium text-text-primary">
               Tipo <span class="text-destructive">*</span>
             </label>
@@ -141,8 +141,8 @@
             </div>
           </div>
 
-          <!-- EDICIÓN: tipo de solo lectura -->
-          <div v-if="isEdit" class="flex flex-col gap-1.5">
+          <!-- EDICIÓN o creación con tipo fijado -->
+          <div v-if="isEdit || lockIngredientType" class="flex flex-col gap-1.5">
             <label class="text-sm font-medium text-text-primary">Tipo</label>
             <div class="h-10 flex items-center px-3 rounded-lg border border-border bg-surface-secondary/60 text-sm text-text-secondary select-none gap-2">
               <template v-if="form.type === 'food'">
@@ -166,7 +166,9 @@
                 Servicio
               </template>
               <template v-else>{{ form.type }}</template>
-              <span class="text-[10px] text-text-tertiary ml-auto">No se puede cambiar</span>
+              <span class="text-[10px] text-text-tertiary ml-auto">
+                {{ isEdit ? 'No se puede cambiar' : 'Elegido en el paso anterior' }}
+              </span>
             </div>
           </div>
 
@@ -482,6 +484,7 @@ interface Props {
   ingredient?: any    // null/undefined = create mode, object = edit mode
   initialName?: string  // pre-fill name when creating from search box
   initialType?: string  // pre-select ingredient type when context is known (e.g. active tab in Compras Directas)
+  lockIngredientType?: boolean  // hide type cards when type was chosen in a prior step
   hideResaleToggle?: boolean
   showBackToChooser?: boolean
 }
@@ -499,6 +502,7 @@ const props = withDefaults(defineProps<Props>(), {
   ingredient: null,
   initialName: '',
   initialType: 'food',
+  lockIngredientType: false,
   hideResaleToggle: false,
   showBackToChooser: false,
 })

--- a/components/menu/InlineCatalogCreateShell.vue
+++ b/components/menu/InlineCatalogCreateShell.vue
@@ -16,6 +16,7 @@
     v-model="showPanel"
     :initial-name="pendingName"
     :initial-type="panelInitialType"
+    :lock-ingredient-type="lockPanelIngredientType"
     :hide-resale-toggle="hideResaleToggle"
     :show-back-to-chooser="canReturnToChooser"
     @back-to-chooser="onPanelBack"
@@ -81,6 +82,7 @@ const {
   busyHint,
   hideResaleToggle,
   panelInitialType,
+  lockPanelIngredientType,
   canReturnToChooser,
   openFromSearch,
   onChooserIntent,

--- a/components/menu/InlineCatalogIngredientTypeChooser.vue
+++ b/components/menu/InlineCatalogIngredientTypeChooser.vue
@@ -79,19 +79,39 @@
               description="Peso o volumen · gr, ml, kg"
               :selected="selectedType === 'food'"
               @click="selectAndConfirm('food')"
-            />
+            >
+              <template #icon>
+                <svg fill="none" stroke="currentColor" stroke-width="1.75" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 2a9 9 0 019 9c0 4.97-4.03 9-9 9S3 15.97 3 11a9 9 0 019-9z" />
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M8 11c0-2.21 1.79-4 4-4s4 1.79 4 4" />
+                </svg>
+              </template>
+            </UiSelectionOptionCard>
             <UiSelectionOptionCard
               title="Insumo"
               description="Unidad fija · und (caja, paquete…)"
               :selected="selectedType === 'supply'"
               @click="selectAndConfirm('supply')"
-            />
+            >
+              <template #icon>
+                <svg fill="none" stroke="currentColor" stroke-width="1.75" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M20 7H4a2 2 0 00-2 2v6a2 2 0 002 2h16a2 2 0 002-2V9a2 2 0 00-2-2z" />
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M16 7V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v2" />
+                </svg>
+              </template>
+            </UiSelectionOptionCard>
             <UiSelectionOptionCard
               title="Servicio"
               description="Horas · hr"
               :selected="selectedType === 'service'"
               @click="selectAndConfirm('service')"
-            />
+            >
+              <template #icon>
+                <svg fill="none" stroke="currentColor" stroke-width="1.75" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+                </svg>
+              </template>
+            </UiSelectionOptionCard>
           </div>
         </div>
 

--- a/composables/useCatalogInlineCreate.ts
+++ b/composables/useCatalogInlineCreate.ts
@@ -101,6 +101,15 @@ export function useCatalogInlineCreate(options: {
     return 'food'
   })
 
+  const lockPanelIngredientType = computed(() => {
+    if (selectedIngredientDbType.value !== null) return true
+    if (!usesIngredientTypeStep.value) {
+      const external = unref(options.initialType)
+      return external === 'supply' || external === 'service'
+    }
+    return false
+  })
+
   function resetIngredientTypeSelection() {
     selectedIngredientDbType.value = null
   }
@@ -217,6 +226,7 @@ export function useCatalogInlineCreate(options: {
     busyHint,
     hideResaleToggle,
     panelInitialType,
+    lockPanelIngredientType,
     canReturnToChooser,
     openFromSearch,
     onChooserIntent,

--- a/pages/abastecimiento/ingredientes-propios.vue
+++ b/pages/abastecimiento/ingredientes-propios.vue
@@ -177,6 +177,7 @@
       v-model="showPanel"
       :ingredient="panelIngredient"
       :initial-type="panelInitialType"
+      :lock-ingredient-type="!!typeFilter"
       hide-resale-toggle
       @saved="onSaved"
       @archived="onArchived"


### PR DESCRIPTION
## Summary
- Add missing icons to `InlineCatalogIngredientTypeChooser` option cards
- Lock ingredient type in `IngredientePropioPanel` when already chosen in the prior inline step (or hub filter / compra row context)
- Avoid redundant 3-card type selector after the dedicated type chooser

## Test plan
- [ ] Receta → inline create → Ingrediente → pick Insumo → panel shows only Insumo (read-only)
- [ ] Type chooser cards show icons
- [ ] Panel back returns to type chooser

Made with [Cursor](https://cursor.com)