### PR TITLE
fix(pos): mobile cart and table action buttons not clickable

### DIFF
--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col lg:w-96 border border-border rounded-2xl bg-surface overflow-hidden shadow-sm">
+  <div class="flex flex-col min-h-0 h-full lg:w-96 border border-border rounded-2xl bg-surface overflow-hidden shadow-sm">
     <!-- Cart Header -->
     <div class="px-4 py-3.5 border-b border-border bg-surface">
       <div class="flex items-center justify-between">
@@ -56,7 +56,7 @@
     </div>
 
     <!-- Items list: tab items (committed) + current cart items -->
-    <div class="flex-1 overflow-y-auto p-4 space-y-2.5">
+    <div class="flex-1 min-h-0 overflow-y-auto overscroll-y-contain p-4 space-y-2.5">
 
       <!-- Skeleton while loading tab items, adding to tab, or clearing -->
       <template v-if="isLoadingTabItems || isAddingToTab || isClearingTab">
@@ -122,10 +122,11 @@
           @duplicate="() => {}"
         />
 
-        <!-- Loading overlay -->
+        <!-- Loading overlay — only while that line is mutating -->
         <div
           v-if="tabItemsLoading.has(item.orderItemId)"
-          class="absolute inset-0 rounded-xl bg-surface/70 flex items-center justify-center backdrop-blur-[1px]"
+          class="absolute inset-0 z-20 rounded-xl bg-surface/70 flex items-center justify-center backdrop-blur-[1px] pointer-events-auto"
+          aria-hidden="true"
         >
           <UiLoadingDots size="9px" />
         </div>
@@ -169,7 +170,7 @@
     </div>
 
     <!-- Cart Footer -->
-    <div class="px-4 py-4 border-t border-border space-y-3 bg-surface-secondary/40">
+    <div class="flex-shrink-0 px-4 py-4 border-t border-border space-y-3 bg-surface-secondary/40">
       <!-- Total — net after line promos (#1022) -->
       <div
         v-if="orderPromoSavings > 0"

--- a/components/ui/BottomSheetModal.vue
+++ b/components/ui/BottomSheetModal.vue
@@ -1,5 +1,6 @@
 <template>
   <Teleport to="body">
+    <!-- Backdrop + sheet as siblings (not nested) so taps on controls are not swallowed by the overlay flex container. -->
     <Transition
       enter-active-class="transition-opacity duration-200"
       enter-from-class="opacity-0"
@@ -10,46 +11,53 @@
     >
       <div
         v-if="modelValue"
-        class="fixed inset-0 bg-black bg-opacity-50 z-[60] flex items-end lg:hidden"
+        class="fixed inset-0 bg-black/50 z-[70] lg:hidden"
+        aria-hidden="true"
         @click="closeModal"
+      />
+    </Transition>
+
+    <Transition
+      enter-active-class="transition-transform duration-300"
+      enter-from-class="translate-y-full"
+      enter-to-class="translate-y-0"
+      leave-active-class="transition-transform duration-300"
+      leave-from-class="translate-y-0"
+      leave-to-class="translate-y-full"
+    >
+      <div
+        v-if="modelValue"
+        class="fixed inset-x-0 bottom-0 z-[71] lg:hidden bg-white rounded-t-2xl w-full flex flex-col overflow-hidden shadow-2xl touch-manipulation"
+        :class="maxHeightClass"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="title"
       >
-        <Transition
-          enter-active-class="transition-transform duration-300"
-          enter-from-class="translate-y-full"
-          enter-to-class="translate-y-0"
-          leave-active-class="transition-transform duration-300"
-          leave-from-class="translate-y-0"
-          leave-to-class="translate-y-full"
-        >
-          <div
-            v-if="modelValue"
-            class="bg-white rounded-t-2xl w-full flex flex-col overflow-hidden"
-            :class="maxHeightClass"
-            @click.stop
+        <!-- Header -->
+        <div class="flex-shrink-0 bg-white border-b border-titan-300 px-4 py-4 flex items-center justify-between">
+          <h3 class="text-lg font-semibold text-ebony-800">{{ title }}</h3>
+          <button
+            type="button"
+            @click="closeModal"
+            class="min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-titan-100 rounded-lg transition-colors"
+            aria-label="Cerrar"
           >
-            <!-- Header -->
-            <div class="flex-shrink-0 bg-white border-b border-titan-300 px-4 py-4 flex items-center justify-between">
-              <h3 class="text-lg font-semibold text-ebony-800">{{ title }}</h3>
-              <button
-                @click="closeModal"
-                class="p-2 hover:bg-titan-100 rounded-lg transition-colors"
-                aria-label="Cerrar"
-              >
-                <XMarkIcon class="w-5 h-5 text-titan-500" />
-              </button>
-            </div>
+            <XMarkIcon class="w-5 h-5 text-titan-500" />
+          </button>
+        </div>
 
-            <!-- Content -->
-            <div class="flex-1 overflow-y-auto">
-              <slot />
-            </div>
+        <!-- Content: default scroll, or fill for self-contained panels (POS cart) -->
+        <div
+          class="flex-1 min-h-0"
+          :class="fillContent ? 'flex flex-col overflow-hidden' : 'overflow-y-auto overscroll-y-contain'"
+        >
+          <slot />
+        </div>
 
-            <!-- Footer (optional, sticky) -->
-            <div v-if="$slots.footer" class="flex-shrink-0 bg-white border-t border-titan-300">
-              <slot name="footer" />
-            </div>
-          </div>
-        </Transition>
+        <!-- Footer (optional, sticky) -->
+        <div v-if="$slots.footer" class="flex-shrink-0 bg-white border-t border-titan-300">
+          <slot name="footer" />
+        </div>
       </div>
     </Transition>
   </Teleport>
@@ -62,6 +70,8 @@ interface Props {
   modelValue: boolean
   title: string
   maxHeight?: 'sm' | 'md' | 'lg' | 'xl'
+  /** When true, slot manages its own internal scroll (e.g. CartPanel). Avoids nested scroll stealing taps on mobile. */
+  fillContent?: boolean
 }
 
 interface Emits {
@@ -69,7 +79,8 @@ interface Emits {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  maxHeight: 'lg'
+  maxHeight: 'lg',
+  fillContent: false,
 })
 
 const emit = defineEmits<Emits>()
@@ -79,7 +90,7 @@ const maxHeightClass = computed(() => {
     sm: 'max-h-[50vh]',
     md: 'max-h-[65vh]',
     lg: 'max-h-[80vh]',
-    xl: 'max-h-[90vh]'
+    xl: 'max-h-[90vh]',
   }
   return heights[props.maxHeight]
 })

--- a/composables/usePosMobileCart.ts
+++ b/composables/usePosMobileCart.ts
@@ -4,6 +4,7 @@ import { readonly, ref } from 'vue'
 
 const _itemCount = ref(0)
 const _formattedTotal = ref('$0')
+const _sheetOpen = ref(false)
 let _openCartHandler: (() => void) | undefined
 
 export const usePosMobileCart = () => {
@@ -23,14 +24,21 @@ export const usePosMobileCart = () => {
   const clearMobileCart = () => {
     _itemCount.value = 0
     _formattedTotal.value = '$0'
+    _sheetOpen.value = false
     _openCartHandler = undefined
+  }
+
+  const setMobileCartSheetOpen = (open: boolean) => {
+    _sheetOpen.value = open
   }
 
   return {
     itemCount: readonly(_itemCount),
     formattedTotal: readonly(_formattedTotal),
+    sheetOpen: readonly(_sheetOpen),
     setMobileCart,
     setOpenCartHandler,
+    setMobileCartSheetOpen,
     openCart,
     clearMobileCart,
   }

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -138,8 +138,10 @@
 
   <!-- Bottom Navigation - Mobile Only -->
   <div
-    class="lg:hidden fixed bottom-0 inset-x-0 z-50 bg-white border-t border-titan-300 shadow-lg"
+    class="lg:hidden fixed bottom-0 inset-x-0 z-50 bg-white border-t border-titan-300 shadow-lg transition-opacity"
+    :class="posMobileCartSheetOpen ? 'pointer-events-none opacity-0' : ''"
     style="padding-bottom: env(safe-area-inset-bottom, 0px)"
+    :aria-hidden="posMobileCartSheetOpen"
   >
     <PosCartBottomBar
       v-if="showPosMobileCartBar"
@@ -1186,7 +1188,7 @@ watch(displayTitle, (nextTitle, previousTitle) => {
 }, { immediate: true })
 
 // Inject cart data from POS page
-const { itemCount: posMobileCartItemCount, formattedTotal: posMobileCartFormattedTotal, openCart: openPosMobileCart } = usePosMobileCart()
+const { itemCount: posMobileCartItemCount, formattedTotal: posMobileCartFormattedTotal, openCart: openPosMobileCart, sheetOpen: posMobileCartSheetOpen } = usePosMobileCart()
 
 const showPosMobileCartBar = computed(() =>
   route.path === '/pos' && posMobileCartItemCount.value > 0,

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -1116,11 +1116,15 @@ const mobileCartItemCount = computed(() =>
 const mobileCartDisplayTotal = computed(() => mobileCartNetTotal.value)
 const mobileCartFormattedTotal = computed(() => formatCurrencyPOS(mobileCartDisplayTotal.value))
 
-const { setMobileCart, setOpenCartHandler, clearMobileCart } = usePosMobileCart()
+const { setMobileCart, setOpenCartHandler, setMobileCartSheetOpen, clearMobileCart } = usePosMobileCart()
 
 watchEffect(() => {
   setMobileCart(mobileCartItemCount.value, mobileCartFormattedTotal.value)
 })
+
+watch(showMobileCartSheet, (open) => {
+  setMobileCartSheetOpen(open)
+}, { immediate: true })
 
 // Navigate to product customization page or add directly to cart
 const selectProduct = async (product: any) => {
@@ -1898,9 +1902,9 @@ onUnmounted(() => {
   />
 
   <!-- warocol.com#1032 — mobile/tablet cart sheet (bar lives in dashboard layout) -->
-  <UiBottomSheetModal v-model="showMobileCartSheet" title="Orden actual" max-height="xl">
+  <UiBottomSheetModal v-model="showMobileCartSheet" title="Orden actual" max-height="xl" fill-content>
     <PosCartPanel
-      class="border-0 shadow-none rounded-none max-h-[70vh]"
+      class="border-0 shadow-none rounded-none h-full min-h-0"
       :items="posStore.cart"
       :total="cartTotal"
       :mesa-mode="isKitchenServiceMode"


### PR DESCRIPTION
## Summary
- Refactors `BottomSheetModal` to sibling backdrop/panel at `z-[70]`+ so taps are not swallowed by the overlay flex container
- POS mobile cart uses `fill-content` + full-height `CartPanel` with a single internal scroll (items list only)
- Dashboard bottom nav gets `pointer-events-none` while the cart sheet is open

Closes #1147

## Test plan
- [ ] Mobile `/pos` mesa mode: open **Orden actual** sheet
- [ ] Tap qty +/−, edit, duplicate, delete on cart and tab lines ("Sin enviar")
- [ ] Tap **Venta libre**, **Pedir cuenta**, **Limpiar**, **Agregar y enviar**
- [ ] Close sheet with X; bottom nav taps work again
- [ ] Desktop sidebar cart unchanged (`lg+`)

## wr-context
See `.wr/1147.yaml` on this branch (local gitignore; contract in PR description).

Made with [Cursor](https://cursor.com)