### PR TITLE
feat(menu): modifier admin UI — recipes and products

### DIFF
--- a/components/menu/MenuModifierOptionEditor.vue
+++ b/components/menu/MenuModifierOptionEditor.vue
@@ -1,0 +1,313 @@
+<template>
+  <div class="border border-border rounded-lg p-3 sm:p-4 bg-background space-y-3">
+    <div class="grid grid-cols-1 md:grid-cols-12 gap-3">
+      <div class="md:col-span-3">
+        <label class="block text-xs font-medium text-text-secondary mb-1">Tipo *</label>
+        <select
+          :value="modifier.option_type"
+          class="input-base w-full px-3 py-2 text-sm"
+          @change="onTypeChange(($event.target as HTMLSelectElement).value)"
+        >
+          <option value="INGREDIENT">Ingrediente / reventa</option>
+          <option value="RECIPE">Receta base</option>
+          <option value="PRODUCT">Producto del menú</option>
+          <option value="NONE">Solo precio</option>
+        </select>
+      </div>
+
+      <div class="md:col-span-3">
+        <label class="block text-xs font-medium text-text-secondary mb-1">Nombre *</label>
+        <input
+          v-model="modifier.name"
+          type="text"
+          placeholder="Nombre en caja"
+          class="input-base w-full px-3 py-2 text-sm"
+        />
+      </div>
+
+      <div class="md:col-span-2">
+        <label class="block text-xs font-medium text-text-secondary mb-1">Precio venta</label>
+        <div class="relative">
+          <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary text-sm">$</span>
+          <input
+            v-model.number="modifier.price"
+            type="number"
+            step="100"
+            class="input-base w-full pl-8 pr-3 py-2 text-sm"
+          />
+        </div>
+      </div>
+
+      <div class="md:col-span-1">
+        <label class="block text-xs font-medium text-text-secondary mb-1">Máx</label>
+        <input
+          v-model.number="modifier.max_limit"
+          type="number"
+          min="1"
+          class="input-base w-full px-3 py-2 text-sm"
+        />
+      </div>
+
+      <div class="md:col-span-1">
+        <label class="block text-xs font-medium text-text-secondary mb-1">Orden</label>
+        <input
+          v-model.number="modifier.sort_order"
+          type="number"
+          min="0"
+          class="input-base w-full px-3 py-2 text-sm"
+        />
+      </div>
+
+      <div class="md:col-span-2 flex items-end justify-end">
+        <button
+          type="button"
+          class="flex items-center justify-center w-full h-[38px] text-destructive hover:bg-destructive/5 rounded-lg transition-colors"
+          title="Eliminar opción"
+          @click="$emit('remove')"
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+          </svg>
+        </button>
+      </div>
+    </div>
+
+    <div v-if="modifier.option_type === 'INGREDIENT'" class="grid grid-cols-1 md:grid-cols-12 gap-3">
+      <div class="md:col-span-5">
+        <label class="block text-xs font-medium text-text-secondary mb-1">Ingrediente o reventa *</label>
+        <UiIngredientSearchInput
+          :allow-create="true"
+          @select="(ing) => $emit('select-ingredient', ing)"
+          @create="(name) => $emit('create-ingredient', name)"
+        />
+        <p v-if="modifier.ingredient_id" class="text-xs text-text-secondary mt-1">
+          {{ modifier.ingredient_name || 'Seleccionado' }}
+        </p>
+      </div>
+      <div class="md:col-span-2">
+        <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad</label>
+        <input
+          v-model.number="modifier.ingredient_quantity"
+          type="number"
+          min="0.01"
+          step="any"
+          class="input-base w-full px-3 py-2 text-sm"
+        />
+      </div>
+      <div class="md:col-span-3">
+        <label class="block text-xs font-medium text-text-secondary mb-1">Unidad</label>
+        <select
+          v-model="modifier.ingredient_unit"
+          :disabled="modifier.ingredient_id && loadingUnits.has(modifier.ingredient_id)"
+          class="input-base w-full py-2 px-3 text-sm disabled:opacity-50"
+        >
+          <option
+            v-for="opt in getIngredientUnitOptions(modifier.ingredient_id)"
+            :key="opt.value"
+            :value="opt.value"
+          >{{ opt.label }}</option>
+        </select>
+      </div>
+      <div class="md:col-span-2 flex items-end">
+        <p class="text-xs text-text-secondary pb-2">Costo unit.: {{ ingredientCostLabel }}</p>
+      </div>
+    </div>
+
+    <div v-else-if="modifier.option_type === 'RECIPE'" class="space-y-2">
+      <div class="grid grid-cols-1 md:grid-cols-12 gap-3">
+        <div class="md:col-span-6">
+          <label class="block text-xs font-medium text-text-secondary mb-1">Receta base *</label>
+          <select
+            v-model="modifier.recipe_base_type_id"
+            class="input-base w-full px-3 py-2 text-sm"
+            @change="onRecipeBaseChange"
+          >
+            <option value="">Elegir receta…</option>
+            <option v-for="recipe in recipeBases" :key="recipe.id" :value="recipe.id">
+              {{ recipe.name }}
+            </option>
+          </select>
+        </div>
+        <div class="md:col-span-3">
+          <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad × receta</label>
+          <input
+            v-model.number="modifier.recipe_base_quantity"
+            type="number"
+            min="0.01"
+            step="any"
+            class="input-base w-full px-3 py-2 text-sm"
+          />
+        </div>
+        <div class="md:col-span-3 flex items-end">
+          <p class="text-xs text-text-secondary pb-2">Costo unit.: {{ recipeCostLabel }}</p>
+        </div>
+      </div>
+      <div
+        v-if="modifier.recipe_base_type_id && recipeBaseIngredients.length > 0"
+        class="p-2 bg-blue-50 dark:bg-blue-900/20 rounded border border-blue-200 dark:border-blue-800"
+      >
+        <div class="text-xs space-y-1">
+          <div
+            v-for="ing in recipeBaseIngredients"
+            :key="ing.id || ing.ingredient_id"
+            class="flex justify-between text-text-secondary"
+          >
+            <span>{{ ing.ingredient_name || ing.name }}</span>
+            <span>{{ scaledRecipeQty(ing) }} {{ ing.unit }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-else-if="modifier.option_type === 'PRODUCT'" class="grid grid-cols-1 md:grid-cols-12 gap-3">
+      <div class="md:col-span-6">
+        <label class="block text-xs font-medium text-text-secondary mb-1">Producto del menú *</label>
+        <UiProductSearchInput
+          :input-id="`modifier-option-product-${index}`"
+          include-all-types
+          @select="onProductSelect"
+        />
+        <p v-if="modifier.linked_product_id" class="text-xs text-text-secondary mt-1">
+          {{ modifier.linked_product_name }}
+        </p>
+      </div>
+      <div class="md:col-span-3">
+        <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad × producto</label>
+        <input
+          v-model.number="modifier.linked_product_quantity"
+          type="number"
+          min="0.01"
+          step="any"
+          class="input-base w-full px-3 py-2 text-sm"
+        />
+      </div>
+      <div class="md:col-span-3 flex items-end">
+        <p class="text-xs text-text-secondary pb-2">Costo unit.: {{ productCostLabel }}</p>
+      </div>
+    </div>
+
+    <p v-else-if="modifier.option_type === 'NONE'" class="text-xs text-text-tertiary">
+      Opción sin composición de inventario; solo aplica el precio de venta.
+    </p>
+
+    <div class="flex flex-wrap gap-4 text-sm">
+      <label class="flex items-center gap-2 cursor-pointer">
+        <input v-model="modifier.is_default" type="checkbox" class="w-4 h-4 text-primary border-border rounded focus:ring-primary" />
+        <span class="text-text-secondary">Por defecto</span>
+      </label>
+      <label class="flex items-center gap-2 cursor-pointer">
+        <input v-model="modifier.is_available" type="checkbox" class="w-4 h-4 text-primary border-border rounded focus:ring-primary" />
+        <span class="text-text-secondary">Disponible</span>
+      </label>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { ProductRow } from '~/composables/useProductSearch'
+import {
+  formatModifierCurrency,
+  resetModifierFieldsForType,
+  type ModifierFormRow,
+  type ModifierOptionType,
+} from '~/composables/useModifierOptionForm'
+
+const props = defineProps<{
+  modifier: ModifierFormRow
+  index: number
+  recipeBases: Array<Record<string, unknown>>
+  loadingUnits: Set<string>
+  getIngredientUnitOptions: (id: string | null) => Array<{ value: string; label: string }>
+  getIngredientById: (id: string) => Record<string, unknown> | undefined
+}>()
+
+defineEmits<{
+  remove: []
+  'select-ingredient': [ingredient: Record<string, unknown>]
+  'create-ingredient': [name: string]
+}>()
+
+function onTypeChange(raw: string) {
+  resetModifierFieldsForType(props.modifier, raw.toUpperCase() as ModifierOptionType)
+}
+
+function onRecipeBaseChange() {
+  if (!props.modifier.recipe_base_type_id) {
+    props.modifier.recipe_base_type_id = null
+    props.modifier.recipe_base_name = null
+    props.modifier.unit_cost = null
+    return
+  }
+  const recipe = props.recipeBases.find((r) => r.id === props.modifier.recipe_base_type_id)
+  props.modifier.recipe_base_name = recipe ? String(recipe.name) : null
+  if (recipe && !props.modifier.name.trim()) {
+    props.modifier.name = String(recipe.name)
+  }
+  props.modifier.unit_cost = null
+}
+
+function onProductSelect(product: ProductRow) {
+  props.modifier.linked_product_id = product.id
+  props.modifier.linked_product_name = product.name
+  if (!props.modifier.name.trim()) {
+    props.modifier.name = product.name
+  }
+  props.modifier.unit_cost = null
+}
+
+const selectedRecipeBase = computed(() =>
+  props.recipeBases.find((r) => r.id === props.modifier.recipe_base_type_id),
+)
+
+const recipeBaseIngredients = computed(() => {
+  const ingredients = selectedRecipeBase.value?.ingredients
+  return Array.isArray(ingredients) ? ingredients : []
+})
+
+function scaledRecipeQty(ing: Record<string, unknown>) {
+  const mult = Number(props.modifier.recipe_base_quantity) || 1
+  return (Number(ing.base_quantity ?? ing.quantity ?? 0) * mult).toFixed(2)
+}
+
+function estimateRecipeCost(): number | null {
+  if (!props.modifier.recipe_base_type_id) return null
+  let total = 0
+  let hasLine = false
+  for (const ing of recipeBaseIngredients.value) {
+    const qty = Number(ing.base_quantity ?? ing.quantity ?? 0) * (Number(props.modifier.recipe_base_quantity) || 1)
+    const unitCost = Number(ing.costo_unitario ?? ing.unit_cost ?? 0)
+    if (qty > 0) hasLine = true
+    total += qty * unitCost
+  }
+  return hasLine ? total : null
+}
+
+const ingredientCostLabel = computed(() => {
+  if (props.modifier.unit_cost != null) return formatModifierCurrency(props.modifier.unit_cost)
+  const ing = props.modifier.ingredient_id
+    ? props.getIngredientById(props.modifier.ingredient_id)
+    : undefined
+  const unit = Number(ing?.costo_unitario ?? 0)
+  const qty = Number(props.modifier.ingredient_quantity) || 0
+  if (!unit || !qty) return '—'
+  return formatModifierCurrency(unit * qty)
+})
+
+const recipeCostLabel = computed(() => {
+  if (props.modifier.unit_cost != null) return formatModifierCurrency(props.modifier.unit_cost)
+  const est = estimateRecipeCost()
+  return est != null ? formatModifierCurrency(est) : '—'
+})
+
+const productCostLabel = computed(() => {
+  if (props.modifier.unit_cost != null) return formatModifierCurrency(props.modifier.unit_cost)
+  return '—'
+})
+</script>
+
+<style scoped>
+.input-base {
+  @apply border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-text-primary bg-surface;
+}
+</style>

--- a/composables/useModifierOptionForm.ts
+++ b/composables/useModifierOptionForm.ts
@@ -1,0 +1,161 @@
+export type ModifierOptionType = 'INGREDIENT' | 'RECIPE' | 'PRODUCT' | 'NONE'
+
+export interface ModifierFormRow {
+  name: string
+  price: number
+  max_limit: number
+  is_default: boolean
+  is_available: boolean
+  sort_order: number
+  option_type: ModifierOptionType
+  ingredient_id: string | null
+  ingredient_name: string | null
+  ingredient_quantity: number | null
+  ingredient_unit: string | null
+  recipe_base_type_id: string | null
+  recipe_base_name: string | null
+  recipe_base_quantity: number
+  linked_product_id: string | null
+  linked_product_name: string | null
+  linked_product_quantity: number
+  unit_cost: number | null
+}
+
+const OPTION_TYPES: ModifierOptionType[] = ['INGREDIENT', 'RECIPE', 'PRODUCT', 'NONE']
+
+export function createEmptyModifier(sortOrder: number): ModifierFormRow {
+  return {
+    name: '',
+    price: 0,
+    max_limit: 1,
+    is_default: false,
+    is_available: true,
+    sort_order: sortOrder,
+    option_type: 'INGREDIENT',
+    ingredient_id: null,
+    ingredient_name: null,
+    ingredient_quantity: null,
+    ingredient_unit: null,
+    recipe_base_type_id: null,
+    recipe_base_name: null,
+    recipe_base_quantity: 1,
+    linked_product_id: null,
+    linked_product_name: null,
+    linked_product_quantity: 1,
+    unit_cost: null,
+  }
+}
+
+export function resetModifierFieldsForType(modifier: ModifierFormRow, nextType: ModifierOptionType) {
+  modifier.option_type = nextType
+  modifier.ingredient_id = null
+  modifier.ingredient_name = null
+  modifier.ingredient_quantity = null
+  modifier.ingredient_unit = null
+  modifier.recipe_base_type_id = null
+  modifier.recipe_base_name = null
+  modifier.recipe_base_quantity = 1
+  modifier.linked_product_id = null
+  modifier.linked_product_name = null
+  modifier.linked_product_quantity = 1
+  modifier.unit_cost = null
+}
+
+export function mapModifierFromApi(m: Record<string, unknown>): ModifierFormRow {
+  const optionType = String(m.option_type || 'INGREDIENT').toUpperCase() as ModifierOptionType
+  const ingredient = m.ingredient as { id?: string; name?: string } | undefined
+  const recipeBase = m.recipe_base as { id?: string; name?: string } | undefined
+  const linkedProduct = m.linked_product as { id?: string; name?: string } | undefined
+
+  return {
+    name: String(m.name || ''),
+    price: Number(m.price ?? 0),
+    max_limit: Number(m.max_limit ?? 1),
+    is_default: Boolean(m.is_default),
+    is_available: m.is_available !== false,
+    sort_order: Number(m.sort_order ?? 0),
+    option_type: OPTION_TYPES.includes(optionType) ? optionType : 'INGREDIENT',
+    ingredient_id: (m.ingredient_id as string) || ingredient?.id || null,
+    ingredient_name: ingredient?.name || null,
+    ingredient_quantity: m.ingredient_quantity != null ? Number(m.ingredient_quantity) : null,
+    ingredient_unit: (m.ingredient_unit as string) || null,
+    recipe_base_type_id: (m.recipe_base_type_id as string) || recipeBase?.id || null,
+    recipe_base_name: recipeBase?.name || null,
+    recipe_base_quantity: Number(m.recipe_base_quantity ?? 1),
+    linked_product_id: (m.linked_product_id as string) || linkedProduct?.id || null,
+    linked_product_name: linkedProduct?.name || null,
+    linked_product_quantity: Number(m.linked_product_quantity ?? 1),
+    unit_cost: m.unit_cost != null ? Number(m.unit_cost) : null,
+  }
+}
+
+export function serializeModifierForApi(row: ModifierFormRow) {
+  const optionType = row.option_type
+  return {
+    name: row.name.trim(),
+    price: row.price,
+    max_limit: row.max_limit,
+    is_default: row.is_default,
+    is_available: row.is_available,
+    sort_order: row.sort_order,
+    option_type: optionType,
+    ingredient_id: optionType === 'INGREDIENT' ? row.ingredient_id : null,
+    ingredient_quantity: optionType === 'INGREDIENT' ? row.ingredient_quantity : null,
+    ingredient_unit: optionType === 'INGREDIENT' ? row.ingredient_unit : null,
+    recipe_base_type_id: optionType === 'RECIPE' ? (row.recipe_base_type_id || null) : null,
+    recipe_base_quantity: optionType === 'RECIPE' ? row.recipe_base_quantity : 1,
+    linked_product_id: optionType === 'PRODUCT' ? (row.linked_product_id || null) : null,
+    linked_product_quantity: optionType === 'PRODUCT' ? row.linked_product_quantity : 1,
+  }
+}
+
+export function validateModifierOption(row: ModifierFormRow): string | null {
+  if (!row.name?.trim()) {
+    return 'Cada opción debe tener un nombre.'
+  }
+
+  const type = row.option_type
+  if (type === 'INGREDIENT') {
+    if (!row.ingredient_id) return `La opción «${row.name}» requiere un ingrediente o reventa.`
+    if (row.ingredient_quantity == null || row.ingredient_quantity <= 0) {
+      return `Indica la cantidad del ingrediente en «${row.name}».`
+    }
+    if (!row.ingredient_unit?.trim()) {
+      return `Indica la unidad del ingrediente en «${row.name}».`
+    }
+  }
+  if (type === 'RECIPE' && !row.recipe_base_type_id) {
+    return `La opción «${row.name}» requiere una receta base.`
+  }
+  if (type === 'PRODUCT') {
+    if (!row.linked_product_id) return `La opción «${row.name}» requiere un producto del menú.`
+    if (row.linked_product_quantity == null || row.linked_product_quantity <= 0) {
+      return `Indica la cantidad del producto en «${row.name}».`
+    }
+  }
+  return null
+}
+
+export function formatModifierOptionTypeLabel(type: string): string {
+  switch (String(type).toUpperCase()) {
+    case 'INGREDIENT':
+      return 'Ingrediente'
+    case 'RECIPE':
+      return 'Receta'
+    case 'PRODUCT':
+      return 'Producto'
+    case 'NONE':
+      return 'Solo precio'
+    default:
+      return type
+  }
+}
+
+export function formatModifierCurrency(value: number | null | undefined): string {
+  if (value == null) return '—'
+  return new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    minimumFractionDigits: 0,
+  }).format(value)
+}

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -131,131 +131,21 @@
               </div>
 
               <div v-else class="space-y-3">
-                <div
+                <MenuModifierOptionEditor
                   v-for="(modifier, index) in form.modifiers"
                   :key="index"
-                  class="border border-border rounded-lg p-3 sm:p-4 bg-background"
-                >
-                  <div class="grid grid-cols-1 md:grid-cols-12 gap-3 mb-3">
-                    <div class="md:col-span-4">
-                      <label class="block text-xs font-medium text-text-secondary mb-1">{{ WAREHOUSE_COPY.warehouseItemOrResaleRequired }}</label>
-                      <UiIngredientSearchInput
-                        :initialValue="modifier.ingredient_name || ''"
-                        :allow-create="true"
-                        @select="(ing) => selectIngredient(modifier, ing)"
-                        @create="(name) => openCustomIngModal(name, index)"
-                      />
-                      <p v-if="modifier.ingredient_id" class="text-xs text-text-secondary mt-1">
-                        Costo: {{ formatCurrency(getIngredientById(modifier.ingredient_id)?.costo_unitario || 0) }}/{{ getIngredientById(modifier.ingredient_id)?.unit }}
-                      </p>
-                    </div>
-
-                    <div class="md:col-span-1">
-                      <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad</label>
-                      <input
-                        v-model.number="modifier.ingredient_quantity"
-                        type="number"
-                        min="0.01"
-                        step="any"
-                        placeholder="50"
-                        class="input-base w-full px-3 py-2 text-sm"
-                      />
-                    </div>
-
-                    <div class="md:col-span-2">
-                      <label class="block text-xs font-medium text-text-secondary mb-1">Unidad</label>
-                      <div class="relative">
-                        <select
-                          v-model="modifier.ingredient_unit"
-                          :disabled="modifier.ingredient_id && loadingUnits.has(modifier.ingredient_id)"
-                          class="input-base w-full py-2 pr-3 text-sm disabled:opacity-50"
-                          :class="modifier.ingredient_id && loadingUnits.has(modifier.ingredient_id) ? 'pl-7' : 'pl-3'"
-                        >
-                          <option
-                            v-for="opt in getIngredientUnitOptions(modifier.ingredient_id)"
-                            :key="opt.value"
-                            :value="opt.value"
-                          >{{ opt.label }}</option>
-                        </select>
-                        <span v-if="modifier.ingredient_id && loadingUnits.has(modifier.ingredient_id)" class="absolute left-2 top-2.5 pointer-events-none text-text-secondary">
-                          <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
-                          </svg>
-                        </span>
-                      </div>
-                    </div>
-
-                    <div class="md:col-span-2">
-                      <label class="block text-xs font-medium text-text-secondary mb-1">Precio venta</label>
-                      <div class="relative">
-                        <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary text-sm">$</span>
-                        <input
-                          v-model.number="modifier.price"
-                          type="number"
-                          step="100"
-                          placeholder="0"
-                          class="input-base w-full pl-8 pr-3 py-2 text-sm"
-                        />
-                      </div>
-                    </div>
-
-                    <div class="md:col-span-1">
-                      <label class="block text-xs font-medium text-text-secondary mb-1">Máx</label>
-                      <input
-                        v-model.number="modifier.max_limit"
-                        type="number"
-                        min="1"
-                        placeholder="1"
-                        class="input-base w-full px-3 py-2 text-sm"
-                      />
-                    </div>
-
-                    <div class="md:col-span-1">
-                      <label class="block text-xs font-medium text-text-secondary mb-1">Orden</label>
-                      <input
-                        v-model.number="modifier.sort_order"
-                        type="number"
-                        min="0"
-                        placeholder="0"
-                        class="input-base w-full px-3 py-2 text-sm"
-                      />
-                    </div>
-
-                    <div class="md:col-span-1">
-                      <label class="block text-xs font-medium text-text-secondary mb-1 invisible select-none" aria-hidden="true">&nbsp;</label>
-                      <button
-                        type="button"
-                        @click="removeModifier(index)"
-                        class="flex items-center justify-center w-full h-[38px] text-destructive hover:bg-destructive/5 rounded-lg transition-colors"
-                        title="Eliminar opción"
-                      >
-                        <Icon name="heroicons:trash" class="h-5 w-5" />
-                      </button>
-                    </div>
-                  </div>
-
-                  <div class="flex flex-wrap gap-4 text-sm">
-                    <label class="flex items-center gap-2 cursor-pointer">
-                      <input
-                        v-model="modifier.is_default"
-                        type="checkbox"
-                        class="w-4 h-4 text-primary border-border rounded focus:ring-primary"
-                      />
-                      <span class="text-text-primary">Predeterminado</span>
-                    </label>
-
-                    <label class="flex items-center gap-2 cursor-pointer">
-                      <input
-                        v-model="modifier.is_available"
-                        type="checkbox"
-                        class="w-4 h-4 text-primary border-border rounded focus:ring-primary"
-                      />
-                      <span class="text-text-primary">Disponible</span>
-                    </label>
-                  </div>
-                </div>
+                  :modifier="modifier"
+                  :index="index"
+                  :recipe-bases="recipeBases"
+                  :loading-units="loadingUnits"
+                  :get-ingredient-unit-options="getIngredientUnitOptions"
+                  :get-ingredient-by-id="getIngredientById"
+                  @remove="removeModifier(index)"
+                  @select-ingredient="(ing) => selectIngredient(modifier, ing)"
+                  @create-ingredient="(name) => openCustomIngModal(name, index)"
+                />
               </div>
+            </MenuCatalogInlineCreateBusyOverlay>
             </MenuCatalogInlineCreateBusyOverlay>
           </UiFormSection>
         </div>
@@ -340,8 +230,14 @@
 </template>
 
 <script setup lang="ts">
-import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import { ref, computed, watch } from 'vue'
+import {
+  createEmptyModifier,
+  mapModifierFromApi,
+  serializeModifierForApi,
+  validateModifierOption,
+  type ModifierFormRow,
+} from '~/composables/useModifierOptionForm'
 import { useQueryCache } from '@pinia/colada'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 import { useMenuIngredientsQuery } from '@/composables/queries/useMenuIngredients'
@@ -370,20 +266,19 @@ const form = ref({
   max_qty: 1,
   is_required: false,
   sort_order: 0,
-  modifiers: [] as Array<{
-    name: string
-    price: number
-    max_limit: number
-    is_default: boolean
-    is_available: boolean
-    sort_order: number
-    ingredient_id: string | null
-    ingredient_name: string | null
-    ingredient_quantity: number | null
-    ingredient_unit: string | null
-  }>,
+  modifiers: [] as ModifierFormRow[],
   tenant_id: currentTenant.value?.id || ''
 })
+
+const { data: recipeBasesData } = useAsyncData(
+  `recipe-bases-modifiers-edit-${currentTenant.value?.id || 'default'}`,
+  () => $fetch('/api/menu/recipe-bases', {
+    query: { limit: 250, is_active: true, include_ingredients: true },
+  }),
+  { server: false, watch: [currentTenant], default: () => ({ data: [] }) },
+)
+
+const recipeBases = computed(() => recipeBasesData.value?.data || [])
 
 const groupId = route.params.id as string
 
@@ -451,9 +346,12 @@ async function loadPurchaseUnits(ingredientId: string) {
   }
 }
 
-function selectIngredient(modifier: any, ing: any) {
+function selectIngredient(modifier: ModifierFormRow, ing: any) {
+  modifier.option_type = 'INGREDIENT'
   modifier.ingredient_id = ing.id
+  modifier.ingredient_name = ing.name
   modifier.name = ing.name
+  modifier.unit_cost = null
   modifier.ingredient_name = ing.name
   cacheIngredientForUnits(ing)
   modifier.ingredient_unit = defaultUnitForIngredient(ingredientCache.value[ing.id])
@@ -506,27 +404,17 @@ watch(groupData, (data) => {
       is_required: group.is_required,
       sort_order: group.sort_order,
       modifiers: group.modifiers.map((m: any) => {
-        if (m.ingredient_id && m.ingredient) {
+        const row = mapModifierFromApi(m)
+        if (row.ingredient_id && m.ingredient) {
           cacheIngredientForUnits({
-            id: m.ingredient_id,
+            id: row.ingredient_id,
             name: m.ingredient.name,
             unit: m.ingredient.unit,
             costo_unitario: m.ingredient.costo_unitario,
           })
-          loadPurchaseUnits(m.ingredient_id)
+          loadPurchaseUnits(row.ingredient_id)
         }
-        return {
-          name: m.name,
-          price: Number(m.price),
-          max_limit: m.max_limit,
-          is_default: m.is_default,
-          is_available: m.is_available,
-          sort_order: m.sort_order,
-          ingredient_id: m.ingredient_id || null,
-          ingredient_name: m.ingredient?.name || null,
-          ingredient_quantity: m.ingredient_quantity ? Number(m.ingredient_quantity) : null,
-          ingredient_unit: m.ingredient_unit || null
-        }
+        return row
       }),
       tenant_id: currentTenant.value?.id || ''
     }
@@ -552,18 +440,7 @@ function getSelectedProductsText() {
 }
 
 function addModifier() {
-  form.value.modifiers.push({
-    name: '',
-    price: 0,
-    max_limit: 1,
-    is_default: false,
-    is_available: true,
-    sort_order: form.value.modifiers.length,
-    ingredient_id: null,
-    ingredient_name: null,
-    ingredient_quantity: null,
-    ingredient_unit: null
-  })
+  form.value.modifiers.push(createEmptyModifier(form.value.modifiers.length))
 }
 
 function removeModifier(index: number) {
@@ -593,10 +470,12 @@ function validateForm(): boolean {
     return false
   }
 
-  const missingIngredient = form.value.modifiers.some(m => !m.ingredient_id)
-  if (missingIngredient) {
-    submitError.value = WAREHOUSE_COPY.allOptionsNeedWarehouseItem
-    return false
+  for (const m of form.value.modifiers) {
+    const err = validateModifierOption(m)
+    if (err) {
+      submitError.value = err
+      return false
+    }
   }
 
   return true
@@ -614,7 +493,10 @@ async function handleSubmit() {
 
     await $fetch(`/api/menu/modifier-groups/${groupId}`, {
       method: 'PUT',
-      body: form.value
+      body: {
+        ...form.value,
+        modifiers: form.value.modifiers.map(serializeModifierForApi),
+      }
     })
 
     cache.invalidateQueries()
@@ -632,14 +514,6 @@ function cancel() {
   router.push('/menu/modificadores')
 }
 
-function formatCurrency(value: number) {
-  if (!value && value !== 0) return '$0'
-  return new Intl.NumberFormat('es-CO', {
-    style: 'currency',
-    currency: 'COP',
-    minimumFractionDigits: 0
-  }).format(value)
-}
 </script>
 
 <style scoped>

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -135,132 +135,21 @@
                 </div>
 
                 <div v-else class="space-y-3">
-                  <div
+                  <MenuModifierOptionEditor
                     v-for="(modifier, index) in form.modifiers"
                     :key="index"
-                    class="border border-border rounded-lg p-3 sm:p-4 bg-background"
-                  >
-                    <div class="grid grid-cols-1 md:grid-cols-12 gap-3 mb-3">
-                      <div class="md:col-span-4">
-                        <label class="block text-xs font-medium text-text-secondary mb-1">{{ WAREHOUSE_COPY.warehouseItemOrResaleRequired }}</label>
-                        <UiIngredientSearchInput
-                          :allow-create="true"
-                          @select="(ing) => selectIngredient(modifier, ing)"
-                          @create="(name) => openCustomIngModal(name, index)"
-                        />
-                        <p v-if="modifier.ingredient_id" class="text-xs text-text-secondary mt-1">
-                          Costo: {{ formatCurrency(getIngredientById(modifier.ingredient_id)?.costo_unitario || 0) }}/{{ getIngredientById(modifier.ingredient_id)?.unit }}
-                        </p>
-                      </div>
-
-                      <div class="md:col-span-1">
-                        <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad</label>
-                        <input
-                          type="number"
-                          v-model.number="modifier.ingredient_quantity"
-                          placeholder="50"
-                          min="0.01"
-                          step="any"
-                          class="input-base w-full px-3 py-2 text-sm"
-                        />
-                      </div>
-
-                      <div class="md:col-span-2">
-                        <label class="block text-xs font-medium text-text-secondary mb-1">Unidad</label>
-                        <div class="relative">
-                          <select
-                            v-model="modifier.ingredient_unit"
-                            :disabled="modifier.ingredient_id && loadingUnits.has(modifier.ingredient_id)"
-                            class="input-base w-full py-2 pr-3 text-sm disabled:opacity-50"
-                            :class="modifier.ingredient_id && loadingUnits.has(modifier.ingredient_id) ? 'pl-7' : 'pl-3'"
-                          >
-                            <option
-                              v-for="opt in getIngredientUnitOptions(modifier.ingredient_id)"
-                              :key="opt.value"
-                              :value="opt.value"
-                            >{{ opt.label }}</option>
-                          </select>
-                          <span v-if="modifier.ingredient_id && loadingUnits.has(modifier.ingredient_id)" class="absolute left-2 top-2.5 pointer-events-none text-text-secondary">
-                            <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
-                            </svg>
-                          </span>
-                        </div>
-                      </div>
-
-                      <div class="md:col-span-2">
-                        <label class="block text-xs font-medium text-text-secondary mb-1">Precio venta</label>
-                        <div class="relative">
-                          <span class="absolute left-3 top-1/2 transform -translate-y-1/2 text-text-secondary text-sm">$</span>
-                          <input
-                            type="number"
-                            v-model.number="modifier.price"
-                            placeholder="0"
-                            step="100"
-                            class="input-base w-full pl-8 pr-3 py-2 text-sm"
-                          />
-                        </div>
-                      </div>
-
-                      <div class="md:col-span-1">
-                        <label class="block text-xs font-medium text-text-secondary mb-1">Máx</label>
-                        <input
-                          type="number"
-                          v-model.number="modifier.max_limit"
-                          placeholder="1"
-                          min="1"
-                          class="input-base w-full px-3 py-2 text-sm"
-                        />
-                      </div>
-
-                      <div class="md:col-span-1">
-                        <label class="block text-xs font-medium text-text-secondary mb-1">Orden</label>
-                        <input
-                          type="number"
-                          v-model.number="modifier.sort_order"
-                          placeholder="0"
-                          min="0"
-                          class="input-base w-full px-3 py-2 text-sm"
-                        />
-                      </div>
-
-                      <div class="md:col-span-1">
-                        <label class="block text-xs font-medium text-text-secondary mb-1 invisible select-none" aria-hidden="true">&nbsp;</label>
-                        <button
-                          type="button"
-                          @click="removeModifier(index)"
-                          class="flex items-center justify-center w-full h-[38px] text-destructive hover:bg-destructive/5 rounded-lg transition-colors"
-                          title="Eliminar opción"
-                        >
-                          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                          </svg>
-                        </button>
-                      </div>
-                    </div>
-
-                    <div class="flex flex-wrap gap-4 text-sm">
-                      <label class="flex items-center gap-2 cursor-pointer">
-                        <input
-                          type="checkbox"
-                          v-model="modifier.is_default"
-                          class="w-4 h-4 text-primary border-border rounded focus:ring-primary"
-                        />
-                        <span class="text-text-primary">Predeterminado</span>
-                      </label>
-
-                      <label class="flex items-center gap-2 cursor-pointer">
-                        <input
-                          type="checkbox"
-                          v-model="modifier.is_available"
-                          class="w-4 h-4 text-primary border-border rounded focus:ring-primary"
-                        />
-                        <span class="text-text-primary">Disponible</span>
-                      </label>
-                    </div>
-                  </div>
+                    :modifier="modifier"
+                    :index="index"
+                    :recipe-bases="recipeBases"
+                    :loading-units="loadingUnits"
+                    :get-ingredient-unit-options="getIngredientUnitOptions"
+                    :get-ingredient-by-id="getIngredientById"
+                    @remove="removeModifier(index)"
+                    @select-ingredient="(ing) => selectIngredient(modifier, ing)"
+                    @create-ingredient="(name) => openCustomIngModal(name, index)"
+                  />
                 </div>
+              </MenuCatalogInlineCreateBusyOverlay>
               </MenuCatalogInlineCreateBusyOverlay>
             </UiFormSection>
           </div>
@@ -302,8 +191,8 @@
               </div>
 
               <div class="flex justify-between text-sm">
-                <span class="text-text-secondary">{{ WAREHOUSE_COPY.withWarehouseItem }}</span>
-                <span class="font-semibold text-text-primary">{{ form.modifiers.filter(m => m.ingredient_id).length }}</span>
+                <span class="text-text-secondary">Con composición:</span>
+                <span class="font-semibold text-text-primary">{{ form.modifiers.filter(m => m.option_type !== 'NONE').length }}</span>
               </div>
 
               <div class="flex justify-between text-sm">
@@ -358,9 +247,14 @@
 </template>
 
 <script setup lang="ts">
-import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import { ref, computed, watch } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
+import {
+  createEmptyModifier,
+  serializeModifierForApi,
+  validateModifierOption,
+  type ModifierFormRow,
+} from '~/composables/useModifierOptionForm'
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
@@ -384,36 +278,26 @@ const form = ref({
   max_qty: 1,
   is_required: false,
   sort_order: 0,
-  modifiers: [] as Array<{
-    name: string
-    price: number
-    max_limit: number
-    is_default: boolean
-    is_available: boolean
-    sort_order: number
-    ingredient_id: string | null
-    ingredient_quantity: number | null
-    ingredient_unit: string | null
-  }>,
+  modifiers: [] as ModifierFormRow[],
   tenant_id: currentTenant.value?.id || ''
 })
+
+const { data: recipeBasesData } = useAsyncData(
+  `recipe-bases-modifiers-create-${currentTenant.value?.id || 'default'}`,
+  () => $fetch('/api/menu/recipe-bases', {
+    query: { limit: 250, is_active: true, include_ingredients: true },
+  }),
+  { server: false, watch: [currentTenant], default: () => ({ data: [] }) },
+)
+
+const recipeBases = computed(() => recipeBasesData.value?.data || [])
 
 watch(selectedProducts, (list) => {
   form.value.product_ids = list.map((p) => p.id)
 }, { deep: true })
 
 function addModifier() {
-  form.value.modifiers.push({
-    name: '',
-    price: 0,
-    max_limit: 1,
-    is_default: false,
-    is_available: true,
-    sort_order: form.value.modifiers.length,
-    ingredient_id: null,
-    ingredient_quantity: null,
-    ingredient_unit: null
-  })
+  form.value.modifiers.push(createEmptyModifier(form.value.modifiers.length))
 }
 
 const ingredientCache = ref<Record<string, any>>({})
@@ -452,9 +336,12 @@ async function loadPurchaseUnits(ingredientId: string) {
   }
 }
 
-function selectIngredient(modifier: any, ing: any) {
+function selectIngredient(modifier: ModifierFormRow, ing: any) {
+  modifier.option_type = 'INGREDIENT'
   modifier.ingredient_id = ing.id
+  modifier.ingredient_name = ing.name
   modifier.name = ing.name
+  modifier.unit_cost = null
   ingredientCache.value[ing.id] = ing
   modifier.ingredient_unit = defaultUnitForIngredient(ingredientCache.value[ing.id])
   loadPurchaseUnits(ing.id)
@@ -525,10 +412,12 @@ async function validateForm(): Promise<boolean> {
     return false
   }
 
-  const invalidModifiers = form.value.modifiers.some(m => !m.ingredient_id || !m.name)
-  if (invalidModifiers) {
-    submitError.value = WAREHOUSE_COPY.completeModifiersWarehouseItem
-    return false
+  for (const m of form.value.modifiers) {
+    const err = validateModifierOption(m)
+    if (err) {
+      submitError.value = err
+      return false
+    }
   }
 
   return true
@@ -546,7 +435,10 @@ async function submitGroup() {
 
     await $fetch('/api/menu/modifier-groups', {
       method: 'POST',
-      body: form.value
+      body: {
+        ...form.value,
+        modifiers: form.value.modifiers.map(serializeModifierForApi),
+      }
     })
 
     // clearNuxtData()
@@ -559,14 +451,6 @@ async function submitGroup() {
   }
 }
 
-function formatCurrency(value: number) {
-  if (!value && value !== 0) return '$0'
-  return new Intl.NumberFormat('es-CO', {
-    style: 'currency',
-    currency: 'COP',
-    minimumFractionDigits: 0
-  }).format(value)
-}
 </script>
 
 <style scoped>

--- a/pages/menu/modificadores/index.vue
+++ b/pages/menu/modificadores/index.vue
@@ -66,9 +66,12 @@
       </template>
 
       <template #cell-opciones="{ row }">
-        <div class="flex justify-center">
+        <div class="flex flex-col items-center gap-0.5 max-w-[220px] mx-auto">
           <span class="text-sm font-semibold text-text-primary">
             {{ getModificadoresByGrupo(row.id).length }}
+          </span>
+          <span class="text-xs text-text-secondary text-center line-clamp-2" :title="formatGroupOptionsSummary(row.id)">
+            {{ formatGroupOptionsSummary(row.id) }}
           </span>
         </div>
       </template>
@@ -125,7 +128,10 @@
         >
           <div class="flex-1 min-w-0">
             <span class="text-sm font-bold text-text-primary">{{ item.name }}</span>
-            <p class="text-xs text-text-secondary mt-0.5">{{ getModificadoresByGrupo(item.id).length }} opciones · sel. {{ item.min_qty }}–{{ item.max_qty }}</p>
+            <p class="text-xs text-text-secondary mt-0.5 line-clamp-2">
+              {{ getModificadoresByGrupo(item.id).length }} opciones · sel. {{ item.min_qty }}–{{ item.max_qty }}
+              <span v-if="formatGroupOptionsSummary(item.id)"> · {{ formatGroupOptionsSummary(item.id) }}</span>
+            </p>
           </div>
           <UiStatusBadge
             :value="item.is_required ? 'Obligatorio' : 'Opcional'"
@@ -484,6 +490,21 @@ const toggleExpanded = (grupoId: string) => {
 const getModificadoresByGrupo = (grupoId: string) => {
   const grupo = modifierGroups.value.find((g: any) => g.id === grupoId)
   return grupo?.modifiers || []
+}
+
+
+function formatGroupOptionsSummary(grupoId: string) {
+  const mods = getModificadoresByGrupo(grupoId)
+  if (!mods.length) return ''
+  const labels = mods.slice(0, 3).map((m: any) => {
+    const type = (m.option_type || 'INGREDIENT').toUpperCase()
+    if (type === 'INGREDIENT') return m.ingredient?.name || m.name
+    if (type === 'RECIPE') return m.recipe_base?.name || m.name
+    if (type === 'PRODUCT') return m.linked_product?.name || m.name
+    return m.name
+  })
+  const suffix = mods.length > 3 ? ` +${mods.length - 3}` : ''
+  return labels.filter(Boolean).join(', ') + suffix
 }
 
 const goToCreateGroup = () => {


### PR DESCRIPTION
## Summary
- Added `MenuModifierOptionEditor` and `useModifierOptionForm` for per-option type (ingredient, recipe, product, price-only).
- Updated `/menu/modificadores/crear` and `[id]` to send API #1121 `option_type` payloads with validation and cost preview.
- List page shows composition summary per group.

Closes #1122

## Test plan
- [ ] Create group with one option of each type
- [ ] Edit existing group; hydrate `option_type` fields
- [ ] Inline ingredient create on INGREDIENT options
- [ ] List shows option composition summary

## wr-context
See issue #1122 ship context comment.

Made with [Cursor](https://cursor.com)