### PR TITLE
Define semantic visual token architecture

### DIFF
--- a/assets/css/design-tokens.css
+++ b/assets/css/design-tokens.css
@@ -1,4 +1,13 @@
 /* Warocol Design System - Purple Theme Tokens */
+/*
+  Token migration rules:
+  1. Primitive tokens define raw brand scales such as crocus, titan, ebony, and status hues.
+  2. Semantic tokens describe shared intent such as primary, surface, text, focus, and state.
+  3. Component tokens describe repeated UI states such as nav, data-table, control-toggle, and chips.
+
+  Data/user colors are intentional exceptions. Values such as station colors should be wrapped for
+  contrast and fallback behavior, not forced into brand tokens.
+*/
 :root {
   /* === TITAN WHITE (Grises Claros) - HSL Tokens === */
   --titan-50: 0 0% 100%; /* #FFFFFF */
@@ -85,6 +94,93 @@
   --info: 218 68% 47%; /* Azul información — separado del primary púrpura */
   --info-foreground: 0 0% 100%; /* Texto información */
 
+  /* === SEMANTIC STATE TOKENS === */
+  --state-danger-bg: 0 86% 97%;
+  --state-danger-border: 0 72% 88%;
+  --state-danger-text: 0 74% 42%;
+  --state-danger-icon: var(--destructive);
+  --state-danger-action-bg: var(--destructive);
+  --state-danger-action-text: var(--destructive-foreground);
+
+  --state-warning-bg: 43 96% 94%;
+  --state-warning-border: 43 96% 82%;
+  --state-warning-text: 32 95% 32%;
+  --state-warning-icon: 32 95% 44%;
+  --state-warning-action-bg: 38 92% 50%;
+  --state-warning-action-text: 0 0% 100%;
+
+  --state-success-bg: 145 81% 94%;
+  --state-success-border: 145 63% 78%;
+  --state-success-text: 150 78% 28%;
+  --state-success-icon: var(--success);
+  --state-success-action-bg: var(--success);
+  --state-success-action-text: var(--success-foreground);
+
+  --state-info-bg: 214 95% 95%;
+  --state-info-border: 214 90% 84%;
+  --state-info-text: 218 68% 37%;
+  --state-info-icon: var(--info);
+  --state-info-action-bg: var(--info);
+  --state-info-action-text: var(--info-foreground);
+
+  /* === FOCUS AND CONTROL TOKENS === */
+  --focus-ring: var(--ring);
+  --focus-ring-subtle: var(--crocus-300);
+  --control-toggle-track-off: var(--border);
+  --control-toggle-track-on: var(--primary);
+  --control-toggle-thumb: 0 0% 100%;
+  --control-toggle-focus-ring: var(--focus-ring-subtle);
+  --control-action-hover-bg: var(--crocus-50);
+  --control-action-hover-text: var(--primary);
+
+  /* === COMPONENT TOKENS: DASHBOARD NAV === */
+  --nav-item-hover-bg: var(--crocus-600);
+  --nav-item-active-bg: var(--crocus-600);
+  --nav-icon-idle: var(--crocus-300);
+  --nav-icon-hover: var(--crocus-300);
+  --nav-icon-active: var(--crocus-300);
+  --nav-label-idle: var(--titan-300);
+  --nav-label-hover: var(--titan-300);
+  --nav-label-active: var(--titan-300);
+  --nav-section-label: var(--titan-300);
+  --nav-divider: var(--titan-300);
+
+  /* === COMPONENT TOKENS: DATA TABLE === */
+  --data-table-container-bg: var(--surface);
+  --data-table-header-bg: var(--surface-secondary);
+  --data-table-header-text: var(--text-secondary);
+  --data-table-row-bg: var(--surface);
+  --data-table-row-alt-bg: var(--surface-secondary);
+  --data-table-row-hover-bg: var(--surface-secondary);
+  --data-table-row-selected-bg: var(--crocus-50);
+  --data-table-row-new-bg: var(--crocus-50);
+  --data-table-border: var(--border);
+  --data-table-cell-text: var(--text-primary);
+  --data-table-cell-muted: var(--text-secondary);
+  --data-table-footer-bg: var(--surface-secondary);
+
+  /* === COMPONENT TOKENS: FILTERS AND STATUS CHIPS === */
+  --filter-surface-bg: var(--surface);
+  --filter-surface-border: var(--border);
+  --filter-control-bg: var(--input);
+  --filter-control-text: var(--text-primary);
+  --filter-control-placeholder: var(--text-tertiary);
+  --filter-control-focus-ring: var(--focus-ring-subtle);
+  --status-chip-bg: var(--surface-secondary);
+  --status-chip-text: var(--text-secondary);
+  --status-chip-border: var(--border);
+
+  /* === DENSE UI TYPOGRAPHY TOKENS === */
+  --type-dense-label-size: 0.75rem;
+  --type-dense-label-line-height: 1rem;
+  --type-dense-label-weight: 600;
+  --type-dense-value-size: 0.875rem;
+  --type-dense-value-line-height: 1.25rem;
+  --type-dense-value-weight: 500;
+  --type-dense-meta-size: 0.6875rem;
+  --type-dense-meta-line-height: 0.875rem;
+  --type-dense-meta-weight: 500;
+
   /* === STATUS BADGE TOKENS (OKLCH — perceptualmente uniformes) ===
      Backgrounds: chroma muy bajo (~0.04) para no saturar tablas densas
      Texts: chroma medio (~0.16–0.18) para legibilidad con buen contraste
@@ -154,6 +250,82 @@
   
   --info: 218 68% 60%; /* Azul información — más claro para tema oscuro */
   --info-foreground: var(--ebony-900); /* Texto información */
+
+  /* === SEMANTIC STATE TOKENS OSCUROS === */
+  --state-danger-bg: 0 62% 18%;
+  --state-danger-border: 0 52% 34%;
+  --state-danger-text: 0 86% 78%;
+  --state-danger-icon: 0 86% 68%;
+  --state-danger-action-bg: 0 62% 51%;
+  --state-danger-action-text: var(--titan-100);
+
+  --state-warning-bg: 35 76% 16%;
+  --state-warning-border: 35 70% 31%;
+  --state-warning-text: 43 96% 76%;
+  --state-warning-icon: 43 96% 68%;
+  --state-warning-action-bg: 38 92% 50%;
+  --state-warning-action-text: var(--ebony-900);
+
+  --state-success-bg: 150 68% 14%;
+  --state-success-border: 150 52% 29%;
+  --state-success-text: 145 66% 72%;
+  --state-success-icon: 145 66% 62%;
+  --state-success-action-bg: 142 71% 45%;
+  --state-success-action-text: var(--titan-100);
+
+  --state-info-bg: 218 58% 18%;
+  --state-info-border: 218 52% 34%;
+  --state-info-text: 214 90% 78%;
+  --state-info-icon: 214 90% 70%;
+  --state-info-action-bg: var(--info);
+  --state-info-action-text: var(--info-foreground);
+
+  /* === FOCUS AND CONTROL TOKENS OSCUROS === */
+  --focus-ring: var(--ring);
+  --focus-ring-subtle: var(--crocus-500);
+  --control-toggle-track-off: var(--border);
+  --control-toggle-track-on: var(--primary);
+  --control-toggle-thumb: var(--ebony-900);
+  --control-toggle-focus-ring: var(--focus-ring-subtle);
+  --control-action-hover-bg: var(--ebony-700);
+  --control-action-hover-text: var(--primary);
+
+  /* === COMPONENT TOKENS OSCUROS: DASHBOARD NAV === */
+  --nav-item-hover-bg: var(--crocus-400);
+  --nav-item-active-bg: var(--crocus-400);
+  --nav-icon-idle: var(--crocus-300);
+  --nav-icon-hover: var(--crocus-300);
+  --nav-icon-active: var(--crocus-300);
+  --nav-label-idle: var(--titan-300);
+  --nav-label-hover: var(--titan-200);
+  --nav-label-active: var(--titan-100);
+  --nav-section-label: var(--titan-500);
+  --nav-divider: var(--titan-500);
+
+  /* === COMPONENT TOKENS OSCUROS: DATA TABLE === */
+  --data-table-container-bg: var(--surface);
+  --data-table-header-bg: var(--surface-secondary);
+  --data-table-header-text: var(--text-secondary);
+  --data-table-row-bg: var(--surface);
+  --data-table-row-alt-bg: var(--surface-secondary);
+  --data-table-row-hover-bg: var(--surface-tertiary);
+  --data-table-row-selected-bg: var(--ebony-700);
+  --data-table-row-new-bg: var(--ebony-700);
+  --data-table-border: var(--border);
+  --data-table-cell-text: var(--text-primary);
+  --data-table-cell-muted: var(--text-secondary);
+  --data-table-footer-bg: var(--surface-secondary);
+
+  /* === COMPONENT TOKENS OSCUROS: FILTERS AND STATUS CHIPS === */
+  --filter-surface-bg: var(--surface);
+  --filter-surface-border: var(--border);
+  --filter-control-bg: var(--input);
+  --filter-control-text: var(--text-primary);
+  --filter-control-placeholder: var(--text-tertiary);
+  --filter-control-focus-ring: var(--focus-ring-subtle);
+  --status-chip-bg: var(--surface-secondary);
+  --status-chip-text: var(--text-secondary);
+  --status-chip-border: var(--border);
 }
 
 /* === TEMA CLARO EXPLÍCITO === */
@@ -203,4 +375,80 @@
   
   --info: 218 68% 47%; /* Azul información */
   --info-foreground: var(--titan-50); /* Texto información */
+
+  /* === SEMANTIC STATE TOKENS CLAROS === */
+  --state-danger-bg: 0 86% 97%;
+  --state-danger-border: 0 72% 88%;
+  --state-danger-text: 0 74% 42%;
+  --state-danger-icon: var(--destructive);
+  --state-danger-action-bg: var(--destructive);
+  --state-danger-action-text: var(--destructive-foreground);
+
+  --state-warning-bg: 43 96% 94%;
+  --state-warning-border: 43 96% 82%;
+  --state-warning-text: 32 95% 32%;
+  --state-warning-icon: 32 95% 44%;
+  --state-warning-action-bg: 38 92% 50%;
+  --state-warning-action-text: 0 0% 100%;
+
+  --state-success-bg: 145 81% 94%;
+  --state-success-border: 145 63% 78%;
+  --state-success-text: 150 78% 28%;
+  --state-success-icon: var(--success);
+  --state-success-action-bg: var(--success);
+  --state-success-action-text: var(--success-foreground);
+
+  --state-info-bg: 214 95% 95%;
+  --state-info-border: 214 90% 84%;
+  --state-info-text: 218 68% 37%;
+  --state-info-icon: var(--info);
+  --state-info-action-bg: var(--info);
+  --state-info-action-text: var(--info-foreground);
+
+  /* === FOCUS AND CONTROL TOKENS CLAROS === */
+  --focus-ring: var(--ring);
+  --focus-ring-subtle: var(--crocus-300);
+  --control-toggle-track-off: var(--border);
+  --control-toggle-track-on: var(--primary);
+  --control-toggle-thumb: 0 0% 100%;
+  --control-toggle-focus-ring: var(--focus-ring-subtle);
+  --control-action-hover-bg: var(--crocus-50);
+  --control-action-hover-text: var(--primary);
+
+  /* === COMPONENT TOKENS CLAROS: DASHBOARD NAV === */
+  --nav-item-hover-bg: var(--crocus-600);
+  --nav-item-active-bg: var(--crocus-600);
+  --nav-icon-idle: var(--crocus-300);
+  --nav-icon-hover: var(--crocus-300);
+  --nav-icon-active: var(--crocus-300);
+  --nav-label-idle: var(--titan-300);
+  --nav-label-hover: var(--titan-300);
+  --nav-label-active: var(--titan-300);
+  --nav-section-label: var(--titan-300);
+  --nav-divider: var(--titan-300);
+
+  /* === COMPONENT TOKENS CLAROS: DATA TABLE === */
+  --data-table-container-bg: var(--surface);
+  --data-table-header-bg: var(--surface-secondary);
+  --data-table-header-text: var(--text-secondary);
+  --data-table-row-bg: var(--surface);
+  --data-table-row-alt-bg: var(--surface-secondary);
+  --data-table-row-hover-bg: var(--surface-secondary);
+  --data-table-row-selected-bg: var(--crocus-50);
+  --data-table-row-new-bg: var(--crocus-50);
+  --data-table-border: var(--border);
+  --data-table-cell-text: var(--text-primary);
+  --data-table-cell-muted: var(--text-secondary);
+  --data-table-footer-bg: var(--surface-secondary);
+
+  /* === COMPONENT TOKENS CLAROS: FILTERS AND STATUS CHIPS === */
+  --filter-surface-bg: var(--surface);
+  --filter-surface-border: var(--border);
+  --filter-control-bg: var(--input);
+  --filter-control-text: var(--text-primary);
+  --filter-control-placeholder: var(--text-tertiary);
+  --filter-control-focus-ring: var(--focus-ring-subtle);
+  --status-chip-bg: var(--surface-secondary);
+  --status-chip-text: var(--text-secondary);
+  --status-chip-border: var(--border);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -75,6 +75,99 @@ module.exports = {
           DEFAULT: "hsl(var(--info) / <alpha-value>)",
           foreground: "hsl(var(--info-foreground) / <alpha-value>)",
         },
+        focus: {
+          ring: "hsl(var(--focus-ring) / <alpha-value>)",
+          subtle: "hsl(var(--focus-ring-subtle) / <alpha-value>)",
+        },
+        state: {
+          danger: {
+            bg: "hsl(var(--state-danger-bg) / <alpha-value>)",
+            border: "hsl(var(--state-danger-border) / <alpha-value>)",
+            text: "hsl(var(--state-danger-text) / <alpha-value>)",
+            icon: "hsl(var(--state-danger-icon) / <alpha-value>)",
+            action: {
+              bg: "hsl(var(--state-danger-action-bg) / <alpha-value>)",
+              text: "hsl(var(--state-danger-action-text) / <alpha-value>)",
+            },
+          },
+          warning: {
+            bg: "hsl(var(--state-warning-bg) / <alpha-value>)",
+            border: "hsl(var(--state-warning-border) / <alpha-value>)",
+            text: "hsl(var(--state-warning-text) / <alpha-value>)",
+            icon: "hsl(var(--state-warning-icon) / <alpha-value>)",
+            action: {
+              bg: "hsl(var(--state-warning-action-bg) / <alpha-value>)",
+              text: "hsl(var(--state-warning-action-text) / <alpha-value>)",
+            },
+          },
+          success: {
+            bg: "hsl(var(--state-success-bg) / <alpha-value>)",
+            border: "hsl(var(--state-success-border) / <alpha-value>)",
+            text: "hsl(var(--state-success-text) / <alpha-value>)",
+            icon: "hsl(var(--state-success-icon) / <alpha-value>)",
+            action: {
+              bg: "hsl(var(--state-success-action-bg) / <alpha-value>)",
+              text: "hsl(var(--state-success-action-text) / <alpha-value>)",
+            },
+          },
+          info: {
+            bg: "hsl(var(--state-info-bg) / <alpha-value>)",
+            border: "hsl(var(--state-info-border) / <alpha-value>)",
+            text: "hsl(var(--state-info-text) / <alpha-value>)",
+            icon: "hsl(var(--state-info-icon) / <alpha-value>)",
+            action: {
+              bg: "hsl(var(--state-info-action-bg) / <alpha-value>)",
+              text: "hsl(var(--state-info-action-text) / <alpha-value>)",
+            },
+          },
+        },
+        nav: {
+          "item-hover-bg": "hsl(var(--nav-item-hover-bg) / <alpha-value>)",
+          "item-active-bg": "hsl(var(--nav-item-active-bg) / <alpha-value>)",
+          "icon-idle": "hsl(var(--nav-icon-idle) / <alpha-value>)",
+          "icon-hover": "hsl(var(--nav-icon-hover) / <alpha-value>)",
+          "icon-active": "hsl(var(--nav-icon-active) / <alpha-value>)",
+          "label-idle": "hsl(var(--nav-label-idle) / <alpha-value>)",
+          "label-hover": "hsl(var(--nav-label-hover) / <alpha-value>)",
+          "label-active": "hsl(var(--nav-label-active) / <alpha-value>)",
+          "section-label": "hsl(var(--nav-section-label) / <alpha-value>)",
+          divider: "hsl(var(--nav-divider) / <alpha-value>)",
+        },
+        "data-table": {
+          "container-bg": "hsl(var(--data-table-container-bg) / <alpha-value>)",
+          "header-bg": "hsl(var(--data-table-header-bg) / <alpha-value>)",
+          "header-text": "hsl(var(--data-table-header-text) / <alpha-value>)",
+          "row-bg": "hsl(var(--data-table-row-bg) / <alpha-value>)",
+          "row-alt-bg": "hsl(var(--data-table-row-alt-bg) / <alpha-value>)",
+          "row-hover-bg": "hsl(var(--data-table-row-hover-bg) / <alpha-value>)",
+          "row-selected-bg": "hsl(var(--data-table-row-selected-bg) / <alpha-value>)",
+          "row-new-bg": "hsl(var(--data-table-row-new-bg) / <alpha-value>)",
+          border: "hsl(var(--data-table-border) / <alpha-value>)",
+          "cell-text": "hsl(var(--data-table-cell-text) / <alpha-value>)",
+          "cell-muted": "hsl(var(--data-table-cell-muted) / <alpha-value>)",
+          "footer-bg": "hsl(var(--data-table-footer-bg) / <alpha-value>)",
+        },
+        control: {
+          "toggle-track-off": "hsl(var(--control-toggle-track-off) / <alpha-value>)",
+          "toggle-track-on": "hsl(var(--control-toggle-track-on) / <alpha-value>)",
+          "toggle-thumb": "hsl(var(--control-toggle-thumb) / <alpha-value>)",
+          "toggle-focus-ring": "hsl(var(--control-toggle-focus-ring) / <alpha-value>)",
+          "action-hover-bg": "hsl(var(--control-action-hover-bg) / <alpha-value>)",
+          "action-hover-text": "hsl(var(--control-action-hover-text) / <alpha-value>)",
+        },
+        filter: {
+          "surface-bg": "hsl(var(--filter-surface-bg) / <alpha-value>)",
+          "surface-border": "hsl(var(--filter-surface-border) / <alpha-value>)",
+          "control-bg": "hsl(var(--filter-control-bg) / <alpha-value>)",
+          "control-text": "hsl(var(--filter-control-text) / <alpha-value>)",
+          "control-placeholder": "hsl(var(--filter-control-placeholder) / <alpha-value>)",
+          "control-focus-ring": "hsl(var(--filter-control-focus-ring) / <alpha-value>)",
+        },
+        "status-chip": {
+          bg: "hsl(var(--status-chip-bg) / <alpha-value>)",
+          text: "hsl(var(--status-chip-text) / <alpha-value>)",
+          border: "hsl(var(--status-chip-border) / <alpha-value>)",
+        },
         // Status badge tokens — OKLCH perceptually uniform
         // bg: very low chroma (barely tinted) / text: readable contrast
         // Usage: bg-status-critical-bg, text-status-critical-text, etc.
@@ -135,6 +228,29 @@ module.exports = {
         principal: ['Lato'],
         sans: ['Lato', 'sans-serif'],
         quantico: ['Quantico', 'Lato', 'sans-serif'],
+      },
+      fontSize: {
+        "dense-label": [
+          "var(--type-dense-label-size)",
+          {
+            lineHeight: "var(--type-dense-label-line-height)",
+            fontWeight: "var(--type-dense-label-weight)",
+          },
+        ],
+        "dense-value": [
+          "var(--type-dense-value-size)",
+          {
+            lineHeight: "var(--type-dense-value-line-height)",
+            fontWeight: "var(--type-dense-value-weight)",
+          },
+        ],
+        "dense-meta": [
+          "var(--type-dense-meta-size)",
+          {
+            lineHeight: "var(--type-dense-meta-line-height)",
+            fontWeight: "var(--type-dense-meta-weight)",
+          },
+        ],
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
## Summary

- Add documented token migration rules for primitive, semantic, and component visual tokens.
- Define semantic state, focus/control, nav, data-table, filter, status-chip, and dense typography token families in `assets/css/design-tokens.css`.
- Expose the new token roles through Tailwind while preserving existing `crocus`, `primary`, `surface`, `text-*`, and `status-*` utilities.

## Validation

- `node -e "const cfg = require('./tailwind.config.js'); const colors = cfg.theme.extend.colors; const fs = cfg.theme.extend.fontSize; console.log(Object.keys(colors).filter(k => ['state','nav','data-table','control','filter','status-chip','focus'].includes(k)).join(',')); console.log(Object.keys(fs).join(','));"`
- `rg -n -- "--(state|nav|data-table|control|filter|status-chip|focus|type-dense)-" assets/css/design-tokens.css`
- `git diff --check`
- `node_modules/.bin/tailwindcss -c tailwind.config.js -i assets/css/design-system.css -o /tmp/wr1168-tailwind.css`

Tailwind compile completed successfully. It emitted an existing ambiguity warning for `ease-[cubic-bezier(0.34,1.56,0.64,1)]`, unrelated to this change.

## Manual Validation Checklist

- `/operaciones/comandas`: token architecture now covers toggles, station table/card, deactivate warning/safe panels for later migration.
- `/operaciones/mesas`: token architecture now covers module toggles, HealthSemaphore table wrapper, deactivate/delete warning/safe panels for later migration.
- Dashboard sidebar: token architecture now covers expanded/collapsed nav active, hover, icon, label, section label, and divider states for #1169.

Closes #1168
