### PR TITLE
docs(menu): modifier option types — user and dev guides

### DIFF
--- a/.wr/1125.yaml
+++ b/.wr/1125.yaml
@@ -1,0 +1,29 @@
+issue: 1125
+title: "docs(menu): modifier options — recipes and products"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/warocol.com
+stack: nuxt
+branch: wr-1125-docs-modifier-options
+
+paths:
+  - docs/usuarios/menu/modificadores.md
+  - docs/dev.md
+  - docs/usuarios/menu.md
+
+ac:
+  - Document four option types and inventory behavior in user docs (Paso 2)
+  - Add dev API examples for option_type on product/modifiers responses
+  - QA regression checklist in PR test plan
+  - Hub links to deep guide in menu.md
+
+out_of_scope:
+  - Application code
+
+hints:
+  entry: "components/menu/MenuModifierOptionEditor.vue:11-14"
+  pattern: "public_restaurant_service option_type on GET /v1/product/{id}"
+  tests: "Manual QA per PR test plan"
+
+skip:
+  audits: [ux, color, typography]

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -98,6 +98,46 @@ Construye tu propia tienda siguiendo este flujo:
 | `POST` | `/v1/menu/recipes` | Lista recetas con composición de ingredientes |
 | `POST` | `/v1/menu/modifiers` | Lista grupos de modificadores con sus opciones |
 
+#### Modificadores — `option_type`
+
+Cada opción de modificador tiene un tipo que define cómo el servidor descuenta inventario al confirmar la venta. El cliente **no** envía el tipo en el carrito: solo el `id` del modificador (y cantidad); la explosión de ingredientes ocurre en el servidor.
+
+| Valor | Significado |
+|-------|-------------|
+| `INGREDIENT` | Un artículo de bodega (cantidad/unidad en la opción) |
+| `RECIPE` | Receta base con multiplicador; puede incluir varios ingredientes |
+| `PRODUCT` | Producto del menú enlazado; descuenta su composición |
+| `NONE` | Solo precio de venta; sin movimiento de inventario |
+
+En `GET /v1/product/{product_id}`, cada opción dentro de `modifier_groups` incluye `option_type`:
+
+```json
+{
+  "modifier_groups": [
+    {
+      "id": "…",
+      "name": "Extras",
+      "modifiers": [
+        {
+          "id": "…",
+          "name": "Queso extra",
+          "price": 2000,
+          "option_type": "INGREDIENT"
+        },
+        {
+          "id": "…",
+          "name": "Porción salsa BBQ",
+          "price": 0,
+          "option_type": "RECIPE"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Al crear o actualizar el carrito (`POST /v1/cart/batch`, etc.), los modificadores siguen el mismo shape de siempre — por ejemplo `{ "id": "…", "name": "Queso extra", "price": 2000, "quantity": 1 }`. No envíes `option_type` ni composición desde el cliente.
+
 ### Clientes API (gestión)
 
 | Método | Endpoint | Descripción |

--- a/docs/usuarios/menu.md
+++ b/docs/usuarios/menu.md
@@ -133,58 +133,9 @@ Desde la pantalla de edición del producto, después de crearlo.
 
 ## Modificadores
 
-Un modificador es una opción adicional que el cliente puede elegir al pedir un producto. Se agrupa en un **grupo de modificadores**.
+Un modificador es una opción adicional al pedir un producto (tamaño, salsa, extras). Cada opción puede ser solo precio, un ingrediente, una **receta base** o un **producto del menú** — WARO descuenta inventario según el tipo que elijas.
 
-**Ejemplos:**
-- Grupo "Tamaño" → Personal, Mediana, Grande
-- Grupo "Salsa" → BBQ, Rosada, Picante
-- Grupo "Extras" → Queso extra (+$2.000), Tocineta (+$3.000)
-
-### Conceptos clave
-
-**Grupo:** la categoría de opciones (ej: "Tamaño").
-
-**Obligatorio vs. opcional:** si el grupo es obligatorio, el cliente no puede pedir el producto sin elegir al menos una opción.
-
-**Selección mínima y máxima:**
-- Mín 0, Máx 1 → puede elegir una o ninguna
-- Mín 1, Máx 1 → debe elegir exactamente una
-- Mín 0, Máx 3 → puede elegir hasta 3 (como extras)
-
-### Cómo crear un grupo de modificadores
-
-Ve a **Menú → Modificadores → Nuevo grupo**. El formulario tiene 3 pasos:
-
-**Paso 1 — Información del grupo**
-
-| Campo | Obligatorio |
-|-------|:-----------:|
-| Productos a los que aplica | Sí |
-| Nombre del grupo | Sí |
-| Selección mínima | Sí |
-| Selección máxima | Sí |
-| Es obligatorio | — |
-
-> Para un grupo de tamaños donde el cliente debe elegir uno: Mín 1, Máx 1, obligatorio.
-
-**Paso 2 — Opciones del grupo**
-
-Por cada opción defines nombre y precio adicional (0 si es gratis). Haz clic en **+ Agregar Modificador** para añadir más.
-
-**Paso 3 — Revisión**
-
-Revisa el resumen y haz clic en **Crear grupo**.
-
-### Preguntas frecuentes — Modificadores
-
-**¿Puedo asignar un grupo a varios productos?**
-Sí. Al crear el grupo seleccionas todos los productos que lo necesitan.
-
-**¿Puedo editar las opciones después?**
-Sí. Ve a **Menú → Modificadores**, abre el grupo y edítalo.
-
-**¿El cliente puede pedir un producto sin elegir un modificador obligatorio?**
-No. El botón de agregar al carrito no se activa hasta que el cliente elija.
+→ **[Guía completa de modificadores](./menu/modificadores.md)** (tipos de opción, inventario al vender y preguntas frecuentes)
 
 ---
 

--- a/docs/usuarios/menu/modificadores.md
+++ b/docs/usuarios/menu/modificadores.md
@@ -54,14 +54,27 @@ Aquí agregas cada opción disponible. Por cada una defines:
 
 | Campo | Qué poner |
 |-------|-----------|
+| **Tipo** | Cómo se descuenta inventario al vender (ver tabla abajo) |
 | Nombre | El nombre de la opción. Ej: `Grande`, `BBQ`, `Queso extra` |
 | Precio adicional | Cuánto suma al precio base. Si es gratis, pon 0. |
+| Máx / Orden | Cantidad máxima por línea y orden en pantalla |
 
 Haz clic en **+ Agregar Modificador** para agregar más opciones.
 
-Cada modificador puede tener artículos de bodega asociados para control de inventario. Si al buscar un artículo de bodega no aparece, encontrarás la opción **+ Crear artículo de bodega** para crearlo en un panel lateral sin salir del formulario. Necesitarás: Nombre, Tipo de medida y Categoría (los tres obligatorios).
+#### Tipos de opción (composición e inventario)
 
-→ [Ver más sobre artículos de bodega propios](https://warocol.com/docs/usuarios/compras#artículos de bodega-propios)
+| Tipo en pantalla | Cuándo usarlo | Qué configuras | Inventario al vender |
+|------------------|---------------|----------------|---------------------|
+| **Ingrediente / reventa** | Un solo insumo (o producto de reventa vinculado a un ingrediente) | Artículo de bodega + cantidad + unidad | Se descuenta ese ingrediente × cantidad del modificador × cantidad del producto |
+| **Receta base** | Varias materias primas según una preparación ya definida | Receta base + multiplicador (cantidad × receta) | Se descuentan **todos** los ingredientes de la receta, escalados por el multiplicador |
+| **Producto del menú** | La opción consume la composición de otro producto del menú | Producto del menú + multiplicador | Se descuenta la receta/composición de ese producto (como si vendieras una porción) |
+| **Solo precio** | Extra sin impacto en bodega (ej. empaque, servicio, “sin hielo”) | Solo nombre y precio | **No** mueve inventario; solo suma al total de la venta |
+
+> **Reventa:** en tipo **Ingrediente / reventa**, si el insumo no existe puedes crear un producto de reventa desde el buscador; WARO lo vincula al ingrediente equivalente.
+
+Si al buscar un artículo de bodega no aparece, usa **+ Crear artículo de bodega** en el panel lateral (Nombre, Tipo de medida y Categoría obligatorios).
+
+→ [Ver más sobre artículos de bodega propios](/docs/usuarios/abastecimiento#catálogo-de-bodega)
 
 ### Paso 3 — Revisión
 
@@ -71,7 +84,16 @@ Revisa el resumen y haz clic en **Crear grupo**.
 
 ## ¿Cuándo el modificador suma al precio?
 
-Cuando el cliente elige una opción con precio adicional, ese valor se suma automáticamente al precio del producto al momento del pago.
+Cuando el cliente elige una opción con precio adicional, ese valor se suma automáticamente al precio del producto al momento del pago (incluye POS, mesas y pedidos en línea).
+
+---
+
+## Inventario y costos al vender
+
+- El **precio de venta** del modificador siempre se guarda en la orden (lo que cobraste).
+- El **descuento de bodega** depende del **tipo** de la opción: ingrediente, receta o producto descontan según su composición; **Solo precio** no descuenta nada.
+- Si editas una venta y **eliminas** un modificador, WARO devuelve al inventario los insumos que se habían descontado por esa opción.
+- Los costos de food cost / cierre contable usan el detalle de ingredientes explotados por cada modificador (no solo un solo insumo cuando la opción es receta o producto).
 
 ---
 
@@ -88,3 +110,9 @@ El grupo se crea vacío. Los clientes no verán nada para seleccionar. Agrégala
 
 **¿El cliente puede pedir un producto sin elegir un modificador obligatorio?**
 No. Si el grupo es obligatorio, el botón de "Agregar al carrito" no se activa hasta que el cliente elija.
+
+**¿Puedo mezclar tipos en el mismo grupo?**
+Sí. Por ejemplo: tamaños con **Solo precio**, extras con **Ingrediente / reventa** y un combo con **Receta base**.
+
+**¿El cliente elige el tipo de opción?**
+No. El tipo solo lo configuras tú en administración; en caja el cliente ve nombre y precio.


### PR DESCRIPTION
## Summary
- Document four modifier option types (ingredient, recipe base, menu product, price-only) and inventory behavior in `docs/usuarios/menu/modificadores.md`.
- Replace duplicate Modificadores section in `docs/usuarios/menu.md` with a link to the full guide.
- Add `option_type` notes and JSON example for integrators in `docs/dev.md`.

Closes #1125

## Test plan
- [ ] Open `/docs/usuarios/menu/modificadores` — Paso 2 lists four types and inventory table
- [ ] Open `/docs/usuarios/menu` — Modificadores section links to the deep guide
- [ ] Open `/docs/dev` — `option_type` section visible under Menú API
- [ ] **QA regression (manual):** create one modifier group with each option type → POS sale → edit sale removing modifier → confirm stock moves match type (RECIPE: multiple ingredients; NONE: no movement)

## wr-context
See `.wr/1125.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)