### PR TITLE
feat(copy): batch 1 — warehouse glossary and copy constants

### DIFF
--- a/components/menu/MenuIngredientProductHint.vue
+++ b/components/menu/MenuIngredientProductHint.vue
@@ -1,6 +1,10 @@
+<script setup lang="ts">
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
+</script>
+
 <template>
   <p class="text-xs text-text-secondary leading-relaxed">
-    <strong class="font-medium text-text-primary">Ingrediente</strong> — materia prima en bodega (harina, queso).
-    <strong class="font-medium text-text-primary">Producto de menú</strong> — lo que vendes en caja; si es reventa (gaseosa, snack), el stock se crea solo al elegir esa opción.
+    <strong class="font-medium text-text-primary">{{ WAREHOUSE_COPY.warehouseItem }}</strong> — materia prima en bodega (harina, queso).
+    <strong class="font-medium text-text-primary">{{ WAREHOUSE_COPY.menuProduct }}</strong> — lo que vendes en caja; si es reventa (gaseosa, snack), el stock se crea solo al elegir esa opción.
   </p>
 </template>

--- a/constants/warehouseCopy.ts
+++ b/constants/warehouseCopy.ts
@@ -1,0 +1,21 @@
+/**
+ * Warehouse vs menu UI copy — single source of truth for the copy epic.
+ *
+ * Glossary table: https://github.com/uno0uno/warocol.com/issues/1113
+ * Batches #1115–#1118 should import from here instead of inline Spanish strings.
+ *
+ * `supply` creation intent (bodega path) is not the same as `ingredients.type === 'supply'`.
+ * @see composables/useCatalogEntityCreation.ts
+ */
+export const WAREHOUSE_COPY = {
+  warehouseItem: 'Artículo de bodega',
+  warehouseCatalog: 'Catálogo de bodega',
+  recipeCostLines: 'Insumos de la receta',
+  menuProduct: 'Producto de menú',
+  waroTemplates: 'Plantillas Waro',
+  typeFood: 'Alimento',
+  typeSupply: 'Insumo',
+  typeService: 'Servicio',
+} as const
+
+export type WarehouseCopyKey = keyof typeof WAREHOUSE_COPY


### PR DESCRIPTION
## Summary

- Add `constants/warehouseCopy.ts` with typed `WAREHOUSE_COPY` glossary (`as const`) and header linking epic #1113.
- Wire `MenuIngredientProductHint.vue` to use `warehouseItem` and `menuProduct` as the proof consumer.

**For batches #1115–#1118:** import shared strings instead of inline copy:

```ts
import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
// e.g. WAREHOUSE_COPY.warehouseCatalog, .recipeCostLines, .waroTemplates
```

Closes #1114

## Test plan

- [ ] Open menu product create/edit where `MenuIngredientProductHint` renders — labels show **Artículo de bodega** and **Producto de menú**
- [ ] No route or API changes; grep confirms only the two files above changed user-facing copy in this PR

## wr-context

See issue #1114 `wr-context` comment (`.wr/` is gitignored locally).

Made with [Cursor](https://cursor.com)