### PR TITLE
fix(ui): flip catalog search dropdowns when near viewport bottom

### DIFF
--- a/components/ui/IngredientSearchInput.vue
+++ b/components/ui/IngredientSearchInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative">
+  <div ref="anchorRef" class="relative">
     <input
       type="text"
       v-model="searchTerm"
@@ -7,7 +7,7 @@
       @focus="onFocus"
       @blur="onBlur"
       role="combobox"
-      :aria-expanded="showResults && groupedResults.length > 0"
+      :aria-expanded="dropdownOpen"
       aria-autocomplete="list"
       aria-controls="ingredient-search-results"
       class="w-full px-3 py-2 pl-8 pr-8 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary bg-surface"
@@ -17,7 +17,7 @@
     <!-- Search icon (left) -->
     <span class="absolute left-2.5 top-2.5 text-text-secondary pointer-events-none" aria-hidden="true">
       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0"/>
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
       </svg>
     </span>
     <!-- Loading spinner (right) -->
@@ -27,71 +27,70 @@
         <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
       </svg>
     </span>
-    <!-- Results dropdown — shown when there are results OR when allowCreate and query has value -->
-    <ul
-      v-if="showResults && (groupedResults.length || (allowCreate && query))"
-      id="ingredient-search-results"
-      role="listbox"
-      class="absolute z-50 w-full mt-1 bg-surface border border-border rounded-lg shadow-lg max-h-48 overflow-y-auto"
-    >
-      <template v-for="row in groupedResults" :key="row._isHeader ? `header-${row.id}` : row.id">
-        <!-- Group header — base ingredient label, non-selectable -->
+    <Teleport to="body">
+      <ul
+        v-if="dropdownOpen"
+        id="ingredient-search-results"
+        role="listbox"
+        :style="panelStyle"
+        class="bg-surface border border-border rounded-lg shadow-lg overflow-y-auto"
+      >
+        <template v-for="row in groupedResults" :key="row._isHeader ? `header-${row.id}` : row.id">
+          <li
+            v-if="row._isHeader"
+            role="presentation"
+            aria-hidden="true"
+            class="px-3 py-1 text-xs font-semibold text-text-secondary uppercase tracking-wide bg-surface-secondary/40 select-none"
+          >
+            {{ row.name }}
+          </li>
+          <li
+            v-else
+            role="option"
+            @mousedown.prevent="select(row)"
+            :class="[
+              'px-3 py-2 text-sm text-text-primary hover:bg-surface-secondary cursor-pointer flex items-center gap-1.5',
+              row.parent_id ? 'pl-6' : ''
+            ]"
+          >
+            <span class="min-w-0 flex-1 flex flex-wrap items-center gap-1.5">
+              <span class="truncate">{{ row.name }} <span class="text-text-secondary">({{ row.unit }})</span></span>
+              <span
+                v-if="row.is_resale"
+                class="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-primary/10 text-primary flex-shrink-0"
+              >Reventa</span>
+              <span v-else-if="row.is_custom" class="text-xs bg-surface-secondary text-text-secondary rounded px-1 flex-shrink-0">Personalizado</span>
+            </span>
+          </li>
+        </template>
         <li
-          v-if="row._isHeader"
+          v-if="!groupedResults.length && !loading && query"
           role="presentation"
           aria-hidden="true"
-          class="px-3 py-1 text-xs font-semibold text-text-secondary uppercase tracking-wide bg-surface-secondary/40 select-none"
+          class="px-3 py-2 text-sm text-text-secondary/60 select-none"
         >
-          {{ row.name }}
+          Sin resultados
         </li>
-        <!-- Selectable item — variant (indented) or standalone base -->
         <li
-          v-else
+          v-if="allowCreate && query && !loading"
           role="option"
-          @mousedown.prevent="select(row)"
-          :class="[
-            'px-3 py-2 text-sm text-text-primary hover:bg-surface-secondary cursor-pointer flex items-center gap-1.5',
-            row.parent_id ? 'pl-6' : ''
-          ]"
+          @mousedown.prevent="$emit('create', query)"
+          class="px-3 py-2 text-sm text-primary border-t border-border hover:bg-surface-secondary cursor-pointer flex items-center gap-1.5"
         >
-          <span class="min-w-0 flex-1 flex flex-wrap items-center gap-1.5">
-            <span class="truncate">{{ row.name }} <span class="text-text-secondary">({{ row.unit }})</span></span>
-            <span
-              v-if="row.is_resale"
-              class="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-primary/10 text-primary flex-shrink-0"
-            >Reventa</span>
-            <span v-else-if="row.is_custom" class="text-xs bg-surface-secondary text-text-secondary rounded px-1 flex-shrink-0">Personalizado</span>
-          </span>
+          <svg class="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+          </svg>
+          Crear "{{ query }}"
         </li>
-      </template>
-      <!-- "No results" message when search ran but found nothing -->
-      <li
-        v-if="!groupedResults.length && !loading && query"
-        role="presentation"
-        aria-hidden="true"
-        class="px-3 py-2 text-sm text-text-secondary/60 select-none"
-      >
-        Sin resultados
-      </li>
-      <!-- "Crear" footer — only when allowCreate prop is true -->
-      <li
-        v-if="allowCreate && query && !loading"
-        role="option"
-        @mousedown.prevent="$emit('create', query)"
-        class="px-3 py-2 text-sm text-primary border-t border-border hover:bg-surface-secondary cursor-pointer flex items-center gap-1.5"
-      >
-        <svg class="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-        </svg>
-        Crear "{{ query }}"
-      </li>
-    </ul>
+      </ul>
+    </Teleport>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue'
 import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
+import { useCatalogSearchDropdownPlacement } from '~/composables/useCatalogSearchDropdownPlacement'
 
 interface Ingredient {
   id: string
@@ -123,6 +122,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<Emits>()
 
+const anchorRef = ref<HTMLElement | null>(null)
 const searchTerm = ref(props.initialValue)
 const showResults = ref(false)
 
@@ -131,6 +131,14 @@ const { query, groupedResults, loading } = useIngredientSearch({
   baseOnly: props.baseOnly,
   type: ingredientType,
 })
+
+const dropdownOpen = computed(
+  () => showResults.value && (groupedResults.value.length > 0 || !!(allowCreate.value && query.value)),
+)
+
+const allowCreate = computed(() => props.allowCreate)
+
+const { panelStyle } = useCatalogSearchDropdownPlacement(anchorRef, dropdownOpen)
 
 watch(() => props.initialValue, (val) => {
   searchTerm.value = val ?? ''

--- a/components/ui/ProductSearchInput.vue
+++ b/components/ui/ProductSearchInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative">
+  <div ref="anchorRef" class="relative">
     <input
       :id="inputId"
       type="text"
@@ -8,7 +8,7 @@
       @focus="onFocus"
       @blur="onBlur"
       role="combobox"
-      :aria-expanded="showResults && visibleResults.length > 0"
+      :aria-expanded="dropdownOpen"
       aria-autocomplete="list"
       aria-controls="product-search-results"
       class="w-full px-3 py-2 pl-8 pr-8 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary bg-surface"
@@ -17,7 +17,7 @@
     />
     <span class="absolute left-2.5 top-2.5 text-text-secondary pointer-events-none" aria-hidden="true">
       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0"/>
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
       </svg>
     </span>
     <span v-if="loading" class="absolute right-2.5 top-2.5 text-text-secondary pointer-events-none" aria-hidden="true">
@@ -26,36 +26,40 @@
         <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
       </svg>
     </span>
-    <ul
-      v-if="showResults && (visibleResults.length > 0 || (!!query.trim() && !loading))"
-      id="product-search-results"
-      role="listbox"
-      class="absolute z-50 w-full mt-1 bg-surface border border-border rounded-lg shadow-lg max-h-48 overflow-y-auto"
-    >
-      <li
-        v-for="product in visibleResults"
-        :key="product.id"
-        role="option"
-        @mousedown.prevent="select(product)"
-        class="px-3 py-2 text-sm text-text-primary hover:bg-surface-secondary cursor-pointer min-h-[44px] flex items-center"
+    <Teleport to="body">
+      <ul
+        v-if="dropdownOpen"
+        id="product-search-results"
+        role="listbox"
+        :style="panelStyle"
+        class="bg-surface border border-border rounded-lg shadow-lg overflow-y-auto"
       >
-        {{ product.name }}
-      </li>
-      <li
-        v-if="!visibleResults.length && !loading && query.trim()"
-        role="presentation"
-        aria-hidden="true"
-        class="px-3 py-2 text-sm text-text-secondary/60 select-none"
-      >
-        Sin resultados
-      </li>
-    </ul>
+        <li
+          v-for="product in visibleResults"
+          :key="product.id"
+          role="option"
+          @mousedown.prevent="select(product)"
+          class="px-3 py-2 text-sm text-text-primary hover:bg-surface-secondary cursor-pointer min-h-[44px] flex items-center"
+        >
+          {{ product.name }}
+        </li>
+        <li
+          v-if="!visibleResults.length && !loading && query.trim()"
+          role="presentation"
+          aria-hidden="true"
+          class="px-3 py-2 text-sm text-text-secondary/60 select-none"
+        >
+          Sin resultados
+        </li>
+      </ul>
+    </Teleport>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useProductSearch, type ProductRow } from '~/composables/useProductSearch'
+import { useCatalogSearchDropdownPlacement } from '~/composables/useCatalogSearchDropdownPlacement'
 
 interface Props {
   placeholder?: string
@@ -80,12 +84,25 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<Emits>()
 
+const anchorRef = ref<HTMLElement | null>(null)
 const searchTerm = ref(props.initialValue)
 const showResults = ref(false)
 
 const { query, results, loading } = useProductSearch({
   includeAllTypes: props.includeAllTypes,
 })
+
+const excludeSet = computed(() => new Set(props.excludeIds))
+
+const visibleResults = computed(() =>
+  results.value.filter((p) => !excludeSet.value.has(p.id)),
+)
+
+const dropdownOpen = computed(
+  () => showResults.value && (visibleResults.value.length > 0 || (!!query.value.trim() && !loading.value)),
+)
+
+const { panelStyle } = useCatalogSearchDropdownPlacement(anchorRef, dropdownOpen)
 
 watch(() => props.initialValue, (val) => {
   searchTerm.value = val ?? ''
@@ -94,12 +111,6 @@ watch(() => props.initialValue, (val) => {
     showResults.value = false
   }
 })
-
-const excludeSet = computed(() => new Set(props.excludeIds))
-
-const visibleResults = computed(() =>
-  results.value.filter((p) => !excludeSet.value.has(p.id)),
-)
 
 function onInput(e: Event) {
   const val = (e.target as HTMLInputElement).value

--- a/composables/useCatalogSearchDropdownPlacement.ts
+++ b/composables/useCatalogSearchDropdownPlacement.ts
@@ -1,0 +1,69 @@
+import { nextTick, onBeforeUnmount, ref, watch, type Ref } from 'vue'
+
+/** Matches Tailwind max-h-48 on catalog search listboxes */
+const MAX_DROPDOWN_PX = 192
+const GAP_PX = 4
+/** Prefer flipping up when less than this space remains below the input */
+const FLIP_THRESHOLD_PX = 160
+
+export function useCatalogSearchDropdownPlacement(
+  anchorRef: Ref<HTMLElement | null>,
+  open: Ref<boolean>,
+) {
+  const openUpward = ref(false)
+  const panelStyle = ref<Record<string, string>>({})
+
+  function updatePlacement() {
+    const el = anchorRef.value
+    if (!el || typeof window === 'undefined') return
+
+    const rect = el.getBoundingClientRect()
+    const spaceBelow = window.innerHeight - rect.bottom - GAP_PX
+    const spaceAbove = rect.top - GAP_PX
+
+    openUpward.value =
+      spaceBelow < FLIP_THRESHOLD_PX && spaceAbove > spaceBelow
+
+    const maxH = Math.min(
+      MAX_DROPDOWN_PX,
+      Math.max(96, openUpward.value ? spaceAbove : spaceBelow),
+    )
+
+    panelStyle.value = {
+      position: 'fixed',
+      left: `${rect.left}px`,
+      width: `${rect.width}px`,
+      maxHeight: `${maxH}px`,
+      zIndex: '9999',
+      ...(openUpward.value
+        ? { bottom: `${window.innerHeight - rect.top + GAP_PX}px` }
+        : { top: `${rect.bottom + GAP_PX}px` }),
+    }
+  }
+
+  let raf = 0
+  const scheduleUpdate = () => {
+    cancelAnimationFrame(raf)
+    raf = requestAnimationFrame(updatePlacement)
+  }
+
+  watch(open, async (isOpen) => {
+    if (isOpen) {
+      await nextTick()
+      updatePlacement()
+      window.addEventListener('scroll', scheduleUpdate, true)
+      window.addEventListener('resize', scheduleUpdate)
+    } else {
+      window.removeEventListener('scroll', scheduleUpdate, true)
+      window.removeEventListener('resize', scheduleUpdate)
+    }
+  })
+
+  onBeforeUnmount(() => {
+    window.removeEventListener('scroll', scheduleUpdate, true)
+    window.removeEventListener('resize', scheduleUpdate)
+    cancelAnimationFrame(raf)
+  })
+
+  return { openUpward, panelStyle, updatePlacement }
+}


### PR DESCRIPTION
## Summary
- Add `useCatalogSearchDropdownPlacement` to measure viewport space and open the listbox upward when there is little room below the input.
- Teleport ingredient and product search result lists to `body` with fixed positioning so parent `overflow-hidden` no longer clips options.

Closes #1142

## Test plan
- [ ] Compras directas crear: focus ingredient search on a bottom line — dropdown visible above or below as needed
- [ ] Modificadores edit: ingredient/product search near page bottom shows full list
- [ ] Product/recipe forms near top still open dropdown downward

## wr-context
Machine contract: branch `wr-1142-catalog-search-dropdown-flip` — `composables/useCatalogSearchDropdownPlacement.ts`, both search inputs.

Made with [Cursor](https://cursor.com)