### PR TITLE
fix(menu): modificadores duplicate overlay end tags

### DIFF
--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -146,7 +146,6 @@
                 />
               </div>
             </MenuCatalogInlineCreateBusyOverlay>
-            </MenuCatalogInlineCreateBusyOverlay>
           </UiFormSection>
         </div>
       </div>

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -150,7 +150,6 @@
                   />
                 </div>
               </MenuCatalogInlineCreateBusyOverlay>
-              </MenuCatalogInlineCreateBusyOverlay>
             </UiFormSection>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Remove duplicate `</MenuCatalogInlineCreateBusyOverlay>` in `modificadores/crear.vue` and `modificadores/[id].vue`.

## Test plan
- [ ] `/menu/modificadores/crear` loads without Vite error
- [ ] `/menu/modificadores/[id]` edit page loads


Made with [Cursor](https://cursor.com)