### PR TITLE
fix(abastecimiento): extend invoice OCR proxy timeout to 240s

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -111,6 +111,8 @@ export default defineNuxtConfig({
           'Access-Control-Allow-Credentials': 'true'
         }
       },
+      // Invoice OCR — server/api/suppliers/purchases/extract-invoice.post.ts (240s proxy)
+      '/api/suppliers/purchases/extract-invoice': { proxy: false },
       '/api/**': {
         proxy: {
           to: process.env.NODE_ENV === 'development'

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -1250,7 +1250,8 @@ const handleScanFileSelect = async (event: Event) => {
     formData.append('file', optimizedFile)
     const response = await $fetch<any>('/api/suppliers/purchases/extract-invoice', {
       method: 'POST',
-      body: formData
+      body: formData,
+      timeout: 240_000, // 4 min — Gemini OCR; was timing out at ~120s
     })
     if (response.success && response.data) {
       const data = response.data

--- a/server/api/suppliers/purchases/extract-invoice.post.ts
+++ b/server/api/suppliers/purchases/extract-invoice.post.ts
@@ -1,0 +1,15 @@
+/**
+ * Invoice OCR proxy with extended timeout (Gemini can exceed default ~120s CDN/proxy limits).
+ * Replaces the generic /api/** routeRule proxy for this path only.
+ */
+const OCR_PROXY_TIMEOUT_MS = 240_000 // 4 min (2× prior ~120s client/CDN cutoff)
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const base = String(config.public.warolabsApiUrl || 'https://api.warolabs.com').replace(/\/$/, '')
+  const target = `${base}/suppliers/purchases/extract-invoice`
+
+  return proxyRequest(event, target, {
+    timeout: OCR_PROXY_TIMEOUT_MS,
+  })
+})


### PR DESCRIPTION
## Summary

- Add `server/api/suppliers/purchases/extract-invoice.post.ts` with an explicit **240s** `proxyRequest` timeout for Gemini invoice OCR.
- Exclude that path from the generic `/api/**` Nitro proxy (`proxy: false` in `nuxt.config.ts`).
- Set `$fetch` timeout to **240s** in compra directa create flow.

Invoice scans were failing with **504** when Gemini took longer than ~120s (CloudFront origin timeout was raised to **120s** separately on AWS).

## Test plan

- [ ] Deploy to staging/dev and scan a real supplier invoice (multi-line receipt).
- [ ] Confirm no 504 before ~4 minutes; OCR fields populate when Gemini succeeds.
- [ ] Smoke-test another `/api/**` route (e.g. scan-usage) still works.

## Infra (already applied, not in this PR)

- CloudFront `warocol.com` + `api.warolabs.com`: `OriginReadTimeout` **30s → 120s** (AWS max for this setting).
- Nginx on warolabs: optional `proxy_read_timeout 240s` still pending manual `sudo reload`.


Made with [Cursor](https://cursor.com)