### PR TITLE
feat(copy): batch 3 — inline create slide-overs (bodega vs menú)

### DIFF
--- a/components/ingredientes/IngredientePropioPanel.vue
+++ b/components/ingredientes/IngredientePropioPanel.vue
@@ -18,7 +18,7 @@
         v-if="modelValue"
         role="dialog"
         aria-modal="true"
-        :aria-label="isEdit ? `Editar ingrediente: ${ingredient?.name}` : 'Crear ingrediente personalizado'"
+        :aria-label="panelAriaLabel"
         class="fixed z-50 flex flex-col bg-surface shadow-2xl
                inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh]
                md:inset-y-0 md:right-0 md:bottom-auto md:left-auto md:inset-x-auto md:rounded-none md:w-full md:max-w-md md:max-h-none md:h-full"
@@ -39,10 +39,10 @@
               </div>
               <div class="min-w-0">
                 <h2 class="text-base font-bold text-text-primary leading-tight">
-                  {{ isEdit ? 'Editar ingrediente' : 'Nuevo ingrediente' }}
+                  {{ isEdit ? WAREHOUSE_COPY.panelEditTitle : WAREHOUSE_COPY.panelNewTitle }}
                 </h2>
                 <p class="text-xs text-text-secondary leading-snug mt-0.5">
-                  {{ isEdit ? ingredient?.name : 'Ingrediente personalizado de tu restaurante' }}
+                  {{ isEdit ? ingredient?.name : WAREHOUSE_COPY.panelNewSubtitle }}
                 </p>
               </div>
             </div>
@@ -71,7 +71,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8l1 12a2 2 0 002 2h8a2 2 0 002-2l1-12M10 12v4m4-4v4" />
             </svg>
             <div>
-              <p class="text-sm font-semibold text-amber-800">Ingrediente archivado</p>
+              <p class="text-sm font-semibold text-amber-800">{{ WAREHOUSE_COPY.panelArchived }}</p>
               <p class="text-xs text-amber-700 mt-0.5 leading-relaxed">
                 No aparece en recetas ni pedidos nuevos. El historial de compras y ventas queda intacto.
               </p>
@@ -100,9 +100,9 @@
               Tipo <span class="text-destructive">*</span>
             </label>
             <p class="text-xs text-text-tertiary leading-snug">
-              Ingrediente de bodega para recetas y costos. Distinto de producto de menú (reventa en POS).
+              {{ WAREHOUSE_COPY.panelTypeHelper }}
             </p>
-            <div class="grid grid-cols-1 sm:grid-cols-3 gap-2" role="group" aria-label="Tipo de ingrediente">
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-2" role="group" :aria-label="WAREHOUSE_COPY.warehouseItemType">
               <button
                 type="button"
                 @click="setIngredientType('food')"
@@ -324,8 +324,8 @@
             />
 
             <p class="text-xs text-text-tertiary">
-              <template v-if="form.unit === 'und'">Si una receta usa este ingrediente en {{ unitWeightUnit }}, el sistema divide por este valor para descontar stock en und.</template>
-              <template v-else>Si una receta usa este ingrediente en und, el sistema multiplica por este valor para descontar stock en {{ form.unit }}.</template>
+              <template v-if="form.unit === 'und'">Si una receta usa este artículo de bodega en {{ unitWeightUnit }}, el sistema divide por este valor para descontar stock en und.</template>
+              <template v-else>Si una receta usa este artículo de bodega en und, el sistema multiplica por este valor para descontar stock en {{ form.unit }}.</template>
             </p>
           </div>
 
@@ -414,7 +414,7 @@
               class="flex-1 h-11 rounded-lg bg-primary text-sm font-semibold text-white transition-all hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed active:scale-[0.98] shadow-sm shadow-primary/30"
             >
               <span v-if="saving">Guardando...</span>
-              <span v-else>{{ isEdit ? 'Guardar cambios' : 'Crear ingrediente' }}</span>
+              <span v-else>{{ isEdit ? 'Guardar cambios' : WAREHOUSE_COPY.createWarehouseItem }}</span>
             </button>
           </div>
 
@@ -425,7 +425,7 @@
             @click="showArchiveConfirm = true"
             class="h-10 w-full rounded-lg border border-amber-300 text-sm font-medium text-amber-700 hover:bg-amber-50 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-300/40"
           >
-            Archivar ingrediente
+            {{ WAREHOUSE_COPY.archiveWarehouseItem }}
           </button>
           <button
             v-if="isEdit && ingredient?.is_active === false"
@@ -435,7 +435,7 @@
             class="h-10 w-full rounded-lg border border-primary/40 text-sm font-medium text-primary hover:bg-primary/5 transition-colors focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:opacity-50"
           >
             <span v-if="restoring">Restaurando...</span>
-            <span v-else>Restaurar ingrediente</span>
+            <span v-else>{{ WAREHOUSE_COPY.restoreWarehouseItem }}</span>
           </button>
         </div>
 
@@ -470,6 +470,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import {
   defaultUndPurchaseUnitsDraft,
   persistDraftPurchaseUnits,
@@ -508,6 +509,14 @@ const props = withDefaults(defineProps<Props>(), {
 })
 const emit = defineEmits<Emits>()
 
+const isEdit = computed(() => !!props.ingredient?.id)
+
+const panelAriaLabel = computed(() =>
+  isEdit.value
+    ? `${WAREHOUSE_COPY.panelEditTitle}: ${props.ingredient?.name ?? ''}`
+    : WAREHOUSE_COPY.panelCreateAria,
+)
+
 // Archive / restore state
 const showArchiveConfirm = ref(false)
 const archiving = ref(false)
@@ -541,8 +550,6 @@ async function restoreIngredient() {
     restoring.value = false
   }
 }
-
-const isEdit = computed(() => !!props.ingredient)
 
 const inputClass = 'h-10 w-full rounded-lg border-2 border-border bg-background px-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 transition-colors'
 
@@ -734,7 +741,7 @@ function validate() {
   }
   if (!form.value.category.trim()) e.category = 'La categoría es obligatoria'
   if (form.value.isResale && form.value.unit !== 'und') {
-    e.general = 'Los ingredientes de reventa deben tener unidad "und" (pieza).'
+    e.general = WAREHOUSE_COPY.resaleWarehouseItemMustBeUnd
   }
   errors.value = e
   return Object.keys(e).length === 0
@@ -808,7 +815,7 @@ async function submit() {
   } catch (err: any) {
     const detail = err?.data?.detail ?? err?.message ?? 'Error al guardar'
     if (detail.toLowerCase().includes('already exists') || detail.toLowerCase().includes('ya existe')) {
-      errors.value.name = 'Ya existe un ingrediente con ese nombre'
+      errors.value.name = WAREHOUSE_COPY.duplicateWarehouseItemName
     } else {
       errors.value.general = detail
     }

--- a/components/menu/CreateCatalogEntityChooser.vue
+++ b/components/menu/CreateCatalogEntityChooser.vue
@@ -21,7 +21,7 @@
         v-if="modelValue && showChooserUi"
         role="dialog"
         aria-modal="true"
-        aria-label="Elegir ingrediente o producto de menú a crear"
+        :aria-label="WAREHOUSE_COPY.createChooserAria"
         class="fixed z-50 flex flex-col bg-surface shadow-2xl
                inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh]
                md:inset-y-0 md:right-0 md:bottom-auto md:left-auto md:inset-x-auto md:rounded-none md:w-full md:max-w-md md:max-h-none md:h-full"
@@ -50,7 +50,7 @@
                     “{{ initialName.trim() }}” no aparece en la búsqueda
                   </template>
                   <template v-else>
-                    Elige ingrediente (bodega) o producto de menú (venta)
+                    {{ WAREHOUSE_COPY.createChooserSubtitle }}
                   </template>
                 </p>
               </div>
@@ -75,7 +75,7 @@
 
           <div class="flex flex-col gap-3" role="group" aria-label="Tipo de ítem">
             <UiSelectionOptionCard
-              title="Ingrediente"
+              :title="WAREHOUSE_COPY.warehouseItem"
               description="Abastecimiento y recetas · gr, ml, und"
               :selected="selectedIntent === 'supply'"
               @click="selectAndConfirm('supply')"
@@ -88,7 +88,7 @@
             </UiSelectionOptionCard>
 
             <UiSelectionOptionCard
-              title="Producto de menú"
+              :title="WAREHOUSE_COPY.menuProduct"
               description="Venta en menú y POS · precio, categoría"
               :selected="selectedIntent === 'menu-product'"
               @click="selectAndConfirm('menu-product')"
@@ -117,6 +117,7 @@
 </template>
 
 <script setup lang="ts">
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import {
   resolveCreationIntent,
   shouldShowCreationChooser,

--- a/components/menu/InlineCatalogIngredientTypeChooser.vue
+++ b/components/menu/InlineCatalogIngredientTypeChooser.vue
@@ -21,7 +21,7 @@
         v-if="modelValue"
         role="dialog"
         aria-modal="true"
-        aria-label="Elegir tipo de ingrediente de bodega"
+        :aria-label="WAREHOUSE_COPY.typeChooserAria"
         class="fixed z-50 flex flex-col bg-surface shadow-2xl
                inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh]
                md:inset-y-0 md:right-0 md:bottom-auto md:left-auto md:inset-x-auto md:rounded-none md:w-full md:max-w-md md:max-h-none md:h-full"
@@ -43,7 +43,7 @@
               </div>
               <div class="min-w-0">
                 <h2 class="text-base font-bold text-text-primary leading-tight">
-                  Tipo de ingrediente
+                  {{ WAREHOUSE_COPY.warehouseItemType }}
                 </h2>
                 <p class="text-xs text-text-secondary leading-snug mt-0.5">
                   <template v-if="initialName.trim()">
@@ -70,12 +70,12 @@
 
         <div class="flex-1 overflow-y-auto px-6 py-5 space-y-4">
           <p class="text-sm text-text-secondary">
-            ¿Qué tipo de ingrediente de bodega quieres crear?
+            {{ WAREHOUSE_COPY.typeChooserPrompt }}
           </p>
 
-          <div class="flex flex-col gap-3" role="group" aria-label="Tipo de ingrediente de bodega">
+          <div class="flex flex-col gap-3" role="group" :aria-label="WAREHOUSE_COPY.typeChooserGroupAria">
             <UiSelectionOptionCard
-              title="Alimento"
+              :title="WAREHOUSE_COPY.typeFood"
               description="Peso o volumen · gr, ml, kg"
               :selected="selectedType === 'food'"
               @click="selectAndConfirm('food')"
@@ -88,7 +88,7 @@
               </template>
             </UiSelectionOptionCard>
             <UiSelectionOptionCard
-              title="Insumo"
+              :title="WAREHOUSE_COPY.typeSupply"
               description="Unidad fija · und (caja, paquete…)"
               :selected="selectedType === 'supply'"
               @click="selectAndConfirm('supply')"
@@ -101,7 +101,7 @@
               </template>
             </UiSelectionOptionCard>
             <UiSelectionOptionCard
-              title="Servicio"
+              :title="WAREHOUSE_COPY.typeService"
               description="Horas · hr"
               :selected="selectedType === 'service'"
               @click="selectAndConfirm('service')"
@@ -130,6 +130,7 @@
 </template>
 
 <script setup lang="ts">
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import type { IngredientDbType } from '@/composables/useCatalogInlineCreate'
 
 const props = withDefaults(

--- a/composables/useCatalogInlineCreate.ts
+++ b/composables/useCatalogInlineCreate.ts
@@ -1,4 +1,5 @@
 import type { MaybeRef } from 'vue'
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import {
   resolveCreationIntent,
   shouldShowCreationChooser,
@@ -59,13 +60,13 @@ export function useCatalogInlineCreate(options: {
   const busyMessage = computed(() => {
     switch (busyPhase.value) {
       case 'linking-ingredient':
-        return 'Vinculando ingrediente…'
+        return WAREHOUSE_COPY.linkingWarehouseItem
       case 'linking-product':
         return 'Vinculando reventa al catálogo…'
       case 'creating-product':
         return 'Creando producto de menú…'
       case 'creating-ingredient':
-        return 'Creando ingrediente…'
+        return WAREHOUSE_COPY.creatingWarehouseItem
       default:
         return ''
     }
@@ -74,7 +75,7 @@ export function useCatalogInlineCreate(options: {
   const busyHint = computed(() => {
     switch (busyPhase.value) {
       case 'linking-ingredient':
-        return 'Se agregará a la fila y se actualizará la lista de ingredientes.'
+        return WAREHOUSE_COPY.linkingWarehouseItemHint
       case 'linking-product':
         return 'Buscando el insumo de reventa vinculado al producto.'
       case 'creating-product':

--- a/constants/warehouseCopy.ts
+++ b/constants/warehouseCopy.ts
@@ -27,6 +27,29 @@ export const WAREHOUSE_COPY = {
   newFood: '+ Nuevo alimento',
   newSupply: '+ Nuevo insumo',
   newService: '+ Nuevo servicio',
+  warehouseItemType: 'Tipo de artículo',
+  createChooserAria: 'Elegir artículo de bodega o producto de menú a crear',
+  createChooserSubtitle: 'Elige artículo de bodega o producto de menú (venta)',
+  typeChooserAria: 'Elegir tipo de artículo de bodega',
+  typeChooserPrompt: '¿Qué tipo de artículo de bodega quieres crear?',
+  typeChooserGroupAria: 'Tipo de artículo de bodega',
+  panelNewTitle: 'Nuevo artículo de bodega',
+  panelEditTitle: 'Editar artículo de bodega',
+  panelCreateAria: 'Crear artículo de bodega personalizado',
+  panelNewSubtitle: 'Artículo de bodega de tu restaurante',
+  panelArchived: 'Artículo archivado',
+  panelTypeHelper:
+    'Para recetas y costos. Distinto de producto de menú (reventa en POS).',
+  createWarehouseItem: 'Crear artículo de bodega',
+  archiveWarehouseItem: 'Archivar artículo de bodega',
+  restoreWarehouseItem: 'Restaurar artículo de bodega',
+  linkingWarehouseItem: 'Vinculando artículo de bodega…',
+  creatingWarehouseItem: 'Creando artículo de bodega…',
+  linkingWarehouseItemHint:
+    'Se agregará a la fila y se actualizará el catálogo de bodega.',
+  duplicateWarehouseItemName: 'Ya existe un artículo de bodega con ese nombre',
+  resaleWarehouseItemMustBeUnd:
+    'Los artículos de bodega de reventa deben tener unidad "und" (pieza).',
 } as const
 
 export type WarehouseCopyKey = keyof typeof WAREHOUSE_COPY


### PR DESCRIPTION
## Summary
- Extend `WAREHOUSE_COPY` with inline-create chooser, type step, panel, and busy-state strings.
- Wire `CreateCatalogEntityChooser`, `InlineCatalogIngredientTypeChooser`, `IngredientePropioPanel`, and `useCatalogInlineCreate` to the glossary (no generic "Ingrediente" in slide-over titles).

Closes #1116

## Test plan
- [ ] `/menu/productos/crear` — search miss → Crear nuevo → **Artículo de bodega** | **Producto de menú** → type step → panel copy
- [ ] `/abastecimiento/ingredientes-propios` — same inline-create flow from search
- [ ] Busy overlay while creating/linking shows bodega wording
- [ ] Type card **Insumo** unchanged

## wr-context
See issue #1116 `wr-context` comment (`.wr/1116.yaml` is gitignored locally).

Made with [Cursor](https://cursor.com)