### PR TITLE
Tokenize operations control states

### DIFF
--- a/components/analytics/HealthSemaphore.vue
+++ b/components/analytics/HealthSemaphore.vue
@@ -30,33 +30,33 @@ const emit = defineEmits<{
 <template>
   <section class="relative">
     <div v-if="!isUnlocked" class="flex items-center justify-end mb-4">
-      <span class="flex items-center gap-1 text-xs font-bold text-slate-500">
+      <span class="flex items-center gap-1 text-xs font-bold text-data-table-cell-muted">
         <Lock :size="12" /> BLOQUEADO
       </span>
     </div>
 
     <div :class="['transition-all duration-700', !isUnlocked ? 'filter blur-sm grayscale pointer-events-none opacity-50' : '']">
-      <div class="bg-slate-50 md:bg-white p-3 md:p-6 rounded-2xl border border-slate-200 shadow-sm">
+      <div class="bg-data-table-container-bg p-3 md:p-6 rounded-2xl border border-data-table-border shadow-sm">
         <div v-if="!hideHeader" class="flex items-center justify-between mb-3 md:mb-6">
-          <h4 class="text-slate-600 font-medium">{{ title || 'Análisis de Menú (Rentabilidad)' }}</h4>
+          <h4 class="text-data-table-cell-muted font-medium">{{ title || 'Análisis de Menú (Rentabilidad)' }}</h4>
           <slot name="header-actions" />
         </div>
         <div
           v-if="!hideFoodCostSummary && foodCostData?.current_period"
           class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-4 text-sm"
         >
-          <div class="rounded-lg border border-slate-200 bg-white px-3 py-2">
-            <span class="text-slate-500 text-xs">Food cost (real)</span>
-            <p class="font-semibold text-slate-800 tabular-nums">
+          <div class="rounded-lg border border-data-table-border bg-data-table-row-bg px-3 py-2">
+            <span class="text-data-table-cell-muted text-xs">Food cost (real)</span>
+            <p class="font-semibold text-data-table-cell-text tabular-nums">
               {{ foodCostData.current_period.food_cost_pct }}%
             </p>
           </div>
           <div
             v-if="foodCostData.current_period.food_cost_operativo_pct != null"
-            class="rounded-lg border border-slate-200 bg-white px-3 py-2"
+            class="rounded-lg border border-data-table-border bg-data-table-row-bg px-3 py-2"
           >
-            <span class="text-slate-500 text-xs">Food cost (operativo)</span>
-            <p class="font-semibold text-slate-800 tabular-nums">
+            <span class="text-data-table-cell-muted text-xs">Food cost (operativo)</span>
+            <p class="font-semibold text-data-table-cell-text tabular-nums">
               {{ foodCostData.current_period.food_cost_operativo_pct }}%
             </p>
           </div>
@@ -68,17 +68,17 @@ const emit = defineEmits<{
     </div>
 
     <div v-if="!isUnlocked" class="absolute inset-0 z-10 flex items-center justify-center">
-      <div class="bg-white/90 backdrop-blur-md p-8 rounded-3xl shadow-2xl border border-indigo-100 text-center max-w-sm">
-        <div class="w-16 h-16 bg-indigo-100 text-indigo-600 rounded-full flex items-center justify-center mx-auto mb-4">
+      <div class="bg-data-table-container-bg/90 backdrop-blur-md p-8 rounded-3xl shadow-2xl border border-state-info-border text-center max-w-sm">
+        <div class="w-16 h-16 bg-state-info-bg text-state-info-icon rounded-full flex items-center justify-center mx-auto mb-4">
           <Lock :size="32" />
         </div>
         <h4 class="text-xl font-bold mb-2">Calculando Dinero Perdido...</h4>
-        <p class="text-slate-600 text-sm mb-6">
+        <p class="text-data-table-cell-muted text-sm mb-6">
           No podemos decirte cuánto estás ganando realmente sin saber cuánto pagaste por tus insumos esta semana.
         </p>
         <button 
           @click="emit('unlock')"
-          class="w-full bg-indigo-600 text-white py-3 rounded-xl font-bold hover:bg-indigo-700 transition-all flex items-center justify-center gap-2"
+          class="w-full bg-state-info-action-bg text-state-info-action-text py-3 rounded-xl font-bold hover:bg-state-info-action-bg/90 transition-all flex items-center justify-center gap-2"
         >
           <Camera :size="20" />
           Subir Factura para Desbloquear

--- a/pages/operaciones/comandas.vue
+++ b/pages/operaciones/comandas.vue
@@ -33,20 +33,20 @@
                   :checked="businessProfile?.comandas_enabled"
                   @change="handleToggleComandas"
                 />
-                <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+                <div class="w-10 h-6 bg-control-toggle-track-off rounded-full peer peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
               </label>
             </div>
           </div>
           <!-- Inline disable-warning banner -->
-          <div v-if="showDisableComandasWarning" class="rounded-xl border border-amber-200 bg-amber-50 p-3 flex items-start justify-between gap-3">
-            <p class="text-xs text-amber-800 leading-relaxed">
+          <div v-if="showDisableComandasWarning" class="rounded-xl border border-state-warning-border bg-state-warning-bg p-3 flex items-start justify-between gap-3">
+            <p class="text-xs text-state-warning-text leading-relaxed">
               Las comandas activas no serán afectadas. Los nuevos pedidos no generarán comandas mientras esté desactivado.
             </p>
             <div class="flex items-center gap-2 flex-shrink-0">
-              <button @click="showDisableComandasWarning = false" class="text-xs text-amber-700 font-medium hover:underline">Cancelar</button>
+              <button @click="showDisableComandasWarning = false" class="text-xs text-state-warning-text font-medium hover:underline">Cancelar</button>
               <button
                 @click="confirmDisableComandas"
-                class="text-xs font-bold text-white bg-amber-500 hover:bg-amber-600 px-3 py-1 rounded-lg transition-colors min-h-[32px]"
+                class="text-xs font-bold text-state-warning-action-text bg-state-warning-action-bg hover:bg-state-warning-action-bg/90 px-3 py-1 rounded-lg transition-colors min-h-[32px]"
               >
                 Sí, desactivar
               </button>
@@ -74,7 +74,7 @@
                   :checked="businessProfile?.kds_enabled"
                   @change="handleToggleKds"
                 />
-                <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+                <div class="w-10 h-6 bg-control-toggle-track-off rounded-full peer peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
               </label>
             </div>
           </div>
@@ -92,7 +92,7 @@
                     v-if="!kdsTokens[st.id]"
                     @click="generateKdsToken(st.id)"
                     :disabled="generatingToken === st.id"
-                    class="min-h-[32px] px-2.5 py-1 text-xs font-medium rounded-lg bg-primary text-white hover:bg-primary/90 transition-colors disabled:opacity-50"
+                    class="min-h-[32px] px-2.5 py-1 text-xs font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
                   >
                     {{ generatingToken === st.id ? 'Generando...' : 'Generar enlace' }}
                   </button>
@@ -142,7 +142,7 @@
                   :checked="businessProfile?.expediter_enabled"
                   @change="handleToggleExpediter"
                 />
-                <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+                <div class="w-10 h-6 bg-control-toggle-track-off rounded-full peer peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
               </label>
             </div>
           </div>
@@ -160,7 +160,7 @@
         </div>
         <button
           @click="openCreateStation"
-          class="flex items-center gap-1.5 px-3 py-2 text-xs font-medium bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors min-h-[36px]"
+          class="flex items-center gap-1.5 px-3 py-2 text-xs font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors min-h-[36px]"
         >
           <PlusIcon class="w-3.5 h-3.5" />
           Nueva
@@ -217,7 +217,7 @@
               @click="handleToggleStation(st)"
               :disabled="togglingStationId === st.id"
               class="px-2.5 py-1 rounded-lg text-xs font-semibold transition-colors disabled:opacity-50"
-              :class="st.is_active ? 'text-amber-600 hover:bg-amber-50 border border-amber-200' : 'text-emerald-600 hover:bg-emerald-50 border border-emerald-200'"
+              :class="st.is_active ? 'text-state-warning-text hover:bg-state-warning-bg border border-state-warning-border' : 'text-state-success-text hover:bg-state-success-bg border border-state-success-border'"
             >
               <UiLoadingDots v-if="togglingStationId === st.id" size="7px" color="currentColor" />
               <span v-else>{{ st.is_active ? 'Desactivar' : 'Activar' }}</span>
@@ -324,8 +324,8 @@
             <div v-if="deactivateModalOpen" class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm overflow-hidden">
               <div class="relative px-5 pt-5 pb-4 border-b border-border/60">
                 <div class="flex items-start gap-3">
-                  <div class="flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center bg-amber-50 border border-amber-200">
-                    <ExclamationTriangleIcon class="w-5 h-5 text-amber-600" />
+                  <div class="flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center bg-state-warning-bg border border-state-warning-border">
+                    <ExclamationTriangleIcon class="w-5 h-5 text-state-warning-icon" />
                   </div>
                   <div class="min-w-0 flex-1 pt-0.5">
                     <h3 class="text-base font-bold text-text-primary leading-tight">Desactivar estación</h3>
@@ -355,44 +355,44 @@
                 </div>
 
                 <template v-else-if="deactivateInfo">
-                  <div v-if="deactivateInfo.active_comandas_count > 0" class="rounded-xl bg-destructive/8 border border-destructive/20 p-4">
+                  <div v-if="deactivateInfo.active_comandas_count > 0" class="rounded-xl bg-state-danger-bg border border-state-danger-border p-4">
                     <div class="flex items-start gap-3">
-                      <div class="w-8 h-8 rounded-lg bg-destructive/10 flex items-center justify-center flex-shrink-0">
-                        <ExclamationTriangleIcon class="w-4 h-4 text-destructive" />
+                      <div class="w-8 h-8 rounded-lg bg-state-danger-bg flex items-center justify-center flex-shrink-0">
+                        <ExclamationTriangleIcon class="w-4 h-4 text-state-danger-icon" />
                       </div>
                       <div>
-                        <p class="text-sm font-semibold text-destructive leading-snug">No se puede desactivar ahora</p>
-                        <p class="text-xs text-destructive/80 mt-1 leading-relaxed">
+                        <p class="text-sm font-semibold text-state-danger-text leading-snug">No se puede desactivar ahora</p>
+                        <p class="text-xs text-state-danger-text/80 mt-1 leading-relaxed">
                           Hay <strong>{{ deactivateInfo.active_comandas_count }} comanda{{ deactivateInfo.active_comandas_count !== 1 ? 's' : '' }} activa{{ deactivateInfo.active_comandas_count !== 1 ? 's' : '' }}</strong> en esta estación. Resuélvelas antes de desactivarla.
                         </p>
                       </div>
                     </div>
                   </div>
 
-                  <div v-if="deactivateInfo.affected_categories.length > 0" class="rounded-xl bg-amber-50 border border-amber-200/70 p-4">
-                    <p class="text-xs font-bold text-amber-700 uppercase tracking-wider mb-2">
+                  <div v-if="deactivateInfo.affected_categories.length > 0" class="rounded-xl bg-state-warning-bg border border-state-warning-border p-4">
+                    <p class="text-xs font-bold text-state-warning-text uppercase tracking-wider mb-2">
                       {{ deactivateInfo.affected_categories.length }} categoría{{ deactivateInfo.affected_categories.length !== 1 ? 's' : '' }} afectada{{ deactivateInfo.affected_categories.length !== 1 ? 's' : '' }}
                     </p>
-                    <p class="text-xs text-amber-700/80 leading-relaxed mb-3">
+                    <p class="text-xs text-state-warning-text/80 leading-relaxed mb-3">
                       Sus productos dejarán de generar comandas mientras la estación esté inactiva.
                     </p>
                     <div class="flex flex-wrap gap-1.5">
                       <span
                         v-for="cat in deactivateInfo.affected_categories"
                         :key="cat.id"
-                        class="text-xs font-semibold px-2.5 py-1 rounded-lg bg-white border border-amber-200 text-amber-800"
+                        class="text-xs font-semibold px-2.5 py-1 rounded-lg bg-surface border border-state-warning-border text-state-warning-text"
                       >{{ cat.name }}</span>
                     </div>
                   </div>
 
                   <div
                     v-if="deactivateInfo.affected_categories.length === 0 && deactivateInfo.active_comandas_count === 0"
-                    class="flex items-center gap-3 rounded-xl bg-emerald-50 border border-emerald-200/70 px-4 py-3"
+                    class="flex items-center gap-3 rounded-xl bg-state-success-bg border border-state-success-border px-4 py-3"
                   >
-                    <div class="w-7 h-7 rounded-full bg-emerald-100 flex items-center justify-center flex-shrink-0">
-                      <svg class="w-3.5 h-3.5 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
+                    <div class="w-7 h-7 rounded-full bg-state-success-bg flex items-center justify-center flex-shrink-0">
+                      <svg class="w-3.5 h-3.5 text-state-success-icon" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
                     </div>
-                    <p class="text-sm text-emerald-700 leading-snug">Sin impacto activo. Se puede desactivar de forma segura.</p>
+                    <p class="text-sm text-state-success-text leading-snug">Sin impacto activo. Se puede desactivar de forma segura.</p>
                   </div>
                 </template>
               </div>
@@ -409,7 +409,7 @@
                   v-if="deactivateInfo"
                   type="button"
                   :disabled="deactivateInfo.active_comandas_count > 0 || isConfirmingDeactivate"
-                  class="flex-1 min-h-[44px] rounded-xl text-sm font-bold transition-all disabled:opacity-40 disabled:cursor-not-allowed bg-destructive text-white hover:bg-destructive/90 active:scale-[0.98] flex items-center justify-center gap-2 shadow-sm"
+                  class="flex-1 min-h-[44px] rounded-xl text-sm font-bold transition-all disabled:opacity-40 disabled:cursor-not-allowed bg-state-danger-action-bg text-state-danger-action-text hover:bg-state-danger-action-bg/90 active:scale-[0.98] flex items-center justify-center gap-2 shadow-sm"
                   @click="confirmDeactivateStation"
                 >
                   <UiLoadingDots v-if="isConfirmingDeactivate" size="8px" color="currentColor" />

--- a/pages/operaciones/mesas.vue
+++ b/pages/operaciones/mesas.vue
@@ -333,20 +333,20 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
         class="rounded-xl border-2 transition-colors divide-y divide-border"
         :class="businessProfile.tables_enabled
           ? 'border-border bg-surface'
-          : 'border-amber-200 bg-amber-50 dark:border-amber-800/40 dark:bg-amber-950/20'"
+          : 'border-state-warning-border bg-state-warning-bg'"
       >
         <!-- Tables module -->
         <div class="flex items-center justify-between gap-4 px-4 py-3">
           <div class="min-w-0">
             <p
               class="text-sm font-semibold leading-snug"
-              :class="businessProfile.tables_enabled ? 'text-text-primary' : 'text-amber-800 dark:text-amber-300'"
+              :class="businessProfile.tables_enabled ? 'text-text-primary' : 'text-state-warning-text'"
             >
               {{ businessProfile.tables_enabled ? `Gestión de ${pluralLower} activa` : `Gestión de ${pluralLower} desactivada` }}
             </p>
             <p
               class="text-xs mt-0.5 leading-snug"
-              :class="businessProfile.tables_enabled ? 'text-text-secondary' : 'text-amber-700 dark:text-amber-400'"
+              :class="businessProfile.tables_enabled ? 'text-text-secondary' : 'text-state-warning-text/80'"
             >
               {{ businessProfile.tables_enabled ? `El flujo de ${pluralLower} está disponible en el punto de venta` : `Actívala para usar el flujo de ${pluralLower} en el punto de venta` }}
             </p>
@@ -363,7 +363,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
               @change="toggleTablesEnabled"
               :disabled="isTogglingTables"
             />
-            <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+            <div class="w-10 h-6 bg-control-toggle-track-off rounded-full peer peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
           </label>
         </div>
 
@@ -390,7 +390,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
               @change="toggleWaiterAttribution"
               :disabled="isTogglingWaiterAttribution"
             />
-            <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+            <div class="w-10 h-6 bg-control-toggle-track-off rounded-full peer peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
           </label>
         </div>
 
@@ -416,7 +416,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
               @change="toggleTableQrModule"
               :disabled="isTogglingTableQrModule"
             >
-            <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+            <div class="w-10 h-6 bg-control-toggle-track-off rounded-full peer peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
           </label>
         </div>
       </div>
@@ -444,7 +444,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
         <template #header-actions>
           <button
             type="button"
-            class="h-9 px-4 rounded-lg bg-primary text-sm font-semibold text-white hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 active:scale-[0.98] transition-all shadow-sm shadow-primary/30 whitespace-nowrap"
+              class="h-9 px-4 rounded-lg bg-primary text-sm font-semibold text-primary-foreground hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 active:scale-[0.98] transition-all shadow-sm shadow-primary/30 whitespace-nowrap"
             @click="openPanel(null)"
           >
             <span class="hidden sm:inline">{{ `+ Nueva ${singularLower}` }}</span>
@@ -501,7 +501,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
                 <button :aria-label="`Editar ${item.name}`" class="flex items-center justify-center min-h-[44px] min-w-[44px] rounded-lg text-text-secondary hover:bg-surface-secondary hover:text-primary transition-colors" @click="openPanel(item)">
                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" /></svg>
                 </button>
-                <button :aria-label="`Desactivar ${item.name}`" class="flex items-center justify-center min-h-[44px] min-w-[44px] rounded-lg text-text-secondary hover:bg-amber-50 hover:text-amber-600 transition-colors" @click="openDeactivateModal(item)">
+                <button :aria-label="`Desactivar ${item.name}`" class="flex items-center justify-center min-h-[44px] min-w-[44px] rounded-lg text-text-secondary hover:bg-state-warning-bg hover:text-state-warning-text transition-colors" @click="openDeactivateModal(item)">
                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 115.636 5.636m12.728 12.728L5.636 5.636" /></svg>
                 </button>
                 <button :aria-label="`Eliminar ${item.name}`" class="flex items-center justify-center min-h-[44px] min-w-[44px] rounded-lg text-text-secondary hover:bg-destructive/10 hover:text-destructive transition-colors" @click="openDeleteModal(item)">
@@ -533,7 +533,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
           <template #cell-mesero="{ row }">
             <span
               v-if="row.assigned_member_name"
-              class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-[11px] font-semibold bg-primary/10 text-primary border border-primary/20"
+              class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-[11px] font-semibold bg-status-chip-bg text-status-chip-text border border-status-chip-border"
             >
               {{ row.assigned_member_name }}
             </span>
@@ -567,7 +567,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
               <button :aria-label="`Editar ${row.name}`" title="Editar" class="flex items-center justify-center h-9 w-9 rounded-lg text-text-secondary hover:bg-surface-secondary hover:text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30" @click="openPanel(row)">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" /></svg>
               </button>
-              <button :aria-label="`Desactivar ${row.name}`" title="Desactivar" class="flex items-center justify-center h-9 w-9 rounded-lg text-text-secondary hover:bg-amber-50 hover:text-amber-600 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400/30" @click="openDeactivateModal(row)">
+              <button :aria-label="`Desactivar ${row.name}`" title="Desactivar" class="flex items-center justify-center h-9 w-9 rounded-lg text-text-secondary hover:bg-state-warning-bg hover:text-state-warning-text transition-colors focus:outline-none focus:ring-2 focus:ring-state-warning-border" @click="openDeactivateModal(row)">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 115.636 5.636m12.728 12.728L5.636 5.636" /></svg>
               </button>
               <button :aria-label="`Eliminar ${row.name}`" title="Eliminar" class="flex items-center justify-center h-9 w-9 rounded-lg text-text-secondary hover:bg-destructive/10 hover:text-destructive transition-colors focus:outline-none focus:ring-2 focus:ring-destructive/30" @click="openDeleteModal(row)">
@@ -597,11 +597,11 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
                 </p>
               </div>
               <div class="flex items-center gap-2 flex-shrink-0">
-                <span class="text-[10px] font-bold uppercase tracking-tight px-2 py-0.5 rounded-full bg-surface-secondary text-text-tertiary border border-border">Inactiva</span>
+                <span class="text-[10px] font-bold uppercase tracking-tight px-2 py-0.5 rounded-full bg-status-chip-bg text-status-chip-text border border-status-chip-border">Inactiva</span>
                 <button
                   :aria-label="`Activar ${item.name}`"
                   :disabled="activatingId === item.id"
-                  class="flex items-center gap-1.5 min-h-[36px] px-3 rounded-lg text-xs font-semibold text-success border border-success/40 hover:bg-success/10 transition-colors disabled:opacity-50"
+                  class="flex items-center gap-1.5 min-h-[36px] px-3 rounded-lg text-xs font-semibold text-state-success-text border border-state-success-border hover:bg-state-success-bg transition-colors disabled:opacity-50"
                   @click="activateTable(item.id)"
                 >
                   <svg v-if="activatingId !== item.id" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
@@ -638,7 +638,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
               <button
                 :aria-label="`Activar ${row.name}`"
                 :disabled="activatingId === row.id"
-                class="flex items-center gap-1.5 h-8 px-3 rounded-lg text-xs font-semibold text-success border border-success/40 hover:bg-success/10 transition-colors focus:outline-none focus:ring-2 focus:ring-success/30 disabled:opacity-50"
+                class="flex items-center gap-1.5 h-8 px-3 rounded-lg text-xs font-semibold text-state-success-text border border-state-success-border hover:bg-state-success-bg transition-colors focus:outline-none focus:ring-2 focus:ring-state-success-border disabled:opacity-50"
                 @click="activateTable(row.id)"
               >
                 <svg v-if="activatingId !== row.id" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
@@ -692,8 +692,8 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
             <div v-if="deactivateModalOpen" class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm overflow-hidden">
               <div class="relative px-5 pt-5 pb-4 border-b border-border/60">
                 <div class="flex items-start gap-3">
-                  <div class="flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center bg-amber-50 border border-amber-200 dark:bg-amber-950/30 dark:border-amber-800/40">
-                    <svg class="w-5 h-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 115.636 5.636m12.728 12.728L5.636 5.636" /></svg>
+                  <div class="flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center bg-state-warning-bg border border-state-warning-border">
+                    <svg class="w-5 h-5 text-state-warning-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 115.636 5.636m12.728 12.728L5.636 5.636" /></svg>
                   </div>
                   <div class="min-w-0 flex-1 pt-0.5">
                     <h3 class="text-base font-bold text-text-primary leading-tight">{{ `Desactivar ${singularLower}` }}</h3>
@@ -730,7 +730,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
                 <button
                   type="button"
                   :disabled="isDeactivating"
-                  class="flex-1 min-h-[44px] rounded-xl text-sm font-bold transition-all disabled:opacity-40 disabled:cursor-not-allowed bg-amber-500 text-white hover:bg-amber-600 active:scale-[0.98] flex items-center justify-center gap-2 shadow-sm"
+                  class="flex-1 min-h-[44px] rounded-xl text-sm font-bold transition-all disabled:opacity-40 disabled:cursor-not-allowed bg-state-warning-action-bg text-state-warning-action-text hover:bg-state-warning-action-bg/90 active:scale-[0.98] flex items-center justify-center gap-2 shadow-sm"
                   @click="confirmDeactivate"
                 >
                   <UiLoadingDots v-if="isDeactivating" size="8px" color="currentColor" />
@@ -790,40 +790,40 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
 
               <div class="px-5 py-4 flex flex-col gap-3">
                 <!-- Blocked: open session -->
-                <div v-if="hasOpenSession" class="rounded-xl bg-destructive/8 border border-destructive/20 p-4">
+                <div v-if="hasOpenSession" class="rounded-xl bg-state-danger-bg border border-state-danger-border p-4">
                   <div class="flex items-start gap-3">
-                    <div class="w-8 h-8 rounded-lg bg-destructive/10 flex items-center justify-center flex-shrink-0">
-                      <svg class="w-4 h-4 text-destructive" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
+                    <div class="w-8 h-8 rounded-lg bg-state-danger-bg flex items-center justify-center flex-shrink-0">
+                      <svg class="w-4 h-4 text-state-danger-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
                     </div>
                     <div>
-                      <p class="text-sm font-semibold text-destructive leading-snug">No se puede eliminar ahora</p>
-                      <p class="text-xs text-destructive/80 mt-1 leading-relaxed">{{ `Esta ${singularLower} tiene una sesión activa. Ciérrala antes de eliminarla.` }}</p>
+                      <p class="text-sm font-semibold text-state-danger-text leading-snug">No se puede eliminar ahora</p>
+                      <p class="text-xs text-state-danger-text/80 mt-1 leading-relaxed">{{ `Esta ${singularLower} tiene una sesión activa. Ciérrala antes de eliminarla.` }}</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Archive warning: has closed history -->
-                <div v-else-if="hasHistory" class="rounded-xl bg-amber-50 border border-amber-200/70 p-4 dark:bg-amber-950/20 dark:border-amber-800/40">
+                <div v-else-if="hasHistory" class="rounded-xl bg-state-warning-bg border border-state-warning-border p-4">
                   <div class="flex items-start gap-3">
-                    <div class="w-8 h-8 rounded-lg bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center flex-shrink-0">
-                      <svg class="w-4 h-4 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" /></svg>
+                    <div class="w-8 h-8 rounded-lg bg-state-warning-bg flex items-center justify-center flex-shrink-0">
+                      <svg class="w-4 h-4 text-state-warning-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" /></svg>
                     </div>
                     <div>
-                      <p class="text-sm font-semibold text-amber-800 dark:text-amber-300 leading-snug">{{ `Esta ${singularLower} se archivará` }}</p>
-                      <p class="text-xs text-amber-700/80 dark:text-amber-400 mt-1 leading-relaxed">Tiene historial de sesiones. Se archivará para preservar los reportes y dejará de aparecer en el sistema.</p>
+                      <p class="text-sm font-semibold text-state-warning-text leading-snug">{{ `Esta ${singularLower} se archivará` }}</p>
+                      <p class="text-xs text-state-warning-text/80 mt-1 leading-relaxed">Tiene historial de sesiones. Se archivará para preservar los reportes y dejará de aparecer en el sistema.</p>
                     </div>
                   </div>
                 </div>
 
                 <!-- Safe: no history, hard delete -->
-                <div v-else class="rounded-xl bg-emerald-50 border border-emerald-200/70 p-4 dark:bg-emerald-950/20 dark:border-emerald-800/40">
+                <div v-else class="rounded-xl bg-state-success-bg border border-state-success-border p-4">
                   <div class="flex items-start gap-3">
-                    <div class="w-8 h-8 rounded-lg bg-emerald-100 dark:bg-emerald-900/30 flex items-center justify-center flex-shrink-0">
-                      <svg class="w-4 h-4 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+                    <div class="w-8 h-8 rounded-lg bg-state-success-bg flex items-center justify-center flex-shrink-0">
+                      <svg class="w-4 h-4 text-state-success-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
                     </div>
                     <div>
-                      <p class="text-sm font-semibold text-emerald-800 dark:text-emerald-300 leading-snug">Sin historial — eliminación permanente</p>
-                      <p class="text-xs text-emerald-700/80 dark:text-emerald-400 mt-1 leading-relaxed">{{ `Esta ${singularLower} no tiene sesiones registradas. Se eliminará de forma definitiva.` }}</p>
+                      <p class="text-sm font-semibold text-state-success-text leading-snug">Sin historial — eliminación permanente</p>
+                      <p class="text-xs text-state-success-text/80 mt-1 leading-relaxed">{{ `Esta ${singularLower} no tiene sesiones registradas. Se eliminará de forma definitiva.` }}</p>
                     </div>
                   </div>
                 </div>
@@ -844,7 +844,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
                 <button
                   type="button"
                   :disabled="hasOpenSession || isDeleting"
-                  class="flex-1 min-h-[44px] rounded-xl text-sm font-bold transition-all disabled:opacity-40 disabled:cursor-not-allowed bg-destructive text-white hover:bg-destructive/90 active:scale-[0.98] flex items-center justify-center gap-2 shadow-sm"
+                  class="flex-1 min-h-[44px] rounded-xl text-sm font-bold transition-all disabled:opacity-40 disabled:cursor-not-allowed bg-state-danger-action-bg text-state-danger-action-text hover:bg-state-danger-action-bg/90 active:scale-[0.98] flex items-center justify-center gap-2 shadow-sm"
                   @click="confirmDelete"
                 >
                   <UiLoadingDots v-if="isDeleting" size="8px" color="currentColor" />


### PR DESCRIPTION
## Summary
- Apply semantic control/state/status tokens to `/operaciones/comandas` toggles, warnings, actions, and deactivate modal states
- Apply semantic tokens to `/operaciones/mesas` module states, row actions, inactive labels, and deactivate/delete modal states
- Tokenize `HealthSemaphore` surfaces used by mesas table sections

## Validation
- `npx nuxi prepare`
- `npx tailwindcss -c tailwind.config.js -i assets/css/design-system.css -o /tmp/wr-1171-front-tailwind.css --content pages/operaciones/comandas.vue,pages/operaciones/mesas.vue,components/analytics/HealthSemaphore.vue`

Closes #1171