### PR TITLE
Audit remaining direct brand colors

### DIFF
--- a/components/DashboardTenantSelector.vue
+++ b/components/DashboardTenantSelector.vue
@@ -67,7 +67,7 @@
       <ChevronDownIcon class="w-3.5 h-3.5 text-text-tertiary flex-shrink-0" />
     </button>
 
-    <!-- User info — name + purple avatar icon -->
+    <!-- User info — name + brand avatar icon -->
     <div class="flex items-center gap-2 h-11 px-3 bg-white border-2 border-surface-secondary rounded-lg">
       <span class="text-sm font-medium text-text-primary truncate max-w-[120px]">{{ userName }}</span>
       <div class="w-8 h-8 bg-surface-secondary border border-surface-secondary rounded-lg flex items-center justify-center flex-shrink-0">

--- a/components/online/checkout/StepConfirm.vue
+++ b/components/online/checkout/StepConfirm.vue
@@ -122,21 +122,20 @@
     <!-- WaRos card -->
     <div
       v-if="warosSystemEnabled === true"
-      class="rounded-2xl overflow-hidden border border-violet-200 shadow-sm"
+      class="rounded-2xl overflow-hidden border border-primary/20 shadow-sm"
     >
-      <!-- Header: crocus-50 (violet-50) — primario suave, no agresivo -->
-      <div class="flex items-center gap-2.5 px-4 py-3 bg-violet-50 border-b border-violet-100">
-        <svg class="w-5 h-5 text-violet-600 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24">
+      <div class="flex items-center gap-2.5 px-4 py-3 bg-primary/10 border-b border-primary/20">
+        <svg class="w-5 h-5 text-primary flex-shrink-0" fill="currentColor" viewBox="0 0 24 24">
           <path d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
         </svg>
-        <p class="text-sm font-bold text-violet-800 tracking-wide">Tus WaRos</p>
+        <p class="text-sm font-bold text-primary tracking-wide">Tus WaRos</p>
       </div>
 
       <!-- Body rows -->
-      <div class="bg-white divide-y divide-violet-100">
+      <div class="bg-surface divide-y divide-border">
         <!-- Saldo actual -->
         <div class="flex items-center justify-between px-4 py-3.5">
-          <p class="text-xs font-semibold text-violet-500 uppercase tracking-wider">Saldo actual</p>
+          <p class="text-xs font-semibold text-text-secondary uppercase tracking-wider">Saldo actual</p>
           <p class="text-lg font-bold text-slate-800 tabular-nums">
             {{ warosBalance !== null ? warosBalance.toLocaleString('es-CO') : '—' }}
           </p>

--- a/components/payments/PaymentMethodSelector.vue
+++ b/components/payments/PaymentMethodSelector.vue
@@ -49,7 +49,7 @@
             </div>
             <div
               v-else-if="group.slug === 'digital'"
-              class="bg-purple-100 text-purple-700 w-8 h-8 md:w-9 md:h-9 rounded-full flex items-center justify-center flex-shrink-0"
+              class="bg-state-info-bg text-state-info-icon w-8 h-8 md:w-9 md:h-9 rounded-full flex items-center justify-center flex-shrink-0"
             >
               <svg class="h-4 w-4 md:h-5 md:w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0 1 3.75 9.375v-4.5ZM3.75 14.625c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5a1.125 1.125 0 0 1-1.125-1.125v-4.5ZM13.5 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0 1 13.5 9.375v-4.5Z" />

--- a/components/pos/CartItem.vue
+++ b/components/pos/CartItem.vue
@@ -25,7 +25,7 @@
                   class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide"
                   :class="{
                     'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400': item.fulfillmentStatus === 'sent',
-                    'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400': item.fulfillmentStatus === 'preparing',
+                    'bg-state-warning-bg text-state-warning-text': item.fulfillmentStatus === 'preparing',
                     'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400': item.fulfillmentStatus === 'ready',
                     'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400': item.fulfillmentStatus === 'delivered' || item.fulfillmentStatus === 'cancelled',
                   }"

--- a/components/puntos/ReglaCard.vue
+++ b/components/puntos/ReglaCard.vue
@@ -192,7 +192,7 @@ const iconZoneBg = computed(() => {
   switch (props.rule.rule_type) {
     case 'ticket_value':   return 'bg-orange-50'
     case 'purchase_count': return 'bg-blue-50'
-    case 'frequency':      return 'bg-violet-50'
+    case 'frequency':      return 'bg-state-info-bg'
     case 'per_ticket_qty': return 'bg-emerald-50'
     default:               return 'bg-slate-50'
   }
@@ -202,7 +202,7 @@ const iconContainerBg = computed(() => {
   switch (props.rule.rule_type) {
     case 'ticket_value':   return 'bg-orange-100'
     case 'purchase_count': return 'bg-blue-100'
-    case 'frequency':      return 'bg-violet-100'
+    case 'frequency':      return 'bg-state-info-bg'
     case 'per_ticket_qty': return 'bg-emerald-100'
     default:               return 'bg-slate-100'
   }
@@ -213,7 +213,7 @@ const iconColor = computed(() => {
   switch (props.rule.rule_type) {
     case 'ticket_value':   return 'text-orange-600'
     case 'purchase_count': return 'text-blue-600'
-    case 'frequency':      return 'text-violet-600'
+    case 'frequency':      return 'text-state-info-icon'
     case 'per_ticket_qty': return 'text-emerald-600'
     default:               return 'text-slate-600'
   }
@@ -223,7 +223,7 @@ const activeBorderClass = computed(() => {
   switch (props.rule.rule_type) {
     case 'ticket_value':   return 'border-orange-200 bg-orange-50/30'
     case 'purchase_count': return 'border-blue-200 bg-blue-50/30'
-    case 'frequency':      return 'border-violet-200 bg-violet-50/30'
+    case 'frequency':      return 'border-state-info-border bg-state-info-bg/30'
     case 'per_ticket_qty': return 'border-emerald-200 bg-emerald-50/30'
     default:               return 'border-primary/20'
   }
@@ -233,7 +233,7 @@ const activeSwitchBg = computed(() => {
   switch (props.rule.rule_type) {
     case 'ticket_value':   return 'bg-orange-500'
     case 'purchase_count': return 'bg-blue-500'
-    case 'frequency':      return 'bg-violet-500'
+    case 'frequency':      return 'bg-state-info-action-bg'
     case 'per_ticket_qty': return 'bg-emerald-500'
     default:               return 'bg-primary'
   }

--- a/components/ui/status-badge/index.vue
+++ b/components/ui/status-badge/index.vue
@@ -18,7 +18,7 @@ const statusBadgeVariants = cva(
         info:        'bg-status-info-bg text-status-info-text',
         // Secondary: neutral values
         secondary:   'bg-secondary text-secondary-foreground',
-        // Primary: brand-highlighted values — purple
+        // Primary: brand-highlighted values
         primary:     'bg-primary/10 text-primary'
       },
       size: {

--- a/composables/useCierrePeriod.ts
+++ b/composables/useCierrePeriod.ts
@@ -51,7 +51,7 @@ export function useCierrePeriod() {
 
   const periodBadgeClass = (cierre: CierrePeriodLike | null | undefined): string => {
     if (isTemplateCierre(cierre)) return 'bg-primary/10 text-primary'
-    if (hasTimeWindow(cierre)) return 'bg-violet-50 text-violet-800 border border-violet-200'
+    if (hasTimeWindow(cierre)) return 'bg-state-info-bg text-state-info-text border border-state-info-border'
     return 'bg-surface-secondary text-text-secondary'
   }
 

--- a/docs/engineering/visual-token-color-audit.md
+++ b/docs/engineering/visual-token-color-audit.md
@@ -1,0 +1,37 @@
+# Visual Token Color Audit
+
+Issue: #1172
+Epic: #1173
+
+## Search Counts
+
+Search scope excludes `node_modules`, lock files, build output, `.nuxt`, `public`, and this audit note.
+
+| Search | Before | After | Notes |
+|---|---:|---:|---|
+| `purple|violet` | 39 | 7 | Remaining refs are token comments, a blog gradient variant name, and one documented data palette. |
+| 6-digit hex colors | 145 | 145 | Mostly token comments, data visualization palettes, social brands, and user-configurable color fallbacks. |
+| Crocus brand hex values | 1 | 1 | `#7C3AED` remains in a POS product category palette. |
+
+## Converted
+
+- Supplier and purchase preparation statuses now use semantic warning state tokens instead of purple utilities.
+- Received supplier transition state now uses semantic success state tokens.
+- POS cart preparation state now uses semantic warning state tokens.
+- Digital payment icons and finance digital badges now use semantic info state tokens.
+- WaRos checkout balance card now uses primary/surface/border tokens instead of violet utilities.
+- Accounting class color helpers now use status chip tokens for the third class family.
+- Auth logo, cierre period badges, loyalty frequency rule styling, and brand-avatar comments no longer use purple/violet literals.
+
+## Intentional Exceptions
+
+- Data and category palettes: POS product category colors, menu product swatches, team member color palettes, and event gradients are visualization colors rather than brand state colors.
+- User-configurable station colors: kitchen station dots, station forms, inherited station colors, and station fallback hex values preserve operator-selected colors.
+- Third-party brand colors: WhatsApp, Facebook, and Instagram hover colors keep their external brand identity.
+- Chart colors: analytics chart series and grid colors are chart configuration, not page chrome.
+- Print/content CSS: print tickets, docs layout surfaces, and article CTA hard white/black values are scoped rendering contexts.
+- Token comments: primitive token files document source hex values for maintainability.
+
+## Follow-Up Rule
+
+New UI state colors should use semantic tokens such as `state-*`, `status-*`, `status-chip-*`, `data-table-*`, `control-*`, or `primary`, not direct `purple-*`, `violet-*`, or brand hex utilities.

--- a/layouts/auth.vue
+++ b/layouts/auth.vue
@@ -7,8 +7,8 @@
     <header class="w-full px-4 py-6">
       <div class="max-w-7xl mx-auto flex items-center justify-between">
         <div class="flex items-center space-x-3">
-          <div class="w-10 h-10 bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg flex items-center justify-center">
-            <span class="text-white font-bold text-xl">W</span>
+          <div class="w-10 h-10 bg-primary rounded-lg flex items-center justify-center">
+            <span class="text-primary-foreground font-bold text-xl">W</span>
           </div>
           <h1 class="text-2xl font-bold text-gray-900">{{ organizationName }}</h1>
         </div>

--- a/pages/abastecimiento/compra/[id]/acciones.vue
+++ b/pages/abastecimiento/compra/[id]/acciones.vue
@@ -305,7 +305,7 @@ function getStatusBadgeClass(status: string): string {
     quotation: 'bg-yellow-500/10 text-yellow-600',
     pending: 'bg-blue-500/10 text-blue-600',
     confirmed: 'bg-green-500/10 text-green-600',
-    preparing: 'bg-purple-500/10 text-purple-600',
+    preparing: 'bg-state-warning-bg text-state-warning-text',
     shipped: 'bg-cyan-500/10 text-cyan-600',
     partially_received: 'bg-orange-500/10 text-orange-600',
     received: 'bg-emerald-500/10 text-emerald-600',

--- a/pages/abastecimiento/compras.vue
+++ b/pages/abastecimiento/compras.vue
@@ -581,7 +581,7 @@ function getStatusClass(status) {
     quotation: '!bg-yellow-500/10 !text-yellow-600',
     pending: '!bg-blue-500/10 !text-blue-600',
     confirmed: '!bg-teal-500/10 !text-teal-600',
-    preparing: '!bg-purple-500/10 !text-purple-600',
+    preparing: '!bg-state-warning-bg !text-state-warning-text',
     shipped: '!bg-cyan-500/10 !text-cyan-600',
     partially_received: '!bg-orange-500/10 !text-orange-600',
     received: '!bg-emerald-500/10 !text-emerald-600',

--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -130,9 +130,9 @@
           </NuxtLink>
           <NuxtLink
             :to="`/finanzas/arqueo/z?mode=custom&start=${today}&end=${today}`"
-            class="flex items-start gap-3 p-4 rounded-lg border-2 border-violet-200 bg-violet-50/40 hover:border-violet-300 hover:bg-violet-50 transition-colors min-h-[44px]"
+            class="flex items-start gap-3 p-4 rounded-lg border-2 border-state-info-border bg-state-info-bg hover:border-state-info-border/80 hover:bg-state-info-bg/80 transition-colors min-h-[44px]"
           >
-            <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-violet-100 flex items-center justify-center text-violet-800" aria-hidden="true">
+            <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-state-info-bg flex items-center justify-center text-state-info-icon" aria-hidden="true">
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>

--- a/pages/finanzas/arqueo/nuevo.vue
+++ b/pages/finanzas/arqueo/nuevo.vue
@@ -969,7 +969,7 @@ const GROUP_LABELS: Record<string, string> = {
 const GROUP_COLORS: Record<string, { dot: string; badge: string }> = {
   cash:    { dot: 'bg-emerald-500', badge: 'bg-emerald-50 text-emerald-700 border border-emerald-200' },
   card:    { dot: 'bg-blue-500',    badge: 'bg-blue-50 text-blue-700 border border-blue-200'         },
-  digital: { dot: 'bg-violet-500',  badge: 'bg-violet-50 text-violet-700 border border-violet-200'   },
+  digital: { dot: 'bg-state-info-icon',  badge: 'bg-state-info-bg text-state-info-text border border-state-info-border'   },
   credit:  { dot: 'bg-amber-500',   badge: 'bg-amber-50 text-amber-700 border border-amber-200'      },
 }
 

--- a/pages/finanzas/arqueo/x.vue
+++ b/pages/finanzas/arqueo/x.vue
@@ -262,7 +262,7 @@ const GROUP_LABELS: Record<string, string> = {
 const GROUP_COLORS: Record<string, { dot: string; badge: string }> = {
   cash:    { dot: 'bg-emerald-500', badge: 'bg-emerald-50 text-emerald-700' },
   card:    { dot: 'bg-blue-500',    badge: 'bg-blue-50 text-blue-700'       },
-  digital: { dot: 'bg-violet-500',  badge: 'bg-violet-50 text-violet-700'   },
+  digital: { dot: 'bg-state-info-icon',  badge: 'bg-state-info-bg text-state-info-text'   },
   credit:  { dot: 'bg-amber-500',   badge: 'bg-amber-50 text-amber-700'     },
 }
 

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -1363,7 +1363,7 @@ const GROUP_LABELS: Record<string, string> = {
 const GROUP_COLORS: Record<string, { dot: string; badge: string }> = {
   cash:    { dot: 'bg-emerald-500', badge: 'bg-emerald-50 text-emerald-700 border border-emerald-200' },
   card:    { dot: 'bg-blue-500',    badge: 'bg-blue-50 text-blue-700 border border-blue-200'         },
-  digital: { dot: 'bg-violet-500',  badge: 'bg-violet-50 text-violet-700 border border-violet-200'   },
+  digital: { dot: 'bg-state-info-icon',  badge: 'bg-state-info-bg text-state-info-text border border-state-info-border'   },
   credit:  { dot: 'bg-amber-500',   badge: 'bg-amber-50 text-amber-700 border border-amber-200'      },
 }
 

--- a/pages/finanzas/contabilidad/cuentas/[id].vue
+++ b/pages/finanzas/contabilidad/cuentas/[id].vue
@@ -34,11 +34,11 @@ const CLASS_VARIANTS: Record<string, string> = {
   '4': 'success', '5': 'destructive', '6': 'warning',
 }
 const CLASS_BG: Record<string, string> = {
-  '1': 'bg-primary/10', '2': 'bg-amber-100', '3': 'bg-violet-100',
+  '1': 'bg-primary/10', '2': 'bg-amber-100', '3': 'bg-status-chip-bg',
   '4': 'bg-green-100',  '5': 'bg-red-100',   '6': 'bg-amber-100',
 }
 const CLASS_TEXT: Record<string, string> = {
-  '1': 'text-primary',   '2': 'text-amber-600',  '3': 'text-violet-600',
+  '1': 'text-primary',   '2': 'text-amber-600',  '3': 'text-status-chip-text',
   '4': 'text-green-600', '5': 'text-red-600',     '6': 'text-amber-600',
 }
 const pucLevel = (code: string) => {

--- a/pages/finanzas/contabilidad/cuentas/index.vue
+++ b/pages/finanzas/contabilidad/cuentas/index.vue
@@ -99,11 +99,11 @@ const CLASS_VARIANTS: Record<string, string> = {
   '4': 'success',  '5': 'destructive', '6': 'warning',
 }
 const CLASS_BG: Record<string, string> = {
-  '1': 'bg-primary/10',  '2': 'bg-amber-100',  '3': 'bg-violet-100',
+  '1': 'bg-primary/10',  '2': 'bg-amber-100',  '3': 'bg-status-chip-bg',
   '4': 'bg-green-100',   '5': 'bg-red-100',    '6': 'bg-amber-100',
 }
 const CLASS_TEXT: Record<string, string> = {
-  '1': 'text-primary',   '2': 'text-amber-700', '3': 'text-violet-700',
+  '1': 'text-primary',   '2': 'text-amber-700', '3': 'text-status-chip-text',
   '4': 'text-green-700', '5': 'text-red-700',   '6': 'text-amber-700',
 }
 

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -2783,7 +2783,7 @@ onUnmounted(() => {
                   <!-- Icon — digital -->
                   <div
                     v-else-if="group.slug === 'digital'"
-                    class="bg-purple-100 text-purple-700 w-8 h-8 md:w-10 md:h-10 rounded-full flex items-center justify-center flex-shrink-0"
+                    class="bg-state-info-bg text-state-info-icon w-8 h-8 md:w-10 md:h-10 rounded-full flex items-center justify-center flex-shrink-0"
                   >
                     <svg class="h-4 w-4 md:h-6 md:w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0 1 3.75 9.375v-4.5ZM3.75 14.625c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5a1.125 1.125 0 0 1-1.125-1.125v-4.5ZM13.5 4.875c0-.621.504-1.125 1.125-1.125h4.5c.621 0 1.125.504 1.125 1.125v4.5c0 .621-.504 1.125-1.125 1.125h-4.5A1.125 1.125 0 0 1 13.5 9.375v-4.5Z" />

--- a/pages/proveedor/[token]/[purchaseId]/acciones.vue
+++ b/pages/proveedor/[token]/[purchaseId]/acciones.vue
@@ -314,7 +314,7 @@ function getStatusBadgeClass(status: string): string {
     'quotation': 'bg-yellow-500/10 text-yellow-600',
     'pending': 'bg-blue-500/10 text-blue-600',
     'confirmed': 'bg-green-500/10 text-green-600',
-    'preparing': 'bg-purple-500/10 text-purple-600',
+    'preparing': 'bg-state-warning-bg text-state-warning-text',
     'invoiced': 'bg-orange-500/10 text-orange-600',
     'shipped': 'bg-cyan-500/10 text-cyan-600',
     'received': 'bg-emerald-500/10 text-emerald-600',

--- a/pages/proveedor/[token]/[purchaseId]/transicion/[id].vue
+++ b/pages/proveedor/[token]/[purchaseId]/transicion/[id].vue
@@ -416,7 +416,7 @@ function getStatusBadgeClass(status: string): string {
     confirmed: 'border-success text-success',
     preparing: 'border-blue-500 text-blue-500',
     shipped: 'border-blue-600 text-blue-600',
-    received: 'border-purple-500 text-purple-500',
+    received: 'border-state-success-border text-state-success-text',
     verified: 'border-indigo-500 text-indigo-500',
     invoiced: 'border-orange-500 text-orange-500',
     paid: 'border-success text-success',


### PR DESCRIPTION
## Summary
- Convert remaining obvious purple/violet UI state usages to semantic state, status-chip, info, or primary tokens
- Keep data palettes, station colors, charts, social brands, and print/content CSS as documented exceptions
- Add a visual token color audit note with before/after search counts

## Search Counts
- `purple|violet`: 39 -> 7
- 6-digit hex colors: 145 -> 145
- Crocus brand hex values: 1 -> 1

## Validation
- `git diff --check`
- `npx nuxi prepare`
- `npx tailwindcss -c tailwind.config.js -i assets/css/design-system.css -o /tmp/wr-1172-tailwind.css --content ...`

Closes #1172