### PR TITLE
feat(pos): modifier option types — pricing, discounts, cart parity

### DIFF
--- a/components/online/ProductDetailDrawer.vue
+++ b/components/online/ProductDetailDrawer.vue
@@ -129,8 +129,20 @@
                       class="option-input"
                     />
                     <span class="option-name">{{ mod.name }}</span>
-                    <span class="option-price" :class="{ 'option-price-free': mod.price === 0 }">
-                      {{ mod.price === 0 ? 'Gratis' : `+${formatPrice(mod.price)}` }}
+                    <span class="option-meta">
+                      <span
+                        v-if="modifierTypeLabel(mod) !== 'Ingrediente'"
+                        class="option-type"
+                      >{{ modifierTypeLabel(mod) }}</span>
+                      <span
+                        class="option-price"
+                        :class="{
+                          'option-price-free': mod.price === 0,
+                          'option-price-discount': mod.price < 0,
+                        }"
+                      >
+                        {{ formatModifierPriceLabel(mod) }}
+                      </span>
                     </span>
                   </label>
                 </template>
@@ -152,8 +164,20 @@
                       class="option-input"
                     />
                     <span class="option-name">{{ mod.name }}</span>
-                    <span class="option-price" :class="{ 'option-price-free': mod.price === 0 }">
-                      {{ mod.price === 0 ? 'Gratis' : `+${formatPrice(mod.price)}` }}
+                    <span class="option-meta">
+                      <span
+                        v-if="modifierTypeLabel(mod) !== 'Ingrediente'"
+                        class="option-type"
+                      >{{ modifierTypeLabel(mod) }}</span>
+                      <span
+                        class="option-price"
+                        :class="{
+                          'option-price-free': mod.price === 0,
+                          'option-price-discount': mod.price < 0,
+                        }"
+                      >
+                        {{ formatModifierPriceLabel(mod) }}
+                      </span>
                     </span>
                   </label>
                 </template>
@@ -261,6 +285,12 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import { useOnlineCartStore, type CartModifier } from '~/stores/online_cart'
+import { formatModifierOptionTypeLabel } from '~/composables/useModifierOptionForm'
+import {
+  formatSaleModifierPriceLabel,
+  modifiersCartTotal,
+  normalizeModifierOptionType,
+} from '~/utils/saleModifierOption'
 
 interface Modifier {
   id: string
@@ -269,6 +299,7 @@ interface Modifier {
   is_available: boolean
   is_default: boolean
   max_limit: number
+  option_type?: string
 }
 
 interface ModifierGroup {
@@ -543,16 +574,23 @@ const isValid = computed(() => {
 const totalPrice = computed(() => {
   const base = Number(props.product?.price ?? productDetail.value?.price ?? 0)
   if (wizardMode.value) {
-    // Show total for all units
     const total = wizardUnits.value.reduce((sum, unit) => {
-      const modTotal = unit.modifiers.reduce((s, m) => s + m.price, 0)
-      return sum + base + modTotal
+      return sum + base + modifiersCartTotal(unit.modifiers)
     }, 0)
     return formatPrice(total)
   }
-  const modTotal = selectedModifiers.value.reduce((sum, m) => sum + m.price, 0)
+  const modTotal = modifiersCartTotal(selectedModifiers.value)
   return formatPrice((base + modTotal) * quantity.value)
 })
+
+function modifierTypeLabel(mod: Modifier): string {
+  return formatModifierOptionTypeLabel(normalizeModifierOptionType(mod.option_type))
+}
+
+function formatModifierPriceLabel(mod: Modifier): string {
+  if (mod.price === 0) return 'Gratis'
+  return formatSaleModifierPriceLabel(mod.price, formatPrice)
+}
 
 function formatPrice(price: number): string {
   return new Intl.NumberFormat('es-CO', {
@@ -876,6 +914,24 @@ onMounted(() => {
 
 .option-price-free {
   color: hsl(var(--success));
+}
+
+.option-price-discount {
+  color: hsl(var(--success));
+}
+
+.option-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+}
+
+.option-type {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: hsl(var(--muted-foreground));
 }
 
 /* Quantity */

--- a/pages/pos/producto/[id].vue
+++ b/pages/pos/producto/[id].vue
@@ -3,6 +3,13 @@ import { ref, computed, onMounted, onUnmounted, inject, watch } from 'vue'
 import { usePOSStore } from '~/stores/usePOSStore'
 import type { CartModifier } from '~/stores/online_cart'
 import {
+  mapApiModifierToSaleOption,
+  modifierLineTotal,
+  formatSaleModifierPriceLabel,
+  saleModifierPriceClass,
+  type SaleModifierOption,
+} from '~/utils/saleModifierOption'
+import {
   ShoppingCartIcon,
   CheckIcon
 } from '@heroicons/vue/24/outline'
@@ -169,11 +176,7 @@ const editCartIndex = computed(() => {
 const isEditMode = computed(() => editCartIndex.value !== null)
 
 // Type definitions
-interface ModifierOption {
-  id: string
-  name: string
-  price: number
-  max_limit: number
+interface ModifierOption extends SaleModifierOption {
   icon?: string
 }
 
@@ -428,13 +431,13 @@ const modifierGroups = computed<ModifierGroup[]>(() => {
         maxSelections: group.max_qty || 1,
         options: (group.modifiers || [])
           .filter((mod: any) => mod && mod.is_available !== false)
-          .map((mod: any) => ({
-            id: mod.id,
-            name: mod.name,
-            price: Number(mod.price) || 0,
-            max_limit: Number(mod.max_limit) || 1,
-            icon: getModifierIcon(mod.name)
-          }))
+          .map((mod: any) => {
+            const mapped = mapApiModifierToSaleOption(mod as Record<string, unknown>)
+            return {
+              ...mapped,
+              icon: getModifierIcon(mapped.name),
+            }
+          })
           .sort((a: any, b: any) => (a.sort_order || 0) - (b.sort_order || 0))
       }))
       .sort((a, b) => (a.group_sort_order || 0) - (b.group_sort_order || 0))
@@ -442,8 +445,6 @@ const modifierGroups = computed<ModifierGroup[]>(() => {
     return []
   }
 })
-
-const modifierLineTotal = (mod: CartModifier) => Number(mod.price) * (mod.quantity ?? 1)
 
 // Computed
 const totalPrice = computed(() => {
@@ -820,13 +821,16 @@ onUnmounted(() => {
                 </div>
                 <div
                   class="mt-1.5 md:mt-2 text-xs md:text-sm font-medium"
-                  :class="option.price > 0 ? 'text-primary' : option.price < 0 ? 'text-success' : 'text-text-secondary'"
+                  :class="saleModifierPriceClass(option.price)"
                 >
-                  {{ option.price > 0 ? '+ ' : '' }}{{ option.price !== 0 ? formatCurrency(option.price) : 'Incluido' }}
+                  {{ formatSaleModifierPriceLabel(option.price, formatCurrency) }}
                 </div>
-                <div class="text-xs text-text-tertiary mt-0.5 md:mt-1">
-                  {{ option.name === 'Pequeño' ? '4 Porciones' : option.name === 'Mediano' ? '8 Porciones' : '12 Porciones' }}
-                </div>
+                <p
+                  v-if="option.option_type !== 'INGREDIENT'"
+                  class="text-xs text-text-tertiary mt-0.5 md:mt-1"
+                >
+                  {{ option.type_label }}
+                </p>
               </div>
             </label>
           </div>
@@ -849,7 +853,18 @@ onUnmounted(() => {
                 </div>
                 <div class="min-w-0 flex-1">
                   <div class="font-medium text-text-primary text-sm leading-snug">{{ option.name }}</div>
-                  <div class="text-xs text-primary font-semibold mt-0.5">+ {{ formatCurrency(option.price) }}</div>
+                  <div
+                    class="text-xs font-semibold mt-0.5"
+                    :class="saleModifierPriceClass(option.price)"
+                  >
+                    {{ formatSaleModifierPriceLabel(option.price, formatCurrency) }}
+                  </div>
+                  <p
+                    v-if="option.option_type !== 'INGREDIENT'"
+                    class="text-xs text-text-tertiary"
+                  >
+                    {{ option.type_label }}
+                  </p>
                 </div>
               </div>
               <div

--- a/pages/ventas/crear.vue
+++ b/pages/ventas/crear.vue
@@ -5,12 +5,16 @@ definePageMeta({
 
 useHead({ title: 'Nueva Venta' })
 
+import { modifiersCartTotal, formatSaleModifierPriceLabel, normalizeModifierOptionType } from '~/utils/saleModifierOption'
+import { formatModifierOptionTypeLabel } from '~/composables/useModifierOptionForm'
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 interface ModifierOption {
   id: string
   name: string
   price: number
+  option_type?: string
 }
 
 interface ModifierGroup {
@@ -168,10 +172,13 @@ function isModifierSelected(item: LineItem, modifierId: string) {
 
 // ─── Totals ───────────────────────────────────────────────────────────────────
 
+function modifierTypeLabel(option: ModifierOption): string {
+  return formatModifierOptionTypeLabel(normalizeModifierOptionType(option.option_type))
+}
+
 function itemTotal(item: LineItem) {
   const base = Number(item.quantity) * Number(item.unit_price)
-  const extras = item.selected_modifiers.reduce((s, m) => s + Number(m.price), 0)
-  return base + extras
+  return base + modifiersCartTotal(item.selected_modifiers)
 }
 
 const total = computed(() =>
@@ -392,10 +399,18 @@ async function submit() {
                     />
                   </svg>
                   {{ option.name }}
-                  <span v-if="option.price > 0" class="text-xs text-text-secondary">
-                    +{{ formatCurrency(option.price) }}
+                  <span
+                    v-if="modifierTypeLabel(option) !== 'Ingrediente'"
+                    class="text-[10px] uppercase tracking-wide text-text-tertiary"
+                  >
+                    {{ modifierTypeLabel(option) }}
                   </span>
-                  <span v-else class="text-xs text-text-secondary">Incluido</span>
+                  <span
+                    class="text-xs"
+                    :class="option.price < 0 ? 'text-success' : 'text-text-secondary'"
+                  >
+                    {{ formatSaleModifierPriceLabel(option.price, formatCurrency) }}
+                  </span>
                 </button>
               </div>
             </div>

--- a/stores/online_cart.ts
+++ b/stores/online_cart.ts
@@ -10,6 +10,7 @@
  * Session state and pure helpers stay outside Pinia Colada.
  */
 import { defineStore } from 'pinia'
+import { modifiersCartTotal } from '~/utils/saleModifierOption'
 
 // Module-level lock: mutations await this before proceeding so they never
 // race with hydrateFromBackend() during the initial session recovery.
@@ -148,7 +149,7 @@ export const useOnlineCartStore = defineStore('onlineCart', () => {
     onMutate({ product, quantity, modifiers = [], notes }: AddItemVars) {
       const snapshot = [...items.value]
       const sortedModifiers = [...modifiers].sort((a, b) => a.id.localeCompare(b.id))
-      const modifiersTotal = modifiers.reduce((sum, mod) => sum + mod.price, 0)
+      const modifiersTotal = modifiersCartTotal(modifiers)
       const existingIndex = items.value.findIndex(
         item => item.product_id === product.id && modifiersKey(item.modifiers) === modifiersKey(modifiers)
       )
@@ -197,7 +198,7 @@ export const useOnlineCartStore = defineStore('onlineCart', () => {
       const snapshot = [...items.value]
       for (const unit of units) {
         const sortedModifiers = [...unit.modifiers].sort((a, b) => a.id.localeCompare(b.id))
-        const modifiersTotal = unit.modifiers.reduce((sum, mod) => sum + mod.price, 0)
+        const modifiersTotal = modifiersCartTotal(unit.modifiers)
         const existingIndex = items.value.findIndex(
           item => item.product_id === product.id && modifiersKey(item.modifiers) === modifiersKey(unit.modifiers)
         )
@@ -247,7 +248,7 @@ export const useOnlineCartStore = defineStore('onlineCart', () => {
     onMutate({ itemId, quantity }: { itemId: string; quantity: number }) {
       const item = items.value.find(i => i.id === itemId)
       if (!item) throw new Error('Item not found')
-      const modifiersTotal = item.modifiers.reduce((sum, mod) => sum + mod.price, 0)
+      const modifiersTotal = modifiersCartTotal(item.modifiers)
       const prevQty = item.quantity
       const prevTotal = item.total
       item.quantity = quantity

--- a/stores/table_qr_cart.ts
+++ b/stores/table_qr_cart.ts
@@ -4,6 +4,7 @@
  */
 import { defineStore } from 'pinia'
 import type { OnlineCartItem, CartModifier } from '~/stores/online_cart'
+import { modifiersCartTotal } from '~/utils/saleModifierOption'
 
 function modifiersKey(mods: CartModifier[]): string {
   return JSON.stringify([...mods].sort((a, b) => a.id.localeCompare(b.id)))
@@ -43,7 +44,7 @@ export const useTableQrCartStore = defineStore('tableQrCart', () => {
     notes?: string,
   ) {
     const sortedModifiers = [...modifiers].sort((a, b) => a.id.localeCompare(b.id))
-    const modifiersTotal = modifiers.reduce((sum, mod) => sum + mod.price, 0)
+    const modifiersTotal = modifiersCartTotal(modifiers)
     const existingIndex = items.value.findIndex(
       item => item.product_id === product.id && modifiersKey(item.modifiers) === modifiersKey(modifiers),
     )
@@ -83,7 +84,7 @@ export const useTableQrCartStore = defineStore('tableQrCart', () => {
       return
     }
     const item = items.value[index]
-    const modifiersTotal = item.modifiers.reduce((sum, mod) => sum + mod.price, 0)
+    const modifiersTotal = modifiersCartTotal(item.modifiers)
     item.quantity = quantity
     item.total = (item.unit_price + modifiersTotal) * quantity
   }

--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -2,8 +2,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import type { CartModifier } from '~/stores/online_cart'
 import { posDebugLog, posDebugSerializeError } from '~/utils/posDebugLog'
-
-const modifierLineTotal = (mod: CartModifier) => Number(mod.price) * (mod.quantity ?? 1)
+import { modifierLineTotal } from '~/utils/saleModifierOption'
 
 const modifiersSignature = (mods: CartModifier[]) =>
     // Parity with online_cart.ts modifiersKey — separate cart rows per modifier config (#1023)

--- a/utils/saleModifierOption.ts
+++ b/utils/saleModifierOption.ts
@@ -1,0 +1,57 @@
+import type { CartModifier } from '~/stores/online_cart'
+import {
+  formatModifierOptionTypeLabel,
+  type ModifierOptionType,
+} from '~/composables/useModifierOptionForm'
+
+export interface SaleModifierOption {
+  id: string
+  name: string
+  price: number
+  max_limit: number
+  option_type: ModifierOptionType
+  type_label: string
+}
+
+/** Line total for one modifier selection (supports qty steppers and negative = discount). */
+export function modifierLineTotal(mod: Pick<CartModifier, 'price' | 'quantity'>): number {
+  return Number(mod.price) * (mod.quantity ?? 1)
+}
+
+export function modifiersCartTotal(mods: CartModifier[]): number {
+  return mods.reduce((sum, mod) => sum + modifierLineTotal(mod), 0)
+}
+
+export function normalizeModifierOptionType(raw: unknown): ModifierOptionType {
+  const t = String(raw || 'INGREDIENT').toUpperCase()
+  if (t === 'INGREDIENT' || t === 'RECIPE' || t === 'PRODUCT' || t === 'NONE') return t
+  return 'INGREDIENT'
+}
+
+export function mapApiModifierToSaleOption(mod: Record<string, unknown>): SaleModifierOption {
+  const option_type = normalizeModifierOptionType(mod.option_type)
+  return {
+    id: String(mod.id),
+    name: String(mod.name || ''),
+    price: Number(mod.price) || 0,
+    max_limit: Number(mod.max_limit) || 1,
+    option_type,
+    type_label: formatModifierOptionTypeLabel(option_type),
+  }
+}
+
+/** Price label for POS / online / manual sale UIs. */
+export function formatSaleModifierPriceLabel(
+  price: number,
+  formatCurrency: (n: number) => string,
+): string {
+  if (price > 0) return `+ ${formatCurrency(price)}`
+  if (price < 0) return formatCurrency(price)
+  return 'Incluido'
+}
+
+export function saleModifierPriceClass(price: number): string {
+  if (price > 0) return 'text-primary'
+  if (price < 0) return 'text-success'
+  return 'text-text-secondary'
+}


### PR DESCRIPTION
## Summary

- Shared `utils/saleModifierOption.ts` for modifier line totals (qty + negative discount prices) and API option mapping.
- POS product picker, online/table-qr drawer, and manual sale (`ventas/crear`) show option type labels and correct discount pricing.
- `online_cart` / `table_qr_cart` / `usePOSStore` use the same total helper; cart POST payloads unchanged (`{ id }` online, full snapshot POS).

## Companion PR

API: https://github.com/uno0uno/api-warolabs/pull/386 — adds `option_type` to product modifier payloads (POS list, public restaurant/table-qr detail).

## Test plan

- [ ] POS: product with INGREDIENT / RECIPE / PRODUCT / NONE modifiers → add to cart → checkout completes
- [ ] POS: modifier with negative `price` shows discount styling and correct line subtotal
- [ ] Same product, two different modifier configs → two cart rows (#1023)
- [ ] Online ordering drawer: negative modifier price + type label for non-ingredient options
- [ ] Table QR: same as online
- [ ] Ventas → Nueva venta: manual sale with modifiers and negative price

Closes #1123