### PR TITLE
fix(abastecimiento): compras-directas crear missing end tags

### DIFF
--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -805,7 +805,9 @@
                     </div>
                   </div>
                 </div>
-              </MenuCatalogInlineCreateBusyOverlay>
+              </div>
+            </div>
+          </MenuCatalogInlineCreateBusyOverlay>
             </UiFormSection>
 
             <UiFormSection


### PR DESCRIPTION
## Summary
- Fixes Vue compile error in `compras-directas/crear.vue` (missing `</div>` for Insumos section + items list wrapper).

## Test plan
- [ ] Open `/abastecimiento/compras-directas/crear` — page loads without Vite overlay
- [ ] Toggle Alimentos / Insumos / Servicios tabs and add items


Made with [Cursor](https://cursor.com)