### PR TITLE
fix(pos): refine cart item layout and promo display

### DIFF
--- a/components/pos/CartItem.vue
+++ b/components/pos/CartItem.vue
@@ -1,143 +1,149 @@
 <template>
-  <div class="rounded-2xl border-2 border-violet-200 bg-violet-50/80 p-5 theme-transition dark:border-violet-800/50 dark:bg-violet-950/20">
+  <div class="overflow-hidden rounded-xl border border-border bg-surface theme-transition">
 
-    <!-- Header: badge + name/status + price -->
-    <div class="flex items-start gap-3">
-      <div class="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary text-base font-bold text-primary-foreground">
-        {{ orderNumber }}
-      </div>
-
-      <div class="min-w-0 flex-1">
-        <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
-          <p class="text-lg font-bold leading-7 text-text-primary">{{ item.product.name }}</p>
-
-          <span
-            v-if="item.fulfillmentStatus === 'new' && showFulfillmentStatus"
-            class="rounded px-3 py-0.5 text-sm font-semibold uppercase tracking-tight text-amber-600 bg-amber-100 dark:bg-amber-900/30 dark:text-amber-400"
-          >Sin enviar</span>
-          <span
-            v-else-if="item.fulfillmentStatus && item.fulfillmentStatus !== 'new'"
-            class="rounded px-3 py-0.5 text-sm font-semibold uppercase tracking-tight"
-            :class="{
-              'bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400': item.fulfillmentStatus === 'sent',
-              'bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400': item.fulfillmentStatus === 'preparing',
-              'bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400': item.fulfillmentStatus === 'ready',
-              'bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400': item.fulfillmentStatus === 'delivered' || item.fulfillmentStatus === 'cancelled',
-            }"
-          >
-            {{
-              item.fulfillmentStatus === 'sent' ? 'En cocina' :
-              item.fulfillmentStatus === 'preparing' ? 'Preparando' :
-              item.fulfillmentStatus === 'ready' ? 'Listo' :
-              item.fulfillmentStatus === 'delivered' ? 'Entregado' : item.fulfillmentStatus
-            }}
-          </span>
-
-          <span
-            v-if="promoLabel"
-            class="rounded px-3 py-0.5 text-sm font-semibold text-white bg-emerald-500 flex-shrink-0"
-            :title="promoTitle || promoLabel"
-          >{{ promoLabel }}</span>
+    <!-- Contenido -->
+    <div class="px-3 pt-2.5 pb-2">
+      <div class="flex items-start gap-2">
+        <div class="inline-flex h-6 min-w-[1.5rem] flex-none items-center justify-center rounded-full bg-primary px-1 text-[11px] font-bold leading-none tabular-nums text-primary-foreground">
+          {{ orderNumber }}
         </div>
 
-        <p v-if="item.sentAt" class="mt-0.5 text-xs text-text-tertiary">Fuego: {{ formatTime(item.sentAt) }}</p>
+        <div class="min-w-0 flex-1">
+          <!-- Fila 1: nombre + badges inline | stack de precios -->
+          <div class="flex items-start justify-between gap-2">
+            <div class="min-w-0 flex-1">
+              <div class="flex flex-wrap items-center gap-x-1.5 gap-y-1">
+                <p class="text-sm font-medium leading-snug text-text-primary">
+                  {{ item.product.name }}
+                </p>
+                <span
+                  v-if="item.fulfillmentStatus === 'new' && showFulfillmentStatus"
+                  class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-amber-700 bg-amber-100 dark:bg-amber-900/30 dark:text-amber-400"
+                >Sin enviar</span>
+                <span
+                  v-else-if="item.fulfillmentStatus && item.fulfillmentStatus !== 'new'"
+                  class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide"
+                  :class="{
+                    'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400': item.fulfillmentStatus === 'sent',
+                    'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400': item.fulfillmentStatus === 'preparing',
+                    'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400': item.fulfillmentStatus === 'ready',
+                    'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400': item.fulfillmentStatus === 'delivered' || item.fulfillmentStatus === 'cancelled',
+                  }"
+                >
+                  {{
+                    item.fulfillmentStatus === 'sent' ? 'En cocina' :
+                    item.fulfillmentStatus === 'preparing' ? 'Preparando' :
+                    item.fulfillmentStatus === 'ready' ? 'Listo' :
+                    item.fulfillmentStatus === 'delivered' ? 'Entregado' : item.fulfillmentStatus
+                  }}
+                </span>
+                <span
+                  v-if="promoLabel"
+                  class="shrink-0 max-w-full rounded px-2 py-0.5 text-[10px] font-semibold leading-tight text-white bg-emerald-500"
+                  :title="promoTitle || promoLabel"
+                >{{ promoLabel }}</span>
+              </div>
+              <p v-if="item.sentAt" class="mt-0.5 text-[10px] text-text-tertiary">Fuego: {{ formatTime(item.sentAt) }}</p>
+            </div>
 
-        <div class="mt-1 flex flex-wrap items-center gap-2">
-          <template v-if="promoSavings > 0 && item.quantity > 0">
-            <span class="text-base line-through text-text-tertiary tabular-nums">{{ formatCurrency(unitGross) }}</span>
-            <span class="text-base font-semibold text-text-secondary tabular-nums">{{ formatCurrency(unitNet) }} c/u</span>
-          </template>
-          <span v-else class="text-base font-semibold text-text-secondary tabular-nums">
-            {{ formatCurrency(Number(item.product.price)) }} c/u
-          </span>
-        </div>
-
-        <div v-if="item.modifiers.length > 0 || item.notes" class="mt-1.5 space-y-0.5">
-          <div v-for="mod in item.modifiers" :key="mod.id" class="flex justify-between gap-2 text-sm">
-            <span class="text-text-tertiary">+ {{ mod.name }}<template v-if="(mod.quantity ?? 1) > 1"> ×{{ mod.quantity }}</template></span>
-            <span class="shrink-0 tabular-nums text-text-secondary">{{ formatCurrency(Number(mod.price) * (mod.quantity ?? 1)) }}</span>
+            <div class="shrink-0 text-right leading-tight">
+              <p
+                v-if="promoSavings > 0"
+                class="text-[11px] line-through text-text-tertiary tabular-nums"
+              >{{ formatCurrency(displayGrossTotal) }}</p>
+              <p
+                class="text-sm font-bold tabular-nums"
+                :class="promoSavings > 0 ? 'text-primary' : 'text-text-primary'"
+              >{{ formatCurrency(netTotal) }}</p>
+              <p
+                v-if="promoSavings > 0"
+                class="mt-0.5 text-[10px] font-semibold tabular-nums text-emerald-600 dark:text-emerald-400"
+              >-{{ formatCurrency(promoSavings) }}</p>
+            </div>
           </div>
-          <p v-if="item.notes" class="text-sm italic text-text-tertiary">Nota: {{ item.notes }}</p>
-        </div>
-      </div>
 
-      <div class="ml-1 flex shrink-0 flex-col items-end">
-        <p
-          v-if="promoSavings > 0"
-          class="text-lg line-through text-text-tertiary tabular-nums"
-        >{{ formatCurrency(displayGrossTotal) }}</p>
-        <p class="text-2xl font-bold tabular-nums text-primary">{{ formatCurrency(netTotal) }}</p>
-        <p
-          v-if="promoSavings > 0"
-          class="text-sm font-semibold tabular-nums text-emerald-500"
-        >-{{ formatCurrency(promoSavings) }}</p>
+          <!-- Fila 2: precio unitario (Figma: tachado + neto c/u) -->
+          <p class="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0 text-xs tabular-nums">
+            <template v-if="promoSavings > 0 && item.quantity > 0">
+              <span class="line-through text-text-tertiary">{{ formatCurrency(unitGross) }}</span>
+              <span class="font-semibold text-text-secondary">{{ formatCurrency(unitNet) }} c/u</span>
+            </template>
+            <span v-else class="font-semibold text-text-secondary">{{ formatCurrency(Number(item.product.price)) }} c/u</span>
+          </p>
+
+          <div v-if="item.modifiers.length > 0 || item.notes" class="mt-1 space-y-0.5">
+            <div v-for="mod in item.modifiers" :key="mod.id" class="flex justify-between gap-2 text-[11px]">
+              <span class="min-w-0 truncate text-text-tertiary">+ {{ mod.name }}<template v-if="(mod.quantity ?? 1) > 1"> ×{{ mod.quantity }}</template></span>
+              <span class="shrink-0 tabular-nums text-text-secondary">{{ formatCurrency(Number(mod.price) * (mod.quantity ?? 1)) }}</span>
+            </div>
+            <p v-if="item.notes" class="text-[11px] italic text-text-tertiary">Nota: {{ item.notes }}</p>
+          </div>
+        </div>
       </div>
     </div>
 
-    <!-- Controls: qty stepper + actions -->
-    <div v-if="!hideLineControls" class="mt-3 flex items-center gap-2">
-      <div class="flex items-center rounded-[14px] border-2 border-border bg-white p-0.5 dark:bg-surface">
+    <!-- Barra de acciones -->
+    <div
+      v-if="!hideLineControls"
+      class="flex items-center justify-between gap-2 border-t border-border bg-surface-secondary/30 px-2.5 py-1.5"
+    >
+      <div class="flex h-8 items-stretch rounded-lg border border-border bg-surface max-lg:h-11">
         <button
           type="button"
-          class="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-xl text-text-tertiary transition-colors hover:bg-violet-50 disabled:cursor-not-allowed disabled:opacity-40"
+          class="cart-item-tool rounded-l-lg text-text-secondary transition-colors hover:bg-primary/5 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
           :disabled="item.quantity <= 1"
           aria-label="Reducir cantidad"
           @click.stop="$emit('decrement')"
         >
-          <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M20 12H4" />
-          </svg>
+          <MinusIcon class="cart-item-icon" aria-hidden="true" />
         </button>
-        <span class="min-w-[2.5rem] text-center text-xl font-bold tabular-nums text-text-primary">{{ item.quantity }}</span>
+        <span class="flex min-w-[1.75rem] items-center justify-center border-x border-border px-1 text-xs font-semibold tabular-nums text-text-primary">
+          {{ item.quantity }}
+        </span>
         <button
           v-if="!lockIncrement"
           type="button"
-          class="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-xl text-text-tertiary transition-colors hover:bg-violet-50"
+          class="cart-item-tool rounded-r-lg text-text-secondary transition-colors hover:bg-primary/5 hover:text-text-primary"
           aria-label="Aumentar cantidad"
           @click.stop="$emit('increment')"
         >
-          <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
-          </svg>
+          <PlusIcon class="cart-item-icon" aria-hidden="true" />
         </button>
+        <span
+          v-else
+          class="cart-item-tool rounded-r-lg"
+          aria-hidden="true"
+        />
       </div>
 
-      <div class="flex-1" />
-
-      <div class="flex items-center gap-2">
+      <div class="flex items-center gap-1">
         <button
           v-if="!hideDuplicate"
           type="button"
-          class="flex min-h-[48px] min-w-[48px] items-center justify-center rounded-[14px] border-2 border-violet-200 bg-white text-primary transition-colors hover:bg-violet-50 dark:border-violet-800 dark:bg-surface"
+          class="cart-item-tool rounded-lg text-text-secondary transition-colors hover:bg-primary/10 hover:text-primary"
           aria-label="Duplicar ítem"
           @click.stop="$emit('duplicate')"
         >
-          <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75" />
-          </svg>
+          <DocumentDuplicateIcon class="cart-item-icon" aria-hidden="true" />
         </button>
 
         <button
           v-if="!hideEdit && !item.is_resale && !item.is_open_sale"
           type="button"
-          class="flex min-h-[48px] min-w-[48px] items-center justify-center rounded-[14px] border-2 border-violet-200 bg-white text-primary transition-colors hover:bg-violet-50 dark:border-violet-800 dark:bg-surface"
+          class="cart-item-tool rounded-lg text-text-secondary transition-colors hover:bg-primary/10 hover:text-primary"
           aria-label="Editar ítem"
           @click.stop="$emit('edit')"
         >
-          <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
-          </svg>
+          <PencilSquareIcon class="cart-item-icon" aria-hidden="true" />
         </button>
 
         <button
           type="button"
-          class="flex min-h-[48px] min-w-[48px] items-center justify-center rounded-[14px] border-2 border-red-200 bg-white text-red-500 transition-colors hover:bg-red-50 dark:border-red-900/40 dark:bg-surface"
+          class="cart-item-tool rounded-lg text-text-secondary transition-colors hover:bg-destructive/10 hover:text-destructive"
           aria-label="Eliminar ítem"
           @click.stop="$emit('remove')"
         >
-          <svg class="size-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-          </svg>
+          <TrashIcon class="cart-item-icon" aria-hidden="true" />
         </button>
       </div>
     </div>
@@ -147,6 +153,13 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import {
+  MinusIcon,
+  PlusIcon,
+  PencilSquareIcon,
+  DocumentDuplicateIcon,
+  TrashIcon,
+} from '@heroicons/vue/24/outline'
 
 interface CartItem {
   product: {
@@ -171,18 +184,12 @@ interface Props {
   showFulfillmentStatus?: boolean
   promoLabel?: string | null
   promoTitle?: string | null
-  /** COP discount for this line (from API preview or client eval). */
   promoSavings?: number
-  /** When set, overrides computed gross (e.g. mesa tab subtotal). */
   grossTotal?: number | null
-  /** Tab lines: hide edit/duplicate (modifiers locked once on the tab). */
   hideEdit?: boolean
   hideDuplicate?: boolean
-  /** @deprecated use hideEdit / hideDuplicate */
   hideEditDuplicate?: boolean
-  /** Fired to kitchen: block qty + (edit/duplicate via hideEditDuplicate). */
   lockIncrement?: boolean
-  /** Hide entire action row (e.g. delivered/cancelled). */
   hideLineControls?: boolean
 }
 
@@ -253,3 +260,31 @@ const formatTime = (isoString: string) => {
   })
 }
 </script>
+
+<style scoped>
+.cart-item-tool {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+}
+
+.cart-item-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+@media (max-width: 1023px) {
+  .cart-item-tool {
+    width: 2.75rem;
+    height: 2.75rem;
+  }
+
+  .cart-item-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+}
+</style>

--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="flex flex-col min-h-0 h-full lg:w-96 border border-border rounded-3xl bg-surface overflow-hidden shadow-lg">
+  <div class="flex flex-col min-h-0 h-full lg:w-96 border border-border rounded-2xl bg-surface overflow-hidden shadow-sm">
     <!-- Cart Header -->
-    <div class="px-6 py-6 border-b border-border bg-surface">
-      <div class="flex items-center justify-between gap-3">
-        <h2 class="text-2xl font-bold text-text-primary tracking-tight sm:text-3xl">Orden Actual</h2>
-        <span class="rounded-full bg-violet-100 px-4 py-2 text-base font-semibold text-primary dark:bg-violet-900/30">
+    <div class="px-4 py-3.5 border-b border-border bg-surface">
+      <div class="flex items-center justify-between gap-2">
+        <h2 class="text-sm font-bold text-text-primary tracking-wide">Orden Actual</h2>
+        <span class="rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-semibold text-primary">
           {{ displayItemCount }} {{ displayItemCount === 1 ? 'ítem' : 'ítems' }}
         </span>
       </div>
@@ -56,24 +56,24 @@
     </div>
 
     <!-- Items list: tab items (committed) + current cart items -->
-    <div class="flex-1 min-h-0 overflow-y-auto overscroll-y-contain p-6 space-y-4">
+    <div class="flex-1 min-h-0 overflow-y-auto overscroll-y-contain p-4 space-y-2.5">
 
       <!-- Skeleton while loading tab items, adding to tab, or clearing -->
       <template v-if="isLoadingTabItems || isAddingToTab || isClearingTab">
-        <div v-for="n in 3" :key="n" class="rounded-2xl border-2 border-violet-200 bg-violet-50/80 p-5 animate-pulse">
-          <div class="flex items-start gap-3">
-            <div class="size-10 rounded-full bg-surface-secondary shrink-0" />
-            <div class="flex-1 space-y-2">
-              <div class="h-5 bg-surface-secondary rounded w-3/4" />
-              <div class="h-4 bg-surface-secondary rounded w-1/3" />
+        <div v-for="n in 3" :key="n" class="rounded-xl border border-border bg-surface-secondary/40 p-3 animate-pulse">
+          <div class="flex items-start gap-2">
+            <div class="h-7 w-7 shrink-0 rounded-full bg-surface-secondary" />
+            <div class="flex-1 space-y-1.5">
+              <div class="h-3.5 bg-surface-secondary rounded w-3/4" />
+              <div class="h-2.5 bg-surface-secondary rounded w-1/3" />
             </div>
-            <div class="h-7 bg-surface-secondary rounded w-16 shrink-0" />
+            <div class="h-3.5 bg-surface-secondary rounded w-12 shrink-0" />
           </div>
-          <div class="mt-3 flex items-center gap-2">
-            <div class="h-12 w-28 bg-surface-secondary rounded-[14px]" />
+          <div class="mt-2.5 pl-9 flex items-center gap-1.5">
+            <div class="h-9 w-20 bg-surface-secondary rounded-lg" />
             <div class="flex-1" />
-            <div class="size-12 bg-surface-secondary rounded-[14px]" />
-            <div class="size-12 bg-surface-secondary rounded-[14px]" />
+            <div class="h-11 w-11 bg-surface-secondary rounded-lg" />
+            <div class="h-11 w-11 bg-surface-secondary rounded-lg" />
           </div>
         </div>
       </template>
@@ -128,7 +128,7 @@
         <!-- Loading overlay — only while that line is mutating -->
         <div
           v-if="tabItemsLoading.has(item.orderItemId)"
-          class="absolute inset-0 z-20 rounded-2xl bg-surface/70 flex items-center justify-center backdrop-blur-[1px] pointer-events-auto"
+          class="absolute inset-0 z-20 rounded-xl bg-surface/70 flex items-center justify-center backdrop-blur-[1px] pointer-events-auto"
           aria-hidden="true"
         >
           <UiLoadingDots size="9px" />
@@ -136,9 +136,9 @@
       </div>
 
       <!-- Divider when there are both tab items and new cart items -->
-      <div v-if="mesaMode && tabItems.length > 0 && items.length > 0" class="flex items-center gap-4 py-2">
+      <div v-if="mesaMode && tabItems.length > 0 && items.length > 0" class="flex items-center gap-2 py-1">
         <div class="flex-1 h-px bg-border" />
-        <span class="text-sm font-semibold text-text-secondary uppercase tracking-wide flex-shrink-0">Por agregar</span>
+        <span class="text-[10px] font-bold text-text-tertiary uppercase tracking-widest flex-shrink-0">Por agregar</span>
         <div class="flex-1 h-px bg-border" />
       </div>
 
@@ -173,23 +173,23 @@
     </div>
 
     <!-- Cart Footer -->
-    <div class="flex-shrink-0 border-t-2 border-border bg-surface-secondary/60 px-6 py-6 space-y-4">
+    <div class="flex-shrink-0 px-4 py-4 border-t border-border space-y-3 bg-surface-secondary/40">
       <!-- Total — net after line promos (#1022) -->
       <div
         v-if="orderPromoSavings > 0"
-        class="flex items-center justify-between text-base"
+        class="flex items-center justify-between text-xs"
       >
-        <span class="font-medium text-text-secondary">Descuentos promoción</span>
-        <span class="font-semibold text-emerald-500 tabular-nums">-{{ formatCurrency(orderPromoSavings) }}</span>
+        <span class="font-medium text-text-tertiary">Descuentos promoción</span>
+        <span class="font-semibold text-emerald-700 dark:text-emerald-400 tabular-nums">-{{ formatCurrency(orderPromoSavings) }}</span>
       </div>
-      <div class="flex items-center justify-between pt-1">
-        <span class="text-2xl font-bold uppercase tracking-tight text-text-secondary">Total</span>
+      <div class="flex items-center justify-between">
+        <span class="text-xs font-semibold text-text-tertiary uppercase tracking-widest">Total</span>
         <div class="flex flex-col items-end">
           <span
             v-if="orderPromoSavings > 0"
-            class="text-2xl line-through text-text-tertiary tabular-nums"
+            class="text-sm text-text-tertiary line-through tabular-nums"
           >{{ formatCurrency(grossOrderTotal) }}</span>
-          <span class="text-4xl font-black text-text-primary tabular-nums leading-none">{{ formatCurrency(netOrderTotal) }}</span>
+          <span class="text-3xl font-black text-text-primary tabular-nums">{{ formatCurrency(netOrderTotal) }}</span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Fix order badge collapse (Tailwind 3.3: no `size-*` utilities)
- Compact toolbar with proportional Heroicons
- Promo pill inline with product name; price stack matches Figma order
- Revert CartPanel header/footer to sidebar scale

## Test plan
- [ ] Desktop cart sidebar: badge circle, promo line, unit price row
- [ ] Mobile bottom sheet: 44px touch targets on toolbar

Made with [Cursor](https://cursor.com)