### PR TITLE
docs(despacho): en-mesa QR notification copy merge

### DIFF
--- a/docs/usuarios/despacho.md
+++ b/docs/usuarios/despacho.md
@@ -128,8 +128,11 @@ Tras aceptar verás un mensaje de confirmación (incluye número de comanda si a
 
 ### Notificaciones
 
+<<<<<<< HEAD
 Cuando llega un pedido nuevo (domicilio o QR en mesa), la campana muestra el aviso y suena un **tono corto** (mismo estilo que cocina). Puedes silenciarlo con el icono de volumen en el panel de notificaciones (campana en escritorio o modal en móvil).
 
+=======
+>>>>>>> 9f22407 (docs(despacho): update en-mesa QR flow for list + detail UX)
 Cuando llega un pedido QR nuevo, la campana muestra **Pedido QR — {nombre de mesa}**.
 
 | Al tocar la notificación | Destino |


### PR DESCRIPTION
Cherry-pick remaining gh-728 docs delta onto main (en-mesa notification table + tone paragraph).

Supersedes gh-728-en-mesa-docs and gh-727-en-mesa-detail (feature already on main).

Made with [Cursor](https://cursor.com)