### PR TITLE
fix(pos): lock tab lines after comanda fire + mobile cart taps

### DIFF
--- a/components/pos/CartItem.vue
+++ b/components/pos/CartItem.vue
@@ -75,10 +75,11 @@
     </div>
 
     <!-- Fila 3: controles de cantidad + acciones -->
-    <div class="mt-2.5 pl-[2.125rem] flex items-center gap-2">
+    <div v-if="!hideLineControls" class="mt-2.5 pl-[2.125rem] flex items-center gap-2">
       <!-- Cantidad -->
       <div class="flex items-center border border-violet-200 rounded-lg bg-white">
         <button
+          type="button"
           class="min-w-[44px] min-h-[44px] flex items-center justify-center text-slate-400 hover:bg-violet-50 rounded-l-lg disabled:opacity-40 disabled:cursor-not-allowed"
           :disabled="item.quantity <= 1"
           aria-label="Reducir cantidad"
@@ -90,6 +91,8 @@
         </button>
         <span class="w-6 text-center text-xs font-medium text-text-primary">{{ item.quantity }}</span>
         <button
+          v-if="!lockIncrement"
+          type="button"
           class="min-w-[44px] min-h-[44px] flex items-center justify-center text-slate-400 hover:bg-violet-50 rounded-r-lg"
           aria-label="Aumentar cantidad"
           @click.stop="$emit('increment')"
@@ -104,6 +107,8 @@
 
       <!-- Duplicar -->
       <button
+        v-if="!hideEditDuplicate"
+        type="button"
         class="min-w-[44px] min-h-[44px] flex items-center justify-center rounded bg-violet-50 border border-violet-300 text-violet-600 hover:bg-violet-100 theme-transition"
         aria-label="Duplicar ítem"
         @click.stop="$emit('duplicate')"
@@ -115,7 +120,8 @@
 
       <!-- Editar (oculto para reventa y venta libre) -->
       <button
-        v-if="!item.is_resale && !item.is_open_sale"
+        v-if="!hideEditDuplicate && !item.is_resale && !item.is_open_sale"
+        type="button"
         class="min-w-[44px] min-h-[44px] flex items-center justify-center rounded bg-violet-50 border border-violet-300 text-violet-600 hover:bg-violet-100 theme-transition"
         aria-label="Editar ítem"
         @click.stop="$emit('edit')"
@@ -127,6 +133,7 @@
 
       <!-- Eliminar -->
       <button
+        type="button"
         class="min-w-[44px] min-h-[44px] flex items-center justify-center rounded bg-red-50 border border-red-300 text-red-500 hover:bg-red-100 theme-transition"
         aria-label="Eliminar ítem"
         @click.stop="$emit('remove')"
@@ -170,6 +177,12 @@ interface Props {
   promoSavings?: number
   /** When set, overrides computed gross (e.g. mesa tab subtotal). */
   grossTotal?: number | null
+  /** Tab lines: hide edit/duplicate (modifiers locked once on the tab). */
+  hideEditDuplicate?: boolean
+  /** Fired to kitchen: block qty + (edit/duplicate via hideEditDuplicate). */
+  lockIncrement?: boolean
+  /** Hide entire action row (e.g. delivered/cancelled). */
+  hideLineControls?: boolean
 }
 
 interface Emits {
@@ -184,6 +197,9 @@ const props = withDefaults(defineProps<Props>(), {
   showFulfillmentStatus: false,
   promoSavings: 0,
   grossTotal: null,
+  hideEditDuplicate: false,
+  lockIncrement: false,
+  hideLineControls: false,
 })
 defineEmits<Emits>()
 

--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col lg:w-96 border border-border rounded-2xl bg-surface overflow-hidden shadow-sm">
+  <div class="flex flex-col min-h-0 h-full lg:w-96 border border-border rounded-2xl bg-surface overflow-hidden shadow-sm">
     <!-- Cart Header -->
     <div class="px-4 py-3.5 border-b border-border bg-surface">
       <div class="flex items-center justify-between">
@@ -56,7 +56,7 @@
     </div>
 
     <!-- Items list: tab items (committed) + current cart items -->
-    <div class="flex-1 overflow-y-auto p-4 space-y-2.5">
+    <div class="flex-1 min-h-0 overflow-y-auto overscroll-y-contain p-4 space-y-2.5">
 
       <!-- Skeleton while loading tab items, adding to tab, or clearing -->
       <template v-if="isLoadingTabItems || isAddingToTab || isClearingTab">
@@ -122,10 +122,11 @@
           @duplicate="() => {}"
         />
 
-        <!-- Loading overlay -->
+        <!-- Loading overlay — only while that line is mutating -->
         <div
           v-if="tabItemsLoading.has(item.orderItemId)"
-          class="absolute inset-0 rounded-xl bg-surface/70 flex items-center justify-center backdrop-blur-[1px]"
+          class="absolute inset-0 z-20 rounded-xl bg-surface/70 flex items-center justify-center backdrop-blur-[1px] pointer-events-auto"
+          aria-hidden="true"
         >
           <UiLoadingDots size="9px" />
         </div>
@@ -169,7 +170,7 @@
     </div>
 
     <!-- Cart Footer -->
-    <div class="px-4 py-4 border-t border-border space-y-3 bg-surface-secondary/40">
+    <div class="flex-shrink-0 px-4 py-4 border-t border-border space-y-3 bg-surface-secondary/40">
       <!-- Total — net after line promos (#1022) -->
       <div
         v-if="orderPromoSavings > 0"

--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -112,8 +112,10 @@
           :promo-title="linePromoBadgeWhenSaving(item.productId, item.categoryId, tabLinePromoSavings(item))?.title ?? null"
           :promo-savings="tabLinePromoSavings(item)"
           :gross-total="item.subtotal"
+          :hide-edit-duplicate="true"
+          :lock-increment="isTabLineFired(item)"
+          :hide-line-controls="isTabLineTerminal(item)"
           :class="[
-            pendingRemoveItemId === item.orderItemId ? 'opacity-40 pointer-events-none' : '',
             showPrintItemSelection && printableOrderItemIds.includes(item.orderItemId) ? 'pl-8' : '',
           ]"
           @increment="$emit('increment-tab-item', item.orderItemId)"
@@ -531,5 +533,20 @@ const formatCurrency = (value: number) => {
     currency: 'COP',
     minimumFractionDigits: 0
   }).format(value)
+}
+
+function tabLineStatus(item: TabItem): string {
+  return item.fulfillmentStatus ?? 'new'
+}
+
+/** Line already fired to kitchen — qty+ locked; qty−/delete use confirm modal (#956). */
+function isTabLineFired(item: TabItem): boolean {
+  return props.comandasEnabled && tabLineStatus(item) !== 'new'
+}
+
+/** Terminal fulfillment — no cart mutations. */
+function isTabLineTerminal(item: TabItem): boolean {
+  const status = tabLineStatus(item)
+  return status === 'delivered' || status === 'cancelled'
 }
 </script>

--- a/components/ui/BottomSheetModal.vue
+++ b/components/ui/BottomSheetModal.vue
@@ -1,5 +1,6 @@
 <template>
   <Teleport to="body">
+    <!-- Backdrop + sheet as siblings (not nested) so taps on controls are not swallowed by the overlay flex container. -->
     <Transition
       enter-active-class="transition-opacity duration-200"
       enter-from-class="opacity-0"
@@ -10,46 +11,53 @@
     >
       <div
         v-if="modelValue"
-        class="fixed inset-0 bg-black bg-opacity-50 z-[60] flex items-end lg:hidden"
+        class="fixed inset-0 bg-black/50 z-[70] lg:hidden"
+        aria-hidden="true"
         @click="closeModal"
+      />
+    </Transition>
+
+    <Transition
+      enter-active-class="transition-transform duration-300"
+      enter-from-class="translate-y-full"
+      enter-to-class="translate-y-0"
+      leave-active-class="transition-transform duration-300"
+      leave-from-class="translate-y-0"
+      leave-to-class="translate-y-full"
+    >
+      <div
+        v-if="modelValue"
+        class="fixed inset-x-0 bottom-0 z-[71] lg:hidden bg-white rounded-t-2xl w-full flex flex-col overflow-hidden shadow-2xl touch-manipulation"
+        :class="maxHeightClass"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="title"
       >
-        <Transition
-          enter-active-class="transition-transform duration-300"
-          enter-from-class="translate-y-full"
-          enter-to-class="translate-y-0"
-          leave-active-class="transition-transform duration-300"
-          leave-from-class="translate-y-0"
-          leave-to-class="translate-y-full"
-        >
-          <div
-            v-if="modelValue"
-            class="bg-white rounded-t-2xl w-full flex flex-col overflow-hidden"
-            :class="maxHeightClass"
-            @click.stop
+        <!-- Header -->
+        <div class="flex-shrink-0 bg-white border-b border-titan-300 px-4 py-4 flex items-center justify-between">
+          <h3 class="text-lg font-semibold text-ebony-800">{{ title }}</h3>
+          <button
+            type="button"
+            @click="closeModal"
+            class="min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-titan-100 rounded-lg transition-colors"
+            aria-label="Cerrar"
           >
-            <!-- Header -->
-            <div class="flex-shrink-0 bg-white border-b border-titan-300 px-4 py-4 flex items-center justify-between">
-              <h3 class="text-lg font-semibold text-ebony-800">{{ title }}</h3>
-              <button
-                @click="closeModal"
-                class="p-2 hover:bg-titan-100 rounded-lg transition-colors"
-                aria-label="Cerrar"
-              >
-                <XMarkIcon class="w-5 h-5 text-titan-500" />
-              </button>
-            </div>
+            <XMarkIcon class="w-5 h-5 text-titan-500" />
+          </button>
+        </div>
 
-            <!-- Content -->
-            <div class="flex-1 overflow-y-auto">
-              <slot />
-            </div>
+        <!-- Content: default scroll, or fill for self-contained panels (POS cart) -->
+        <div
+          class="flex-1 min-h-0"
+          :class="fillContent ? 'flex flex-col overflow-hidden' : 'overflow-y-auto overscroll-y-contain'"
+        >
+          <slot />
+        </div>
 
-            <!-- Footer (optional, sticky) -->
-            <div v-if="$slots.footer" class="flex-shrink-0 bg-white border-t border-titan-300">
-              <slot name="footer" />
-            </div>
-          </div>
-        </Transition>
+        <!-- Footer (optional, sticky) -->
+        <div v-if="$slots.footer" class="flex-shrink-0 bg-white border-t border-titan-300">
+          <slot name="footer" />
+        </div>
       </div>
     </Transition>
   </Teleport>
@@ -62,6 +70,8 @@ interface Props {
   modelValue: boolean
   title: string
   maxHeight?: 'sm' | 'md' | 'lg' | 'xl'
+  /** When true, slot manages its own internal scroll (e.g. CartPanel). Avoids nested scroll stealing taps on mobile. */
+  fillContent?: boolean
 }
 
 interface Emits {
@@ -69,7 +79,8 @@ interface Emits {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  maxHeight: 'lg'
+  maxHeight: 'lg',
+  fillContent: false,
 })
 
 const emit = defineEmits<Emits>()
@@ -79,7 +90,7 @@ const maxHeightClass = computed(() => {
     sm: 'max-h-[50vh]',
     md: 'max-h-[65vh]',
     lg: 'max-h-[80vh]',
-    xl: 'max-h-[90vh]'
+    xl: 'max-h-[90vh]',
   }
   return heights[props.maxHeight]
 })

--- a/components/ui/ConfirmActionModal.vue
+++ b/components/ui/ConfirmActionModal.vue
@@ -10,7 +10,7 @@
     >
       <div
         v-if="modelValue"
-        class="fixed inset-0 z-[70] flex items-center justify-center p-4 bg-black/50"
+        class="fixed inset-0 z-[80] flex items-center justify-center p-4 bg-black/50"
         role="alertdialog"
         aria-modal="true"
         :aria-labelledby="titleId"

--- a/components/ui/ErrorAlertModal.vue
+++ b/components/ui/ErrorAlertModal.vue
@@ -10,7 +10,7 @@
     >
       <div
         v-if="modelValue"
-        class="fixed inset-0 z-[70] flex items-center justify-center p-4 bg-black/50"
+        class="fixed inset-0 z-[80] flex items-center justify-center p-4 bg-black/50"
         role="alertdialog"
         aria-modal="true"
         :aria-labelledby="titleId"

--- a/composables/usePosMobileCart.ts
+++ b/composables/usePosMobileCart.ts
@@ -4,6 +4,7 @@ import { readonly, ref } from 'vue'
 
 const _itemCount = ref(0)
 const _formattedTotal = ref('$0')
+const _sheetOpen = ref(false)
 let _openCartHandler: (() => void) | undefined
 
 export const usePosMobileCart = () => {
@@ -23,14 +24,21 @@ export const usePosMobileCart = () => {
   const clearMobileCart = () => {
     _itemCount.value = 0
     _formattedTotal.value = '$0'
+    _sheetOpen.value = false
     _openCartHandler = undefined
+  }
+
+  const setMobileCartSheetOpen = (open: boolean) => {
+    _sheetOpen.value = open
   }
 
   return {
     itemCount: readonly(_itemCount),
     formattedTotal: readonly(_formattedTotal),
+    sheetOpen: readonly(_sheetOpen),
     setMobileCart,
     setOpenCartHandler,
+    setMobileCartSheetOpen,
     openCart,
     clearMobileCart,
   }

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -138,8 +138,10 @@
 
   <!-- Bottom Navigation - Mobile Only -->
   <div
-    class="lg:hidden fixed bottom-0 inset-x-0 z-50 bg-white border-t border-titan-300 shadow-lg"
+    class="lg:hidden fixed bottom-0 inset-x-0 z-50 bg-white border-t border-titan-300 shadow-lg transition-opacity"
+    :class="posMobileCartSheetOpen ? 'pointer-events-none opacity-0' : ''"
     style="padding-bottom: env(safe-area-inset-bottom, 0px)"
+    :aria-hidden="posMobileCartSheetOpen"
   >
     <PosCartBottomBar
       v-if="showPosMobileCartBar"
@@ -1186,7 +1188,7 @@ watch(displayTitle, (nextTitle, previousTitle) => {
 }, { immediate: true })
 
 // Inject cart data from POS page
-const { itemCount: posMobileCartItemCount, formattedTotal: posMobileCartFormattedTotal, openCart: openPosMobileCart } = usePosMobileCart()
+const { itemCount: posMobileCartItemCount, formattedTotal: posMobileCartFormattedTotal, openCart: openPosMobileCart, sheetOpen: posMobileCartSheetOpen } = usePosMobileCart()
 
 const showPosMobileCartBar = computed(() =>
   route.path === '/pos' && posMobileCartItemCount.value > 0,

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -7,7 +7,7 @@ import type { CachedProduct, TabItem } from '~/stores/usePOSStore'
 import { usePOSStore } from '~/stores/usePOSStore'
 import { useOpenSale } from '~/composables/useOpenSale'
 import { registerTableSessionRefresh } from '~/composables/useTableSessionSync'
-import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
+import type { ComandaPrintPayload, FireTableResponse } from '~/composables/useComandaPrint'
 import {
   mapComandasForPrint,
   orderItemIdsFromComandas,
@@ -415,11 +415,25 @@ function applyFireResult(rawComandas: unknown[], firedCount: number) {
           ? firedIds.has(item.orderItemId)
           : item.fulfillmentStatus === 'new'
         return shouldMarkSent
-          ? { ...item, fulfillmentStatus: 'sent' as const, sentAt: new Date().toISOString() }
+          ? { ...item, fulfillmentStatus: 'sent' as const, sentAt: item.sentAt ?? new Date().toISOString() }
           : item
       }),
     )
     selectedTabItemIds.value = []
+  }
+}
+
+async function syncTabAfterAdd(addRes: unknown, addedCount: number) {
+  await refreshTableSession()
+  if (!comandasEnabled.value || addedCount <= 0) return
+  const { comandas, fired_items_count } = parseFireTableResponse(addRes as FireTableResponse)
+  applyFireResult(comandas, fired_items_count)
+  if (fired_items_count > 0) {
+    tabSuccess.value = `${fired_items_count} ${fired_items_count === 1 ? 'ítem enviado' : 'ítems enviados'} a cocina`
+    setTimeout(() => { tabSuccess.value = null }, 3000)
+  } else {
+    tabError.value = 'Ítems agregados a la mesa pero no se enviaron a cocina. Verifica que el producto tenga estación de cocina.'
+    setTimeout(() => { tabError.value = null }, 6000)
   }
 }
 
@@ -455,8 +469,8 @@ const mapTabItemsFromApi = (rows: any[]): TabItem[] =>
       quantity: Number(m.quantity) || 1,
     })),
     notes: i.notes ?? null,
-    fulfillmentStatus: i.fulfillmentStatus ?? 'new',
-    sentAt: i.sentAt ?? null,
+    fulfillmentStatus: i.fulfillmentStatus ?? i.fulfillment_status ?? 'new',
+    sentAt: i.sentAt ?? i.sent_at ?? null,
   }))
 
 const applyTableSessionFromApi = (
@@ -828,6 +842,7 @@ const updateTabItemQuantity = async (orderItemId: string, quantity: number, reas
 }
 
 const incrementTabItem = (orderItemId: string) => {
+  if (comandasEnabled.value && isTabItemFired(orderItemId)) return
   const item = storeTabItems.value.find(t => t.orderItemId === orderItemId)
   if (item) updateTabItemQuantity(orderItemId, item.quantity + 1)
 }
@@ -874,19 +889,7 @@ const addToTab = async () => {
     })
     // Clear cart — items committed to tab
     await posStore.clearCart()
-    // tab/add already auto-fires when comandas enabled; use its payload for print (#753)
-    if (comandasEnabled.value) {
-      const { comandas, fired_items_count } = parseFireTableResponse(addRes as any)
-      if (comandas.length > 0 || fired_items_count > 0) {
-        applyFireResult(comandas, fired_items_count)
-        if (fired_items_count > 0) {
-          tabSuccess.value = `${fired_items_count} ${fired_items_count === 1 ? 'ítem enviado' : 'ítems enviados'} a cocina`
-          setTimeout(() => { tabSuccess.value = null }, 3000)
-        }
-      }
-    }
-    // Refresh session + tab items
-    await refreshTableSession()
+    await syncTabAfterAdd(addRes, items.length)
   } catch (e: any) {
     tabError.value = e?.data?.detail ?? `Error al agregar a la ${tableSingularLower.value}`
   } finally {
@@ -1178,16 +1181,10 @@ const addOpenSaleToTab = async (amount: number, description?: string) => {
       body: { items: [tabItem] },
     })
     if (comandasEnabled.value) {
-      const { comandas, fired_items_count } = parseFireTableResponse(addRes as any)
-      if (comandas.length > 0 || fired_items_count > 0) {
-        applyFireResult(comandas, fired_items_count)
-        if (fired_items_count > 0) {
-          tabSuccess.value = `${fired_items_count} ${fired_items_count === 1 ? 'ítem enviado' : 'ítems enviados'} a cocina`
-          setTimeout(() => { tabSuccess.value = null }, 3000)
-        }
-      }
+      await syncTabAfterAdd(addRes, 1)
+    } else {
+      await refreshTableSession()
     }
-    await refreshTableSession()
   } catch (e: any) {
     tabError.value = e?.data?.detail ?? e?.data?.message ?? `Error al agregar a la ${tableSingularLower.value}`
     throw e

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -1116,11 +1116,15 @@ const mobileCartItemCount = computed(() =>
 const mobileCartDisplayTotal = computed(() => mobileCartNetTotal.value)
 const mobileCartFormattedTotal = computed(() => formatCurrencyPOS(mobileCartDisplayTotal.value))
 
-const { setMobileCart, setOpenCartHandler, clearMobileCart } = usePosMobileCart()
+const { setMobileCart, setOpenCartHandler, setMobileCartSheetOpen, clearMobileCart } = usePosMobileCart()
 
 watchEffect(() => {
   setMobileCart(mobileCartItemCount.value, mobileCartFormattedTotal.value)
 })
+
+watch(showMobileCartSheet, (open) => {
+  setMobileCartSheetOpen(open)
+}, { immediate: true })
 
 // Navigate to product customization page or add directly to cart
 const selectProduct = async (product: any) => {
@@ -1898,9 +1902,9 @@ onUnmounted(() => {
   />
 
   <!-- warocol.com#1032 — mobile/tablet cart sheet (bar lives in dashboard layout) -->
-  <UiBottomSheetModal v-model="showMobileCartSheet" title="Orden actual" max-height="xl">
+  <UiBottomSheetModal v-model="showMobileCartSheet" title="Orden actual" max-height="xl" fill-content>
     <PosCartPanel
-      class="border-0 shadow-none rounded-none max-h-[70vh]"
+      class="border-0 shadow-none rounded-none h-full min-h-0"
       :items="posStore.cart"
       :total="cartTotal"
       :mesa-mode="isKitchenServiceMode"


### PR DESCRIPTION
## Summary
- Tab lines hide edit/duplicate; block qty+ and all controls once delivered/cancelled; fired lines use confirm modal above the cart sheet (z-80)
- After `tab/add`: refresh session first, then merge fire status; warn when auto-fire returns 0 (e.g. missing kitchen station)
- Includes #1147 mobile cart sheet tap fixes (sibling backdrop, single scroll, bottom nav pointer-events)

Closes #1149

Related: #1147

## Test plan
- [ ] Mesa + comandas: add item → **Agregar y enviar** → badge **En cocina**; no edit/duplicate on tab line; qty+ disabled
- [ ] Product without station → error banner about not fired
- [ ] Fired line: qty− / delete → confirm modal visible on mobile sheet
- [ ] Pending cart lines (Por agregar) still fully editable
- [ ] Desktop sidebar unchanged

## wr-context
Branch stacks wr-1147 mobile sheet fix + wr-1149 fulfillment gating.

Made with [Cursor](https://cursor.com)