### PR TITLE
Tokenizar shell dashboard, headers y navegación

### DIFF
--- a/components/DashboardBottomNav.vue
+++ b/components/DashboardBottomNav.vue
@@ -5,14 +5,14 @@
       <!-- User Profile -->
       <div class="flex items-center gap-3">
         <div class="relative flex-shrink-0">
-          <div class="w-10 h-10 bg-crocus-600 rounded-full flex items-center justify-center font-semibold text-white text-sm">
+          <div class="w-10 h-10 bg-primary rounded-full flex items-center justify-center font-semibold text-primary-foreground text-sm">
             {{ userInitials }}
           </div>
-          <span class="absolute bottom-0 right-0 w-2.5 h-2.5 bg-green-500 border-2 border-white rounded-full"></span>
+          <span class="absolute bottom-0 right-0 w-2.5 h-2.5 bg-success border-2 border-shell-mobile-bg rounded-full"></span>
         </div>
         <div class="flex flex-col">
-          <span class="text-sm font-semibold text-ebony-800 leading-tight">{{ userName }}</span>
-          <span class="text-xs text-titan-500 leading-tight">{{ selectedTenant?.name || 'Sin tenant' }}</span>
+          <span class="text-sm font-semibold text-text-primary leading-tight">{{ userName }}</span>
+          <span class="text-xs text-text-tertiary leading-tight">{{ selectedTenant?.name || 'Sin tenant' }}</span>
         </div>
       </div>
 
@@ -23,11 +23,11 @@
           @click="handleRefresh"
           :disabled="isLoading"
           aria-label="Actualizar página"
-          class="w-10 h-10 flex items-center justify-center rounded-full transition-all duration-200 hover:bg-titan-100 disabled:opacity-50 disabled:cursor-not-allowed"
+          class="w-10 h-10 flex items-center justify-center rounded-full transition-all duration-200 hover:bg-icon-button-neutral-hover-bg focus:outline-none focus:ring-2 focus:ring-icon-button-focus-ring disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <UiLoadingMatrix v-if="isLoading" size="5.5px" />
           <svg v-else
-            class="w-5 h-5 text-titan-500 transition-transform duration-300 hover:rotate-180"
+            class="w-5 h-5 text-icon-button-neutral-text transition-transform duration-300 hover:rotate-180"
             fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
           </svg>
@@ -37,13 +37,13 @@
         <button
           @click="openNotificationsModal"
           aria-label="Ver notificaciones"
-          class="relative w-10 h-10 flex items-center justify-center rounded-full transition-all duration-200 hover:bg-titan-100"
+          class="relative w-10 h-10 flex items-center justify-center rounded-full transition-all duration-200 hover:bg-icon-button-neutral-hover-bg focus:outline-none focus:ring-2 focus:ring-icon-button-focus-ring"
         >
           <BellAlertIcon v-if="notificationsCount > 0" class="w-5 h-5 text-primary" aria-hidden="true" />
-          <BellIcon v-else class="w-5 h-5 text-titan-500" aria-hidden="true" />
+          <BellIcon v-else class="w-5 h-5 text-icon-button-neutral-text" aria-hidden="true" />
           <span
             v-if="notificationsCount > 0"
-            class="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 flex items-center justify-center bg-crocus-500 text-white text-[10px] font-bold rounded-full leading-none"
+            class="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 flex items-center justify-center bg-badge-danger-bg text-badge-danger-text text-[10px] font-bold rounded-full leading-none"
             aria-hidden="true"
           >
             {{ notificationsCount > 9 ? '9+' : notificationsCount }}
@@ -54,18 +54,18 @@
         <button
           @click="showMenuModal = true"
           aria-label="Abrir navegación"
-          class="w-10 h-10 flex items-center justify-center rounded-full transition-all duration-200 hover:bg-titan-100"
+          class="w-10 h-10 flex items-center justify-center rounded-full transition-all duration-200 hover:bg-icon-button-neutral-hover-bg focus:outline-none focus:ring-2 focus:ring-icon-button-focus-ring"
         >
-          <Bars3Icon class="w-5 h-5 text-titan-500" />
+          <Bars3Icon class="w-5 h-5 text-icon-button-neutral-text" />
         </button>
 
         <!-- Configuración/Tenant -->
         <button
           @click="showTenantModal = true"
           aria-label="Configuración"
-          class="w-10 h-10 flex items-center justify-center rounded-full transition-all duration-200 hover:bg-titan-100"
+          class="w-10 h-10 flex items-center justify-center rounded-full transition-all duration-200 hover:bg-icon-button-neutral-hover-bg focus:outline-none focus:ring-2 focus:ring-icon-button-focus-ring"
         >
-          <Cog6ToothIcon class="w-5 h-5 text-titan-500" />
+          <Cog6ToothIcon class="w-5 h-5 text-icon-button-neutral-text" />
         </button>
       </div>
     </div>
@@ -85,21 +85,21 @@
             <div class="relative">
               <div
                 class="w-12 h-12 rounded-full flex items-center justify-center transition-colors"
-                :class="activePage === item.page ? 'bg-crocus-100' : 'bg-titan-100 hover:bg-titan-200'"
+                :class="activePage === item.page ? 'bg-icon-button-primary-bg' : 'bg-badge-neutral-bg hover:bg-badge-neutral-hover-bg'"
               >
                 <component
                   :is="item.icon"
                   class="w-6 h-6"
-                  :class="activePage === item.page ? 'text-crocus-600' : 'text-titan-600'"
+                  :class="activePage === item.page ? 'text-icon-button-primary-text' : 'text-badge-neutral-text'"
                 />
               </div>
               <span
                 v-if="item.showCriticalDot && hasCriticalAlerts"
-                class="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 bg-destructive border-2 border-white rounded-full"
+                class="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 bg-destructive border-2 border-shell-mobile-bg rounded-full"
                 :aria-label="`Alertas críticas en ${item.label.toLowerCase()}`"
               />
             </div>
-            <span class="text-[10px] text-titan-600">{{ item.label }}</span>
+            <span class="text-[10px] text-badge-neutral-text">{{ item.label }}</span>
           </NuxtLink>
         </div>
 
@@ -110,10 +110,10 @@
             class="flex flex-col items-center gap-1"
             @click="showMenuModal = false"
           >
-            <div class="w-12 h-12 rounded-full flex items-center justify-center bg-crocus-100">
-              <HomeIcon class="w-6 h-6 text-crocus-600" />
+            <div class="w-12 h-12 rounded-full flex items-center justify-center bg-icon-button-primary-bg">
+              <HomeIcon class="w-6 h-6 text-icon-button-primary-text" />
             </div>
-            <span class="text-[10px] text-titan-600">Inicio</span>
+            <span class="text-[10px] text-badge-neutral-text">Inicio</span>
           </NuxtLink>
         </div>
       </div>
@@ -121,14 +121,14 @@
 
     <!-- Notifications Modal -->
     <UiBottomSheetModal v-model="showNotificationsModal" title="Notificaciones" max-height="lg">
-      <div class="flex items-center justify-between px-4 py-2 border-b border-titan-100">
-        <span class="text-xs text-titan-600">Sonido de alertas</span>
+      <div class="flex items-center justify-between px-4 py-2 border-b border-sheet-border">
+        <span class="text-xs text-text-secondary">Sonido de alertas</span>
         <button
           type="button"
           @click="handleToggleDespachoSound"
           :aria-label="despachoSoundEnabled ? 'Silenciar alertas sonoras' : 'Activar alertas sonoras'"
-          class="w-8 h-8 flex items-center justify-center rounded-full hover:bg-titan-100 transition-colors"
-          :class="despachoSoundEnabled ? 'text-ebony-800' : 'text-titan-400'"
+          class="w-8 h-8 flex items-center justify-center rounded-full hover:bg-icon-button-neutral-hover-bg focus:outline-none focus:ring-2 focus:ring-icon-button-focus-ring transition-colors"
+          :class="despachoSoundEnabled ? 'text-text-primary' : 'text-icon-button-neutral-text'"
         >
           <SpeakerWaveIcon v-if="despachoSoundEnabled" class="w-4 h-4" aria-hidden="true" />
           <SpeakerXMarkIcon v-else class="w-4 h-4" aria-hidden="true" />
@@ -140,24 +140,24 @@
         <p class="text-sm text-muted-foreground text-center">Sin notificaciones nuevas</p>
       </div>
       <!-- List -->
-      <ul v-else class="divide-y divide-titan-100">
+      <ul v-else class="divide-y divide-sheet-border">
         <li v-for="notification in notifications" :key="notification.id">
           <NuxtLink
             :to="notificationDespachoPath(notification)"
             @click="handleMarkAsRead(notification.id); showNotificationsModal = false"
-            class="flex items-start gap-3 px-4 py-3 hover:bg-titan-50 transition-colors"
-            :class="!notification.read_at ? 'bg-crocus-50/40' : ''"
+            class="flex items-start gap-3 px-4 py-3 hover:bg-icon-button-neutral-hover-bg transition-colors"
+            :class="!notification.read_at ? 'bg-icon-button-primary-bg/40' : ''"
           >
-            <div class="flex-shrink-0 w-8 h-8 rounded-full bg-crocus-100 flex items-center justify-center mt-0.5">
-              <ShoppingBagIcon class="w-4 h-4 text-crocus-600" aria-hidden="true" />
+            <div class="flex-shrink-0 w-8 h-8 rounded-full bg-icon-button-primary-bg flex items-center justify-center mt-0.5">
+              <ShoppingBagIcon class="w-4 h-4 text-icon-button-primary-text" aria-hidden="true" />
             </div>
             <div class="flex-1 min-w-0">
-              <p class="text-sm font-semibold text-ebony-800 leading-snug">
+              <p class="text-sm font-semibold text-text-primary leading-snug">
                 {{ notificationDespachoTitle(notification) }}
               </p>
-              <p class="text-xs text-titan-500 mt-0.5">{{ formatRelativeTime(notification.created_at) }}</p>
+              <p class="text-xs text-text-tertiary mt-0.5">{{ formatRelativeTime(notification.created_at) }}</p>
             </div>
-            <span v-if="!notification.read_at" class="flex-shrink-0 w-2 h-2 rounded-full bg-crocus-500 mt-1.5" aria-hidden="true" />
+            <span v-if="!notification.read_at" class="flex-shrink-0 w-2 h-2 rounded-full bg-primary mt-1.5" aria-hidden="true" />
           </NuxtLink>
         </li>
       </ul>
@@ -168,12 +168,12 @@
       <div class="p-4 space-y-6">
         <!-- Tenant Selector -->
         <div>
-          <label class="text-sm text-titan-600 font-medium mb-2 block">Seleccionar Tenant</label>
+          <label class="text-sm text-text-secondary font-medium mb-2 block">Seleccionar Tenant</label>
           <div class="space-y-2">
-            <div v-if="isLoadingTenants" class="text-sm text-titan-600 py-2">
+            <div v-if="isLoadingTenants" class="text-sm text-text-secondary py-2">
               Cargando tenants...
             </div>
-            <div v-else-if="tenants.length === 0" class="text-sm text-titan-600 py-2">
+            <div v-else-if="tenants.length === 0" class="text-sm text-text-secondary py-2">
               No hay tenants disponibles
             </div>
             <button
@@ -184,33 +184,33 @@
               :disabled="isLoadingTenants"
               class="w-full flex items-center justify-between px-4 py-3 rounded-lg border-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               :class="selectedTenant?.id === tenant.id
-                ? 'border-crocus-600 bg-crocus-50'
-                : 'border-titan-200 hover:border-crocus-300 hover:bg-titan-50'"
+                ? 'border-primary bg-icon-button-primary-bg'
+                : 'border-form-control-border hover:border-form-control-focus-border hover:bg-icon-button-neutral-hover-bg'"
             >
               <div class="flex items-center gap-3">
                 <div
                   class="w-3 h-3 rounded-full"
-                  :class="selectedTenant?.id === tenant.id ? 'bg-crocus-600' : 'bg-titan-400'"
+                  :class="selectedTenant?.id === tenant.id ? 'bg-primary' : 'bg-badge-neutral-bg'"
                 ></div>
-                <span class="font-medium text-ebony-800">{{ tenant.name }}</span>
+                <span class="font-medium text-text-primary">{{ tenant.name }}</span>
               </div>
               <CheckCircleIcon
                 v-if="selectedTenant?.id === tenant.id"
-                class="w-5 h-5 text-crocus-600"
+                class="w-5 h-5 text-primary"
               />
             </button>
           </div>
         </div>
 
         <!-- User Info -->
-        <div class="pt-4 border-t border-titan-300">
-          <div class="flex items-center gap-3 px-4 py-3 bg-titan-50 rounded-lg">
-            <div class="w-10 h-10 bg-ebony-800 rounded-full flex items-center justify-center font-bold text-white text-sm">
+        <div class="pt-4 border-t border-sheet-border">
+          <div class="flex items-center gap-3 px-4 py-3 bg-shell-account-hover-bg rounded-lg">
+            <div class="w-10 h-10 bg-primary rounded-full flex items-center justify-center font-bold text-primary-foreground text-sm">
               {{ userInitials }}
             </div>
             <div>
-              <div class="font-semibold text-sm text-ebony-800">{{ userName }}</div>
-              <div class="text-xs text-titan-600">{{ userEmail }}</div>
+              <div class="font-semibold text-sm text-text-primary">{{ userName }}</div>
+              <div class="text-xs text-text-secondary">{{ userEmail }}</div>
             </div>
           </div>
         </div>

--- a/components/DashboardTenantSelector.vue
+++ b/components/DashboardTenantSelector.vue
@@ -8,32 +8,32 @@
         class="fixed inset-0 z-[9998] flex items-end sm:items-center justify-center"
         @click.self="closeTenantModal"
       >
-        <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" @click="closeTenantModal" />
-        <div class="relative w-full sm:w-[420px] sm:max-w-[90vw] bg-white sm:rounded-xl rounded-t-2xl shadow-2xl flex flex-col max-h-[80vh] sm:max-h-[60vh]">
-          <div class="flex items-center justify-between px-5 pt-5 pb-3 border-b border-titan-200 flex-shrink-0">
-            <p class="text-sm font-semibold text-ebony-800">Cambiar negocio</p>
-            <button @click="closeTenantModal" class="p-1.5 rounded-lg text-titan-400 hover:bg-titan-100 hover:text-ebony-700 transition-colors">
+        <div class="absolute inset-0 bg-overlay-backdrop-strong/60 backdrop-blur-sm" @click="closeTenantModal" />
+        <div class="relative w-full sm:w-[420px] sm:max-w-[90vw] bg-sheet-surface-bg sm:rounded-xl rounded-t-2xl shadow-2xl flex flex-col max-h-[80vh] sm:max-h-[60vh]">
+          <div class="flex items-center justify-between px-5 pt-5 pb-3 border-b border-sheet-border flex-shrink-0">
+            <p class="text-sm font-semibold text-modal-surface-text">Cambiar negocio</p>
+            <button @click="closeTenantModal" class="p-1.5 rounded-lg text-icon-button-neutral-text hover:bg-icon-button-neutral-hover-bg hover:text-icon-button-neutral-hover-text focus:outline-none focus:ring-2 focus:ring-icon-button-focus-ring transition-colors">
               <XMarkIcon class="w-4 h-4" />
             </button>
           </div>
           <div class="px-4 py-3 flex-shrink-0">
-            <div class="flex items-center gap-2 px-3 py-2 border-b border-titan-200 focus-within:border-crocus-400 transition-colors">
-              <MagnifyingGlassIcon class="w-4 h-4 text-titan-400 flex-shrink-0" />
+            <div class="flex items-center gap-2 px-3 py-2 border-b border-form-control-border focus-within:border-form-control-focus-border transition-colors">
+              <MagnifyingGlassIcon class="w-4 h-4 text-form-control-placeholder flex-shrink-0" />
               <input
                 ref="searchInputRef"
                 v-model="tenantSearch"
                 type="text"
                 placeholder="Buscar negocio..."
-                class="flex-1 bg-transparent text-sm text-ebony-800 placeholder-titan-400 outline-none"
+                class="flex-1 bg-transparent text-sm text-form-control-text placeholder-form-control-placeholder outline-none"
               />
-              <button v-if="tenantSearch" @click="tenantSearch = ''" class="text-titan-400 hover:text-ebony-700">
+              <button v-if="tenantSearch" @click="tenantSearch = ''" class="text-form-control-placeholder hover:text-form-control-text">
                 <XMarkIcon class="w-3.5 h-3.5" />
               </button>
             </div>
           </div>
           <div class="overflow-y-auto px-3 pb-4 space-y-0.5">
-            <div v-if="isLoadingTenants" class="px-3 py-3 text-sm text-titan-400 text-center">Cargando...</div>
-            <div v-else-if="filteredTenants.length === 0" class="px-3 py-3 text-sm text-titan-400 text-center">Sin resultados</div>
+            <div v-if="isLoadingTenants" class="px-3 py-3 text-sm text-form-control-help text-center">Cargando...</div>
+            <div v-else-if="filteredTenants.length === 0" class="px-3 py-3 text-sm text-form-control-help text-center">Sin resultados</div>
             <button
               v-else
               v-for="tenant in filteredTenants"
@@ -41,11 +41,11 @@
               @click="selectTenant(tenant)"
               :disabled="isLoadingTenants"
               class="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm transition-colors text-left disabled:opacity-50"
-              :class="selectedTenant?.id === tenant.id ? 'bg-crocus-50 text-crocus-700 font-medium' : 'text-ebony-700 hover:bg-titan-50'"
+              :class="selectedTenant?.id === tenant.id ? 'bg-icon-button-primary-bg text-icon-button-primary-text font-medium' : 'text-text-secondary hover:bg-icon-button-neutral-hover-bg'"
             >
-              <div class="w-2 h-2 rounded-full flex-shrink-0" :class="selectedTenant?.id === tenant.id ? 'bg-crocus-500' : 'bg-titan-300'" />
+              <div class="w-2 h-2 rounded-full flex-shrink-0" :class="selectedTenant?.id === tenant.id ? 'bg-primary' : 'bg-badge-neutral-bg'" />
               <span class="truncate">{{ tenant.name }}</span>
-              <CheckIcon v-if="selectedTenant?.id === tenant.id" class="w-4 h-4 ml-auto text-crocus-500 flex-shrink-0" />
+              <CheckIcon v-if="selectedTenant?.id === tenant.id" class="w-4 h-4 ml-auto text-primary flex-shrink-0" />
             </button>
           </div>
         </div>
@@ -60,15 +60,15 @@
       @click="openTenantModal"
       :disabled="isLoadingTenants"
       aria-label="Cambiar negocio"
-      class="flex items-center gap-2 h-11 px-3 bg-white border-2 border-surface-secondary rounded-lg text-sm font-medium text-text-primary hover:bg-surface-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      class="flex items-center gap-2 h-11 px-3 bg-shell-account-bg border-2 border-shell-action-border rounded-lg text-sm font-medium text-shell-account-text hover:bg-shell-account-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
     >
       <span class="w-2 h-2 bg-primary rounded-full flex-shrink-0" />
       <span class="truncate max-w-[150px]">{{ isLoadingTenants ? 'Cargando...' : (selectedTenant?.name || 'Seleccionar') }}</span>
       <ChevronDownIcon class="w-3.5 h-3.5 text-text-tertiary flex-shrink-0" />
     </button>
 
-    <!-- User info — name + brand avatar icon -->
-    <div class="flex items-center gap-2 h-11 px-3 bg-white border-2 border-surface-secondary rounded-lg">
+    <!-- User info — name + purple avatar icon -->
+    <div class="flex items-center gap-2 h-11 px-3 bg-shell-account-bg border-2 border-shell-action-border rounded-lg">
       <span class="text-sm font-medium text-text-primary truncate max-w-[120px]">{{ userName }}</span>
       <div class="w-8 h-8 bg-surface-secondary border border-surface-secondary rounded-lg flex items-center justify-center flex-shrink-0">
         <UserIcon class="w-4 h-4 text-primary" />

--- a/components/dashboard/BusinessStatusToggle.vue
+++ b/components/dashboard/BusinessStatusToggle.vue
@@ -37,7 +37,7 @@
         :aria-labelledby="'modal-title-' + _uid"
       >
         <!-- Backdrop -->
-        <div class="absolute inset-0 bg-black/50" @click="closeModal" />
+        <div class="absolute inset-0 bg-overlay-backdrop/50" @click="closeModal" />
 
         <!-- Dialog -->
         <div class="relative bg-surface border border-border rounded-xl shadow-xl w-full max-w-sm p-6 space-y-4">
@@ -82,13 +82,13 @@
             <button
               @click="confirmToggle"
               :disabled="isUpdating"
-              class="flex-1 min-h-[44px] px-4 py-2 text-sm font-semibold rounded-lg text-white transition-all focus:outline-none focus:ring-2 focus:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed"
+              class="flex-1 min-h-[44px] px-4 py-2 text-sm font-semibold rounded-lg text-primary-foreground transition-all focus:outline-none focus:ring-2 focus:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed"
               :class="businessProfile.is_manually_open
                 ? 'bg-destructive hover:bg-destructive/90 focus:ring-destructive'
                 : 'bg-success hover:bg-success/90 focus:ring-success'"
             >
               <span v-if="isUpdating" class="flex items-center justify-center gap-2">
-                <span class="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" aria-hidden="true" />
+                <span class="w-4 h-4 border-2 border-primary-foreground border-t-transparent rounded-full animate-spin" aria-hidden="true" />
                 Guardando...
               </span>
               <span v-else>

--- a/components/dashboard/DashboardMobileChrome.vue
+++ b/components/dashboard/DashboardMobileChrome.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="lg:hidden fixed bottom-0 inset-x-0 z-50 bg-white border-t border-titan-300 shadow-lg transition-opacity"
+    class="lg:hidden fixed bottom-0 inset-x-0 z-50 bg-shell-mobile-bg border-t border-shell-mobile-border shadow-lg transition-opacity"
     :class="posCartSheetOpen ? 'pointer-events-none opacity-0' : ''"
     style="padding-bottom: env(safe-area-inset-bottom, 0px)"
     :aria-hidden="posCartSheetOpen"

--- a/components/dashboard/DashboardShellHeader.vue
+++ b/components/dashboard/DashboardShellHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="bg-surface border-b border-border px-4 py-3 md:px-8 md:py-4 flex-shrink-0">
+  <header class="bg-shell-header-bg border-b border-shell-header-border px-4 py-3 md:px-8 md:py-4 flex-shrink-0">
     <div class="flex items-center justify-between gap-3">
       <div class="flex items-center gap-2 sm:gap-4 min-w-0">
         <div class="min-w-0">
@@ -21,7 +21,7 @@
         <NuxtLink
           key="upload-invoice"
           to="/abastecimiento/compras-directas/crear"
-          class="flex items-center gap-1 md:gap-2 h-11 bg-primary text-primary-foreground px-2 md:px-4 rounded-xl font-medium hover:bg-primary/90 transition-all"
+          class="flex items-center gap-1 md:gap-2 h-11 bg-primary text-primary-foreground px-2 md:px-4 rounded-xl font-medium hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring transition-all"
           title="Cargar Factura IA"
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z" /><path d="M20 2v4" /><path d="M22 4h-4" /><circle cx="4" cy="20" r="2" /></svg>
@@ -31,7 +31,7 @@
         <button
           key="pos-link"
           type="button"
-          class="flex items-center gap-1 md:gap-2 h-11 bg-white border-2 border-surface-secondary text-text-primary px-2 md:px-4 rounded-lg text-sm font-medium hover:bg-surface-secondary transition-colors"
+          class="flex items-center gap-1 md:gap-2 h-11 bg-shell-action-bg border-2 border-shell-action-border text-shell-action-text px-2 md:px-4 rounded-lg text-sm font-medium hover:bg-shell-action-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring transition-colors"
           title="Venta POS"
           @click="$emit('navigate-pos')"
         >
@@ -44,7 +44,7 @@
         <button
           v-if="headerAction"
           key="dynamic-header-action"
-          class="h-11 px-4 bg-primary text-primary-foreground rounded-lg font-medium hover:bg-primary/90 transition-colors flex items-center gap-2"
+          class="h-11 px-4 bg-primary text-primary-foreground rounded-lg font-medium hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring transition-colors flex items-center gap-2"
           @click="headerAction.handler"
         >
           <svg v-if="headerAction.icon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -68,7 +68,7 @@
           :disabled="isRefreshing || isProgressiveLoading"
           aria-label="Refrescar datos"
           :aria-busy="isRefreshing || isProgressiveLoading"
-          class="hidden md:flex w-11 h-11 items-center justify-center bg-surface-secondary border-0 rounded-lg text-primary transition-all focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50 disabled:cursor-not-allowed"
+          class="hidden md:flex w-11 h-11 items-center justify-center bg-shell-icon-bg border-0 rounded-lg text-shell-icon-text hover:bg-shell-icon-hover-bg transition-all focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring disabled:opacity-50 disabled:cursor-not-allowed"
           title="Refrescar"
           @click="$emit('refresh')"
         >

--- a/components/notifications/NotificationBell.vue
+++ b/components/notifications/NotificationBell.vue
@@ -7,7 +7,7 @@
       :aria-expanded="isOpen"
       aria-haspopup="true"
       aria-label="Notificaciones"
-      class="relative w-11 h-11 flex items-center justify-center rounded-full hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-primary/50 transition-colors"
+      class="relative w-11 h-11 flex items-center justify-center rounded-full hover:bg-icon-button-neutral-hover-bg focus:outline-none focus:ring-2 focus:ring-icon-button-focus-ring transition-colors"
     >
       <!-- Animated bell icon: solid when there are unread notifications -->
       <BellAlertIcon v-if="unreadCount > 0" class="w-6 h-6 text-primary" aria-hidden="true" />
@@ -18,7 +18,7 @@
         v-if="unreadCount > 0"
         aria-live="polite"
         aria-atomic="true"
-        class="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 flex items-center justify-center bg-red-500 text-white text-[10px] font-bold rounded-full leading-none"
+        class="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 flex items-center justify-center bg-badge-danger-bg text-badge-danger-text text-[10px] font-bold rounded-full leading-none"
       >
         {{ unreadCount > 99 ? '99+' : unreadCount }}
       </span>
@@ -48,7 +48,7 @@
               @click="handleToggleSound"
               :title="soundEnabled ? 'Silenciar alertas sonoras' : 'Activar alertas sonoras'"
               :aria-label="soundEnabled ? 'Silenciar alertas sonoras' : 'Activar alertas sonoras'"
-              class="w-8 h-8 flex items-center justify-center rounded-full hover:bg-surface-secondary transition-colors"
+              class="w-8 h-8 flex items-center justify-center rounded-full hover:bg-icon-button-neutral-hover-bg focus:outline-none focus:ring-2 focus:ring-icon-button-focus-ring transition-colors"
               :class="soundEnabled ? 'text-text-primary' : 'text-muted-foreground'"
             >
               <SpeakerWaveIcon v-if="soundEnabled" class="w-4 h-4" aria-hidden="true" />

--- a/components/ui/BottomSheetModal.vue
+++ b/components/ui/BottomSheetModal.vue
@@ -11,7 +11,7 @@
     >
       <div
         v-if="modelValue"
-        class="fixed inset-0 bg-black/50 z-[70] lg:hidden"
+        class="fixed inset-0 bg-overlay-backdrop/50 z-[70] lg:hidden"
         aria-hidden="true"
         @click="closeModal"
       />
@@ -27,22 +27,22 @@
     >
       <div
         v-if="modelValue"
-        class="fixed inset-x-0 bottom-0 z-[71] lg:hidden bg-white rounded-t-2xl w-full flex flex-col overflow-hidden shadow-2xl touch-manipulation"
+        class="fixed inset-x-0 bottom-0 z-[71] lg:hidden bg-sheet-surface-bg rounded-t-2xl w-full flex flex-col overflow-hidden shadow-2xl touch-manipulation"
         :class="maxHeightClass"
         role="dialog"
         aria-modal="true"
         :aria-label="title"
       >
         <!-- Header -->
-        <div class="flex-shrink-0 bg-white border-b border-titan-300 px-4 py-4 flex items-center justify-between">
-          <h3 class="text-lg font-semibold text-ebony-800">{{ title }}</h3>
+        <div class="flex-shrink-0 bg-sheet-header-bg border-b border-sheet-border px-4 py-4 flex items-center justify-between">
+          <h3 class="text-lg font-semibold text-modal-surface-text">{{ title }}</h3>
           <button
             type="button"
             @click="closeModal"
-            class="min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-titan-100 rounded-lg transition-colors"
+            class="min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-icon-button-neutral-hover-bg focus:outline-none focus:ring-2 focus:ring-icon-button-focus-ring rounded-lg transition-colors"
             aria-label="Cerrar"
           >
-            <XMarkIcon class="w-5 h-5 text-titan-500" />
+            <XMarkIcon class="w-5 h-5 text-icon-button-neutral-text" />
           </button>
         </div>
 
@@ -55,7 +55,7 @@
         </div>
 
         <!-- Footer (optional, sticky) -->
-        <div v-if="$slots.footer" class="flex-shrink-0 bg-white border-t border-titan-300">
+        <div v-if="$slots.footer" class="flex-shrink-0 bg-sheet-footer-bg border-t border-sheet-border">
           <slot name="footer" />
         </div>
       </div>

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -33,14 +33,14 @@
             <ol class="inline-flex items-center space-x-1 md:space-x-3">
               <li class="inline-flex items-center">
                 <NuxtLink to="/financiero"
-                  class="text-sm font-medium text-titan-600 hover:text-crocus-600 transition-colors">
+                  class="text-sm font-medium text-text-secondary hover:text-primary transition-colors">
                   Financiero
                 </NuxtLink>
               </li>
               <li v-if="breadcrumbPage">
                 <div class="flex items-center">
-                  <ChevronRightIcon class="w-4 h-4 text-titan-400" />
-                  <span class="ml-1 text-sm font-medium text-ebony-800">{{ breadcrumbPage }}</span>
+                  <ChevronRightIcon class="w-4 h-4 text-text-tertiary" />
+                  <span class="ml-1 text-sm font-medium text-text-primary">{{ breadcrumbPage }}</span>
                 </div>
               </li>
             </ol>
@@ -303,15 +303,15 @@ main::-webkit-scrollbar {
 }
 
 main::-webkit-scrollbar-track {
-  background: hsl(var(--titan-100));
+  background: hsl(var(--surface-secondary));
 }
 
 main::-webkit-scrollbar-thumb {
-  background: hsl(var(--titan-300));
+  background: hsl(var(--surface-tertiary));
   border-radius: 4px;
 }
 
 main::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--titan-400));
+  background: hsl(var(--border));
 }
 </style>


### PR DESCRIPTION
## Summary

- Migrates dashboard header controls, tenant selector, notification bell, business status modal, mobile chrome, mobile navigation sheets, bottom sheet primitive usage, and dashboard breadcrumb/scrollbar colors to semantic token aliases.
- Uses the token foundation now on `main` from #1180: `overlay`, `sheet`, `modal`, `shell`, `icon-button`, `form-control`, `badge`, `state`, and existing text/surface tokens.
- Preserves navigation destinations, module gates, permissions, and dashboard behavior.

## Before / After Counts

Targeted hardcoded color search in #1181 scope:

- Before: `82`
- After: `0`

Targeted state references in #1181 scope:

- Before: `35`
- After: `34`

The remaining state references are semantic hover/focus/disabled/active token classes or opacity/transform-only states.

## Validation

- `rg` targeted hardcoded-color count over dashboard shell/navigation scope: `0`
- `rg` targeted hover/focus/active/disabled count over same scope: `34`
- `node -e "require('./tailwind.config.js'); console.log('tailwind config ok')"`
- `npm exec nuxi prepare`

`nuxi prepare` completed and reported an existing duplicated-import warning for `ActivePromotionRow` between `composables/useActivePromotions.ts` and `utils/promoProductMatch.ts`.

## Manual Visual Validation

No dev server was opened automatically. Please check:

- Desktop dashboard header actions
- Tenant selector modal/search/selected tenant
- Notification bell dropdown and unread badge
- Business status confirm modal
- Desktop sidebar logout/loading overlay
- Mobile chrome bottom bar
- Mobile navigation sheet
- Mobile notifications sheet
- Mobile tenant/config sheet

Closes #1181
