### PR TITLE
feat(copy): batch 2 — abastecimiento catalog and nav labels

### DIFF
--- a/.wr/1115.yaml
+++ b/.wr/1115.yaml
@@ -1,0 +1,32 @@
+issue: 1115
+title: "feat(copy): batch 2 — abastecimiento catalog and nav labels"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1115-abastecimiento-catalog-copy
+
+paths:
+  - pages/abastecimiento.vue
+  - pages/abastecimiento/ingredientes-propios.vue
+  - pages/abastecimiento/index.vue
+  - layouts/dashboard.vue
+  - constants/warehouseCopy.ts
+
+ac:
+  - No visible "Ingredientes Propios" vs "Personalizados" mismatch on same flow
+  - Search placeholder uses bodega wording (not "Buscar ingredientes")
+  - Manual test /abastecimiento/ingredientes-propios — create, filter by type, archive
+
+out_of_scope:
+  - Slide-overs (batch 3)
+  - Stock/movimientos/calidad-datos pages (batch 5)
+  - Archive modal copy on ingredientes-propios.vue
+
+hints:
+  entry: constants/warehouseCopy.ts — WAREHOUSE_COPY
+  pattern: Import WAREHOUSE_COPY in scoped pages; extend constants for catalog phrases
+  tests: Manual per AC
+
+skip:
+  audits: [ux, color, typography]

--- a/constants/warehouseCopy.ts
+++ b/constants/warehouseCopy.ts
@@ -16,6 +16,17 @@ export const WAREHOUSE_COPY = {
   typeFood: 'Alimento',
   typeSupply: 'Insumo',
   typeService: 'Servicio',
+  catalogSearchPlaceholder: 'Buscar en catálogo de bodega...',
+  catalogStatsTotal: 'Total en catálogo',
+  catalogEmptyTitle: 'Aún no tienes artículos en tu catálogo de bodega',
+  catalogEmptySub:
+    'Crea tu primer artículo de bodega desde aquí o desde cualquier receta o modificador',
+  catalogHubDescription:
+    'Artículos de bodega de tu restaurante, creados para tus recetas específicas',
+  newWarehouseItemDefault: '+ Nuevo artículo de bodega',
+  newFood: '+ Nuevo alimento',
+  newSupply: '+ Nuevo insumo',
+  newService: '+ Nuevo servicio',
 } as const
 
 export type WarehouseCopyKey = keyof typeof WAREHOUSE_COPY

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -172,6 +172,7 @@ import {
 import { useNotifications } from '~/composables/useNotifications'
 import { useBilling } from '~/composables/useBilling'
 import { usePosMobileCart } from '~/composables/usePosMobileCart'
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 
 // Notifications — init here so SSE starts on all screen sizes (not just when bell mounts)
 const { unreadCount: notificationsUnreadCount, init: initNotifications, disconnect: disconnectNotifications } = useNotifications()
@@ -331,9 +332,9 @@ const getPageConfig = () => {
     }
   } else if (path === '/abastecimiento/ingredientes-propios') {
     return {
-      pageTitle: 'Ingredientes Personalizados',
+      pageTitle: WAREHOUSE_COPY.warehouseCatalog,
       pageSubtitle: undefined,
-      searchPlaceholder: 'Buscar ingredientes...',
+      searchPlaceholder: WAREHOUSE_COPY.catalogSearchPlaceholder,
       activePage: 'abastecimiento' as const,
       showBreadcrumb: false,
       breadcrumbPage: undefined,

--- a/pages/abastecimiento.vue
+++ b/pages/abastecimiento.vue
@@ -13,6 +13,8 @@
 </template>
 
 <script setup lang="ts">
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
+
 const route = useRoute()
 const lastAbastecimientoPath = useState<string | null>('abastecimiento-last-path', () => null)
 
@@ -35,7 +37,7 @@ const navigationItems = [
   { to: '/abastecimiento/stock', label: 'Stock' },
   { to: '/abastecimiento/movimientos', label: 'Movimientos' },
   { to: '/abastecimiento/ajustes', label: 'Historial de ajustes', matchPath: '/abastecimiento/ajustes' },
-  { to: '/abastecimiento/ingredientes-propios', label: 'Ingredientes Propios' },
+  { to: '/abastecimiento/ingredientes-propios', label: WAREHOUSE_COPY.warehouseCatalog },
   { to: '/abastecimiento/calidad-datos', label: 'Calidad de Datos' }
 ]
 

--- a/pages/abastecimiento/index.vue
+++ b/pages/abastecimiento/index.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
+
 useHead({ title: 'Abastecimiento' })
 </script>
 
@@ -15,8 +17,8 @@ useHead({ title: 'Abastecimiento' })
           </svg>
         </div>
         <div class="min-w-0">
-          <p class="text-sm font-semibold text-text-primary">Ingredientes Personalizados</p>
-          <p class="text-xs text-text-secondary mt-0.5 leading-relaxed">Ingredientes propios de tu restaurante, creados para tus recetas específicas</p>
+          <p class="text-sm font-semibold text-text-primary">{{ WAREHOUSE_COPY.warehouseCatalog }}</p>
+          <p class="text-xs text-text-secondary mt-0.5 leading-relaxed">{{ WAREHOUSE_COPY.catalogHubDescription }}</p>
         </div>
       </NuxtLink>
     </div>

--- a/pages/abastecimiento/ingredientes-propios.vue
+++ b/pages/abastecimiento/ingredientes-propios.vue
@@ -9,14 +9,14 @@
     <div v-else class="flex flex-col gap-3 md:gap-4">
       <!-- Stats Cards -->
       <UiStats>
-        <UiStatsCard label="Total ingredientes" :value="stats.total" icon="beaker" />
+        <UiStatsCard :label="WAREHOUSE_COPY.catalogStatsTotal" :value="stats.total" icon="beaker" />
         <UiStatsCard label="Con costo" :value="stats.withCost" icon="currency-dollar" />
       </UiStats>
 
       <UiAdvancedFiltersBar
         v-model:search="localSearchTerm"
         :search-fields="[]"
-        search-placeholder="Buscar ingredientes..."
+        :search-placeholder="WAREHOUSE_COPY.catalogSearchPlaceholder"
         :show-date-range="false"
         :show-clear="hasActiveFilters"
         @search="performSearch"
@@ -30,9 +30,9 @@
             @change="currentPage = 1"
           >
             <option value="">Tipo</option>
-            <option value="food">Alimento</option>
-            <option value="supply">Insumo</option>
-            <option value="service">Servicio</option>
+            <option value="food">{{ WAREHOUSE_COPY.typeFood }}</option>
+            <option value="supply">{{ WAREHOUSE_COPY.typeSupply }}</option>
+            <option value="service">{{ WAREHOUSE_COPY.typeService }}</option>
           </select>
           <button
             type="button"
@@ -53,7 +53,7 @@
       </UiAdvancedFiltersBar>
 
       <!-- Data View -->
-      <HealthSemaphore :is-unlocked="true" title="Ingredientes Personalizados">
+      <HealthSemaphore :is-unlocked="true" :title="WAREHOUSE_COPY.warehouseCatalog">
         <template #header-actions>
           <button
             @click="openPanel(null)"
@@ -68,8 +68,8 @@
         :sort-field="sortField"
         :sort-direction="sortDirection"
         @sort="handleSort"
-        empty-message="Aún no tienes ingredientes personalizados"
-        empty-sub-message="Crea tu primer ingrediente personalizado desde aquí o desde cualquier receta o modificador"
+        :empty-message="WAREHOUSE_COPY.catalogEmptyTitle"
+        :empty-sub-message="WAREHOUSE_COPY.catalogEmptySub"
         variant="default"
         row-size="xs"
       >
@@ -239,12 +239,17 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 
-useHead({ title: 'Ingredientes Personalizados' })
+useHead({ title: WAREHOUSE_COPY.warehouseCatalog })
 
 const { currentTenant } = useTenantReactive()
 
-const TYPE_LABELS: Record<string, string> = { food: 'Alimento', supply: 'Insumo', service: 'Servicio' }
+const TYPE_LABELS: Record<string, string> = {
+  food: WAREHOUSE_COPY.typeFood,
+  supply: WAREHOUSE_COPY.typeSupply,
+  service: WAREHOUSE_COPY.typeService,
+}
 
 const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
 const typeFilter = ref('')
@@ -256,10 +261,10 @@ const panelInitialType = computed(() => {
 })
 
 const nuevoButtonLabel = computed(() => {
-  if (typeFilter.value === 'supply') return '+ Nuevo insumo'
-  if (typeFilter.value === 'service') return '+ Nuevo servicio'
-  if (typeFilter.value === 'food') return '+ Nuevo alimento'
-  return '+ Nuevo ingrediente'
+  if (typeFilter.value === 'supply') return WAREHOUSE_COPY.newSupply
+  if (typeFilter.value === 'service') return WAREHOUSE_COPY.newService
+  if (typeFilter.value === 'food') return WAREHOUSE_COPY.newFood
+  return WAREHOUSE_COPY.newWarehouseItemDefault
 })
 const currentPage = ref(1)
 const itemsPerPage = ref(50)


### PR DESCRIPTION
## Summary
- Extend `WAREHOUSE_COPY` with catalog search, stats, empty states, hub description, and type-aware CTAs.
- Unify nav, page title, dashboard header, hub card, and `ingredientes-propios` copy to **Catálogo de bodega** (no Propios/Personalizados split).

Closes #1115

## Test plan
- [ ] Abastecimiento nav shows **Catálogo de bodega**
- [ ] `/abastecimiento/ingredientes-propios` — title, search placeholder, stats, empties use bodega wording
- [ ] Filter by Alimento/Insumo/Servicio — CTAs stay type-specific; create and archive still work

## wr-context
See `.wr/1115.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)