### PR TITLE
Componentize stock inventory views

### DIFF
--- a/components/inventario/StockInventoryView.vue
+++ b/components/inventario/StockInventoryView.vue
@@ -1,0 +1,440 @@
+<template>
+  <div class="flex flex-col gap-3 md:gap-4">
+    <UiStats>
+      <UiStatsCard
+        :label="copy.statsTotal"
+        :value="stats.total_ingredients"
+        icon="beaker"
+      />
+      <UiStatsCard
+        label="Stock Bajo"
+        :value="stats.low_stock_count"
+        icon="exclamation"
+      />
+      <UiStatsCard
+        label="Stock Crítico"
+        :value="stats.critical_count"
+        icon="exclamation-circle"
+      />
+      <UiStatsCard
+        label="Valor Total"
+        :value="formatCurrency(stats.total_inventory_value)"
+        icon="currency-dollar"
+      />
+    </UiStats>
+
+    <UiAdvancedFiltersBar
+      :search="search"
+      :search-fields="[]"
+      :search-placeholder="copy.searchPlaceholder"
+      :show-date-range="false"
+      :show-clear="hasActiveFilters"
+      @update:search="$emit('update:search', $event)"
+      @search="$emit('search')"
+      @clear="$emit('clear')"
+    >
+      <template #additional-filters>
+        <select
+          :value="categoryFilter"
+          :class="filterSelectClass"
+          aria-label="Filtrar por categoría"
+          @change="$emit('update:categoryFilter', ($event.target as HTMLSelectElement).value)"
+        >
+          <option value="">Categoría</option>
+          <option v-for="category in categories" :key="category" :value="category">
+            {{ category }}
+          </option>
+        </select>
+
+        <select
+          :value="statusFilter"
+          :class="filterSelectClass"
+          aria-label="Filtrar por estado"
+          @change="$emit('update:statusFilter', ($event.target as HTMLSelectElement).value)"
+        >
+          <option value="all">Estado</option>
+          <option v-for="option in statusOptions" :key="option.value" :value="option.value">
+            {{ option.label }}
+          </option>
+        </select>
+
+        <select
+          :value="unitFilter"
+          :class="filterSelectClass"
+          aria-label="Filtrar por unidad"
+          @change="$emit('update:unitFilter', ($event.target as HTMLSelectElement).value)"
+        >
+          <option value="">Unidad</option>
+          <option v-for="unit in units" :key="unit" :value="unit">
+            {{ unit }}
+          </option>
+        </select>
+
+        <slot name="filter-actions" />
+      </template>
+    </UiAdvancedFiltersBar>
+
+    <HealthSemaphore :is-unlocked="true" title="Stock de Inventario">
+      <UiResponsiveDataView
+        row-size="sm"
+        :columns="stockTableColumns"
+        :data="inventory"
+        :sort-field="sortField"
+        :sort-direction="sortDirection"
+        :empty-message="copy.emptyMessage"
+        empty-sub-message="Comienza recibiendo compras en Abastecimiento"
+        variant="default"
+        @sort="$emit('sort', $event)"
+      >
+        <template #card="{ item, index }">
+          <div
+            class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-surface-secondary"
+            :class="index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'"
+          >
+            <div class="flex-1 min-w-0">
+              <span class="text-sm font-bold text-text-primary">{{ item.ingredient_name }}</span>
+              <p class="text-xs text-text-secondary mt-0.5">
+                {{ mobileSubtitle(item) }}
+              </p>
+            </div>
+            <div class="flex items-center gap-2 flex-shrink-0">
+              <div class="flex flex-col items-end gap-1.5">
+                <span
+                  class="text-sm font-bold tabular-nums"
+                  :class="highlightNegativeStock && item.current_stock < 0 ? 'text-destructive' : 'text-text-primary'"
+                >
+                  {{ formatNumber(item.current_stock) }}
+                </span>
+                <UiStatusBadge
+                  :value="getStatusLabel(item.status)"
+                  :variant="getStockVariant(item.status)"
+                  size="sm"
+                  format="text"
+                />
+              </div>
+              <button
+                type="button"
+                title="Ajustar stock"
+                class="w-7 h-7 flex items-center justify-center rounded bg-surface-secondary border border-border text-text-secondary hover:text-primary transition-colors"
+                @click.stop="navigateToAdjustment(item.ingredient_id)"
+              >
+                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </template>
+
+        <template #cell-ingredient_name="{ value }">
+          <span class="text-sm font-bold text-text-primary">{{ value }}</span>
+        </template>
+
+        <template #cell-unit="{ value }">
+          <span class="text-sm text-text-secondary">{{ value }}</span>
+        </template>
+
+        <template #cell-current_stock="{ value }">
+          <span
+            class="text-sm font-bold tabular-nums"
+            :class="highlightNegativeStock && value < 0 ? 'text-destructive' : 'text-text-primary'"
+          >
+            {{ formatNumber(value) }}
+          </span>
+        </template>
+
+        <template #cell-minimum_stock="{ value }">
+          <span class="text-sm text-text-primary">{{ formatNumber(value) }}</span>
+        </template>
+
+        <template #cell-maximum_stock="{ value }">
+          <span class="text-sm text-text-primary">{{ value ? formatNumber(value) : '-' }}</span>
+        </template>
+
+        <template #cell-stock_percentage="{ row }">
+          <div v-if="row.maximum_stock" class="w-full bg-surface-secondary rounded-full h-2">
+            <div
+              class="h-2 rounded-full transition-all"
+              :class="{
+                'bg-destructive': getStockVariant(row.status) === 'destructive',
+                'bg-warning': getStockVariant(row.status) === 'warning',
+                'bg-success': getStockVariant(row.status) === 'success'
+              }"
+              :style="{ width: `${Math.min(getStockPercentage(row.current_stock, row.maximum_stock), 100)}%` }"
+            />
+          </div>
+          <span v-else class="text-xs text-text-secondary">-</span>
+        </template>
+
+        <template #cell-unit_cost="{ value }">
+          <span class="text-sm font-bold text-primary">{{ value ? formatCurrency(value) : '-' }}</span>
+        </template>
+
+        <template #cell-total_value="{ value }">
+          <span class="text-sm font-bold text-primary">{{ formatCurrency(value) }}</span>
+        </template>
+
+        <template #cell-status="{ value }">
+          <UiStatusBadge
+            :label="getStatusLabel(value)"
+            :variant="getStockVariant(value)"
+          />
+        </template>
+
+        <template #cell-actions="{ row }">
+          <div class="flex justify-center gap-1">
+            <button
+              v-if="movementsPath"
+              type="button"
+              title="Ver movimientos"
+              aria-label="Ver movimientos"
+              class="p-1.5 rounded-md hover:bg-surface-secondary transition-colors text-text-secondary hover:text-primary"
+              @click="navigateTo(`${movementsPath}?ingredient_id=${row.ingredient_id}`)"
+            >
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              title="Ajustar stock"
+              aria-label="Ajustar stock"
+              class="p-1.5 rounded-md hover:bg-surface-secondary transition-colors text-primary"
+              @click="navigateToAdjustment(row.ingredient_id)"
+            >
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+              </svg>
+            </button>
+          </div>
+        </template>
+      </UiResponsiveDataView>
+
+      <div
+        v-if="total > itemsPerPage"
+        class="mt-4 bg-white px-4 py-3 flex items-center justify-between border border-titan-200 rounded-lg"
+      >
+        <p class="text-sm text-titan-700">
+          Mostrando <span class="font-medium">{{ startItem }}</span> a
+          <span class="font-medium">{{ endItem }}</span> de
+          <span class="font-medium">{{ total }}</span>
+        </p>
+        <div class="flex gap-2">
+          <button
+            type="button"
+            :disabled="!canGoPrevious"
+            class="px-4 py-2 border border-titan-300 text-sm rounded-md disabled:opacity-50"
+            @click="$emit('previous-page')"
+          >
+            Anterior
+          </button>
+          <button
+            type="button"
+            :disabled="!canGoNext"
+            class="px-4 py-2 border border-titan-300 text-sm rounded-md disabled:opacity-50"
+            @click="$emit('next-page')"
+          >
+            Siguiente
+          </button>
+        </div>
+      </div>
+    </HealthSemaphore>
+  </div>
+</template>
+
+<script setup lang="ts">
+// @ts-ignore
+import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
+
+interface StockStats {
+  total_ingredients: number
+  critical_count: number
+  low_stock_count: number
+  total_inventory_value: number
+}
+
+interface StockStatusOption {
+  value: string
+  label: string
+  variant: string
+}
+
+interface StockCopy {
+  statsTotal: string
+  searchPlaceholder: string
+  emptyMessage: string
+  ingredientColumn: string
+}
+
+interface StockItem {
+  ingredient_id: string
+  ingredient_name: string
+  unit: string
+  category?: string
+  current_stock: number
+  minimum_stock: number
+  maximum_stock?: number | null
+  unit_cost?: number | null
+  total_value: number
+  status: string
+}
+
+const props = withDefaults(defineProps<{
+  stats: StockStats
+  inventory: StockItem[]
+  total: number
+  itemsPerPage: number
+  startItem: number
+  endItem: number
+  canGoPrevious: boolean
+  canGoNext: boolean
+  search: string
+  hasActiveFilters: boolean
+  categories: string[]
+  units: string[]
+  categoryFilter: string
+  statusFilter: string
+  unitFilter: string
+  sortField: string
+  sortDirection: 'asc' | 'desc'
+  adjustmentPath: string
+  movementsPath?: string
+  copy: StockCopy
+  statusOptions: StockStatusOption[]
+  showMobileStockLimits?: boolean
+  highlightNegativeStock?: boolean
+}>(), {
+  movementsPath: '',
+  showMobileStockLimits: false,
+  highlightNegativeStock: false,
+})
+
+defineEmits<{
+  'update:search': [value: string]
+  'update:categoryFilter': [value: string]
+  'update:statusFilter': [value: string]
+  'update:unitFilter': [value: string]
+  search: []
+  clear: []
+  sort: [field: string]
+  'previous-page': []
+  'next-page': []
+}>()
+
+const filterSelectClass = 'h-10 min-h-[44px] px-3 rounded-lg border border-border bg-surface text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 flex-shrink-0'
+
+const stockTableColumns = computed(() => [
+  {
+    key: 'ingredient_name',
+    title: props.copy.ingredientColumn,
+    sortable: true,
+    format: 'text',
+    align: 'left',
+  },
+  {
+    key: 'unit',
+    title: 'Unidad',
+    sortable: false,
+    format: 'text',
+    align: 'left',
+  },
+  {
+    key: 'current_stock',
+    title: 'Stock Actual',
+    sortable: true,
+    format: 'number',
+    align: 'right',
+  },
+  {
+    key: 'minimum_stock',
+    title: 'Stock Mín',
+    sortable: true,
+    format: 'number',
+    align: 'right',
+  },
+  {
+    key: 'maximum_stock',
+    title: 'Stock Máx',
+    sortable: true,
+    format: 'number',
+    align: 'right',
+  },
+  {
+    key: 'stock_percentage',
+    title: '% Stock',
+    sortable: false,
+    format: 'custom',
+    align: 'center',
+  },
+  {
+    key: 'unit_cost',
+    title: 'Costo Unit.',
+    sortable: true,
+    format: 'currency',
+    align: 'right',
+  },
+  {
+    key: 'total_value',
+    title: 'Valor Total',
+    sortable: true,
+    format: 'currency',
+    align: 'right',
+  },
+  {
+    key: 'status',
+    title: 'Estado',
+    sortable: true,
+    format: 'badge',
+    align: 'center',
+  },
+  {
+    key: 'actions',
+    title: 'Acciones',
+    sortable: false,
+    format: 'custom',
+    align: 'center',
+  },
+])
+
+const getStockPercentage = (current: number, max: number) => {
+  if (!max || max === 0) return 0
+  return Math.round((current / max) * 100)
+}
+
+const getStatusOption = (status: string) =>
+  props.statusOptions.find(option => option.value === status)
+
+const getStockVariant = (status: string) =>
+  getStatusOption(status)?.variant || 'default'
+
+const getStatusLabel = (status: string) =>
+  getStatusOption(status)?.label || status
+
+const mobileSubtitle = (item: StockItem) => {
+  if (!props.showMobileStockLimits) return item.unit
+
+  const maxLabel = item.maximum_stock
+    ? ` · máx ${formatNumber(item.maximum_stock)}`
+    : ''
+  return `${item.unit} · mín ${formatNumber(item.minimum_stock)}${maxLabel}`
+}
+
+const navigateToAdjustment = (ingredientId: string) => {
+  navigateTo(`${props.adjustmentPath}?ingredientId=${ingredientId}`)
+}
+
+const formatCurrency = (value: number) => {
+  return new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    minimumFractionDigits: 0,
+  }).format(value)
+}
+
+const formatNumber = (value: number) => {
+  return new Intl.NumberFormat('es-CO', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+</script>

--- a/pages/abastecimiento/stock.vue
+++ b/pages/abastecimiento/stock.vue
@@ -5,253 +5,51 @@
       <CommonsTheCustomLoader size="large" />
     </div>
 
-    <!-- Main Content -->
-    <div v-else class="flex flex-col gap-3 md:gap-4">
-      <!-- Stats Cards -->
-      <UiStats>
-        <UiStatsCard
-          :label="WAREHOUSE_COPY.stockStatsTotal"
-          :value="stats.total_ingredients"
-          icon="beaker"
-        />
-        <UiStatsCard
-          label="Stock Bajo"
-          :value="stats.low_stock_count"
-          icon="exclamation"
-        />
-        <UiStatsCard
-          label="Stock Crítico"
-          :value="stats.critical_count"
-          icon="exclamation-circle"
-        />
-        <UiStatsCard
-          label="Valor Total"
-          :value="formatCurrency(stats.total_inventory_value)"
-          icon="currency-dollar"
-        />
-      </UiStats>
-
-      <UiAdvancedFiltersBar
-        v-model:search="localSearchTerm"
-        :search-fields="[]"
-        :search-placeholder="WAREHOUSE_COPY.stockSearchPlaceholder"
-        :show-date-range="false"
-        :show-clear="hasActiveFilters"
-        @search="performSearch"
-        @clear="clearFilters"
-      >
-        <template #additional-filters>
-          <select
-            v-model="categoryFilter"
-            :class="filterSelectClass"
-            aria-label="Filtrar por categoría"
-          >
-            <option value="">Categoría</option>
-            <option v-for="category in categories" :key="category" :value="category">
-              {{ category }}
-            </option>
-          </select>
-
-          <select
-            v-model="statusFilter"
-            :class="filterSelectClass"
-            aria-label="Filtrar por estado"
-            @change="currentPage = 1"
-          >
-            <option value="all">Estado</option>
-            <option value="negative">Crítico</option>
-            <option value="low">Bajo</option>
-            <option value="ok">Normal</option>
-          </select>
-
-          <select
-            v-model="unitFilter"
-            :class="filterSelectClass"
-            aria-label="Filtrar por unidad"
-          >
-            <option value="">Unidad</option>
-            <option v-for="unit in units" :key="unit" :value="unit">
-              {{ unit }}
-            </option>
-          </select>
-
-          <button
-            type="button"
-            title="Ajustar stock"
-            @click="showAdjustmentPanel = true"
-            class="min-h-[44px] h-10 px-3 inline-flex items-center gap-1.5 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 transition-colors flex-shrink-0"
-          >
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
-            </svg>
-            <span class="hidden sm:inline">Ajustar stock</span>
-          </button>
-        </template>
-      </UiAdvancedFiltersBar>
-
-      <!-- Responsive Data View -->
-      <HealthSemaphore :is-unlocked="true" title="Stock de Inventario">
-      <UiResponsiveDataView
-        :columns="stockTableColumns"
-        :data="displayInventory"
-        :sort-field="sortField"
-        :sort-direction="sortDirection"
-        @sort="handleSort"
-        :empty-message="WAREHOUSE_COPY.stockEmptyMessage"
-        empty-sub-message="Comienza recibiendo compras en Abastecimiento"
-        variant="default"
-        row-size="sm"
-      >
-        <!-- Mobile Card -->
-        <template #card="{ item, index }">
-          <div
-            class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-surface-secondary"
-            :class="index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'"
-          >
-            <div class="flex-1 min-w-0">
-              <span class="text-sm font-bold text-text-primary">{{ item.ingredient_name }}</span>
-              <p class="text-xs text-text-secondary mt-0.5">{{ item.unit }}</p>
-            </div>
-            <div class="flex items-center gap-2 flex-shrink-0">
-              <div class="flex flex-col items-end gap-1.5">
-                <p
-                  class="text-sm font-bold tabular-nums"
-                  :class="item.current_stock < 0 ? 'text-destructive' : 'text-text-primary'"
-                >
-                  {{ formatNumber(item.current_stock) }}
-                </p>
-                <UiStatusBadge
-                  :value="getStatusLabel(item.status)"
-                  :variant="getStockVariant(item.status)"
-                  size="sm"
-                  format="text"
-                />
-              </div>
-              <button
-                @click.stop="navigateTo(`/abastecimiento/ajustes/crear?ingredientId=${item.ingredient_id}`)"
-                title="Ajustar stock"
-                class="w-7 h-7 flex items-center justify-center rounded bg-surface-secondary border border-border text-text-secondary hover:text-primary transition-colors"
-              >
-                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
-                </svg>
-              </button>
-            </div>
-          </div>
-        </template>
-
-        <!-- Desktop Table Cells -->
-        <template #cell-ingredient_name="{ value }">
-          <span class="text-sm font-bold text-text-primary">{{ value }}</span>
-        </template>
-
-        <template #cell-unit="{ value }">
-          <span class="text-sm text-text-secondary">{{ value }}</span>
-        </template>
-
-        <template #cell-current_stock="{ value }">
-          <span
-            class="text-sm font-bold tabular-nums"
-            :class="value < 0 ? 'text-destructive' : 'text-text-primary'"
-          >
-            {{ formatNumber(value) }}
-          </span>
-        </template>
-
-        <template #cell-minimum_stock="{ value }">
-          <span class="text-sm text-text-primary">{{ formatNumber(value) }}</span>
-        </template>
-
-        <template #cell-maximum_stock="{ value }">
-          <span class="text-sm text-text-primary">{{ value ? formatNumber(value) : '-' }}</span>
-        </template>
-
-        <template #cell-stock_percentage="{ row }">
-          <div v-if="row.maximum_stock" class="w-full bg-surface-secondary rounded-full h-2">
-            <div
-              class="h-2 rounded-full transition-all"
-              :class="{
-                'bg-destructive': row.status === 'negative',
-                'bg-warning': row.status === 'low',
-                'bg-success': row.status === 'ok'
-              }"
-              :style="{ width: `${Math.min(getStockPercentage(row.current_stock, row.minimum_stock, row.maximum_stock), 100)}%` }"
-            />
-          </div>
-          <span v-else class="text-xs text-text-secondary">-</span>
-        </template>
-
-        <template #cell-unit_cost="{ value }">
-          <span class="text-sm font-bold text-primary">{{ value ? formatCurrency(value) : '-' }}</span>
-        </template>
-
-        <template #cell-total_value="{ value }">
-          <span class="text-sm font-bold text-primary">{{ formatCurrency(value) }}</span>
-        </template>
-
-        <template #cell-status="{ value, row }">
-          <UiStatusBadge
-            :label="getStatusLabel(value)"
-            :variant="getStockVariant(value)"
-          />
-        </template>
-
-        <template #cell-actions="{ row }">
-          <div class="flex justify-center gap-1">
-            <button
-              @click="navigateTo(`/abastecimiento/movimientos?ingredient_id=${row.ingredient_id}`)"
-              title="Ver movimientos"
-              aria-label="Ver movimientos"
-              class="p-1.5 rounded-md hover:bg-surface-secondary transition-colors text-text-secondary hover:text-primary"
-            >
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-              </svg>
-            </button>
-            <button
-              @click="navigateTo(`/abastecimiento/ajustes/crear?ingredientId=${row.ingredient_id}`)"
-              title="Ajustar stock"
-              aria-label="Ajustar stock"
-              class="p-1.5 rounded-md hover:bg-surface-secondary transition-colors text-primary"
-            >
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
-              </svg>
-            </button>
-          </div>
-        </template>
-      </UiResponsiveDataView>
-
-      <div
-        v-if="(inventoryData?.total ?? 0) > itemsPerPage"
-        class="mt-4 bg-white px-4 py-3 flex items-center justify-between border border-titan-200 rounded-lg"
-      >
-        <p class="text-sm text-titan-700">
-          Mostrando <span class="font-medium">{{ startItem }}</span> a
-          <span class="font-medium">{{ endItem }}</span> de
-          <span class="font-medium">{{ inventoryData?.total ?? 0 }}</span>
-        </p>
-        <div class="flex gap-2">
-          <button
-            type="button"
-            :disabled="!canGoPrevious"
-            class="px-4 py-2 border border-titan-300 text-sm rounded-md disabled:opacity-50"
-            @click="previousPage"
-          >
-            Anterior
-          </button>
-          <button
-            type="button"
-            :disabled="!canGoNext"
-            class="px-4 py-2 border border-titan-300 text-sm rounded-md disabled:opacity-50"
-            @click="nextPage"
-          >
-            Siguiente
-          </button>
-        </div>
-      </div>
-      </HealthSemaphore>
-    </div>
+    <InventarioStockInventoryView
+      v-else
+      v-model:search="localSearchTerm"
+      v-model:category-filter="categoryFilter"
+      v-model:unit-filter="unitFilter"
+      :status-filter="statusFilter"
+      :stats="stats"
+      :inventory="displayInventory"
+      :total="inventoryData?.total ?? 0"
+      :items-per-page="itemsPerPage"
+      :start-item="startItem"
+      :end-item="endItem"
+      :can-go-previous="canGoPrevious"
+      :can-go-next="canGoNext"
+      :has-active-filters="hasActiveFilters"
+      :categories="categories"
+      :units="units"
+      :sort-field="sortField"
+      :sort-direction="sortDirection"
+      adjustment-path="/abastecimiento/ajustes/crear"
+      movements-path="/abastecimiento/movimientos"
+      :copy="stockCopy"
+      :status-options="stockStatusOptions"
+      highlight-negative-stock
+      @update:status-filter="updateStatusFilter"
+      @search="performSearch"
+      @clear="clearFilters"
+      @sort="handleSort"
+      @previous-page="previousPage"
+      @next-page="nextPage"
+    >
+      <template #filter-actions>
+        <button
+          type="button"
+          title="Ajustar stock"
+          class="min-h-[44px] h-10 px-3 inline-flex items-center gap-1.5 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 transition-colors flex-shrink-0"
+          @click="showAdjustmentPanel = true"
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+          </svg>
+          <span class="hidden sm:inline">Ajustar stock</span>
+        </button>
+      </template>
+    </InventarioStockInventoryView>
 
     <!-- warocol.com#608 — Stock adjustment slide-over -->
     <AbastecimientoStockAdjustmentPanel
@@ -264,7 +62,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useQueryCache } from '@pinia/colada'
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 
@@ -306,7 +103,20 @@ const onAdjustmentSaved = () => {
 }
 
 const sortField = ref('current_stock')
-const sortDirection = ref('desc')
+const sortDirection = ref<'asc' | 'desc'>('desc')
+
+const stockCopy = {
+  statsTotal: WAREHOUSE_COPY.stockStatsTotal,
+  searchPlaceholder: WAREHOUSE_COPY.stockSearchPlaceholder,
+  emptyMessage: WAREHOUSE_COPY.stockEmptyMessage,
+  ingredientColumn: WAREHOUSE_COPY.warehouseItemColumn,
+}
+
+const stockStatusOptions = [
+  { value: 'negative', label: 'Crítico', variant: 'destructive' },
+  { value: 'low', label: 'Bajo', variant: 'warning' },
+  { value: 'ok', label: 'Normal', variant: 'success' },
+]
 
 const { data: inventoryData, asyncStatus: queryAsyncStatus, refetch } = useQuery({
   key: () => ['inventory', 'stock', currentTenant.value?.id, {
@@ -394,6 +204,11 @@ const nextPage = () => {
   if (canGoNext.value) currentPage.value++
 }
 
+const updateStatusFilter = (value: string) => {
+  statusFilter.value = value
+  currentPage.value = 1
+}
+
 const handleSort = (field: string) => {
   if (sortField.value === field) {
     sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
@@ -410,118 +225,6 @@ const clearFilters = () => {
   statusFilter.value = 'all'
   unitFilter.value = ''
   currentPage.value = 1
-}
-
-// Table columns configuration
-const stockTableColumns = [
-  {
-    key: 'ingredient_name',
-    title: WAREHOUSE_COPY.warehouseItemColumn,
-    sortable: true,
-    format: 'text',
-    align: 'left'
-  },
-  {
-    key: 'unit',
-    title: 'Unidad',
-    sortable: false,
-    format: 'text',
-    align: 'left'
-  },
-  {
-    key: 'current_stock',
-    title: 'Stock Actual',
-    sortable: true,
-    format: 'number',
-    align: 'right'
-  },
-  {
-    key: 'minimum_stock',
-    title: 'Stock Mín',
-    sortable: true,
-    format: 'number',
-    align: 'right'
-  },
-  {
-    key: 'maximum_stock',
-    title: 'Stock Máx',
-    sortable: true,
-    format: 'number',
-    align: 'right'
-  },
-  {
-    key: 'stock_percentage',
-    title: '% Stock',
-    sortable: false,
-    format: 'custom',
-    align: 'center'
-  },
-  {
-    key: 'unit_cost',
-    title: 'Costo Unit.',
-    sortable: true,
-    format: 'currency',
-    align: 'right'
-  },
-  {
-    key: 'total_value',
-    title: 'Valor Total',
-    sortable: true,
-    format: 'currency',
-    align: 'right'
-  },
-  {
-    key: 'status',
-    title: 'Estado',
-    sortable: true,
-    format: 'badge',
-    align: 'center'
-  },
-  {
-    key: 'actions',
-    title: 'Acciones',
-    sortable: false,
-    format: 'custom',
-    align: 'center'
-  }
-]
-
-const getStockPercentage = (current: number, min: number, max: number) => {
-  if (!max || max === 0) return 0
-  return Math.round((current / max) * 100)
-}
-
-const getStockVariant = (status: string) => {
-  const variants: Record<string, string> = {
-    negative: 'destructive',
-    low: 'warning',
-    ok: 'success',
-  }
-  return variants[status] || 'default'
-}
-
-const getStatusLabel = (status: string) => {
-  const labels: Record<string, string> = {
-    negative: 'Crítico',
-    low: 'Bajo',
-    ok: 'Normal',
-  }
-  return labels[status] || status
-}
-
-const formatCurrency = (value: number) => {
-  return new Intl.NumberFormat('es-CO', {
-    style: 'currency',
-    currency: 'COP',
-    minimumFractionDigits: 0
-  }).format(value)
-}
-
-const formatNumber = (value: number) => {
-  return new Intl.NumberFormat('es-CO', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2
-  }).format(value)
 }
 
 // Set refresh handler for layout

--- a/pages/inventario/stock.vue
+++ b/pages/inventario/stock.vue
@@ -5,227 +5,41 @@
       <CommonsTheCustomLoader size="large" />
     </div>
 
-    <!-- Main Content -->
-    <div v-else class="flex flex-col gap-3 md:gap-4">
-      <!-- Stats Cards -->
-      <UiStats>
-        <UiStatsCard
-          label="Total Ingredientes"
-          :value="stats.total_ingredients"
-          icon="beaker"
-        />
-        <UiStatsCard
-          label="Stock Bajo"
-          :value="stats.low_stock_count"
-          icon="exclamation"
-        />
-        <UiStatsCard
-          label="Stock Crítico"
-          :value="stats.critical_count"
-          icon="exclamation-circle"
-        />
-        <UiStatsCard
-          label="Valor Total"
-          :value="formatCurrency(stats.total_inventory_value)"
-          icon="currency-dollar"
-        />
-      </UiStats>
-
-      <UiAdvancedFiltersBar
-        v-model:search="localSearchTerm"
-        :search-fields="[]"
-        search-placeholder="Buscar ingredientes..."
-        :show-date-range="false"
-        :show-clear="hasActiveFilters"
-        @search="performSearch"
-        @clear="clearFilters"
-      >
-        <template #additional-filters>
-          <select
-            v-model="categoryFilter"
-            :class="filterSelectClass"
-            aria-label="Filtrar por categoría"
-          >
-            <option value="">Categoría</option>
-            <option v-for="category in categories" :key="category" :value="category">
-              {{ category }}
-            </option>
-          </select>
-
-          <select
-            v-model="statusFilter"
-            :class="filterSelectClass"
-            aria-label="Filtrar por estado"
-            @change="currentPage = 1"
-          >
-            <option value="all">Estado</option>
-            <option value="critical">Crítico</option>
-            <option value="low">Bajo</option>
-            <option value="ok">Normal</option>
-          </select>
-
-          <select
-            v-model="unitFilter"
-            :class="filterSelectClass"
-            aria-label="Filtrar por unidad"
-          >
-            <option value="">Unidad</option>
-            <option v-for="unit in units" :key="unit" :value="unit">
-              {{ unit }}
-            </option>
-          </select>
-        </template>
-      </UiAdvancedFiltersBar>
-
-      <!-- Responsive Data View -->
-      <HealthSemaphore :is-unlocked="true" title="Stock de Inventario">
-      <UiResponsiveDataView
-        row-size="sm"
-        :columns="stockTableColumns"
-        :data="displayInventory"
-        :sort-field="sortField"
-        :sort-direction="sortDirection"
-        @sort="handleSort"
-        empty-message="No hay ingredientes en inventario"
-        empty-sub-message="Comienza recibiendo compras en Abastecimiento"
-        variant="default"
-      >
-        <!-- Mobile Card -->
-        <template #card="{ item, index }">
-          <div
-            class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-surface-secondary"
-            :class="index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'"
-          >
-            <div class="flex-1 min-w-0">
-              <span class="text-sm font-bold text-text-primary">{{ item.ingredient_name }}</span>
-              <p class="text-xs text-text-secondary mt-0.5">{{ item.unit }} · mín {{ formatNumber(item.minimum_stock) }}{{ item.maximum_stock ? ` · máx ${formatNumber(item.maximum_stock)}` : '' }}</p>
-            </div>
-            <div class="flex items-center gap-2 flex-shrink-0">
-              <div class="flex flex-col items-end gap-1.5">
-                <span class="text-sm font-bold tabular-nums text-text-primary">{{ formatNumber(item.current_stock) }}</span>
-                <UiStatusBadge
-                  :value="getStatusLabel(item.status)"
-                  :variant="getStockVariant(item.status)"
-                  size="sm"
-                  format="text"
-                />
-              </div>
-              <button
-                @click.stop="navigateTo(`/inventario/ajustes/crear?ingredientId=${item.ingredient_id}`)"
-                title="Ajustar stock"
-                class="w-7 h-7 flex items-center justify-center rounded bg-surface-secondary border border-border text-text-secondary hover:text-primary transition-colors"
-              >
-                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
-                </svg>
-              </button>
-            </div>
-          </div>
-        </template>
-
-        <!-- Desktop Table Cells -->
-        <template #cell-ingredient_name="{ value }">
-          <span class="text-sm font-bold text-text-primary">{{ value }}</span>
-        </template>
-
-        <template #cell-unit="{ value }">
-          <span class="text-sm text-text-secondary">{{ value }}</span>
-        </template>
-
-        <template #cell-current_stock="{ value }">
-          <span class="text-sm font-bold text-text-primary">{{ formatNumber(value) }}</span>
-        </template>
-
-        <template #cell-minimum_stock="{ value }">
-          <span class="text-sm text-text-primary">{{ formatNumber(value) }}</span>
-        </template>
-
-        <template #cell-maximum_stock="{ value }">
-          <span class="text-sm text-text-primary">{{ value ? formatNumber(value) : '-' }}</span>
-        </template>
-
-        <template #cell-stock_percentage="{ row }">
-          <div v-if="row.maximum_stock" class="w-full bg-surface-secondary rounded-full h-2">
-            <div
-              class="h-2 rounded-full transition-all"
-              :class="{
-                'bg-destructive': row.status === 'critical',
-                'bg-warning': row.status === 'low',
-                'bg-success': row.status === 'ok'
-              }"
-              :style="{ width: `${Math.min(getStockPercentage(row.current_stock, row.minimum_stock, row.maximum_stock), 100)}%` }"
-            />
-          </div>
-          <span v-else class="text-xs text-text-secondary">-</span>
-        </template>
-
-        <template #cell-unit_cost="{ value }">
-          <span class="text-sm font-bold text-primary">{{ value ? formatCurrency(value) : '-' }}</span>
-        </template>
-
-        <template #cell-total_value="{ value }">
-          <span class="text-sm font-bold text-primary">{{ formatCurrency(value) }}</span>
-        </template>
-
-        <template #cell-status="{ value, row }">
-          <UiStatusBadge
-            :label="getStatusLabel(value)"
-            :variant="getStockVariant(value)"
-          />
-        </template>
-
-        <template #cell-actions="{ row }">
-          <div class="flex justify-center">
-            <button
-              @click="navigateTo(`/inventario/ajustes/crear?ingredientId=${row.ingredient_id}`)"
-              title="Ajustar stock"
-              class="p-1.5 rounded-md hover:bg-surface-secondary transition-colors text-primary"
-            >
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
-              </svg>
-            </button>
-          </div>
-        </template>
-      </UiResponsiveDataView>
-
-      <div
-        v-if="(inventoryData?.total ?? 0) > itemsPerPage"
-        class="mt-4 bg-white px-4 py-3 flex items-center justify-between border border-titan-200 rounded-lg"
-      >
-        <p class="text-sm text-titan-700">
-          Mostrando <span class="font-medium">{{ startItem }}</span> a
-          <span class="font-medium">{{ endItem }}</span> de
-          <span class="font-medium">{{ inventoryData?.total ?? 0 }}</span>
-        </p>
-        <div class="flex gap-2">
-          <button
-            type="button"
-            :disabled="!canGoPrevious"
-            class="px-4 py-2 border border-titan-300 text-sm rounded-md disabled:opacity-50"
-            @click="previousPage"
-          >
-            Anterior
-          </button>
-          <button
-            type="button"
-            :disabled="!canGoNext"
-            class="px-4 py-2 border border-titan-300 text-sm rounded-md disabled:opacity-50"
-            @click="nextPage"
-          >
-            Siguiente
-          </button>
-        </div>
-      </div>
-    </HealthSemaphore>
-    </div>
+    <InventarioStockInventoryView
+      v-else
+      v-model:search="localSearchTerm"
+      v-model:category-filter="categoryFilter"
+      v-model:unit-filter="unitFilter"
+      :status-filter="statusFilter"
+      :stats="stats"
+      :inventory="displayInventory"
+      :total="inventoryData?.total ?? 0"
+      :items-per-page="itemsPerPage"
+      :start-item="startItem"
+      :end-item="endItem"
+      :can-go-previous="canGoPrevious"
+      :can-go-next="canGoNext"
+      :has-active-filters="hasActiveFilters"
+      :categories="categories"
+      :units="units"
+      :sort-field="sortField"
+      :sort-direction="sortDirection"
+      adjustment-path="/inventario/ajustes/crear"
+      :copy="stockCopy"
+      :status-options="stockStatusOptions"
+      show-mobile-stock-limits
+      @update:status-filter="updateStatusFilter"
+      @search="performSearch"
+      @clear="clearFilters"
+      @sort="handleSort"
+      @previous-page="previousPage"
+      @next-page="nextPage"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 
 useHead({ title: 'Stock' })
 
@@ -255,7 +69,20 @@ const performSearch = () => applySearch(() => { currentPage.value = 1 })
 watch(() => currentTenant.value?.id, () => { currentPage.value = 1 })
 
 const sortField = ref('current_stock')
-const sortDirection = ref('desc')
+const sortDirection = ref<'asc' | 'desc'>('desc')
+
+const stockCopy = {
+  statsTotal: 'Total Ingredientes',
+  searchPlaceholder: 'Buscar ingredientes...',
+  emptyMessage: 'No hay ingredientes en inventario',
+  ingredientColumn: 'Ingrediente',
+}
+
+const stockStatusOptions = [
+  { value: 'critical', label: 'Crítico', variant: 'destructive' },
+  { value: 'low', label: 'Bajo', variant: 'warning' },
+  { value: 'ok', label: 'Normal', variant: 'success' },
+]
 
 const { data: inventoryData, asyncStatus: queryAsyncStatus, refetch } = useQuery({
   key: () => ['inventory', 'stock', currentTenant.value?.id, {
@@ -342,6 +169,11 @@ const nextPage = () => {
   if (canGoNext.value) currentPage.value++
 }
 
+const updateStatusFilter = (value: string) => {
+  statusFilter.value = value
+  currentPage.value = 1
+}
+
 const handleSort = (field: string) => {
   if (sortField.value === field) {
     sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
@@ -358,118 +190,6 @@ const clearFilters = () => {
   statusFilter.value = 'all'
   unitFilter.value = ''
   currentPage.value = 1
-}
-
-// Table columns configuration
-const stockTableColumns = [
-  {
-    key: 'ingredient_name',
-    title: 'Ingrediente',
-    sortable: true,
-    format: 'text',
-    align: 'left'
-  },
-  {
-    key: 'unit',
-    title: 'Unidad',
-    sortable: false,
-    format: 'text',
-    align: 'left'
-  },
-  {
-    key: 'current_stock',
-    title: 'Stock Actual',
-    sortable: true,
-    format: 'number',
-    align: 'right'
-  },
-  {
-    key: 'minimum_stock',
-    title: 'Stock Mín',
-    sortable: true,
-    format: 'number',
-    align: 'right'
-  },
-  {
-    key: 'maximum_stock',
-    title: 'Stock Máx',
-    sortable: true,
-    format: 'number',
-    align: 'right'
-  },
-  {
-    key: 'stock_percentage',
-    title: '% Stock',
-    sortable: false,
-    format: 'custom',
-    align: 'center'
-  },
-  {
-    key: 'unit_cost',
-    title: 'Costo Unit.',
-    sortable: true,
-    format: 'currency',
-    align: 'right'
-  },
-  {
-    key: 'total_value',
-    title: 'Valor Total',
-    sortable: true,
-    format: 'currency',
-    align: 'right'
-  },
-  {
-    key: 'status',
-    title: 'Estado',
-    sortable: true,
-    format: 'badge',
-    align: 'center'
-  },
-  {
-    key: 'actions',
-    title: 'Acciones',
-    sortable: false,
-    format: 'custom',
-    align: 'center'
-  }
-]
-
-const getStockPercentage = (current: number, min: number, max: number) => {
-  if (!max || max === 0) return 0
-  return Math.round((current / max) * 100)
-}
-
-const getStockVariant = (status: string) => {
-  const variants = {
-    critical: 'destructive',
-    low: 'warning',
-    ok: 'success'
-  }
-  return variants[status] || 'default'
-}
-
-const getStatusLabel = (status: string) => {
-  const labels = {
-    critical: 'Crítico',
-    low: 'Bajo',
-    ok: 'Normal'
-  }
-  return labels[status] || status
-}
-
-const formatCurrency = (value: number) => {
-  return new Intl.NumberFormat('es-CO', {
-    style: 'currency',
-    currency: 'COP',
-    minimumFractionDigits: 0
-  }).format(value)
-}
-
-const formatNumber = (value: number) => {
-  return new Intl.NumberFormat('es-CO', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2
-  }).format(value)
 }
 
 // Set refresh handler for layout


### PR DESCRIPTION
## Summary\n- Extract shared stock inventory presentation into `InventarioStockInventoryView`\n- Reuse it from `/inventario/stock` and `/abastecimiento/stock` while keeping query, pagination, sorting, and refresh behavior in the pages\n- Preserve route-specific actions for inventory adjustments, abastecimiento movements, and the stock adjustment slide-over\n\n## Validation\n- `npm run build`\n- Manual smoke routes: `/inventario/stock`, `/abastecimiento/stock`\n\nCloses #1158