### PR TITLE
feat(copy): menu/recipe/modifier copy — batch 4 (#1117)

### DIFF
--- a/.wr/1117.yaml
+++ b/.wr/1117.yaml
@@ -1,0 +1,36 @@
+issue: 1117
+title: "feat(copy): batch 4 — menú, recetas, productos, modificadores copy"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1117-menu-recipe-copy
+epic: 1113
+
+paths:
+  - constants/warehouseCopy.ts
+  - pages/menu/productos/crear.vue
+  - pages/menu/productos/[id].vue
+  - pages/menu/recetas/index.vue
+  - pages/menu/recetas/crear.vue
+  - pages/menu/recetas/[id].vue
+  - pages/menu/modificadores/crear.vue
+  - pages/menu/modificadores/[id].vue
+  - components/ui/IngredientSearchInput.vue
+  - components/ui/IngredientFilterSearch.vue
+
+ac:
+  - Section title Insumos de la receta on product create/edit
+  - Hint artículo de bodega vs producto de menú (MenuIngredientProductHint unchanged)
+  - Search placeholders/aria + reventa block use bodega glossary
+  - Manual test create product with extra lines + link to receta
+
+out_of_scope:
+  - abastecimiento list, compras/docs, inline-create choosers, URLs, API identifiers
+
+hints:
+  glossary: constants/warehouseCopy.ts — WAREHOUSE_COPY keys for batch 4 menu copy
+  verify: rg -i ingrediente pages/menu/productos pages/menu/recetas pages/menu/modificadores — allow code keys/comments only
+
+skip:
+  audits: [ux, color, typography]

--- a/components/ui/IngredientFilterSearch.vue
+++ b/components/ui/IngredientFilterSearch.vue
@@ -3,13 +3,13 @@
     <UiIngredientSearchInput
       :key="inputKey"
       :initial-value="displayValue"
-      placeholder="Ingrediente..."
+      :placeholder="WAREHOUSE_COPY.menuFilterPlaceholder"
       @select="onSelect"
     />
     <button
       v-if="modelValue"
       type="button"
-      aria-label="Quitar filtro de ingrediente"
+      :aria-label="WAREHOUSE_COPY.menuFilterClearAria"
       class="absolute right-2 top-1/2 -translate-y-1/2 min-h-[28px] min-w-[28px] inline-flex items-center justify-center rounded-md text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
       @mousedown.prevent
       @click="clear"
@@ -23,6 +23,7 @@
 
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue'
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 
 const props = defineProps<{
   modelValue: string

--- a/components/ui/IngredientSearchInput.vue
+++ b/components/ui/IngredientSearchInput.vue
@@ -91,6 +91,7 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 
 interface Ingredient {
   id: string
@@ -112,7 +113,7 @@ interface Emits {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  placeholder: 'Buscar ingrediente o reventa...',
+  placeholder: WAREHOUSE_COPY.menuSearchPlaceholder,
   initialValue: '',
   allowCreate: false,
   baseOnly: false,

--- a/constants/warehouseCopy.ts
+++ b/constants/warehouseCopy.ts
@@ -50,6 +50,49 @@ export const WAREHOUSE_COPY = {
   duplicateWarehouseItemName: 'Ya existe un artículo de bodega con ese nombre',
   resaleWarehouseItemMustBeUnd:
     'Los artículos de bodega de reventa deben tener unidad "und" (pieza).',
+  menuSearchPlaceholder: 'Buscar artículo de bodega o reventa...',
+  menuFilterPlaceholder: 'Artículo de bodega...',
+  menuFilterClearAria: 'Quitar filtro de artículo de bodega',
+  warehouseItemOrResaleRequired: 'Artículo de bodega o reventa *',
+  selectWarehouseItem: 'Selecciona artículo de bodega',
+  selectWarehouseItemPrompt: 'Seleccione un artículo de bodega',
+  removeWarehouseItemLine: 'Eliminar línea',
+  recipeCompositionSection: 'Composición',
+  recipeCompositionSummary: 'Líneas:',
+  recipeCompositionEmptyHelp: 'Agrega artículos de bodega o productos de reventa',
+  recipeCompositionSavingHint: 'Estamos guardando la receta y consolidando su composición.',
+  recipeLinesColumn: 'Líneas',
+  recipeCompositionTableHeader: 'Artículo de bodega',
+  recipeLinesCountSuffix: 'líneas',
+  withWarehouseItem: 'Con artículo de bodega:',
+  linkedWarehouseItem: 'Artículo de bodega vinculado',
+  linkedWarehouseItemLoading: 'Cargando artículo de bodega vinculado…',
+  linkedWarehouseItemHelp: '1 und por venta · costo desde compras del artículo de bodega.',
+  linkedWarehouseItemNotFound: 'Artículo de bodega no encontrado. Revisa en Abastecimiento.',
+  linkedWarehouseItemNotFoundCatalog:
+    'No se encontró el artículo de bodega vinculado. Revísalo en Abastecimiento → Catálogo de bodega.',
+  resaleLinkedStockHelp:
+    'Este producto descuenta stock del artículo de bodega vinculado (1 und por venta). El costo real se calcula desde compras de ese artículo, no desde una receta editable aquí.',
+  recipeCostLinesSectionHelp:
+    'Artículos de bodega o productos de reventa que descuentan inventario al vender este plato',
+  addRecipeCostLinesHelp: 'Agrega artículos de bodega o productos de reventa para calcular el costo',
+  completeRecipeCostLinesError: 'Completa todos los artículos de bodega con cantidad mayor a 0.',
+  allRecipeCostLinesNeedQuantity: 'Todos los artículos de bodega deben tener una cantidad mayor a 0.',
+  addWarehouseItemToRecipe: 'Agrega al menos un artículo de bodega a la receta.',
+  duplicateWarehouseItemInList: 'No puedes agregar el mismo artículo de bodega más de una vez.',
+  completeModifiersWarehouseItem: 'Completa todos los modificadores con artículo de bodega o reventa.',
+  allOptionsNeedWarehouseItem: 'Todas las opciones deben tener un artículo de bodega o reventa.',
+  inventoryRecipeHelp: 'Configura receta o artículos de bodega abajo.',
+  defineRecipeInventoryHelp:
+    'Define la receta del producto. Cada venta descontará los artículos de bodega del inventario.',
+  recipeBaseLinesHelp: 'Selecciona una o más recetas base para usar sus líneas predefinidas.',
+  resaleLineSummaryLabel: 'Artículo de bodega:',
+  linkedWarehouseItemUpdateFailed:
+    'Producto guardado, pero no se pudo actualizar el artículo de bodega vinculado',
+  linkedWarehouseItemUpdateFailedDetail: 'Producto guardado, pero el artículo de bodega no se actualizó:',
+  linkedWarehouseItemNotSynced: 'Artículo de bodega no sincronizado',
+  cookedWithWarehouseItemsDescription:
+    'Cocina con artículos de bodega y recetas base. Cada venta descuenta inventario.',
 } as const
 
 export type WarehouseCopyKey = keyof typeof WAREHOUSE_COPY

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -138,7 +138,7 @@
                 >
                   <div class="grid grid-cols-1 md:grid-cols-12 gap-3 mb-3">
                     <div class="md:col-span-4">
-                      <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
+                      <label class="block text-xs font-medium text-text-secondary mb-1">{{ WAREHOUSE_COPY.warehouseItemOrResaleRequired }}</label>
                       <UiIngredientSearchInput
                         :initialValue="modifier.ingredient_name || ''"
                         :allow-create="true"
@@ -340,6 +340,7 @@
 </template>
 
 <script setup lang="ts">
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import { ref, computed, watch } from 'vue'
 import { useQueryCache } from '@pinia/colada'
 import { useTenantReactive } from '@/composables/useTenantReactive'
@@ -594,7 +595,7 @@ function validateForm(): boolean {
 
   const missingIngredient = form.value.modifiers.some(m => !m.ingredient_id)
   if (missingIngredient) {
-    submitError.value = 'Todas las opciones deben tener un ingrediente o reventa.'
+    submitError.value = WAREHOUSE_COPY.allOptionsNeedWarehouseItem
     return false
   }
 

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -142,7 +142,7 @@
                   >
                     <div class="grid grid-cols-1 md:grid-cols-12 gap-3 mb-3">
                       <div class="md:col-span-4">
-                        <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
+                        <label class="block text-xs font-medium text-text-secondary mb-1">{{ WAREHOUSE_COPY.warehouseItemOrResaleRequired }}</label>
                         <UiIngredientSearchInput
                           :allow-create="true"
                           @select="(ing) => selectIngredient(modifier, ing)"
@@ -302,7 +302,7 @@
               </div>
 
               <div class="flex justify-between text-sm">
-                <span class="text-text-secondary">Con ingrediente:</span>
+                <span class="text-text-secondary">{{ WAREHOUSE_COPY.withWarehouseItem }}</span>
                 <span class="font-semibold text-text-primary">{{ form.modifiers.filter(m => m.ingredient_id).length }}</span>
               </div>
 
@@ -358,6 +358,7 @@
 </template>
 
 <script setup lang="ts">
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import { ref, computed, watch } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 
@@ -526,7 +527,7 @@ async function validateForm(): Promise<boolean> {
 
   const invalidModifiers = form.value.modifiers.some(m => !m.ingredient_id || !m.name)
   if (invalidModifiers) {
-    submitError.value = 'Completa todos los modificadores con ingrediente o reventa.'
+    submitError.value = WAREHOUSE_COPY.completeModifiersWarehouseItem
     return false
   }
 

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -335,11 +335,11 @@
             <div class="p-4 rounded-xl border border-border bg-surface-secondary/40 space-y-2">
               <p class="text-sm font-medium text-text-primary">Inventario y compras</p>
               <p class="text-xs text-text-secondary">
-                Este producto descuenta stock del insumo vinculado (1 und por venta). El costo real se calcula desde compras de ese insumo, no desde una receta editable aquí.
+                {{ WAREHOUSE_COPY.resaleLinkedStockHelp }}
               </p>
               <div v-if="resaleLinkedLoading" class="text-xs text-text-tertiary flex items-center gap-2">
                 <UiLoadingDots size="8px" color="var(--color-primary)" />
-                Cargando insumo vinculado…
+                {{ WAREHOUSE_COPY.linkedWarehouseItemLoading }}
               </div>
               <NuxtLink
                 v-else-if="linkedResaleIngredient"
@@ -351,7 +351,7 @@
                 <Icon name="heroicons:arrow-top-right-on-square" class="h-3.5 w-3.5" />
               </NuxtLink>
               <p v-else class="text-xs text-text-tertiary">
-                No se encontró el insumo vinculado. Revísalo en Abastecimiento → Ingredientes propios.
+                {{ WAREHOUSE_COPY.linkedWarehouseItemNotFoundCatalog }}
               </p>
             </div>
           </div>
@@ -386,7 +386,7 @@
               <p class="text-sm font-semibold text-text-primary">Este producto controla inventario</p>
               <p class="text-xs text-text-secondary mt-1">
                 <template v-if="tracksInventory">
-                  Define la receta del producto. Cada venta descontará los ingredientes del inventario.
+                  {{ WAREHOUSE_COPY.defineRecipeInventoryHelp }}
                 </template>
                 <template v-else>
                   No se descontará nada del inventario al venderlo. Útil para servicios, propinas, promos o productos sin trazabilidad de costo.
@@ -409,7 +409,7 @@
               </button>
             </div>
             <p class="text-sm text-text-secondary mb-4">
-              Selecciona una o más recetas base para usar sus ingredientes predefinidos.
+              {{ WAREHOUSE_COPY.recipeBaseLinesHelp }}
             </p>
             <p v-if="duplicateRecipeBaseError" class="text-sm text-destructive flex items-center gap-1 mb-3">
               <svg class="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
@@ -486,9 +486,9 @@
           <!-- Ingredientes y reventa adicionales -->
           <div class="mt-8">
             <MenuIngredientProductHint class="mb-4" />
-            <h3 class="text-lg font-semibold text-text-primary mb-2">Ingredientes y reventa (adicionales)</h3>
+            <h3 class="text-lg font-semibold text-text-primary mb-2">{{ WAREHOUSE_COPY.recipeCostLines }}</h3>
             <p class="text-sm text-text-secondary mb-4">
-              Materias primas o productos de reventa que descuentan inventario al vender este plato
+              {{ WAREHOUSE_COPY.recipeCostLinesSectionHelp }}
             </p>
             <p v-if="quantityError" class="text-sm text-destructive flex items-center gap-1 mb-3">
               <svg class="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/></svg>
@@ -531,7 +531,7 @@
                       :class="loadingUnits.has(ingredient.ingredient_id) ? 'pl-7' : 'pl-3'"
                     >
                       <option v-if="!ingredient.ingredient_id" value="" disabled>
-                        Selecciona ingrediente
+                        {{ WAREHOUSE_COPY.selectWarehouseItem }}
                       </option>
                       <option
                         v-for="opt in getIngredientUnitOptions(ingredient.ingredient_id)"
@@ -551,7 +551,7 @@
                   type="button"
                   @click="removeIngredient(index)"
                   class="p-2 text-destructive hover:bg-destructive/10 rounded-lg transition-colors"
-                  title="Eliminar ingrediente"
+                  :title="WAREHOUSE_COPY.removeWarehouseItemLine"
                 >
                   <Icon name="heroicons:trash" class="h-5 w-5" />
                 </button>
@@ -670,7 +670,7 @@
             </div>
 
             <div class="flex justify-between text-sm gap-2">
-              <span class="text-text-secondary flex-shrink-0">{{ isResaleProduct ? 'Insumo:' : 'Líneas receta:' }}</span>
+              <span class="text-text-secondary flex-shrink-0">{{ isResaleProduct ? WAREHOUSE_COPY.resaleLineSummaryLabel : WAREHOUSE_COPY.recipeCompositionSummary }}</span>
               <span class="font-semibold text-text-primary text-right truncate">
                 <template v-if="isResaleProduct">
                   {{ linkedResaleIngredient?.name ?? '—' }}
@@ -788,6 +788,7 @@
 </template>
 
 <script setup lang="ts">
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useQuery, useQueryCache } from '@pinia/colada'
 import { useMenuIngredientsQuery } from '@/composables/queries/useMenuIngredients'
@@ -1296,7 +1297,7 @@ const removeIngredient = (index: number) => {
 
 const getIngredientName = (ingredientId: string) => {
   const ingredient = ingredientCache.value[ingredientId]
-  return ingredient?.name || 'Seleccione un ingrediente'
+  return ingredient?.name || WAREHOUSE_COPY.selectWarehouseItemPrompt
 }
 
 const handleSubmit = async () => {
@@ -1320,7 +1321,7 @@ const handleSubmit = async () => {
   if (!isResaleProduct.value && tracksInventory.value) {
     const hasZeroQuantity = form.value.ingredients.some(ing => !ing.quantity || ing.quantity <= 0)
     if (hasZeroQuantity) {
-      quantityError.value = 'Todos los ingredientes deben tener una cantidad mayor a 0.'
+      quantityError.value = WAREHOUSE_COPY.allRecipeCostLinesNeedQuantity
       return
     }
   }
@@ -1417,9 +1418,9 @@ const handleSubmit = async () => {
           const detail = e?.data?.detail ?? e?.message
           toast.error(
             detail
-              ? `Producto guardado, pero el insumo no se actualizó: ${detail}`
-              : 'Producto guardado, pero no se pudo actualizar el insumo vinculado',
-            { title: 'Insumo no sincronizado' },
+              ? `${WAREHOUSE_COPY.linkedWarehouseItemUpdateFailedDetail} ${detail}`
+              : WAREHOUSE_COPY.linkedWarehouseItemUpdateFailed,
+            { title: WAREHOUSE_COPY.linkedWarehouseItemNotSynced },
           )
         }
       }

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -24,7 +24,7 @@
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3" role="group" aria-label="Tipo de creación de producto">
           <UiSelectionOptionCard
             title="Con receta"
-            description="Cocina con ingredientes y recetas base. Cada venta descuenta inventario."
+            :description="WAREHOUSE_COPY.cookedWithWarehouseItemsDescription"
             :selected="productCreateMode === 'recipe'"
             @click="setProductCreateMode('recipe')"
           >
@@ -433,12 +433,12 @@
                 </div>
               </UiFormSection>
 
-              <UiFormSection title="Ingredientes extra">
+              <UiFormSection :title="WAREHOUSE_COPY.recipeCostLines">
                 <MenuIngredientProductHint class="mb-3" />
 
                 <div v-if="form.ingredients.length === 0" class="text-center py-8 text-text-secondary border border-dashed border-border/80 rounded-lg mb-4">
                   <p class="text-sm font-medium">Sin líneas adicionales</p>
-                  <p class="text-xs mt-1">Agrega ingredientes o productos de reventa para calcular el costo</p>
+                  <p class="text-xs mt-1">{{ WAREHOUSE_COPY.addRecipeCostLinesHelp }}</p>
                 </div>
 
                 <div v-else class="space-y-3 mb-4">
@@ -475,7 +475,7 @@
                           :class="loadingUnits.has(ingredient.ingredient_id) ? 'pl-7' : 'pl-3'"
                         >
                           <option v-if="!ingredient.ingredient_id" value="" disabled>
-                            Selecciona ingrediente
+                            {{ WAREHOUSE_COPY.selectWarehouseItem }}
                           </option>
                           <option
                             v-for="opt in getIngredientUnitOptions(ingredient.ingredient_id)"
@@ -495,7 +495,7 @@
                       type="button"
                       @click="removeIngredient(index)"
                       class="p-2 text-destructive hover:bg-destructive/10 rounded-lg transition-colors"
-                      title="Eliminar ingrediente"
+                      :title="WAREHOUSE_COPY.removeWarehouseItemLine"
                     >
                       <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -698,6 +698,7 @@
 </template>
 
 <script setup lang="ts">
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import { ref, computed, watch } from 'vue'
 import { useQuery, useQueryCache } from '@pinia/colada'
 import { useMenuIngredientsQuery } from '@/composables/queries/useMenuIngredients'
@@ -1056,7 +1057,7 @@ async function validateForm(): Promise<boolean> {
       i => !i.ingredient_id || !i.quantity || i.quantity <= 0,
     )
     if (invalid) {
-      submitError.value = 'Completa todos los ingredientes con cantidad mayor a 0.'
+      submitError.value = WAREHOUSE_COPY.completeRecipeCostLinesError
       return false
     }
   }

--- a/pages/menu/recetas/[id].vue
+++ b/pages/menu/recetas/[id].vue
@@ -55,7 +55,7 @@
             </div>
           </UiFormSection>
 
-          <UiFormSection title="Ingredientes">
+          <UiFormSection :title="WAREHOUSE_COPY.recipeCompositionSection">
             <template #actions>
               <UiButton
                 type="button"
@@ -77,7 +77,7 @@
               <div v-if="form.ingredients.length === 0" class="text-center py-10 text-text-secondary border border-dashed border-border rounded-lg">
                 <Icon name="heroicons:cube" class="h-12 w-12 mx-auto mb-3 text-text-tertiary/50" />
                 <p class="text-sm font-medium mb-0.5">Sin líneas en la receta</p>
-                <p class="text-xs text-text-tertiary">Agrega ingredientes o productos de reventa</p>
+                <p class="text-xs text-text-tertiary">{{ WAREHOUSE_COPY.recipeCompositionEmptyHelp }}</p>
               </div>
 
               <div v-else class="space-y-3">
@@ -88,7 +88,7 @@
                 >
                   <div class="grid grid-cols-1 md:grid-cols-12 gap-3">
                     <div class="md:col-span-5">
-                      <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
+                      <label class="block text-xs font-medium text-text-secondary mb-1">{{ WAREHOUSE_COPY.warehouseItemOrResaleRequired }}</label>
                       <UiIngredientSearchInput
                         :initialValue="ingredient.ingredient_name"
                         :allow-create="true"
@@ -169,7 +169,7 @@
 
           <div class="space-y-3">
             <div class="flex justify-between text-sm">
-              <span class="text-text-secondary">Ingredientes:</span>
+              <span class="text-text-secondary">{{ WAREHOUSE_COPY.recipeCompositionSummary }}</span>
               <span class="font-semibold text-text-primary">{{ form.ingredients.length }}</span>
             </div>
 
@@ -239,6 +239,7 @@
 </template>
 
 <script setup lang="ts">
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useQueryCache } from '@pinia/colada'
 import { useMenuIngredientsQuery } from '@/composables/queries/useMenuIngredients'
@@ -432,7 +433,7 @@ const handleSubmit = async () => {
 
   const hasZeroQuantity = form.value.ingredients.some(ing => !ing.base_quantity || ing.base_quantity <= 0)
   if (hasZeroQuantity) {
-    submitError.value = 'Todos los ingredientes deben tener cantidad mayor a 0.'
+    submitError.value = WAREHOUSE_COPY.allRecipeCostLinesNeedQuantity
     return
   }
 
@@ -442,7 +443,7 @@ const handleSubmit = async () => {
 
   const uniqueIds = new Set(ingredientIds)
   if (ingredientIds.length !== uniqueIds.size) {
-    submitError.value = 'No puedes agregar el mismo ingrediente más de una vez.'
+    submitError.value = WAREHOUSE_COPY.duplicateWarehouseItemInList
     return
   }
 

--- a/pages/menu/recetas/crear.vue
+++ b/pages/menu/recetas/crear.vue
@@ -3,7 +3,7 @@
     <UiSubmitBusyOverlay
       :busy="isSubmitting"
       label="Creando receta base..."
-      hint="Estamos guardando la receta y consolidando sus ingredientes."
+      :hint="WAREHOUSE_COPY.recipeCompositionSavingHint"
       variant="glass"
       indicator="matrix"
     />
@@ -68,7 +68,7 @@
               </div>
             </UiFormSection>
 
-            <UiFormSection title="Ingredientes">
+            <UiFormSection :title="WAREHOUSE_COPY.recipeCompositionSection">
               <template #actions>
                 <button
                   type="button"
@@ -96,7 +96,7 @@
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
                   </svg>
                   <p class="text-sm font-medium mb-0.5">Sin líneas en la receta</p>
-                  <p class="text-xs text-text-tertiary">Agrega ingredientes o productos de reventa</p>
+                  <p class="text-xs text-text-tertiary">{{ WAREHOUSE_COPY.recipeCompositionEmptyHelp }}</p>
                 </div>
 
                 <div v-else class="space-y-3">
@@ -107,7 +107,7 @@
                   >
                     <div class="grid grid-cols-1 md:grid-cols-12 gap-3">
                       <div class="md:col-span-5">
-                        <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
+                        <label class="block text-xs font-medium text-text-secondary mb-1">{{ WAREHOUSE_COPY.warehouseItemOrResaleRequired }}</label>
                         <UiIngredientSearchInput
                           :allow-create="true"
                           @select="(ing) => selectIngredient(ing, index)"
@@ -196,7 +196,7 @@
               </div>
 
               <div class="flex justify-between text-sm">
-                <span class="text-text-secondary">Ingredientes:</span>
+                <span class="text-text-secondary">{{ WAREHOUSE_COPY.recipeCompositionSummary }}</span>
                 <span class="font-semibold text-text-primary">{{ form.ingredients.length }}</span>
               </div>
 
@@ -257,6 +257,7 @@
 </template>
 
 <script setup lang="ts">
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import { ref } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 
@@ -392,7 +393,7 @@ async function validateForm(): Promise<boolean> {
   }
 
   if (form.value.ingredients.length === 0) {
-    submitError.value = 'Agrega al menos un ingrediente a la receta.'
+    submitError.value = WAREHOUSE_COPY.addWarehouseItemToRecipe
     return false
   }
 
@@ -400,7 +401,7 @@ async function validateForm(): Promise<boolean> {
     i => !i.ingredient_id || !i.base_quantity || i.base_quantity <= 0,
   )
   if (invalid) {
-    submitError.value = 'Completa todos los ingredientes con cantidad mayor a 0.'
+    submitError.value = WAREHOUSE_COPY.completeRecipeCostLinesError
     return false
   }
 
@@ -410,7 +411,7 @@ async function validateForm(): Promise<boolean> {
 
   const uniqueIds = new Set(ingredientIds)
   if (ingredientIds.length !== uniqueIds.size) {
-    duplicateIngredientError.value = 'No puedes agregar el mismo ingrediente más de una vez.'
+    duplicateIngredientError.value = WAREHOUSE_COPY.duplicateWarehouseItemInList
     return false
   }
 

--- a/pages/menu/recetas/index.vue
+++ b/pages/menu/recetas/index.vue
@@ -91,7 +91,7 @@
             >
               <div class="flex-1 min-w-0">
                 <span class="text-sm font-bold text-text-primary">{{ item.producto_name }}</span>
-                <p class="text-xs text-text-secondary mt-0.5">{{ item.ingredientes.length }} ingredientes · {{ formatCurrency(item.costo_total) }}</p>
+                <p class="text-xs text-text-secondary mt-0.5">{{ item.ingredientes.length }} {{ WAREHOUSE_COPY.recipeLinesCountSuffix }} · {{ formatCurrency(item.costo_total) }}</p>
               </div>
               <UiStatusBadge
                 :value="item.is_active ? 'Activa' : 'Inactiva'"
@@ -187,14 +187,14 @@
           class="hidden md:block bg-surface border border-border rounded-lg p-4 -mt-3"
         >
           <h4 class="text-sm font-semibold text-text-primary mb-3">
-            Ingredientes de {{ recipe.producto_name }}
+            Composición de {{ recipe.producto_name }}
           </h4>
           <div class="overflow-x-auto">
             <table class="w-full">
               <thead>
                 <tr class="border-b border-border">
                   <th class="text-left py-2 px-2 text-xs font-medium text-text-secondary">
-                    Ingrediente
+                    {{ WAREHOUSE_COPY.recipeCompositionTableHeader }}
                   </th>
                   <th class="text-center py-2 px-2 text-xs font-medium text-text-secondary">
                     Control Stock
@@ -266,6 +266,7 @@
 </template>
 
 <script setup lang="ts">
+import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import { ref, computed, onMounted, onUnmounted, inject, watch } from 'vue'
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
@@ -437,7 +438,7 @@ const recetasTableColumns = [
   },
   {
     key: 'ingredientes_count',
-    title: 'Ingredientes',
+    title: WAREHOUSE_COPY.recipeLinesColumn,
     sortable: true,
     format: 'number',
     align: 'center'


### PR DESCRIPTION
## Summary
- Replace user-facing **ingrediente** / **insumo** strings in menu product, recipe, and modifier flows with `WAREHOUSE_COPY` (Insumos de la receta, Artículo de bodega).
- Extend `warehouseCopy.ts` with batch 4 menu keys; wire search placeholders and reventa linked-item copy.

Closes #1117

## Test plan
- [ ] Create product with receta: section shows **Insumos de la receta**; hint shows artículo de bodega vs producto de menú
- [ ] Edit resale product: linked block says artículo de bodega vinculado
- [ ] Recipe create/edit: **Composición** section; label **Artículo de bodega o reventa**
- [ ] Modifier create: same label on options

## wr-context
See `.wr/1117.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)