### PR TITLE
Tokenizar módulos operativos principales

### DIFF
--- a/components/abastecimiento/AbastecimientoStockAdjustmentFullForm.vue
+++ b/components/abastecimiento/AbastecimientoStockAdjustmentFullForm.vue
@@ -26,7 +26,7 @@
               <!-- Ingredient Selection -->
               <div>
                 <label class="block text-sm font-medium text-text-primary mb-2">
-                  {{ WAREHOUSE_COPY.warehouseItemColumn }} <span class="text-red-500">*</span>
+                  {{ WAREHOUSE_COPY.warehouseItemColumn }} <span class="text-destructive">*</span>
                 </label>
                 <!-- If ingredient is pre-selected from URL, show it as read-only -->
                 <div v-if="route.query.ingredientId && selectedIngredient" class="w-full px-4 py-3 border-2 border-border rounded-lg bg-surface-secondary text-text-primary">
@@ -113,7 +113,7 @@
               <!-- Adjustment Type -->
               <div>
                 <label class="block text-sm font-medium text-text-primary mb-3">
-                  Tipo de Ajuste <span class="text-red-500">*</span>
+                  Tipo de Ajuste <span class="text-destructive">*</span>
                 </label>
                 <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
                   <button
@@ -121,12 +121,12 @@
                     @click="form.adjustmentType = 'increment'"
                     class="p-4 border-2 rounded-lg transition-all hover:shadow-md"
                     :class="form.adjustmentType === 'increment'
-                      ? 'border-green-500 bg-green-50 dark:bg-green-900/20'
-                      : 'border-border hover:border-green-300'"
+                      ? 'border-state-success-border bg-state-success-bg'
+                      : 'border-border hover:border-state-success-border'"
                   >
                     <div class="flex items-center justify-center gap-2">
-                      <Icon name="heroicons:arrow-up-circle" class="w-6 h-6 text-green-600" />
-                      <span class="font-semibold" :class="form.adjustmentType === 'increment' ? 'text-green-700 dark:text-green-400' : 'text-text-primary'">
+                      <Icon name="heroicons:arrow-up-circle" class="w-6 h-6 text-state-success-icon" />
+                      <span class="font-semibold" :class="form.adjustmentType === 'increment' ? 'text-state-success-text' : 'text-text-primary'">
                         Incremento
                       </span>
                     </div>
@@ -138,12 +138,12 @@
                     @click="form.adjustmentType = 'decrement'"
                     class="p-4 border-2 rounded-lg transition-all hover:shadow-md"
                     :class="form.adjustmentType === 'decrement'
-                      ? 'border-red-500 bg-red-50 dark:bg-red-900/20'
-                      : 'border-border hover:border-red-300'"
+                      ? 'border-state-danger-border bg-state-danger-bg'
+                      : 'border-border hover:border-state-danger-border'"
                   >
                     <div class="flex items-center justify-center gap-2">
-                      <Icon name="heroicons:arrow-down-circle" class="w-6 h-6 text-red-600" />
-                      <span class="font-semibold" :class="form.adjustmentType === 'decrement' ? 'text-red-700 dark:text-red-400' : 'text-text-primary'">
+                      <Icon name="heroicons:arrow-down-circle" class="w-6 h-6 text-state-danger-icon" />
+                      <span class="font-semibold" :class="form.adjustmentType === 'decrement' ? 'text-state-danger-text' : 'text-text-primary'">
                         Decremento
                       </span>
                     </div>
@@ -155,12 +155,12 @@
                     @click="form.adjustmentType = 'set'"
                     class="p-4 border-2 rounded-lg transition-all hover:shadow-md"
                     :class="form.adjustmentType === 'set'
-                      ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
-                      : 'border-border hover:border-blue-300'"
+                      ? 'border-state-info-border bg-state-info-bg'
+                      : 'border-border hover:border-state-info-border'"
                   >
                     <div class="flex items-center justify-center gap-2">
-                      <Icon name="heroicons:arrows-right-left" class="w-6 h-6 text-blue-600" />
-                      <span class="font-semibold" :class="form.adjustmentType === 'set' ? 'text-blue-700 dark:text-blue-400' : 'text-text-primary'">
+                      <Icon name="heroicons:arrows-right-left" class="w-6 h-6 text-state-info-icon" />
+                      <span class="font-semibold" :class="form.adjustmentType === 'set' ? 'text-state-info-text' : 'text-text-primary'">
                         Ajustar a
                       </span>
                     </div>
@@ -174,7 +174,7 @@
                 <!-- Quantity -->
                 <div>
                   <label class="block text-sm font-medium text-text-primary mb-2">
-                    {{ form.adjustmentType === 'set' ? 'Nuevo Stock' : 'Cantidad' }} <span class="text-red-500">*</span>
+                    {{ form.adjustmentType === 'set' ? 'Nuevo Stock' : 'Cantidad' }} <span class="text-destructive">*</span>
                   </label>
                   <UiDecimalInput
                     v-model="form.quantity"
@@ -189,7 +189,7 @@
                 <!-- Unit Selection -->
                 <div>
                   <label class="block text-sm font-medium text-text-primary mb-2">
-                    Unidad <span class="text-red-500">*</span>
+                    Unidad <span class="text-destructive">*</span>
                   </label>
                   <select
                     v-model="form.unit"
@@ -237,13 +237,13 @@
               </div>
 
               <!-- Preview of new stock -->
-              <div v-if="form.quantity && form.quantity > 0" class="mt-2 p-3 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
-                <p class="text-sm text-blue-900 dark:text-blue-300">
+              <div v-if="form.quantity && form.quantity > 0" class="mt-2 p-3 bg-state-info-bg border border-state-info-border rounded-lg">
+                <p class="text-sm text-state-info-text">
                   <span class="font-semibold">Resultado:</span>
                   Stock {{ form.adjustmentType === 'increment' ? 'aumentará' : form.adjustmentType === 'decrement' ? 'disminuirá' : 'se establecerá' }} a
                   <span class="font-bold">{{ formatNumber(newStockInBase) }} {{ selectedIngredient?.unit }}</span>
                 </p>
-                <p v-if="form.cost_per_unit && form.adjustmentType === 'increment'" class="text-xs text-blue-800 dark:text-blue-400 mt-1">
+                <p v-if="form.cost_per_unit && form.adjustmentType === 'increment'" class="text-xs text-state-info-text mt-1">
                   Costo unitario: ${{ form.cost_per_unit.toLocaleString('es-CO') }} por {{ form.unit }}
                 </p>
               </div>
@@ -251,7 +251,7 @@
               <!-- Reason Selection -->
               <div v-if="form.adjustmentType">
                 <label class="block text-sm font-medium text-text-primary mb-2">
-                  Motivo del Ajuste <span class="text-red-500">*</span>
+                  Motivo del Ajuste <span class="text-destructive">*</span>
                 </label>
                 <select
                   v-model="form.reason"
@@ -266,7 +266,7 @@
               <!-- Notes -->
               <div v-if="form.reason">
                 <label class="block text-sm font-medium text-text-primary mb-2">
-                  Notas <span v-if="form.reason === 'other'" class="text-red-500">*</span>
+                  Notas <span v-if="form.reason === 'other'" class="text-destructive">*</span>
                   <span v-else class="text-xs text-text-secondary font-normal">(opcional)</span>
                 </label>
                 <textarea
@@ -279,13 +279,13 @@
               </div>
 
               <!-- Warning Message -->
-              <div v-if="showLargeWarning" class="bg-yellow-50 dark:bg-yellow-900/20 border-l-4 border-yellow-400 p-4 rounded">
+              <div v-if="showLargeWarning" class="bg-state-warning-bg border-l-4 border-state-warning-border p-4 rounded">
                 <div class="flex">
                   <div class="flex-shrink-0">
-                    <Icon name="heroicons:exclamation-triangle" class="h-5 w-5 text-yellow-400" />
+                    <Icon name="heroicons:exclamation-triangle" class="h-5 w-5 text-state-warning-icon" />
                   </div>
                   <div class="ml-3">
-                    <p class="text-sm text-yellow-700 dark:text-yellow-300">
+                    <p class="text-sm text-state-warning-text">
                       <span class="font-semibold">Advertencia:</span> Este ajuste representa un cambio mayor al 50% del stock actual. Por favor, verifica los datos antes de continuar.
                     </p>
                   </div>
@@ -326,9 +326,9 @@
                 <span
                   class="px-2 py-1 rounded text-xs font-medium"
                   :class="{
-                    'bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400': form.adjustmentType === 'increment',
-                    'bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-400': form.adjustmentType === 'decrement',
-                    'bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-400': form.adjustmentType === 'set'
+                    'bg-state-success-bg text-state-success-text': form.adjustmentType === 'increment',
+                    'bg-state-danger-bg text-state-danger-text': form.adjustmentType === 'decrement',
+                    'bg-state-info-bg text-state-info-text': form.adjustmentType === 'set'
                   }"
                 >
                   {{ form.adjustmentType === 'increment' ? 'Incremento' : form.adjustmentType === 'decrement' ? 'Decremento' : 'Ajustar a' }}
@@ -352,7 +352,7 @@
             <button
               type="submit"
               :disabled="!isFormValid || isSubmitting"
-              class="w-full py-3 bg-emerald-500 text-white rounded-lg hover:bg-emerald-600 transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold shadow-lg shadow-emerald-500/20"
+              class="w-full py-3 bg-action-success-bg text-action-success-text rounded-lg hover:bg-action-success-hover-bg transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold shadow-lg shadow-action-success-bg/20"
             >
               <CommonsTheCustomLoader v-if="isSubmitting" size="small" />
               <span v-else>

--- a/components/abastecimiento/StockAdjustmentPanel.vue
+++ b/components/abastecimiento/StockAdjustmentPanel.vue
@@ -11,7 +11,7 @@
     >
       <div
         v-if="modelValue"
-        class="fixed inset-0 z-40 bg-black/40"
+        class="fixed inset-0 z-40 bg-overlay-backdrop/40"
         @click="close"
         aria-hidden="true"
       />
@@ -31,7 +31,7 @@
       >
         <!-- Mobile drag handle -->
         <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
-          <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+          <div class="w-10 h-1 rounded-full bg-sheet-border" aria-hidden="true" />
         </div>
 
         <!-- Header -->
@@ -52,7 +52,7 @@
               type="button"
               aria-label="Cerrar panel"
               :disabled="isSubmitting"
-              class="flex-shrink-0 min-h-[44px] min-w-[44px] inline-flex items-center justify-center rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50 transition-colors"
+              class="flex-shrink-0 min-h-[44px] min-w-[44px] inline-flex items-center justify-center rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 disabled:opacity-50 transition-colors"
               @click="close"
             >
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -64,11 +64,11 @@
 
         <!-- ─── Success state ─────────────────────────────────────────────── -->
         <div v-if="state === 'success'" class="flex-1 overflow-y-auto px-6 py-5 space-y-4">
-          <div class="flex items-start gap-3 rounded-xl border border-green-200 bg-green-50 p-4 dark:border-green-700/40 dark:bg-green-900/20">
-            <CheckCircleIcon class="w-5 h-5 text-green-700 dark:text-green-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
+          <div class="flex items-start gap-3 rounded-xl border border-state-success-border bg-state-success-bg p-4">
+            <CheckCircleIcon class="w-5 h-5 text-state-success-icon flex-shrink-0 mt-0.5" aria-hidden="true" />
             <div class="min-w-0 flex-1">
-              <p class="text-sm font-semibold text-green-900 dark:text-green-200">Ajuste registrado</p>
-              <p class="text-xs text-green-800 dark:text-green-300 mt-0.5 leading-snug break-words">
+              <p class="text-sm font-semibold text-state-success-text">Ajuste registrado</p>
+              <p class="text-xs text-state-success-text mt-0.5 leading-snug break-words">
                 {{ successMessage }}
               </p>
             </div>
@@ -236,10 +236,10 @@
           <!-- 4b. Amber empty-state for ingredients without purchase units -->
           <div
             v-if="selectedIngredient && !purchaseUnitsApi.isLoading(form.ingredientId) && purchaseUnitOptions.length === 0"
-            class="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3 dark:border-amber-700/40 dark:bg-amber-900/20"
+            class="flex items-start gap-2 rounded-xl border border-state-warning-border bg-state-warning-bg p-3"
           >
-            <ExclamationTriangleIcon class="w-4 h-4 text-amber-700 dark:text-amber-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
-            <p class="text-xs text-amber-800 dark:text-amber-300 leading-snug">
+            <ExclamationTriangleIcon class="w-4 h-4 text-state-warning-icon flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <p class="text-xs text-state-warning-text leading-snug">
               Sin unidades de compra configuradas. Podés ajustar usando la unidad base ({{ selectedIngredient.unit }}) o
               <a :href="`/abastecimiento/ingredientes-propios?highlight=${selectedIngredient.id}`" class="underline font-medium">configurar unidades</a>.
             </p>
@@ -313,10 +313,10 @@
           <!-- 9. Large adjustment warning -->
           <div
             v-if="showLargeWarning"
-            class="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3 dark:border-amber-700/40 dark:bg-amber-900/20"
+            class="flex items-start gap-2 rounded-xl border border-state-warning-border bg-state-warning-bg p-3"
           >
-            <ExclamationTriangleIcon class="w-4 h-4 text-amber-700 dark:text-amber-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
-            <p class="text-xs text-amber-800 dark:text-amber-300 leading-snug">
+            <ExclamationTriangleIcon class="w-4 h-4 text-state-warning-icon flex-shrink-0 mt-0.5" aria-hidden="true" />
+            <p class="text-xs text-state-warning-text leading-snug">
               <strong>Advertencia:</strong> este ajuste representa un cambio mayor al 50% del stock actual. Verificá los datos antes de registrar.
             </p>
           </div>
@@ -344,7 +344,7 @@
             </button>
             <button
               type="button"
-              class="flex-1 min-h-[44px] py-3 px-4 bg-primary text-primary-foreground rounded-xl font-semibold hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/40 active:scale-95 transition-all"
+              class="flex-1 min-h-[44px] py-3 px-4 bg-action-primary-bg text-action-primary-text rounded-xl font-semibold hover:bg-action-primary-hover-bg focus:outline-none focus:ring-2 focus:ring-primary/40 active:scale-95 transition-all"
               @click="resetForAnother"
             >
               Hacer otro ajuste
@@ -362,7 +362,7 @@
             <button
               type="button"
               :disabled="!isFormValid || isSubmitting"
-              class="flex-1 min-h-[44px] py-3 px-4 bg-primary text-primary-foreground rounded-xl font-semibold hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:opacity-50 disabled:cursor-not-allowed active:scale-95 transition-all inline-flex items-center justify-center gap-2"
+              class="flex-1 min-h-[44px] py-3 px-4 bg-action-primary-bg text-action-primary-text rounded-xl font-semibold hover:bg-action-primary-hover-bg focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:opacity-50 disabled:cursor-not-allowed active:scale-95 transition-all inline-flex items-center justify-center gap-2"
               @click="onSubmit"
             >
               <UiLoadingDots v-if="isSubmitting" size="8px" color="currentColor" />
@@ -415,9 +415,9 @@ const notesId = `stock-adj-notes-${uid}`
 const REASONS = ADJUSTMENT_REASONS
 
 const TYPE_OPTIONS = [
-  { value: 'increment' as const, label: 'Incremento', icon: ArrowUpCircleIcon,    activeClass: 'border-green-500 bg-green-50 dark:bg-green-900/20', iconClass: 'text-green-600', labelClass: 'text-green-700 dark:text-green-400' },
-  { value: 'decrement' as const, label: 'Decremento', icon: ArrowDownCircleIcon,  activeClass: 'border-red-500 bg-red-50 dark:bg-red-900/20',       iconClass: 'text-red-600',   labelClass: 'text-red-700 dark:text-red-400' },
-  { value: 'set'       as const, label: 'Ajustar a',  icon: ArrowsRightLeftIcon,  activeClass: 'border-primary bg-primary/5',                      iconClass: 'text-primary',   labelClass: 'text-primary' },
+  { value: 'increment' as const, label: 'Incremento', icon: ArrowUpCircleIcon,    activeClass: 'border-state-success-border bg-state-success-bg', iconClass: 'text-state-success-icon', labelClass: 'text-state-success-text' },
+  { value: 'decrement' as const, label: 'Decremento', icon: ArrowDownCircleIcon,  activeClass: 'border-state-danger-border bg-state-danger-bg',   iconClass: 'text-state-danger-icon',  labelClass: 'text-state-danger-text' },
+  { value: 'set'       as const, label: 'Ajustar a',  icon: ArrowsRightLeftIcon,  activeClass: 'border-state-info-border bg-state-info-bg',       iconClass: 'text-state-info-icon',    labelClass: 'text-state-info-text' },
 ]
 
 const purchaseUnitsApi = useIngredientPurchaseUnits()

--- a/components/cocina/ComandaCard.vue
+++ b/components/cocina/ComandaCard.vue
@@ -164,8 +164,8 @@ onUnmounted(() => {
       />
 
       <!-- Comanda Notes -->
-      <div v-if="comanda.notes" class="mt-2 p-2 bg-amber-50 dark:bg-amber-950/20 rounded-lg border border-amber-200 dark:border-amber-900">
-        <p class="text-[11px] font-bold text-amber-800 dark:text-amber-300 uppercase">
+      <div v-if="comanda.notes" class="mt-2 p-2 bg-state-warning-bg  rounded-lg border border-state-warning-border ">
+        <p class="text-[11px] font-bold text-state-warning-text  uppercase">
           📝 Nota: {{ comanda.notes }}
         </p>
       </div>

--- a/components/cocina/ItemRow.vue
+++ b/components/cocina/ItemRow.vue
@@ -59,7 +59,7 @@ const toggleStatus = async () => {
         <span
           v-for="(mod, idx) in item.modifiers_snapshot"
           :key="idx"
-          class="text-[10px] font-bold bg-titan-200 text-titan-800 px-1.5 py-0.5 rounded uppercase"
+          class="text-[10px] font-bold bg-surface-secondary text-text-secondary px-1.5 py-0.5 rounded uppercase"
         >
           + {{ mod.name }}
         </span>
@@ -88,8 +88,8 @@ const toggleStatus = async () => {
         :disabled="isUpdating"
         class="h-7 w-7 rounded-lg flex items-center justify-center transition-all border active:scale-90"
         :class="item.status === 'ready'
-          ? 'bg-success border-success text-white shadow-sm shadow-success/30'
-          : 'bg-surface border-border text-titan-300 hover:border-primary hover:text-primary'"
+          ? 'bg-action-success-bg border-action-success-border text-action-success-text shadow-sm shadow-action-success-bg/30'
+          : 'bg-surface border-border text-text-tertiary hover:border-primary hover:text-primary'"
       >
         <UiLoadingMatrix v-if="isUpdating" size="4px" />
         <svg v-else class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/components/cocina/StationPanel.vue
+++ b/components/cocina/StationPanel.vue
@@ -31,7 +31,7 @@
       >
         <!-- Mobile drag handle -->
         <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
-          <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+          <div class="w-10 h-1 rounded-full bg-sheet-border" aria-hidden="true" />
         </div>
 
         <!-- Header -->
@@ -54,7 +54,7 @@
               @click="close"
               type="button"
               aria-label="Cerrar panel"
-              class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+              class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30"
             >
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -77,7 +77,7 @@
               required
               maxlength="100"
               placeholder="Ej: Cocina Principal, Bar, Parrilla"
-              class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary bg-surface"
+              class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring text-sm text-text-primary bg-surface"
               autocomplete="off"
               :disabled="loading"
             />
@@ -102,7 +102,7 @@
                 placeholder="#6B7280"
                 aria-label="Código de color en hex"
                 :disabled="loading"
-                class="flex-1 px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm font-mono uppercase text-text-primary bg-surface"
+                class="flex-1 px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring text-sm font-mono uppercase text-text-primary bg-surface"
               />
             </div>
             <p class="text-xs text-text-tertiary">
@@ -120,7 +120,7 @@
               type="text"
               maxlength="50"
               placeholder="Ej: K1, BAR-01"
-              class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary bg-surface"
+              class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring text-sm text-text-primary bg-surface"
               autocomplete="off"
               :disabled="loading"
             />
@@ -139,7 +139,7 @@
               type="number"
               min="0"
               placeholder="0"
-              class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary text-sm text-text-primary bg-surface"
+              class="w-full px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring text-sm text-text-primary bg-surface"
               :disabled="loading"
             />
             <p class="text-xs text-text-tertiary">
@@ -165,7 +165,7 @@
             type="button"
             @click="close"
             :disabled="loading"
-            class="px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-primary/30 rounded-lg"
+            class="px-4 py-2 text-sm font-medium text-text-secondary hover:text-text-primary disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 rounded-lg"
           >
             Cancelar
           </button>
@@ -173,7 +173,7 @@
             type="button"
             @click="submit"
             :disabled="loading || !canSubmit"
-            class="min-h-[44px] px-5 py-2 rounded-lg bg-primary text-white text-sm font-semibold hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition-colors flex items-center gap-2"
+            class="min-h-[44px] px-5 py-2 rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold hover:bg-action-primary-hover-bg disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring focus:ring-offset-2 transition-colors flex items-center gap-2"
           >
             <template v-if="loading">
               <span>Creando</span>

--- a/components/despacho/ComandaDetailPanel.vue
+++ b/components/despacho/ComandaDetailPanel.vue
@@ -140,7 +140,7 @@ const activeItems = computed(() => props.comanda?.items ?? [])
     >
       <div
         v-if="modelValue"
-        class="fixed inset-0 z-40 bg-black/40"
+        class="fixed inset-0 z-40 bg-overlay-backdrop/40"
         aria-hidden="true"
         @click="close"
       />
@@ -159,7 +159,7 @@ const activeItems = computed(() => props.comanda?.items ?? [])
       >
         <!-- Mobile drag handle -->
         <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
-          <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+          <div class="w-10 h-1 rounded-full bg-sheet-border" aria-hidden="true" />
         </div>
 
         <!-- Header -->
@@ -182,7 +182,7 @@ const activeItems = computed(() => props.comanda?.items ?? [])
             <button
               type="button"
               aria-label="Cerrar panel"
-              class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+              class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30"
               @click="close"
             >
               <X :size="20" aria-hidden="true" />
@@ -258,7 +258,7 @@ const activeItems = computed(() => props.comanda?.items ?? [])
               </div>
 
               <!-- Notes -->
-              <p v-if="item.notes && item.status !== 'cancelled'" class="flex items-center gap-1.5 text-xs text-amber-700 font-medium bg-amber-50 rounded-lg px-2.5 py-1.5 pl-1">
+              <p v-if="item.notes && item.status !== 'cancelled'" class="flex items-center gap-1.5 text-xs text-state-warning-text font-medium bg-state-warning-bg rounded-lg px-2.5 py-1.5 pl-1">
                 <MessageSquare :size="12" aria-hidden="true" class="flex-shrink-0" />
                 {{ item.notes }}
               </p>
@@ -276,7 +276,7 @@ const activeItems = computed(() => props.comanda?.items ?? [])
             class="h-11 rounded-xl text-sm font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
             :class="status === 'cancelled'
               ? 'px-4 border border-border text-text-secondary hover:bg-destructive/10 hover:text-destructive hover:border-destructive'
-              : 'flex-1 bg-primary text-primary-foreground hover:bg-primary/90'"
+              : 'flex-1 bg-action-primary-bg text-action-primary-text hover:bg-action-primary-hover-bg'"
             @click="updateStatus(status)"
           >
             <UiLoadingDots v-if="isUpdating && status !== 'cancelled'" size="9px" color="currentColor" />

--- a/components/gestion/cocina/StationCard.vue
+++ b/components/gestion/cocina/StationCard.vue
@@ -21,7 +21,7 @@
           </div>
           <!-- Threshold 2 -->
           <div class="flex items-center gap-1.5">
-            <div class="w-2 h-2 rounded-full bg-red-500" />
+            <div class="w-2 h-2 rounded-full bg-state-danger-icon" />
             <span class="text-xs text-text-secondary font-medium">{{ station.alert_threshold_2_min }}m</span>
           </div>
         </div>
@@ -37,7 +37,7 @@
         </button>
         <button
           class="px-2.5 py-1 rounded-lg text-xs font-semibold transition-colors disabled:opacity-50"
-          :class="station.is_active ? 'text-amber-600 hover:bg-amber-50 border border-amber-200' : 'text-emerald-600 hover:bg-emerald-50 border border-emerald-200'"
+          :class="station.is_active ? 'text-state-warning-text hover:bg-state-warning-bg border border-state-warning-border' : 'text-state-success-text hover:bg-state-success-bg border border-state-success-border'"
           :disabled="isToggling"
           @click="$emit('toggle', station)"
         >

--- a/components/gestion/cocina/StationFormModal.vue
+++ b/components/gestion/cocina/StationFormModal.vue
@@ -56,14 +56,14 @@
                 <div class="w-2 h-2 rounded-full bg-amber-400" />
                 <label class="text-[10px] font-bold text-text-secondary uppercase">Aviso Amarillo</label>
               </div>
-              <input v-model.number="form.alert_threshold_1_min" type="number" min="1" class="w-full px-3 py-2 bg-background border border-border rounded-lg focus:ring-2 focus:ring-amber-400/20 focus:border-amber-400 transition-all text-sm text-text-primary" />
+              <input v-model.number="form.alert_threshold_1_min" type="number" min="1" class="w-full px-3 py-2 bg-background border border-border rounded-lg focus:ring-2 focus:ring-state-warning-border/20 focus:border-state-warning-border transition-all text-sm text-text-primary" />
             </div>
             <div class="space-y-1.5">
               <div class="flex items-center gap-2">
-                <div class="w-2 h-2 rounded-full bg-red-500" />
+                <div class="w-2 h-2 rounded-full bg-state-danger-icon" />
                 <label class="text-[10px] font-bold text-text-secondary uppercase">Aviso Rojo</label>
               </div>
-              <input v-model.number="form.alert_threshold_2_min" type="number" min="1" class="w-full px-3 py-2 bg-background border border-border rounded-lg focus:ring-2 focus:ring-red-500/20 focus:border-red-500 transition-all text-sm text-text-primary" />
+              <input v-model.number="form.alert_threshold_2_min" type="number" min="1" class="w-full px-3 py-2 bg-background border border-border rounded-lg focus:ring-2 focus:ring-red-500/20 focus:border-state-danger-border transition-all text-sm text-text-primary" />
             </div>
           </div>
         </div>
@@ -73,7 +73,7 @@
           <button type="button" @click="$emit('close')" class="flex-1 px-4 py-2.5 text-sm font-medium text-text-secondary bg-surface-secondary rounded-xl hover:bg-border transition-colors">
             Cancelar
           </button>
-          <button type="submit" form="station-form-desktop" :disabled="loading" class="flex-[2] px-4 py-2.5 text-sm font-bold text-white bg-primary rounded-xl hover:bg-primary/90 transition-all disabled:opacity-50 min-h-[44px]">
+          <button type="submit" form="station-form-desktop" :disabled="loading" class="flex-[2] px-4 py-2.5 text-sm font-bold text-action-primary-text bg-action-primary-bg rounded-xl hover:bg-action-primary-hover-bg transition-all disabled:opacity-50 min-h-[44px]">
             {{ loading ? 'Guardando...' : (isEditing ? 'Guardar Cambios' : 'Crear Estación') }}
           </button>
         </div>
@@ -136,14 +136,14 @@
                 <div class="w-2 h-2 rounded-full bg-amber-400" />
                 <label class="text-[10px] font-bold text-text-secondary uppercase">Aviso Amarillo</label>
               </div>
-              <input v-model.number="form.alert_threshold_1_min" type="number" min="1" class="w-full px-3 py-2 bg-background border border-border rounded-lg focus:ring-2 focus:ring-amber-400/20 focus:border-amber-400 transition-all text-sm text-text-primary" />
+              <input v-model.number="form.alert_threshold_1_min" type="number" min="1" class="w-full px-3 py-2 bg-background border border-border rounded-lg focus:ring-2 focus:ring-state-warning-border/20 focus:border-state-warning-border transition-all text-sm text-text-primary" />
             </div>
             <div class="space-y-1.5">
               <div class="flex items-center gap-2">
-                <div class="w-2 h-2 rounded-full bg-red-500" />
+                <div class="w-2 h-2 rounded-full bg-state-danger-icon" />
                 <label class="text-[10px] font-bold text-text-secondary uppercase">Aviso Rojo</label>
               </div>
-              <input v-model.number="form.alert_threshold_2_min" type="number" min="1" class="w-full px-3 py-2 bg-background border border-border rounded-lg focus:ring-2 focus:ring-red-500/20 focus:border-red-500 transition-all text-sm text-text-primary" />
+              <input v-model.number="form.alert_threshold_2_min" type="number" min="1" class="w-full px-3 py-2 bg-background border border-border rounded-lg focus:ring-2 focus:ring-red-500/20 focus:border-state-danger-border transition-all text-sm text-text-primary" />
             </div>
           </div>
         </div>
@@ -153,7 +153,7 @@
           <button type="button" @click="$emit('close')" class="flex-1 px-4 py-2.5 text-sm font-medium text-text-secondary bg-surface-secondary rounded-xl hover:bg-border transition-colors">
             Cancelar
           </button>
-          <button type="submit" form="station-form-mobile" :disabled="loading" class="flex-[2] px-4 py-2.5 text-sm font-bold text-white bg-primary rounded-xl hover:bg-primary/90 transition-all disabled:opacity-50 min-h-[44px]">
+          <button type="submit" form="station-form-mobile" :disabled="loading" class="flex-[2] px-4 py-2.5 text-sm font-bold text-action-primary-text bg-action-primary-bg rounded-xl hover:bg-action-primary-hover-bg transition-all disabled:opacity-50 min-h-[44px]">
             {{ loading ? 'Guardando...' : (isEditing ? 'Guardar Cambios' : 'Crear Estación') }}
           </button>
         </div>

--- a/components/gestion/operaciones/MesaAssignmentHistoryModal.vue
+++ b/components/gestion/operaciones/MesaAssignmentHistoryModal.vue
@@ -10,7 +10,7 @@
     >
       <div
         v-if="open"
-        class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+        class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-overlay-backdrop/50"
         @click.self="$emit('close')"
       >
         <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md max-h-[80vh] flex flex-col overflow-hidden">
@@ -23,7 +23,7 @@
             <button
               type="button"
               aria-label="Cerrar"
-              class="flex-shrink-0 min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+              class="flex-shrink-0 min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30"
               @click="$emit('close')"
             >
               <XMarkIcon class="w-5 h-5" />
@@ -90,7 +90,7 @@
           <div class="flex-shrink-0 px-5 py-3 border-t border-border bg-surface-secondary/40">
             <button
               type="button"
-              class="w-full min-h-[44px] rounded-lg bg-surface border border-border text-sm font-semibold text-text-primary hover:bg-surface-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+              class="w-full min-h-[44px] rounded-lg bg-surface border border-border text-sm font-semibold text-text-primary hover:bg-surface-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30"
               @click="$emit('close')"
             >
               Cerrar

--- a/components/gestion/operaciones/MesaMemberAssignRow.vue
+++ b/components/gestion/operaciones/MesaMemberAssignRow.vue
@@ -44,7 +44,7 @@
       <button
         type="button"
         :aria-label="`Ver historial de ${table.name}`"
-        class="min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg border border-border text-text-secondary hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+        class="min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg border border-border text-text-secondary hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30"
         @click="emit('view-history')"
       >
         <ClockIcon class="w-4 h-4" aria-hidden="true" />

--- a/components/mesas/MesaPanel.vue
+++ b/components/mesas/MesaPanel.vue
@@ -9,7 +9,7 @@
       leave-from-class="opacity-100"
       leave-to-class="opacity-0"
     >
-      <div v-if="modelValue" class="fixed inset-0 z-40 bg-black/40" aria-hidden="true" @click="close" />
+      <div v-if="modelValue" class="fixed inset-0 z-40 bg-overlay-backdrop/40" aria-hidden="true" @click="close" />
     </Transition>
 
     <!-- Panel: bottom sheet on mobile, slide-over on desktop -->
@@ -25,7 +25,7 @@
       >
         <!-- Mobile drag handle -->
         <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
-          <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+          <div class="w-10 h-1 rounded-full bg-sheet-border" aria-hidden="true" />
         </div>
 
         <!-- Header -->
@@ -49,7 +49,7 @@
             <button
               type="button"
               aria-label="Cerrar panel"
-              class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+              class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30"
               @click="close"
             >
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -164,7 +164,7 @@
           <button
             type="button"
             :disabled="saving"
-            class="flex-1 h-11 rounded-lg bg-primary text-sm font-semibold text-white transition-all hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed active:scale-[0.98] shadow-sm shadow-primary/30"
+            class="flex-1 h-11 rounded-lg bg-action-primary-bg text-sm font-semibold text-action-primary-text transition-all hover:bg-action-primary-hover-bg focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed active:scale-[0.98] shadow-sm shadow-action-primary-bg/30"
             @click="submit"
           >
             <span v-if="saving">Guardando...</span>

--- a/components/mesas/TableQrControls.vue
+++ b/components/mesas/TableQrControls.vue
@@ -94,7 +94,7 @@ const regenerateToken = async () => {
           @change="toggleQr"
         >
         <div
-          class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full"
+          class="w-10 h-6 bg-control-toggle-track-off rounded-full peer peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full"
         />
       </label>
     </div>
@@ -125,7 +125,7 @@ const regenerateToken = async () => {
         <button
           v-if="showRegenerate && !showRegenerateConfirm"
           type="button"
-          class="h-9 px-3 rounded-lg border border-amber-200 text-xs font-semibold text-amber-700 hover:bg-amber-50 dark:border-amber-800 dark:text-amber-300 dark:hover:bg-amber-950/30 transition-colors"
+          class="h-9 px-3 rounded-lg border border-state-warning-border text-xs font-semibold text-state-warning-text hover:bg-state-warning-bg    transition-colors"
           @click="showRegenerateConfirm = true"
         >
           Regenerar enlace
@@ -133,9 +133,9 @@ const regenerateToken = async () => {
       </div>
       <div
         v-if="showRegenerate && showRegenerateConfirm"
-        class="rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-800/40 dark:bg-amber-950/20"
+        class="rounded-lg border border-state-warning-border bg-state-warning-bg p-3  "
       >
-        <p class="text-xs text-amber-800 dark:text-amber-300 leading-relaxed">
+        <p class="text-xs text-state-warning-text  leading-relaxed">
           Los QR impresos dejarán de funcionar. ¿Continuar?
         </p>
         <div class="flex gap-2 mt-2">
@@ -149,7 +149,7 @@ const regenerateToken = async () => {
           <button
             type="button"
             :disabled="isRegenerating"
-            class="h-8 px-3 rounded-lg text-xs font-bold bg-amber-500 text-white disabled:opacity-50"
+            class="h-8 px-3 rounded-lg text-xs font-bold bg-action-warning-bg text-action-primary-text disabled:opacity-50"
             @click="regenerateToken"
           >
             {{ isRegenerating ? 'Regenerando…' : 'Sí, regenerar' }}
@@ -177,7 +177,7 @@ const regenerateToken = async () => {
         @change="toggleQr"
       >
       <div
-        class="w-8 h-5 bg-border rounded-full peer peer-checked:bg-primary after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-3"
+        class="w-8 h-5 bg-control-toggle-track-off rounded-full peer peer-checked:bg-control-toggle-track-on after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-3"
       />
     </label>
     <button

--- a/components/operaciones/ShiftTemplatePanel.vue
+++ b/components/operaciones/ShiftTemplatePanel.vue
@@ -10,7 +10,7 @@
     >
       <div
         v-if="modelValue"
-        class="fixed inset-0 z-40 bg-black/40"
+        class="fixed inset-0 z-40 bg-overlay-backdrop/40"
         aria-hidden="true"
         @click="close"
       />
@@ -25,7 +25,7 @@
         class="fixed z-50 flex flex-col bg-surface shadow-2xl inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh] md:inset-y-0 md:right-0 md:bottom-auto md:left-auto md:inset-x-auto md:rounded-none md:w-full md:max-w-md md:max-h-none md:h-full"
       >
         <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
-          <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+          <div class="w-10 h-1 rounded-full bg-sheet-border" aria-hidden="true" />
         </div>
 
         <div class="flex-shrink-0 bg-surface-secondary/40 border-b border-border px-6 py-4">
@@ -47,7 +47,7 @@
               type="button"
               aria-label="Cerrar panel"
               :disabled="saving"
-              class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50 transition-colors"
+              class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 disabled:opacity-50 transition-colors"
               @click="close"
             >
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -107,7 +107,7 @@
             </div>
             <label class="relative inline-flex items-center cursor-pointer flex-shrink-0 mt-0.5">
               <input v-model="form.crosses_midnight" type="checkbox" class="sr-only peer" />
-              <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+              <div class="w-10 h-6 bg-control-toggle-track-off rounded-full peer peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
             </label>
           </div>
 
@@ -128,7 +128,7 @@
             <button
               type="button"
               :disabled="saving || !form.name.trim()"
-              class="flex-1 min-h-[44px] py-3 px-4 bg-primary text-primary-foreground rounded-lg font-semibold hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-60 disabled:cursor-not-allowed transition-all flex items-center justify-center gap-2"
+              class="flex-1 min-h-[44px] py-3 px-4 bg-action-primary-bg text-action-primary-text rounded-lg font-semibold hover:bg-action-primary-hover-bg focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-60 disabled:cursor-not-allowed transition-all flex items-center justify-center gap-2"
               @click="submit"
             >
               <UiLoadingDots v-if="saving" size="8px" color="currentColor" />

--- a/components/pos/CartBottomBar.vue
+++ b/components/pos/CartBottomBar.vue
@@ -25,7 +25,7 @@
           </div>
           <button
             type="button"
-            class="flex items-center gap-2 flex-shrink-0 min-h-[44px] py-2.5 px-4 sm:px-6 bg-primary text-primary-foreground rounded-lg font-semibold text-sm sm:text-base transition-opacity hover:opacity-90 active:opacity-80"
+            class="flex items-center gap-2 flex-shrink-0 min-h-[44px] py-2.5 px-4 sm:px-6 bg-action-primary-bg text-action-primary-text rounded-lg font-semibold text-sm sm:text-base transition-opacity hover:opacity-90 active:opacity-80"
             aria-label="Ver orden actual"
             @click="$emit('open-cart')"
           >

--- a/components/pos/CartItem.vue
+++ b/components/pos/CartItem.vue
@@ -18,16 +18,16 @@
                 </p>
                 <span
                   v-if="item.fulfillmentStatus === 'new' && showFulfillmentStatus"
-                  class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-amber-700 bg-amber-100 dark:bg-amber-900/30 dark:text-amber-400"
+                  class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-state-warning-text bg-state-warning-bg  "
                 >Sin enviar</span>
                 <span
                   v-else-if="item.fulfillmentStatus && item.fulfillmentStatus !== 'new'"
                   class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide"
                   :class="{
-                    'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400': item.fulfillmentStatus === 'sent',
+                    'bg-state-info-bg text-state-info-text  ': item.fulfillmentStatus === 'sent',
                     'bg-state-warning-bg text-state-warning-text': item.fulfillmentStatus === 'preparing',
-                    'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400': item.fulfillmentStatus === 'ready',
-                    'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400': item.fulfillmentStatus === 'delivered' || item.fulfillmentStatus === 'cancelled',
+                    'bg-state-success-bg text-state-success-text': item.fulfillmentStatus === 'ready',
+                    'bg-status-chip-bg text-status-chip-text': item.fulfillmentStatus === 'delivered' || item.fulfillmentStatus === 'cancelled',
                   }"
                 >
                   {{
@@ -39,7 +39,7 @@
                 </span>
                 <span
                   v-if="promoLabel"
-                  class="shrink-0 max-w-full rounded px-2 py-0.5 text-[10px] font-semibold leading-tight text-white bg-emerald-500"
+                  class="shrink-0 max-w-full rounded px-2 py-0.5 text-[10px] font-semibold leading-tight text-badge-success-text bg-badge-success-bg"
                   :title="promoTitle || promoLabel"
                 >{{ promoLabel }}</span>
               </div>
@@ -57,7 +57,7 @@
               >{{ formatCurrency(netTotal) }}</p>
               <p
                 v-if="promoSavings > 0"
-                class="mt-0.5 text-[10px] font-semibold tabular-nums text-emerald-600 dark:text-emerald-400"
+                class="mt-0.5 text-[10px] font-semibold tabular-nums text-state-success-text"
               >-{{ formatCurrency(promoSavings) }}</p>
             </div>
           </div>

--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -91,7 +91,7 @@
         >
           <input
             type="checkbox"
-            class="h-4 w-4 rounded border-border text-primary focus:ring-primary/30"
+            class="h-4 w-4 rounded border-border text-primary focus:ring-action-primary-focus-ring/30"
             :checked="selectedTabItemIds.includes(item.orderItemId)"
             :aria-label="`Seleccionar ${item.productName} para reimprimir comanda`"
             @change="$emit('toggle-tab-selection', item.orderItemId)"
@@ -180,7 +180,7 @@
         class="flex items-center justify-between text-xs"
       >
         <span class="font-medium text-text-tertiary">Descuentos promoción</span>
-        <span class="font-semibold text-emerald-700 dark:text-emerald-400 tabular-nums">-{{ formatCurrency(orderPromoSavings) }}</span>
+        <span class="font-semibold text-state-success-text  tabular-nums">-{{ formatCurrency(orderPromoSavings) }}</span>
       </div>
       <div class="flex items-center justify-between">
         <span class="text-xs font-semibold text-text-tertiary uppercase tracking-widest">Total</span>
@@ -200,7 +200,7 @@
             type="button"
             :aria-disabled="!openSaleEnabled"
             :title="openSaleTooltip ?? undefined"
-            class="w-full h-12 rounded-xl bg-primary text-primary-foreground text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 shadow-sm"
+            class="w-full h-12 rounded-xl bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 shadow-sm"
             @click="$emit('open-sale')"
           >
             <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
@@ -228,7 +228,7 @@
             v-if="hasCartItems && !hideProcessOrder"
             type="button"
             :disabled="isDeleting"
-            class="w-full h-12 rounded-xl bg-primary text-primary-foreground text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
+            class="w-full h-12 rounded-xl bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
             @click="$emit('process-order')"
           >
             <svg v-if="isDeleting" class="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -262,7 +262,7 @@
             type="button"
             :aria-disabled="!openSaleEnabled"
             :title="openSaleTooltip ?? undefined"
-            class="w-full h-12 rounded-xl bg-primary text-primary-foreground text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 shadow-sm"
+            class="w-full h-12 rounded-xl bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 shadow-sm"
             @click="$emit('open-sale')"
           >
             <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
@@ -291,7 +291,7 @@
           v-if="showBarProcessOrder"
           type="button"
           :disabled="items.length === 0 || isDeleting"
-          class="w-full h-12 rounded-xl bg-primary text-primary-foreground text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
+          class="w-full h-12 rounded-xl bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
           @click="$emit('process-order')"
         >
           <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
@@ -350,7 +350,7 @@
         <button
           type="button"
           :disabled="items.length === 0 || isDeleting || isAddingToTab"
-          class="w-full h-12 rounded-xl bg-primary text-primary-foreground text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
+          class="w-full h-12 rounded-xl bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
           :aria-label="`Agregar items a la ${tableSingularLower}`"
           @click="$emit('add-to-tab')"
         >

--- a/components/pos/ComandasEstadoPanel.vue
+++ b/components/pos/ComandasEstadoPanel.vue
@@ -152,14 +152,14 @@ const cardClass = (firedAt: string, selected: boolean): string => {
   const tier = agingTier(firedAt)
   if (selected) return 'bg-primary/5 border-primary'
   if (tier === 'urgent')  return 'bg-destructive/5 border-destructive'
-  if (tier === 'warning') return 'bg-amber-50/60 border-amber-300'
-  return 'bg-surface border-emerald-200'
+  if (tier === 'warning') return 'bg-state-warning-bg/60 border-state-warning-border'
+  return 'bg-surface border-state-success-border'
 }
 const chipClass = (firedAt: string): string => {
   const tier = agingTier(firedAt)
   if (tier === 'urgent')  return 'bg-destructive/10 text-destructive'
-  if (tier === 'warning') return 'bg-amber-100 text-amber-800'
-  return 'bg-emerald-50 text-emerald-700'
+  if (tier === 'warning') return 'bg-state-warning-bg text-state-warning-text'
+  return 'bg-state-success-bg text-state-success-text'
 }
 const ageLabel = (firedAt: string): string => {
   const m = ageMinutes(firedAt)
@@ -224,7 +224,7 @@ const submit = async () => {
       leave-from-class="opacity-100"
       leave-to-class="opacity-0"
     >
-      <div v-if="modelValue" class="fixed inset-0 z-40 bg-black/40" aria-hidden="true" @click="close" />
+      <div v-if="modelValue" class="fixed inset-0 z-40 bg-overlay-backdrop/40" aria-hidden="true" @click="close" />
     </Transition>
 
     <Transition name="panel">
@@ -239,7 +239,7 @@ const submit = async () => {
       >
         <!-- Mobile drag handle -->
         <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
-          <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+          <div class="w-10 h-1 rounded-full bg-sheet-border" aria-hidden="true" />
         </div>
 
         <!-- Header -->
@@ -260,7 +260,7 @@ const submit = async () => {
             <button
               type="button"
               aria-label="Cerrar panel"
-              class="flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center text-text-tertiary hover:bg-surface-secondary hover:text-text-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+              class="flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center text-text-tertiary hover:bg-surface-secondary hover:text-text-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30"
               @click="close"
             >
               <XMarkIcon class="w-4 h-4" />
@@ -283,7 +283,7 @@ const submit = async () => {
               <span
                 class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full text-[11px] font-bold tabular-nums"
                 :class="activeTab === 'ready'
-                  ? 'bg-primary text-white'
+                  ? 'bg-action-primary-bg text-action-primary-text'
                   : 'bg-surface-secondary text-text-tertiary'"
               >{{ readyComandas.length }}</span>
             </button>
@@ -299,7 +299,7 @@ const submit = async () => {
               <span
                 class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full text-[11px] font-bold tabular-nums"
                 :class="activeTab === 'preparing'
-                  ? 'bg-primary text-white'
+                  ? 'bg-action-primary-bg text-action-primary-text'
                   : 'bg-surface-secondary text-text-tertiary'"
               >{{ preparingComandas.length }}</span>
             </button>
@@ -335,7 +335,7 @@ const submit = async () => {
               class="w-full text-left rounded-xl border-2 p-3.5 transition-all"
               :class="[
                 cardClass(c.fired_at, selectedIds.has(c.id)),
-                flashIds.has(c.id) ? 'animate-pulse ring-2 ring-emerald-400' : '',
+                flashIds.has(c.id) ? 'animate-pulse ring-2 ring-state-success-border' : '',
               ]"
               @click="toggleSelected(c.id)"
             >
@@ -343,7 +343,7 @@ const submit = async () => {
                 <input
                   type="checkbox"
                   :checked="selectedIds.has(c.id)"
-                  class="mt-1 h-4 w-4 rounded text-primary focus:ring-2 focus:ring-primary/30 cursor-pointer"
+                  class="mt-1 h-4 w-4 rounded text-primary focus:ring-2 focus:ring-action-primary-focus-ring/30 cursor-pointer"
                   @click.stop
                   @change="toggleSelected(c.id)"
                 />
@@ -412,7 +412,7 @@ const submit = async () => {
           <button
             type="button"
             :disabled="selectedIds.size === 0 || submitting"
-            class="w-full min-h-[52px] rounded-xl bg-primary text-white text-base font-bold transition-all hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/30 active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            class="w-full min-h-[52px] rounded-xl bg-action-primary-bg text-action-primary-text text-base font-bold transition-all hover:bg-action-primary-hover-bg focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-2"
             @click="submit"
           >
             <UiLoadingDots v-if="submitting" size="9px" color="currentColor" />

--- a/components/pos/CustomerIdentificationModal.vue
+++ b/components/pos/CustomerIdentificationModal.vue
@@ -2,7 +2,7 @@
   <Transition name="sheet">
     <div
       v-if="modelValue"
-      class="fixed inset-0 z-[60] flex items-end md:items-center justify-center md:p-4 bg-black/50"
+      class="fixed inset-0 z-[60] flex items-end md:items-center justify-center md:p-4 bg-overlay-backdrop/50"
       @click.self="handleClose"
     >
       <div class="bottom-sheet-panel bg-surface w-full md:max-w-md border border-border flex flex-col rounded-t-2xl md:rounded-2xl shadow-2xl max-h-[85vh] md:max-h-[90vh]" @click.stop>
@@ -124,7 +124,7 @@
               <div class="space-y-3">
                 <button
                   @click="state = 'create'"
-                  class="w-full min-h-[44px] px-4 py-3 bg-primary text-primary-foreground font-semibold rounded-xl hover:bg-primary/90 active:scale-95 transition-all"
+                  class="w-full min-h-[44px] px-4 py-3 bg-action-primary-bg text-action-primary-text font-semibold rounded-xl hover:bg-action-primary-hover-bg active:scale-95 transition-all"
                 >
                   Crear cliente nuevo
                 </button>
@@ -182,7 +182,7 @@
               <!-- Phone -->
               <div class="flex flex-col gap-1">
                 <label for="new-phone" class="text-sm font-medium text-text-primary">
-                  Teléfono <span class="text-red-500">*</span>
+                  Teléfono <span class="text-destructive">*</span>
                 </label>
                 <input
                   id="new-phone"
@@ -249,7 +249,7 @@
                   <!-- Tipo doc -->
                   <div class="flex flex-col gap-1">
                     <label for="new-fiscal-type" class="text-sm font-medium text-text-primary">
-                      Tipo de documento <span class="text-red-500">*</span>
+                      Tipo de documento <span class="text-destructive">*</span>
                     </label>
                     <select
                       id="new-fiscal-type"
@@ -269,7 +269,7 @@
                   <!-- Número doc -->
                   <div class="flex flex-col gap-1">
                     <label for="new-fiscal-id" class="text-sm font-medium text-text-primary">
-                      Número de documento <span class="text-red-500">*</span>
+                      Número de documento <span class="text-destructive">*</span>
                     </label>
                     <input
                       id="new-fiscal-id"
@@ -288,7 +288,7 @@
                   <div class="flex flex-col gap-1">
                     <label for="new-fiscal-name" class="text-sm font-medium text-text-primary">
                       {{ createForm.fiscal_id_type === 'NIT' ? 'Razón social' : 'Nombre legal completo' }}
-                      <span class="text-red-500">*</span>
+                      <span class="text-destructive">*</span>
                     </label>
                     <input
                       id="new-fiscal-name"
@@ -303,11 +303,11 @@
               </div>
 
               <!-- Error -->
-              <div v-if="createError" class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl p-4 flex items-start gap-3">
-                <svg class="h-5 w-5 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <div v-if="createError" class="bg-state-danger-bg  border border-state-danger-border  rounded-xl p-4 flex items-start gap-3">
+                <svg class="h-5 w-5 text-state-danger-text  flex-shrink-0 mt-0.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
                 </svg>
-                <p class="text-sm text-red-800 dark:text-red-200">{{ createError }}</p>
+                <p class="text-sm text-state-danger-text ">{{ createError }}</p>
               </div>
 
             </div>
@@ -324,7 +324,7 @@
               <button
                 type="submit"
                 :disabled="!canSubmitCreate || isCreating"
-                class="flex-1 min-h-[44px] px-4 py-3 bg-primary text-primary-foreground font-semibold rounded-xl hover:bg-primary/90 active:scale-95 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                class="flex-1 min-h-[44px] px-4 py-3 bg-action-primary-bg text-action-primary-text font-semibold rounded-xl hover:bg-action-primary-hover-bg active:scale-95 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
               >
                 <CommonsTheCustomLoader v-if="isCreating" size="small" />
                 <span>{{ isCreating ? 'Guardando...' : 'Guardar y continuar' }}</span>
@@ -345,7 +345,7 @@
               <!-- Tipo doc -->
               <div class="flex flex-col gap-1">
                 <label for="edit-fiscal-type" class="text-sm font-medium text-text-primary">
-                  Tipo de documento <span class="text-red-500">*</span>
+                  Tipo de documento <span class="text-destructive">*</span>
                 </label>
                 <select
                   id="edit-fiscal-type"
@@ -365,7 +365,7 @@
               <!-- Número doc -->
               <div class="flex flex-col gap-1">
                 <label for="edit-fiscal-id" class="text-sm font-medium text-text-primary">
-                  Número de documento <span class="text-red-500">*</span>
+                  Número de documento <span class="text-destructive">*</span>
                 </label>
                 <input
                   id="edit-fiscal-id"
@@ -384,7 +384,7 @@
               <div class="flex flex-col gap-1">
                 <label for="edit-fiscal-name" class="text-sm font-medium text-text-primary">
                   {{ fiscalForm.fiscal_id_type === 'NIT' ? 'Razón social' : 'Nombre legal completo' }}
-                  <span class="text-red-500">*</span>
+                  <span class="text-destructive">*</span>
                 </label>
                 <input
                   id="edit-fiscal-name"
@@ -397,11 +397,11 @@
               </div>
 
               <!-- Error -->
-              <div v-if="createError" class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl p-4 flex items-start gap-3">
-                <svg class="h-5 w-5 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <div v-if="createError" class="bg-state-danger-bg  border border-state-danger-border  rounded-xl p-4 flex items-start gap-3">
+                <svg class="h-5 w-5 text-state-danger-text  flex-shrink-0 mt-0.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
                 </svg>
-                <p class="text-sm text-red-800 dark:text-red-200">{{ createError }}</p>
+                <p class="text-sm text-state-danger-text ">{{ createError }}</p>
               </div>
 
             </div>
@@ -418,7 +418,7 @@
               <button
                 type="submit"
                 :disabled="!canSubmitFiscal || isCreating"
-                class="flex-1 min-h-[44px] px-4 py-3 bg-primary text-primary-foreground font-semibold rounded-xl hover:bg-primary/90 active:scale-95 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                class="flex-1 min-h-[44px] px-4 py-3 bg-action-primary-bg text-action-primary-text font-semibold rounded-xl hover:bg-action-primary-hover-bg active:scale-95 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
               >
                 <CommonsTheCustomLoader v-if="isCreating" size="small" />
                 <span>{{ isCreating ? 'Guardando...' : 'Guardar datos' }}</span>

--- a/components/pos/MesasFloorPlan.vue
+++ b/components/pos/MesasFloorPlan.vue
@@ -213,7 +213,7 @@ const tableStatusTheme = (status: string) => {
     name: 'text-text-secondary',
     divider: 'bg-border',
     dot: 'bg-text-tertiary',
-    moveHover: 'hover:bg-black/5 focus-visible:ring-border/60',
+    moveHover: 'hover:bg-surface-secondary/50 focus-visible:ring-border/60',
   }
 }
 
@@ -369,7 +369,7 @@ onUnmounted(() => {
                   <template v-if="props.comandasEnabled && table.session?.unfired_count > 0">
                     <span class="relative flex h-2 w-2 flex-shrink-0">
                       <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
-                      <span class="relative inline-flex rounded-full h-2 w-2 bg-red-500" />
+                      <span class="relative inline-flex rounded-full h-2 w-2 bg-state-danger-icon" />
                     </span>
                   </template>
                 </div>

--- a/components/pos/MoveTableModal.vue
+++ b/components/pos/MoveTableModal.vue
@@ -68,7 +68,7 @@ const handleClose = () => {
     >
       <!-- Backdrop -->
       <div
-        class="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        class="absolute inset-0 bg-overlay-backdrop/40 backdrop-blur-sm"
         @click="handleClose"
       />
 
@@ -101,7 +101,7 @@ const handleClose = () => {
           <!-- Error message -->
           <div
             v-if="moveError"
-            class="mb-4 px-4 py-3 rounded-xl bg-red-50 border border-red-200 text-sm text-red-700"
+            class="mb-4 px-4 py-3 rounded-xl bg-state-danger-bg border border-state-danger-border text-sm text-state-danger-text"
           >
             {{ moveError }}
           </div>
@@ -147,7 +147,7 @@ const handleClose = () => {
               </span>
               <span
                 v-if="table.status !== 'free'"
-                class="text-[9px] font-bold text-amber-600 uppercase tracking-wide mt-0.5"
+                class="text-[9px] font-bold text-state-warning-text uppercase tracking-wide mt-0.5"
               >
                 Ocupada
               </span>
@@ -179,7 +179,7 @@ const handleClose = () => {
           </button>
           <button
             type="button"
-            class="flex-1 px-4 py-2.5 rounded-xl bg-primary text-white text-sm font-bold transition-colors hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            class="flex-1 px-4 py-2.5 rounded-xl bg-action-primary-bg text-action-primary-text text-sm font-bold transition-colors hover:bg-action-primary-hover-bg disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
             :disabled="!selectedTableId || isMoving"
             @click="handleConfirm"
           >

--- a/components/pos/OpenSaleModal.vue
+++ b/components/pos/OpenSaleModal.vue
@@ -2,7 +2,7 @@
   <Transition name="sheet">
     <div
       v-if="modelValue"
-      class="fixed inset-0 z-[60] flex items-end md:items-center justify-center md:p-4 bg-black/50"
+      class="fixed inset-0 z-[60] flex items-end md:items-center justify-center md:p-4 bg-overlay-backdrop/50"
       @click.self="handleClose"
     >
       <div
@@ -35,7 +35,7 @@
         <form class="p-5 space-y-4" @submit.prevent="handleSubmit">
           <div>
             <label for="open-sale-amount" class="block text-sm font-medium text-text-primary mb-1.5">
-              Monto (COP) <span class="text-red-500">*</span>
+              Monto (COP) <span class="text-destructive">*</span>
             </label>
             <input
               id="open-sale-amount"
@@ -65,7 +65,7 @@
             />
           </div>
 
-          <p v-if="errorMessage" class="text-sm text-red-600" role="alert">{{ errorMessage }}</p>
+          <p v-if="errorMessage" class="text-sm text-state-danger-text" role="alert">{{ errorMessage }}</p>
 
           <div class="flex gap-2 pt-1">
             <button
@@ -78,7 +78,7 @@
             <button
               type="submit"
               :disabled="isSubmitting"
-              class="flex-1 min-h-[44px] px-4 py-3 rounded-xl bg-primary text-primary-foreground font-semibold hover:opacity-90 active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+              class="flex-1 min-h-[44px] px-4 py-3 rounded-xl bg-action-primary-bg text-action-primary-text font-semibold hover:opacity-90 active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {{ isSubmitting ? 'Agregando...' : confirmLabel }}
             </button>

--- a/components/pos/PosDestructiveReasonModal.vue
+++ b/components/pos/PosDestructiveReasonModal.vue
@@ -10,7 +10,7 @@
     >
       <div
         v-if="modelValue"
-        class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+        class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-overlay-backdrop/50"
         role="dialog"
         aria-modal="true"
         :aria-labelledby="titleId"
@@ -62,7 +62,7 @@
               rows="2"
               :disabled="loading"
               :placeholder="reasonPlaceholder"
-              class="w-full px-3 py-2 bg-surface-secondary border border-border rounded-lg text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50"
+              class="w-full px-3 py-2 bg-surface-secondary border border-border rounded-lg text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 disabled:opacity-50"
             />
             <p v-if="error" class="mt-2 text-sm text-destructive">
               {{ error }}
@@ -83,8 +83,8 @@
               :disabled="loading || !reason.trim()"
               class="flex-1 min-h-[44px] rounded-xl text-sm font-semibold active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
               :class="variant === 'warning'
-                ? 'bg-slate-700 text-white hover:bg-slate-800 focus-visible:ring-slate-500'
-                : 'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive'"
+                ? 'bg-action-secondary-bg text-action-secondary-text hover:bg-action-secondary-hover-bg focus-visible:ring-action-secondary-focus-ring'
+                : 'bg-action-destructive-bg text-action-destructive-text hover:bg-action-destructive-hover-bg focus-visible:ring-action-destructive-focus-ring'"
               @click="submit"
             >
               <UiLoadingDots v-if="loading" size="9px" :color="variant === 'warning' ? 'white' : 'white'" />

--- a/components/pos/ProductCard.vue
+++ b/components/pos/ProductCard.vue
@@ -10,7 +10,7 @@
     <div :style="iconSlotStyle" class="relative w-full aspect-[3/2] border border-border/30 rounded-2xl shadow-sm flex items-center justify-center mb-1.5 md:mb-3 select-none flex-shrink-0 overflow-hidden">
       <span
         v-if="promoBadge"
-        class="absolute top-1 left-1 right-1 z-10 max-w-full text-[9px] md:text-[10px] bg-emerald-500/90 text-white px-1.5 py-0.5 rounded-full font-semibold truncate text-center shadow-sm pointer-events-none"
+        class="absolute top-1 left-1 right-1 z-10 max-w-full text-[9px] md:text-[10px] bg-badge-success-bg text-badge-success-text px-1.5 py-0.5 rounded-full font-semibold truncate text-center shadow-sm pointer-events-none"
         :title="promoBadge.title || promoBadge.label"
       >
         {{ promoBadge.label }}
@@ -31,7 +31,7 @@
     </p>
 
     <!-- Price -->
-    <div class="w-full mt-1.5 md:mt-2.5 pt-1.5 md:pt-2.5 border-t border-black/15">
+    <div class="w-full mt-1.5 md:mt-2.5 pt-1.5 md:pt-2.5 border-t border-border/60">
       <p class="text-[10px] md:text-sm font-bold text-primary text-center">
         {{ formatCurrency(product.price) }}
       </p>

--- a/components/pos/WaroRewardPickerModal.vue
+++ b/components/pos/WaroRewardPickerModal.vue
@@ -54,7 +54,7 @@ function rewardSubtitle(reward: WaroReward) {
   <Transition name="sheet">
     <div
       v-if="modelValue"
-      class="fixed inset-0 z-[70] flex items-end md:items-center justify-center md:p-4 bg-black/50"
+      class="fixed inset-0 z-[70] flex items-end md:items-center justify-center md:p-4 bg-overlay-backdrop/50"
       @click.self="close"
     >
       <div
@@ -93,7 +93,7 @@ function rewardSubtitle(reward: WaroReward) {
                 type="button"
                 class="w-full text-left p-4 rounded-xl border transition-colors min-h-[44px]"
                 :class="warosBalance >= reward.waros_cost
-                  ? 'border-border hover:border-amber-400 hover:bg-amber-50/50'
+                  ? 'border-border hover:border-state-warning-border hover:bg-state-warning-bg/50'
                   : 'border-border opacity-50 cursor-not-allowed'"
                 :disabled="warosBalance < reward.waros_cost"
                 @click="pick(reward)"

--- a/components/pos/checkout/DeliveryAddressForm.vue
+++ b/components/pos/checkout/DeliveryAddressForm.vue
@@ -185,7 +185,7 @@ const submit = () => {
       </button>
       <button
         type="submit"
-        class="min-h-[44px] px-4 py-2 text-sm font-semibold bg-primary text-primary-foreground rounded-lg disabled:opacity-50 disabled:cursor-not-allowed hover:opacity-90 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+        class="min-h-[44px] px-4 py-2 text-sm font-semibold bg-action-primary-bg text-action-primary-text rounded-lg disabled:opacity-50 disabled:cursor-not-allowed hover:opacity-90 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-action-primary-focus-ring/30"
         :disabled="!isValid || loading"
       >
         {{ loading ? 'Guardando...' : 'Guardar dirección' }}

--- a/components/pos/checkout/DeliveryAddressPicker.vue
+++ b/components/pos/checkout/DeliveryAddressPicker.vue
@@ -76,7 +76,7 @@ const ADDRESS_TYPE_LABELS: Record<string, string> = {
     <!-- Add new button -->
     <button
       type="button"
-      class="w-full min-h-[44px] py-2.5 px-4 border-2 border-dashed border-border rounded-xl text-sm font-semibold text-primary hover:bg-primary/5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+      class="w-full min-h-[44px] py-2.5 px-4 border-2 border-dashed border-border rounded-xl text-sm font-semibold text-primary hover:bg-primary/5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-action-primary-focus-ring/30"
       @click="$emit('add-new')"
     >
       + Agregar nueva dirección

--- a/composables/usePurchaseStatus.ts
+++ b/composables/usePurchaseStatus.ts
@@ -7,6 +7,7 @@ export const usePurchaseStatus = () => {
       confirmed: 'Confirmada',
       preparing: 'En Preparación',
       shipped: 'Enviada',
+      partially_received: 'Parcialmente recibida',
       received: 'Recibida',
       verified: 'Verificada',
       invoiced: 'Facturada',
@@ -37,6 +38,7 @@ export const usePurchaseStatus = () => {
         return 'info'
 
       // 📦 Recibida (Verde claro - Éxito parcial)
+      case 'partially_received':
       case 'received':
         return 'success'
 

--- a/pages/abastecimiento/compra/[id]/acciones.vue
+++ b/pages/abastecimiento/compra/[id]/acciones.vue
@@ -21,11 +21,11 @@
       <!-- Left Column: Form Content -->
       <div class="xl:col-span-2">
         <!-- APPROVE FORM -->
-        <div v-if="purchase?.status === 'pending'" class="bg-surface border-2 border-success rounded-xl overflow-hidden shadow-sm">
-          <div class="p-6 border-b-2 border-success/20" style="background-color: hsl(var(--success) / 0.05);">
+        <div v-if="purchase?.status === 'pending'" class="bg-surface border-2 border-state-success-border rounded-xl overflow-hidden shadow-sm">
+          <div class="p-6 border-b-2 border-state-success-border bg-state-success-bg">
             <div class="flex items-center gap-4">
-              <div class="p-3 rounded-lg bg-success/10">
-                <svg class="w-8 h-8 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <div class="p-3 rounded-lg bg-state-success-bg">
+                <svg class="w-8 h-8 text-state-success-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                     d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
@@ -49,7 +49,7 @@
               <div>
                 <label class="block text-sm font-medium text-text-primary mb-2">Notas (Opcional)</label>
                 <textarea v-model="approveFormData.notes" rows="3"
-                  class="w-full px-4 py-3 bg-surface border-2 border-border rounded-lg text-text-primary placeholder-text-secondary focus:border-success focus:ring-2 focus:ring-success/20 transition-all resize-none"
+                  class="w-full px-4 py-3 bg-form-control-bg border-2 border-form-control-border rounded-lg text-form-control-text placeholder:text-form-control-placeholder focus:border-form-control-focus-border focus:ring-2 focus:ring-form-control-focus-ring transition-all resize-none"
                   placeholder="Agrega notas sobre la confirmación..."></textarea>
               </div>
             </div>
@@ -58,8 +58,8 @@
 
         <!-- RECEIVE FORM -->
         <div v-if="purchase?.status === 'shipped' || purchase?.status === 'partially_received'"
-          class="bg-surface border-2 border-primary rounded-xl overflow-hidden shadow-sm">
-          <div class="p-6 border-b-2 border-primary/20" style="background-color: hsl(var(--primary) / 0.05);">
+          class="bg-surface border-2 border-badge-primary-border rounded-xl overflow-hidden shadow-sm">
+          <div class="p-6 border-b-2 border-badge-primary-border bg-badge-primary-bg">
             <div class="flex items-center gap-4">
               <div class="p-3 rounded-lg bg-primary/10">
                 <svg class="w-8 h-8 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -96,7 +96,7 @@
             Esta orden no tiene acciones que puedas realizar en este momento
           </p>
           <NuxtLink :to="`/abastecimiento/compra/${purchaseId}`"
-            class="inline-flex items-center gap-2 px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors">
+            class="inline-flex items-center gap-2 px-6 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
             </svg>
@@ -127,9 +127,9 @@
             </div>
             <div>
               <p class="text-sm text-text-secondary mb-1">Estado</p>
-              <span class="px-2 py-1 rounded text-xs font-medium" :class="getStatusBadgeClass(purchase?.status)">
+              <UiStatusBadge :variant="getStatusVariant(purchase?.status)" size="sm">
                 {{ getStatusText(purchase?.status) }}
-              </span>
+              </UiStatusBadge>
             </div>
           </div>
 
@@ -140,7 +140,7 @@
               <button 
                 @click="handleApprove"
                 :disabled="isApproving"
-                class="w-full py-3 bg-success text-white rounded-lg hover:bg-success/90 transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold shadow-lg shadow-success/20">
+                class="w-full py-3 bg-action-success-bg text-action-success-text rounded-lg hover:bg-action-success-hover-bg transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold shadow-lg shadow-action-success-bg/20">
                 <CommonsTheCustomLoader v-if="isApproving" size="small" />
                 <span>{{ isApproving ? 'Aprobando...' : 'Aprobar Orden' }}</span>
               </button>
@@ -151,7 +151,7 @@
               <button 
                 @click="handleReceiveSubmit"
                 :disabled="isSubmitting"
-                class="w-full py-3 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold shadow-lg shadow-primary/20">
+                class="w-full py-3 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold shadow-lg shadow-action-primary-bg/20">
                 <CommonsTheCustomLoader v-if="isSubmitting" size="small" />
                 <span>{{ isSubmitting ? 'Procesando...' : 'Registrar Recepción' }}</span>
               </button>
@@ -298,24 +298,6 @@ function getStatusText(status: string) {
     overdue: 'Vencido'
   }
   return texts[status] || status
-}
-
-function getStatusBadgeClass(status: string): string {
-  const classes: Record<string, string> = {
-    quotation: 'bg-yellow-500/10 text-yellow-600',
-    pending: 'bg-blue-500/10 text-blue-600',
-    confirmed: 'bg-green-500/10 text-green-600',
-    preparing: 'bg-state-warning-bg text-state-warning-text',
-    shipped: 'bg-cyan-500/10 text-cyan-600',
-    partially_received: 'bg-orange-500/10 text-orange-600',
-    received: 'bg-emerald-500/10 text-emerald-600',
-    verified: 'bg-green-600/10 text-green-700',
-    invoiced: 'bg-indigo-500/10 text-indigo-600',
-    paid: 'bg-green-600/10 text-green-700',
-    cancelled: 'bg-destructive/10 text-destructive',
-    overdue: 'bg-destructive/10 text-destructive'
-  }
-  return classes[status] || 'bg-surface-secondary text-text-secondary'
 }
 
 // Generate confirmation number

--- a/pages/abastecimiento/compra/[id]/index.vue
+++ b/pages/abastecimiento/compra/[id]/index.vue
@@ -90,7 +90,7 @@
               @click="selectedIngredientType = typeOption.value"
               class="flex-1 min-w-[100px] px-3 py-2 text-sm font-medium rounded-md transition-all"
               :class="selectedIngredientType === typeOption.value
-                ? 'bg-primary text-white shadow-sm'
+                ? 'bg-action-primary-bg text-action-primary-text shadow-sm'
                 : 'text-text-secondary hover:text-text-primary hover:bg-surface'"
             >
               {{ typeOption.label }}
@@ -109,7 +109,7 @@
                   type="button"
                   @click="removeEditItem(index)"
                   :disabled="editForm.items.length === 1"
-                  class="text-red-600 hover:text-red-700 disabled:opacity-50 disabled:cursor-not-allowed p-1"
+                  class="text-state-danger-text hover:text-state-danger-text disabled:opacity-50 disabled:cursor-not-allowed p-1"
                 >
                   <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -192,7 +192,7 @@
             type="button"
             @click="saveEdit"
             :disabled="isSubmitting || !isEditFormValid"
-            class="px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center space-x-2"
+            class="px-6 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors disabled:opacity-50 flex items-center space-x-2"
           >
             <CommonsTheCustomLoader v-if="isSubmitting" size="small" />
             <span>{{ isSubmitting ? 'Guardando...' : 'Guardar Cambios' }}</span>

--- a/pages/abastecimiento/compra/[id]/transicion/[transitionId].vue
+++ b/pages/abastecimiento/compra/[id]/transicion/[transitionId].vue
@@ -261,7 +261,7 @@
             <button 
               @click="handleUploadFiles" 
               :disabled="isUploading"
-              class="px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center space-x-2 font-medium">
+              class="px-6 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors disabled:opacity-50 flex items-center space-x-2 font-medium">
               <CommonsTheCustomLoader v-if="isUploading" size="small" />
               <span>{{ isUploading ? 'Subiendo...' : 'Subir Archivos' }}</span>
             </button>

--- a/pages/abastecimiento/compra/crear.vue
+++ b/pages/abastecimiento/compra/crear.vue
@@ -87,7 +87,7 @@
               <div
                 class="flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full transition-colors border-2 flex-shrink-0"
                 :class="{
-                  'bg-primary text-primary-foreground border-primary': currentStep === 1,
+                  'bg-action-primary-bg text-action-primary-text border-primary': currentStep === 1,
                   'bg-secondary text-secondary-foreground border-secondary': currentStep > 1,
                   'border-border text-text-secondary bg-transparent': currentStep < 1
                 }"
@@ -112,7 +112,7 @@
               <div
                 class="flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full transition-colors border-2 flex-shrink-0"
                 :class="{
-                  'bg-primary text-primary-foreground border-primary': currentStep === 2,
+                  'bg-action-primary-bg text-action-primary-text border-primary': currentStep === 2,
                   'bg-secondary text-secondary-foreground border-secondary': currentStep > 2,
                   'border-border text-text-secondary bg-transparent': currentStep < 2
                 }"
@@ -136,7 +136,7 @@
               <div
                 class="flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full transition-colors border-2 flex-shrink-0"
                 :class="{
-                  'bg-primary text-primary-foreground border-primary': currentStep === 3,
+                  'bg-action-primary-bg text-action-primary-text border-primary': currentStep === 3,
                   'bg-secondary text-secondary-foreground border-secondary': currentStep > 3,
                   'border-border text-text-secondary bg-transparent': currentStep < 3
                 }"
@@ -204,7 +204,7 @@
                           type="checkbox" 
                           class="sr-only peer"
                         >
-                        <div class="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary/20 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-primary"></div>
+                        <div class="w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-control-toggle-track-on"></div>
                       </div>
                     </label>
                   </div>
@@ -324,7 +324,7 @@
                 @click="selectedIngredientType = typeOption.value"
                 class="flex-1 min-w-[100px] px-3 py-2 text-sm font-medium rounded-md transition-all"
                 :class="selectedIngredientType === typeOption.value
-                  ? 'bg-primary text-white shadow-sm'
+                  ? 'bg-action-primary-bg text-action-primary-text shadow-sm'
                   : 'text-text-secondary hover:text-text-primary hover:bg-surface'"
               >
                 {{ typeOption.label }}
@@ -343,7 +343,7 @@
                     type="button"
                     @click="removeItem(index)"
                     :disabled="form.items.length === 1"
-                    class="text-red-600 hover:text-red-700 disabled:opacity-50 disabled:cursor-not-allowed p-1"
+                    class="text-state-danger-text hover:text-state-danger-text disabled:opacity-50 disabled:cursor-not-allowed p-1"
                   >
                     <svg class="w-4 h-4 sm:w-5 sm:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />

--- a/pages/abastecimiento/compras-directas/[id]/editar.vue
+++ b/pages/abastecimiento/compras-directas/[id]/editar.vue
@@ -90,7 +90,7 @@
               <div
                 class="flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full transition-colors border-2 flex-shrink-0"
                 :class="{
-                  'bg-primary text-primary-foreground border-primary': currentStep === 1,
+                  'bg-action-primary-bg text-action-primary-text border-primary': currentStep === 1,
                   'bg-secondary text-secondary-foreground border-secondary': currentStep > 1,
                   'border-border text-text-secondary bg-transparent': currentStep < 1
                 }"
@@ -114,7 +114,7 @@
               <div
                 class="flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full transition-colors border-2 flex-shrink-0"
                 :class="{
-                  'bg-primary text-primary-foreground border-primary': currentStep === 2,
+                  'bg-action-primary-bg text-action-primary-text border-primary': currentStep === 2,
                   'bg-secondary text-secondary-foreground border-secondary': currentStep > 2,
                   'border-border text-text-secondary bg-transparent': currentStep < 2
                 }"
@@ -139,7 +139,7 @@
               <div
                 class="flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-full transition-colors border-2 flex-shrink-0"
                 :class="{
-                  'bg-primary text-primary-foreground border-primary': currentStep === 3,
+                  'bg-action-primary-bg text-action-primary-text border-primary': currentStep === 3,
                   'bg-secondary text-secondary-foreground border-secondary': currentStep > 3,
                   'border-border text-text-secondary bg-transparent': currentStep < 3
                 }"
@@ -172,7 +172,7 @@
               <button
                 type="button"
                 @click="addItem"
-                class="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors text-sm"
+                class="px-4 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors text-sm"
               >
                 + Agregar Item
               </button>

--- a/pages/abastecimiento/compras-directas/[id]/index.vue
+++ b/pages/abastecimiento/compras-directas/[id]/index.vue
@@ -55,7 +55,7 @@
           <UiStatusBadge
             :value="isEditMode ? 'Editando' : getStatusText(purchase.status)"
             format="text"
-            :class="isEditMode ? 'bg-yellow-100 text-yellow-800 border-0' : ['border-0', getStatusClass(purchase.status)]"
+            :variant="isEditMode ? 'warning' : getStatusVariant(purchase.status)"
           />
         </PurchasesPurchaseInfoCard>
 
@@ -103,7 +103,7 @@
             <button
               @click="saveChanges"
               :disabled="!isFormValid || isSaving"
-              class="px-3 py-1.5 text-xs font-medium text-white bg-primary rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center space-x-1"
+              class="px-3 py-1.5 text-xs font-medium text-action-primary-text bg-action-primary-bg rounded-lg hover:bg-action-primary-hover-bg transition-colors disabled:opacity-50 flex items-center space-x-1"
             >
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
@@ -220,7 +220,7 @@
                 type="button"
                 @click="removeItem(index)"
                 :disabled="editItems.length === 1"
-                class="text-red-600 hover:text-red-700 disabled:opacity-50 disabled:cursor-not-allowed p-1"
+                class="text-state-danger-text hover:text-state-danger-text disabled:opacity-50 disabled:cursor-not-allowed p-1"
               >
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -399,7 +399,7 @@
                 type="button"
                 @click="addNewItem"
                 :disabled="!newItem.ingredient_id || newItem.purchase_quantity <= 0"
-                class="w-full px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center space-x-2"
+                class="w-full px-4 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center space-x-2"
               >
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
@@ -940,13 +940,13 @@ const getStatusText = (status: string) => {
   return statusMap[status] || status
 }
 
-const getStatusClass = (status: string) => {
-  const classMap: Record<string, string> = {
-    'received': 'bg-blue-100 text-blue-800',
-    'invoiced': 'bg-yellow-100 text-yellow-800',
-    'paid': 'bg-green-100 text-green-800'
+const getStatusVariant = (status: string) => {
+  const variantMap: Record<string, 'success' | 'warning' | 'info' | 'secondary'> = {
+    received: 'info',
+    invoiced: 'warning',
+    paid: 'success'
   }
-  return classMap[status] || 'bg-gray-100 text-gray-800'
+  return variantMap[status] || 'secondary'
 }
 
 

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -152,7 +152,7 @@
                   <p class="font-medium text-warning mb-1">¿Es este tu proveedor?</p>
                   <p class="text-text-secondary mb-3">Encontramos "<strong>{{ similarSupplier?.name }}</strong>", similar a "<em>{{ ocrSupplierName }}</em>" en la factura.</p>
                   <div class="flex gap-2">
-                    <button type="button" @click="selectSimilarSupplier" class="px-3 py-1.5 bg-warning text-white rounded-lg text-xs font-medium hover:bg-warning/90 transition-colors">
+                    <button type="button" @click="selectSimilarSupplier" class="px-3 py-1.5 bg-action-warning-bg text-action-warning-text rounded-lg text-xs font-medium hover:bg-action-warning-hover-bg transition-colors">
                       Sí, usar ese
                     </button>
                     <button type="button" @click="supplierScanStatus = 'not_found'; similarSupplier = null" class="px-3 py-1.5 bg-surface border border-border rounded-lg text-xs font-medium hover:bg-background transition-colors">
@@ -166,7 +166,7 @@
                     type="button"
                     @click="createSupplierFromOcr"
                     :disabled="isCreatingSupplier"
-                    class="px-3 py-1.5 bg-primary text-primary-foreground rounded-lg text-xs font-medium hover:bg-primary/90 disabled:opacity-50 transition-colors"
+                    class="px-3 py-1.5 bg-action-primary-bg text-action-primary-text rounded-lg text-xs font-medium hover:bg-action-primary-hover-bg disabled:opacity-50 transition-colors"
                   >
                     {{ isCreatingSupplier ? 'Creando...' : `+ Crear "${ocrSupplierName}"` }}
                   </button>
@@ -228,7 +228,7 @@
                 <button
                   type="button"
                   @click="addItem"
-                  class="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors text-sm min-h-[44px]"
+                  class="px-4 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors text-sm min-h-[44px]"
                 >
                   + Agregar ítem
                 </button>
@@ -412,7 +412,7 @@
                         </div>
                         <div
                           v-if="item.ingredient_id && getPurchaseUnitOptions(item.ingredient_id).length === 0"
-                          class="flex items-start gap-1.5 px-2.5 py-2 rounded-lg bg-amber-50 border border-amber-200 text-xs text-amber-800 flex-1"
+                          class="flex items-start gap-1.5 px-2.5 py-2 rounded-lg bg-state-warning-bg border border-state-warning-border text-xs text-state-warning-text flex-1"
                         >
                           <svg class="w-3.5 h-3.5 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
@@ -590,7 +590,7 @@
                   <button
                     type="submit"
                     :disabled="isSubmitting"
-                    class="w-full min-h-[48px] rounded-lg font-semibold text-base bg-success text-white hover:bg-success/90 active:scale-[0.98] disabled:opacity-50 transition-all flex items-center justify-center gap-2"
+                    class="w-full min-h-[48px] rounded-lg font-semibold text-base bg-action-success-bg text-action-success-text hover:bg-action-success-hover-bg active:scale-[0.98] disabled:opacity-50 transition-all flex items-center justify-center gap-2"
                   >
                     <svg v-if="!isSubmitting" class="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
@@ -617,7 +617,7 @@
   <!-- Quota exceeded modal -->
   <div
     v-if="showQuotaModal"
-    class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+    class="fixed inset-0 bg-overlay-backdrop/50 flex items-center justify-center z-50 p-4"
     role="dialog"
     aria-modal="true"
     aria-labelledby="quota-modal-title"

--- a/pages/abastecimiento/compras-directas/index.vue
+++ b/pages/abastecimiento/compras-directas/index.vue
@@ -104,7 +104,7 @@
               <UiStatusBadge
                 :value="getStatusText(item.status)"
                 format="text"
-                :variant="item.status === 'paid' ? 'success' : item.status === 'invoiced' ? 'warning' : 'info'"
+                :variant="getStatusVariant(item.status)"
                 size="sm"
               />
             </div>
@@ -136,7 +136,7 @@
           <UiStatusBadge
             :value="getStatusText(value)"
             format="text"
-            :variant="value === 'paid' ? 'success' : value === 'invoiced' ? 'warning' : 'info'"
+            :variant="getStatusVariant(value)"
             size="sm"
           />
         </template>
@@ -157,14 +157,14 @@
       </HealthSemaphore>
 
       <!-- Pagination -->
-      <div v-if="purchasesData.total > itemsPerPage" class="bg-white px-4 py-3 flex items-center justify-between border border-titan-200 rounded-lg">
+      <div v-if="purchasesData.total > itemsPerPage" class="bg-surface px-4 py-3 flex items-center justify-between border border-border rounded-lg">
         <div class="flex-1 flex justify-between sm:hidden">
           <button
             @click="previousPage"
             :disabled="!canGoPrevious"
             :class="[
-              'relative inline-flex items-center px-4 py-2 border border-titan-300 text-sm font-medium rounded-md',
-              canGoPrevious ? 'text-titan-700 bg-white hover:bg-titan-50' : 'text-titan-400 bg-titan-50 cursor-not-allowed'
+              'relative inline-flex items-center px-4 py-2 border border-action-outline-border text-sm font-medium rounded-md',
+              canGoPrevious ? 'text-action-outline-text bg-action-outline-bg hover:bg-action-outline-hover-bg' : 'text-action-outline-disabled-text bg-action-outline-disabled-bg cursor-not-allowed'
             ]">
             Anterior
           </button>
@@ -172,15 +172,15 @@
             @click="nextPage"
             :disabled="!canGoNext"
             :class="[
-              'relative inline-flex items-center px-4 py-2 border border-titan-300 text-sm font-medium rounded-md',
-              canGoNext ? 'text-titan-700 bg-white hover:bg-titan-50' : 'text-titan-400 bg-titan-50 cursor-not-allowed'
+              'relative inline-flex items-center px-4 py-2 border border-action-outline-border text-sm font-medium rounded-md',
+              canGoNext ? 'text-action-outline-text bg-action-outline-bg hover:bg-action-outline-hover-bg' : 'text-action-outline-disabled-text bg-action-outline-disabled-bg cursor-not-allowed'
             ]">
             Siguiente
           </button>
         </div>
         <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
           <div>
-            <p class="text-sm text-titan-700">
+            <p class="text-sm text-text-secondary">
               Mostrando
               <span class="font-medium">{{ startItem }}</span>
               a
@@ -196,20 +196,20 @@
                 @click="previousPage"
                 :disabled="!canGoPrevious"
                 :class="[
-                  'relative inline-flex items-center px-2 py-2 rounded-l-md border border-titan-300 text-sm font-medium',
-                  canGoPrevious ? 'text-titan-500 bg-white hover:bg-titan-50' : 'text-titan-300 bg-titan-50 cursor-not-allowed'
+                  'relative inline-flex items-center px-2 py-2 rounded-l-md border border-action-outline-border text-sm font-medium',
+                  canGoPrevious ? 'text-action-outline-text bg-action-outline-bg hover:bg-action-outline-hover-bg' : 'text-action-outline-disabled-text bg-action-outline-disabled-bg cursor-not-allowed'
                 ]">
                 <ChevronLeftIcon class="h-5 w-5" />
               </button>
-              <span class="relative inline-flex items-center px-4 py-2 border border-titan-300 bg-white text-sm font-medium text-titan-700">
+              <span class="relative inline-flex items-center px-4 py-2 border border-action-outline-border bg-action-outline-bg text-sm font-medium text-action-outline-text">
                 {{ currentPage }} / {{ totalPages }}
               </span>
               <button
                 @click="nextPage"
                 :disabled="!canGoNext"
                 :class="[
-                  'relative inline-flex items-center px-2 py-2 rounded-r-md border border-titan-300 text-sm font-medium',
-                  canGoNext ? 'text-titan-500 bg-white hover:bg-titan-50' : 'text-titan-300 bg-titan-50 cursor-not-allowed'
+                  'relative inline-flex items-center px-2 py-2 rounded-r-md border border-action-outline-border text-sm font-medium',
+                  canGoNext ? 'text-action-outline-text bg-action-outline-bg hover:bg-action-outline-hover-bg' : 'text-action-outline-disabled-text bg-action-outline-disabled-bg cursor-not-allowed'
                 ]">
                 <ChevronRightIcon class="h-5 w-5" />
               </button>
@@ -360,13 +360,13 @@ const getStatusText = (status: string) => {
   return statusMap[status] || status
 }
 
-const getStatusClass = (status: string) => {
-  const classMap: Record<string, string> = {
-    'received': 'bg-blue-100 text-blue-800',
-    'invoiced': 'bg-yellow-100 text-yellow-800',
-    'paid': 'bg-green-100 text-green-800'
+const getStatusVariant = (status: string) => {
+  const variantMap: Record<string, 'success' | 'warning' | 'info' | 'secondary'> = {
+    received: 'info',
+    invoiced: 'warning',
+    paid: 'success'
   }
-  return classMap[status] || 'bg-gray-100 text-gray-800'
+  return variantMap[status] || 'secondary'
 }
 
 const handleSort = (field: string) => {

--- a/pages/abastecimiento/compras.vue
+++ b/pages/abastecimiento/compras.vue
@@ -136,7 +136,7 @@
           <UiStatusBadge
             :value="getStatusText(value)"
             format="text"
-            :class="['border-0', getStatusClass(value)]"
+            :variant="getStatusVariant(value)"
             size="sm"
           />
         </template>
@@ -160,14 +160,14 @@
       </HealthSemaphore>
 
       <!-- Pagination -->
-      <div v-if="purchasesData.total > itemsPerPage" class="bg-white px-4 py-3 flex items-center justify-between border border-titan-200 rounded-lg">
+      <div v-if="purchasesData.total > itemsPerPage" class="bg-surface px-4 py-3 flex items-center justify-between border border-border rounded-lg">
         <div class="flex-1 flex justify-between sm:hidden">
           <button
             @click="previousPage"
             :disabled="!canGoPrevious"
             :class="[
-              'relative inline-flex items-center px-4 py-2 border border-titan-300 text-sm font-medium rounded-md',
-              canGoPrevious ? 'text-titan-700 bg-white hover:bg-titan-50' : 'text-titan-400 bg-titan-50 cursor-not-allowed'
+              'relative inline-flex items-center px-4 py-2 border border-action-outline-border text-sm font-medium rounded-md',
+              canGoPrevious ? 'text-action-outline-text bg-action-outline-bg hover:bg-action-outline-hover-bg' : 'text-action-outline-disabled-text bg-action-outline-disabled-bg cursor-not-allowed'
             ]">
             Anterior
           </button>
@@ -175,15 +175,15 @@
             @click="nextPage"
             :disabled="!canGoNext"
             :class="[
-              'ml-3 relative inline-flex items-center px-4 py-2 border border-titan-300 text-sm font-medium rounded-md',
-              canGoNext ? 'text-titan-700 bg-white hover:bg-titan-50' : 'text-titan-400 bg-titan-50 cursor-not-allowed'
+              'ml-3 relative inline-flex items-center px-4 py-2 border border-action-outline-border text-sm font-medium rounded-md',
+              canGoNext ? 'text-action-outline-text bg-action-outline-bg hover:bg-action-outline-hover-bg' : 'text-action-outline-disabled-text bg-action-outline-disabled-bg cursor-not-allowed'
             ]">
             Siguiente
           </button>
         </div>
         <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
           <div>
-            <p class="text-sm text-titan-700">
+            <p class="text-sm text-text-secondary">
               Mostrando <span class="font-medium">{{ startItem }}</span> a <span class="font-medium">{{ endItem }}</span> de
               <span class="font-medium">{{ purchasesData.total }}</span> resultados
             </p>
@@ -194,20 +194,20 @@
                 @click="previousPage"
                 :disabled="!canGoPrevious"
                 :class="[
-                  'relative inline-flex items-center px-2 py-2 rounded-l-md border border-titan-300 text-sm font-medium',
-                  canGoPrevious ? 'bg-white text-titan-500 hover:bg-titan-50' : 'bg-titan-50 text-titan-300 cursor-not-allowed'
+                  'relative inline-flex items-center px-2 py-2 rounded-l-md border border-action-outline-border text-sm font-medium',
+                  canGoPrevious ? 'bg-action-outline-bg text-action-outline-text hover:bg-action-outline-hover-bg' : 'bg-action-outline-disabled-bg text-action-outline-disabled-text cursor-not-allowed'
                 ]">
                 <ChevronLeftIcon class="h-5 w-5" />
               </button>
-              <span class="relative inline-flex items-center px-4 py-2 border border-titan-300 bg-white text-sm font-medium text-titan-700">
+              <span class="relative inline-flex items-center px-4 py-2 border border-action-outline-border bg-action-outline-bg text-sm font-medium text-action-outline-text">
                 {{ currentPage }} / {{ totalPages }}
               </span>
               <button
                 @click="nextPage"
                 :disabled="!canGoNext"
                 :class="[
-                  'relative inline-flex items-center px-2 py-2 rounded-r-md border border-titan-300 text-sm font-medium',
-                  canGoNext ? 'bg-white text-titan-500 hover:bg-titan-50' : 'bg-titan-50 text-titan-300 cursor-not-allowed'
+                  'relative inline-flex items-center px-2 py-2 rounded-r-md border border-action-outline-border text-sm font-medium',
+                  canGoNext ? 'bg-action-outline-bg text-action-outline-text hover:bg-action-outline-hover-bg' : 'bg-action-outline-disabled-bg text-action-outline-disabled-text cursor-not-allowed'
                 ]">
                 <ChevronRightIcon class="h-5 w-5" />
               </button>
@@ -574,26 +574,6 @@ const handleSort = (field) => {
 // Helper functions
 const { formatDate, formatDateShort } = useFormatters()
 
-// Helper function for status variants
-// Helper function for status classes (matching acciones.vue)
-function getStatusClass(status) {
-  const classes = {
-    quotation: '!bg-yellow-500/10 !text-yellow-600',
-    pending: '!bg-blue-500/10 !text-blue-600',
-    confirmed: '!bg-teal-500/10 !text-teal-600',
-    preparing: '!bg-state-warning-bg !text-state-warning-text',
-    shipped: '!bg-cyan-500/10 !text-cyan-600',
-    partially_received: '!bg-orange-500/10 !text-orange-600',
-    received: '!bg-emerald-500/10 !text-emerald-600',
-    verified: '!bg-green-600/10 !text-green-700',
-    invoiced: '!bg-indigo-500/10 !text-indigo-600',
-    paid: '!bg-green-600/10 !text-green-700',
-    cancelled: '!bg-destructive/10 !text-destructive',
-    overdue: '!bg-destructive/10 !text-destructive'
-  }
-  return classes[status] || 'bg-titan-200 text-titan-700'
-}
-
 const getStatusVariant = (status) => {
   const variants: Record<string, string> = {
     quotation: 'secondary',
@@ -601,6 +581,7 @@ const getStatusVariant = (status) => {
     confirmed: 'primary',
     preparing: 'info',
     shipped: 'info',
+    partially_received: 'success',
     received: 'success',
     verified: 'success',
     invoiced: 'secondary',

--- a/pages/abastecimiento/ingredientes-propios.vue
+++ b/pages/abastecimiento/ingredientes-propios.vue
@@ -40,7 +40,7 @@
             :class="[
               'h-10 px-3 rounded-lg border-2 text-sm font-medium transition-colors flex-shrink-0 flex items-center gap-1.5',
               showArchived
-                ? 'border-amber-400 bg-amber-50 text-amber-700'
+                ? 'border-state-warning-border bg-state-warning-bg text-state-warning-text'
                 : 'border-border bg-background text-text-secondary hover:border-border hover:text-text-primary'
             ]"
           >
@@ -83,7 +83,7 @@
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-1.5 flex-wrap">
                 <span class="text-sm font-bold text-text-primary">{{ item.name }}</span>
-                <span v-if="item.is_active === false" class="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 flex-shrink-0">Archivado</span>
+                <span v-if="item.is_active === false" class="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-state-warning-bg text-state-warning-text flex-shrink-0">Archivado</span>
               </div>
               <div class="flex items-center gap-2 mt-0.5 flex-wrap">
                 <span class="text-xs text-text-secondary font-mono">{{ item.unit }}{{ item.unit_weight_gr ? ` · ${item.unit_weight_gr} gr/und` : '' }}</span>
@@ -101,7 +101,7 @@
         <template #cell-name="{ value, row }">
           <div class="flex items-center gap-1.5 flex-wrap">
             <span class="text-sm font-bold capitalize" :class="row.is_active === false ? 'text-text-tertiary' : 'text-text-primary'">{{ value }}</span>
-            <span v-if="row.is_active === false" class="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 flex-shrink-0">Archivado</span>
+            <span v-if="row.is_active === false" class="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-state-warning-bg text-state-warning-text flex-shrink-0">Archivado</span>
           </div>
         </template>
 
@@ -149,7 +149,7 @@
               @click="openArchiveModal(row)"
               :aria-label="`Archivar ${row.name}`"
               title="Archivar"
-              class="p-1.5 rounded-md hover:bg-amber-50 transition-colors text-text-secondary hover:text-amber-600"
+              class="p-1.5 rounded-md hover:bg-state-warning-bg transition-colors text-text-secondary hover:text-state-warning-text"
             >
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8l1 12a2 2 0 002 2h8a2 2 0 002-2l1-12M10 12v4m4-4v4" />
@@ -187,11 +187,11 @@
     <!-- Archive Confirmation Modal -->
     <Teleport to="body">
       <Transition enter-active-class="transition-opacity duration-200" enter-from-class="opacity-0" enter-to-class="opacity-100" leave-active-class="transition-opacity duration-200" leave-from-class="opacity-100" leave-to-class="opacity-0">
-        <div v-if="showArchiveModal" class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40" @click.self="showArchiveModal = false">
+        <div v-if="showArchiveModal" class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-overlay-backdrop/40" @click.self="showArchiveModal = false">
           <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm p-6 flex flex-col gap-4">
             <div class="flex items-start gap-3">
-              <div class="flex-shrink-0 w-10 h-10 rounded-xl bg-amber-100 flex items-center justify-center">
-                <svg class="w-5 h-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <div class="flex-shrink-0 w-10 h-10 rounded-xl bg-state-warning-bg flex items-center justify-center">
+                <svg class="w-5 h-5 text-state-warning-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8l1 12a2 2 0 002 2h8a2 2 0 002-2l1-12M10 12v4m4-4v4" />
                 </svg>
               </div>
@@ -223,7 +223,7 @@
                 type="button"
                 @click="confirmArchive"
                 :disabled="archiving"
-                class="flex-1 h-10 rounded-lg bg-amber-500 text-sm font-semibold text-white hover:bg-amber-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                class="flex-1 h-10 rounded-lg bg-action-warning-bg text-action-warning-text text-sm font-semibold text-action-primary-text hover:bg-action-warning-hover-bg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <span v-if="archiving">Archivando...</span>
                 <span v-else>Archivar</span>

--- a/pages/abastecimiento/proveedor/[id].vue
+++ b/pages/abastecimiento/proveedor/[id].vue
@@ -88,7 +88,7 @@
               <button
                 type="button"
                 @click="openAgreementModal()"
-                class="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors text-sm font-medium"
+                class="px-4 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors text-sm font-medium"
               >
                 + Nuevo Acuerdo
               </button>
@@ -122,7 +122,7 @@
                       </span>
                       <span
                         v-if="agreement.auto_apply"
-                        class="px-2 py-0.5 rounded text-xs font-medium bg-blue-500/10 text-blue-600"
+                        class="px-2 py-0.5 rounded text-xs font-medium bg-state-info-bg text-state-info-text"
                       >
                         Auto-aplicar
                       </span>
@@ -174,7 +174,7 @@
                 v-model="form.is_active"
                 type="checkbox"
                 id="is_active"
-                class="h-4 w-4 text-primary focus:ring-primary border-border rounded"
+                class="h-4 w-4 text-primary focus:ring-action-primary-focus-ring border-border rounded"
               />
               <label for="is_active" class="text-sm font-medium text-text-primary">
                 Proveedor activo
@@ -216,7 +216,7 @@
             <button 
               type="submit" 
               :disabled="isSubmitting"
-              class="w-full py-3 bg-emerald-500 text-white rounded-lg hover:bg-emerald-600 transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold shadow-lg shadow-emerald-500/20">
+              class="w-full py-3 bg-action-success-bg text-action-success-text rounded-lg hover:bg-action-success-hover-bg transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold shadow-lg shadow-action-success-bg/20">
               <CommonsTheCustomLoader v-if="isSubmitting" size="small" />
               <span>{{ isSubmitting ? 'Guardando...' : 'Guardar Cambios' }}</span>
             </button>
@@ -231,7 +231,7 @@
               type="button"
               @click="requestDelete"
               :disabled="isDeleting"
-              class="w-full py-3 bg-destructive text-destructive-foreground rounded-lg hover:bg-destructive/90 transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold">
+              class="w-full py-3 bg-destructive text-destructive-foreground rounded-lg hover:bg-action-destructive-hover-bg transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold">
               <UiLoadingDots v-if="isDeleting" size="9px" color="currentColor" />
               <span>{{ isDeleting ? 'Eliminando...' : 'Eliminar Proveedor' }}</span>
             </button>
@@ -243,7 +243,7 @@
     <!-- Modal para Acuerdos de Pago -->
     <div
       v-if="showAgreementModal"
-      class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+      class="fixed inset-0 bg-overlay-backdrop/50 flex items-center justify-center z-50 p-4"
       @click.self="closeAgreementModal"
     >
       <div class="bg-surface rounded-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
@@ -343,7 +343,7 @@
                 v-model="agreementForm.is_active"
                 type="checkbox"
                 id="agreement_active"
-                class="h-4 w-4 text-primary focus:ring-primary border-border rounded"
+                class="h-4 w-4 text-primary focus:ring-action-primary-focus-ring border-border rounded"
               />
               <label for="agreement_active" class="ml-2 text-sm font-medium text-text-primary">
                 Acuerdo activo
@@ -355,7 +355,7 @@
                 v-model="agreementForm.auto_apply"
                 type="checkbox"
                 id="agreement_auto_apply"
-                class="h-4 w-4 text-primary focus:ring-primary border-border rounded"
+                class="h-4 w-4 text-primary focus:ring-action-primary-focus-ring border-border rounded"
               />
               <label for="agreement_auto_apply" class="ml-2 text-sm font-medium text-text-primary">
                 Auto-aplicar
@@ -368,7 +368,7 @@
             <button
               type="submit"
               :disabled="isSavingAgreement"
-              class="flex-1 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 font-medium"
+              class="flex-1 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors disabled:opacity-50 font-medium"
             >
               {{ isSavingAgreement ? 'Guardando...' : 'Guardar Acuerdo' }}
             </button>

--- a/pages/abastecimiento/proveedor/crear.vue
+++ b/pages/abastecimiento/proveedor/crear.vue
@@ -96,7 +96,7 @@
             <button
               type="button"
               @click="openAgreementModal()"
-              class="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors text-sm font-medium"
+              class="px-4 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors text-sm font-medium"
             >
               + Nuevo Acuerdo
             </button>
@@ -130,7 +130,7 @@
                     </span>
                     <span
                       v-if="agreement.auto_apply"
-                      class="px-2 py-0.5 rounded text-xs font-medium bg-blue-500/10 text-blue-600"
+                      class="px-2 py-0.5 rounded text-xs font-medium bg-state-info-bg text-state-info-text"
                     >
                       Auto-aplicar
                     </span>
@@ -182,7 +182,7 @@
               v-model="form.is_active"
               type="checkbox"
               id="is_active"
-              class="h-4 w-4 text-primary focus:ring-primary border-border rounded"
+              class="h-4 w-4 text-primary focus:ring-action-primary-focus-ring border-border rounded"
             />
             <label for="is_active" class="text-sm font-medium text-text-primary">
               Proveedor activo
@@ -228,7 +228,7 @@
               'w-full py-3 rounded-lg transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold',
               isSubmitting
                 ? 'bg-background border border-border text-text-primary shadow-none'
-                : 'bg-emerald-500 text-white hover:bg-emerald-600 shadow-lg shadow-emerald-500/20'
+                : 'bg-action-success-bg text-action-success-text hover:bg-action-success-hover-bg shadow-lg shadow-action-success-bg/20'
             ]">
             <CommonsTheCustomLoader v-if="isSubmitting" size="small" />
             <span>{{ isSubmitting ? 'Creando...' : 'Crear Proveedor' }}</span>
@@ -247,7 +247,7 @@
   <!-- Modal para Acuerdos de Pago -->
   <div
     v-if="showAgreementModal"
-    class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+    class="fixed inset-0 bg-overlay-backdrop/50 flex items-center justify-center z-50 p-4"
     @click.self="closeAgreementModal"
   >
     <div class="bg-surface rounded-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
@@ -347,7 +347,7 @@
               v-model="agreementForm.is_active"
               type="checkbox"
               id="agreement_active"
-              class="h-4 w-4 text-primary focus:ring-primary border-border rounded"
+              class="h-4 w-4 text-primary focus:ring-action-primary-focus-ring border-border rounded"
             />
             <label for="agreement_active" class="ml-2 text-sm font-medium text-text-primary">
               Acuerdo activo
@@ -359,7 +359,7 @@
               v-model="agreementForm.auto_apply"
               type="checkbox"
               id="agreement_auto_apply"
-              class="h-4 w-4 text-primary focus:ring-primary border-border rounded"
+              class="h-4 w-4 text-primary focus:ring-action-primary-focus-ring border-border rounded"
             />
             <label for="agreement_auto_apply" class="ml-2 text-sm font-medium text-text-primary">
               Auto-aplicar
@@ -371,7 +371,7 @@
         <div class="flex gap-3 pt-4 border-t border-border">
           <button
             type="submit"
-            class="flex-1 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors font-medium"
+            class="flex-1 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors font-medium"
           >
             {{ editingIndex !== null ? 'Actualizar' : 'Agregar' }} Acuerdo
           </button>

--- a/pages/abastecimiento/proveedores.vue
+++ b/pages/abastecimiento/proveedores.vue
@@ -144,20 +144,20 @@
       </HealthSemaphore>
 
       <!-- Pagination -->
-      <div class="bg-white px-4 py-3 flex items-center justify-between border border-titan-200 rounded-lg">
+      <div class="bg-surface px-4 py-3 flex items-center justify-between border border-border rounded-lg">
         <div class="flex-1 flex justify-between sm:hidden">
           <button @click="prevPage" :disabled="currentPage === 1"
-            class="relative inline-flex items-center px-4 py-2 border border-titan-300 text-sm font-medium rounded-md text-titan-700 bg-white hover:bg-titan-50">
+            class="relative inline-flex items-center px-4 py-2 border border-action-outline-border text-sm font-medium rounded-md text-action-outline-text bg-action-outline-bg hover:bg-action-outline-hover-bg">
             Anterior
           </button>
           <button @click="nextPage" :disabled="currentPage === totalPages"
-            class="ml-3 relative inline-flex items-center px-4 py-2 border border-titan-300 text-sm font-medium rounded-md text-titan-700 bg-white hover:bg-titan-50">
+            class="ml-3 relative inline-flex items-center px-4 py-2 border border-action-outline-border text-sm font-medium rounded-md text-action-outline-text bg-action-outline-bg hover:bg-action-outline-hover-bg">
             Siguiente
           </button>
         </div>
         <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
           <div>
-            <p class="text-sm text-titan-700">
+            <p class="text-sm text-text-secondary">
               Mostrando <span class="font-medium">{{ startIndex }}</span> a <span class="font-medium">{{ endIndex }}</span>
               de <span class="font-medium">{{ totalSuppliers }}</span> resultados
             </p>
@@ -165,17 +165,17 @@
           <div>
             <nav class="relative z-0 inline-flex rounded-md shadow-sm -space-x-px">
               <button @click="prevPage" :disabled="currentPage === 1"
-                class="relative inline-flex items-center px-2 py-2 rounded-l-md border border-titan-300 bg-white text-sm font-medium text-titan-500 hover:bg-titan-50">
+                class="relative inline-flex items-center px-2 py-2 rounded-l-md border border-action-outline-border bg-action-outline-bg text-sm font-medium text-action-outline-text hover:bg-action-outline-hover-bg">
                 <ChevronLeftIcon class="h-5 w-5" />
               </button>
               <button v-for="page in totalPages" :key="page" @click="goToPage(page)" :class="[
-                'relative inline-flex items-center px-4 py-2 border border-titan-300 text-sm font-medium',
-                currentPage === page ? 'bg-crocus-50 border-crocus-500 text-crocus-600' : 'bg-white text-titan-700 hover:bg-titan-50'
+                'relative inline-flex items-center px-4 py-2 border border-action-outline-border text-sm font-medium',
+                currentPage === page ? 'bg-badge-primary-bg border-badge-primary-border text-badge-primary-text' : 'bg-action-outline-bg text-action-outline-text hover:bg-action-outline-hover-bg'
               ]">
                 {{ page }}
               </button>
               <button @click="nextPage" :disabled="currentPage === totalPages"
-                class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-titan-300 bg-white text-sm font-medium text-titan-500 hover:bg-titan-50">
+                class="relative inline-flex items-center px-2 py-2 rounded-r-md border border-action-outline-border bg-action-outline-bg text-sm font-medium text-action-outline-text hover:bg-action-outline-hover-bg">
                 <ChevronRightIcon class="h-5 w-5" />
               </button>
             </nav>

--- a/pages/abastecimiento/stock.vue
+++ b/pages/abastecimiento/stock.vue
@@ -40,7 +40,7 @@
         <button
           type="button"
           title="Ajustar stock"
-          class="min-h-[44px] h-10 px-3 inline-flex items-center gap-1.5 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 transition-colors flex-shrink-0"
+          class="min-h-[44px] h-10 px-3 inline-flex items-center gap-1.5 rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold hover:bg-action-primary-hover-bg focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 transition-colors flex-shrink-0"
           @click="showAdjustmentPanel = true"
         >
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/pages/cocina/[id].vue
+++ b/pages/cocina/[id].vue
@@ -278,7 +278,7 @@ watch(isRefreshing, (v) => v ? startPhrases() : stopPhrases(), { immediate: true
           <button
             type="button"
             :disabled="isAuthorizingAudio"
-            class="flex-1 min-h-[60px] px-6 rounded-2xl bg-primary text-white text-base md:text-lg font-bold shadow-md hover:bg-primary/90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-4 focus-visible:ring-primary/30 disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            class="flex-1 min-h-[60px] px-6 rounded-2xl bg-action-primary-bg text-action-primary-text text-base md:text-lg font-bold shadow-md hover:bg-action-primary-hover-bg active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-4 focus-visible:ring-action-primary-focus-ring/30 disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center gap-2"
             @click="authorizeAudio"
           >
             <UiLoadingDots v-if="isAuthorizingAudio" size="9px" color="currentColor" />

--- a/pages/comandas/index.vue
+++ b/pages/comandas/index.vue
@@ -129,7 +129,7 @@ onUnmounted(() => {
       v-if="!comandasEnabled && businessProfile !== undefined"
       class="flex flex-col items-center justify-center h-full text-center p-8 bg-surface border-2 border-dashed border-border rounded-2xl"
     >
-      <div class="w-16 h-16 bg-titan-200 rounded-full flex items-center justify-center mb-4 text-primary">
+      <div class="w-16 h-16 bg-surface-secondary rounded-full flex items-center justify-center mb-4 text-primary">
         <Icon name="lucide:queue" size="32" />
       </div>
       <h3 class="text-lg font-bold text-text-primary">Comandas no activadas</h3>
@@ -138,7 +138,7 @@ onUnmounted(() => {
       </p>
       <NuxtLink
         to="/negocio"
-        class="mt-4 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-primary text-white text-sm font-semibold transition-colors hover:bg-primary/90"
+        class="mt-4 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold transition-colors hover:bg-action-primary-hover-bg"
       >
         <Icon name="lucide:settings" class="w-4 h-4" />
         Ir a Mi Negocio
@@ -186,7 +186,7 @@ onUnmounted(() => {
             type="button"
             class="px-3 rounded-md text-xs font-semibold transition-all min-h-[44px]"
             :class="selectedSourceType === src.value
-              ? 'bg-primary text-white shadow-sm'
+              ? 'bg-action-primary-bg text-action-primary-text shadow-sm'
               : 'text-text-secondary hover:bg-surface-tertiary'"
             @click="selectedSourceType = src.value"
           >
@@ -198,7 +198,7 @@ onUnmounted(() => {
         <select
           v-if="activeStations.length > 0"
           v-model="selectedStationId"
-          class="min-h-[44px] px-3 py-2 rounded-lg bg-surface border border-border text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 flex-shrink-0"
+          class="min-h-[44px] px-3 py-2 rounded-lg bg-surface border border-border text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 flex-shrink-0"
         >
           <option value="">Todas las estaciones</option>
           <option v-for="station in activeStations" :key="station.id" :value="station.id">
@@ -209,7 +209,7 @@ onUnmounted(() => {
         <!-- Status dropdown -->
         <select
           v-model="selectedStatus"
-          class="min-h-[44px] px-3 py-2 rounded-lg bg-surface border border-border text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 flex-shrink-0"
+          class="min-h-[44px] px-3 py-2 rounded-lg bg-surface border border-border text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 flex-shrink-0"
         >
           <option v-for="opt in STATUS_OPTIONS" :key="opt.value" :value="opt.value">
             {{ opt.label }}
@@ -220,7 +220,7 @@ onUnmounted(() => {
         <input
           v-model="selectedDate"
           type="date"
-          class="min-h-[44px] px-3 py-2 rounded-lg bg-surface border border-border text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 flex-shrink-0"
+          class="min-h-[44px] px-3 py-2 rounded-lg bg-surface border border-border text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 flex-shrink-0"
         />
       </div>
 
@@ -244,7 +244,7 @@ onUnmounted(() => {
           v-else-if="!allComandas.length"
           class="flex flex-col items-center justify-center h-full text-center p-8 bg-surface/50 border border-border rounded-2xl min-h-[300px]"
         >
-          <div class="w-16 h-16 bg-titan-100 rounded-full flex items-center justify-center mb-4 text-titan-500">
+          <div class="w-16 h-16 bg-surface-secondary rounded-full flex items-center justify-center mb-4 text-text-tertiary">
             <Icon name="lucide:check-circle-2" size="32" />
           </div>
           <h3 class="text-lg font-bold text-text-primary">
@@ -266,7 +266,7 @@ onUnmounted(() => {
               <h2 class="text-sm font-black uppercase tracking-wider text-text-secondary">Activas</h2>
               <span
                 v-if="activeComandas.length > 0"
-                class="inline-flex items-center justify-center h-5 min-w-[1.25rem] px-1.5 rounded-full bg-primary text-white text-[10px] font-black"
+                class="inline-flex items-center justify-center h-5 min-w-[1.25rem] px-1.5 rounded-full bg-action-primary-bg text-action-primary-text text-[10px] font-black"
               >
                 {{ activeComandas.length }}
               </span>
@@ -296,7 +296,7 @@ onUnmounted(() => {
               <h2 class="text-sm font-black uppercase tracking-wider text-success">Listas para entregar</h2>
               <span
                 v-if="readyComandas.length > 0"
-                class="inline-flex items-center justify-center h-5 min-w-[1.25rem] px-1.5 rounded-full bg-success text-white text-[10px] font-black"
+                class="inline-flex items-center justify-center h-5 min-w-[1.25rem] px-1.5 rounded-full bg-action-success-bg text-action-success-text text-[10px] font-black"
               >
                 {{ readyComandas.length }}
               </span>

--- a/pages/despacho/comandas.vue
+++ b/pages/despacho/comandas.vue
@@ -291,7 +291,7 @@ const getComandaStatusVariant = (status: string): string => {
               class="h-9 px-4 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
               :class="status === 'cancelled'
                 ? 'border border-destructive text-destructive hover:bg-destructive/10'
-                : 'bg-primary text-primary-foreground hover:bg-primary/90'"
+                : 'bg-action-primary-bg text-action-primary-text hover:bg-action-primary-hover-bg'"
               @click="executeBulkUpdate(status)"
             >
               <UiLoadingDots v-if="isBulkUpdating" size="8px" color="currentColor" />
@@ -326,7 +326,7 @@ const getComandaStatusVariant = (status: string): string => {
         <div class="flex items-center justify-center">
           <label class="cursor-pointer">
             <input type="checkbox" class="sr-only peer" :checked="allPageSelected" @change="toggleSelectAll" />
-            <span class="w-5 h-5 rounded-[5px] border-2 border-border bg-background peer-checked:bg-primary peer-checked:border-primary transition-colors flex items-center justify-center text-white">
+            <span class="w-5 h-5 rounded-[5px] border-2 border-border bg-background peer-checked:bg-control-toggle-track-on peer-checked:border-primary transition-colors flex items-center justify-center text-action-primary-text">
               <svg v-if="allPageSelected" viewBox="0 0 10 8" fill="none" class="w-2.5 h-2">
                 <path d="M1 4l2.5 2.5L9 1" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
               </svg>
@@ -339,7 +339,7 @@ const getComandaStatusVariant = (status: string): string => {
       <template #cell-_select="{ row }">
         <label @click.stop class="flex items-center justify-center cursor-pointer">
           <input type="checkbox" class="sr-only peer" :checked="selectedIds.includes(row.id)" @change.stop="toggleSelect(row.id)" />
-          <span class="w-5 h-5 rounded-[5px] border-2 border-border bg-background peer-checked:bg-primary peer-checked:border-primary transition-colors flex items-center justify-center text-white">
+          <span class="w-5 h-5 rounded-[5px] border-2 border-border bg-background peer-checked:bg-control-toggle-track-on peer-checked:border-primary transition-colors flex items-center justify-center text-action-primary-text">
             <svg v-if="selectedIds.includes(row.id)" viewBox="0 0 10 8" fill="none" class="w-2.5 h-2">
               <path d="M1 4l2.5 2.5L9 1" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
@@ -375,7 +375,7 @@ const getComandaStatusVariant = (status: string): string => {
                 {{ item.kitchen_name }}
               </span>
               <span v-if="item.status === 'cancelled'" class="text-[10px] font-semibold text-destructive bg-destructive/10 px-1 rounded">✕</span>
-              <span v-if="item.notes" class="text-amber-500 text-[10px]" :title="item.notes">📝</span>
+              <span v-if="item.notes" class="text-state-warning-icon text-[10px]" :title="item.notes">📝</span>
             </div>
         </div>
       </template>

--- a/pages/despacho/domicilios/[id].vue
+++ b/pages/despacho/domicilios/[id].vue
@@ -475,7 +475,7 @@ onUnmounted(() => {
       >
         <div
           v-if="paymentModal.open"
-          class="fixed inset-0 z-[70] flex items-end sm:items-center justify-center p-4 sm:p-6 bg-black/50"
+          class="fixed inset-0 z-[70] flex items-end sm:items-center justify-center p-4 sm:p-6 bg-overlay-backdrop/50"
           role="dialog"
           aria-modal="true"
           aria-labelledby="payment-modal-title"
@@ -507,7 +507,7 @@ onUnmounted(() => {
                   type="button"
                   :disabled="isStatusUpdating"
                   aria-label="Cerrar"
-                  class="flex-shrink-0 min-h-[44px] min-w-[44px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50 transition-colors"
+                  class="flex-shrink-0 min-h-[44px] min-w-[44px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 disabled:opacity-50 transition-colors"
                   @click="closePaymentModal"
                 >
                   <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -542,7 +542,7 @@ onUnmounted(() => {
                 <button
                   type="button"
                   :disabled="!canConfirmDelivered || isStatusUpdating"
-                  class="flex-1 min-h-[44px] py-3 px-4 bg-primary text-primary-foreground rounded-lg font-semibold hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-60 disabled:cursor-not-allowed transition-all flex items-center justify-center gap-2"
+                  class="flex-1 min-h-[44px] py-3 px-4 bg-action-primary-bg text-action-primary-text rounded-lg font-semibold hover:bg-action-primary-hover-bg focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-60 disabled:cursor-not-allowed transition-all flex items-center justify-center gap-2"
                   @click="confirmDelivered"
                 >
                   <UiLoadingDots v-if="isStatusUpdating" size="8px" color="currentColor" />

--- a/pages/operaciones/bitacora.vue
+++ b/pages/operaciones/bitacora.vue
@@ -296,7 +296,7 @@ const tableNameFor = (row: OperationEventRow) =>
     >
       <div
         v-if="detailOpen && selectedEvent"
-        class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 bg-black/50"
+        class="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 bg-overlay-backdrop/50"
         @click.self="closeDetail"
       >
         <div
@@ -347,7 +347,7 @@ const tableNameFor = (row: OperationEventRow) =>
           <div class="px-5 pb-5 pt-2 border-t border-border">
             <button
               type="button"
-              class="w-full min-h-[44px] rounded-xl bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 transition-colors"
+              class="w-full min-h-[44px] rounded-xl bg-action-primary-bg text-action-primary-text text-sm font-semibold hover:bg-action-primary-hover-bg transition-colors"
               @click="closeDetail"
             >
               Cerrar

--- a/pages/operaciones/comandas.vue
+++ b/pages/operaciones/comandas.vue
@@ -92,7 +92,7 @@
                     v-if="!kdsTokens[st.id]"
                     @click="generateKdsToken(st.id)"
                     :disabled="generatingToken === st.id"
-                    class="min-h-[32px] px-2.5 py-1 text-xs font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
+                    class="min-h-[32px] px-2.5 py-1 text-xs font-medium rounded-lg bg-action-primary-bg text-action-primary-text hover:bg-action-primary-hover-bg transition-colors disabled:opacity-50"
                   >
                     {{ generatingToken === st.id ? 'Generando...' : 'Generar enlace' }}
                   </button>
@@ -108,7 +108,7 @@
                     <button
                       @click="revokeKdsToken(st.id)"
                       :disabled="revokingToken === st.id"
-                      class="min-h-[32px] px-2.5 py-1 text-xs font-medium rounded-lg text-red-600 hover:bg-red-50 transition-colors disabled:opacity-50"
+                      class="min-h-[32px] px-2.5 py-1 text-xs font-medium rounded-lg text-state-danger-text hover:bg-state-danger-bg transition-colors disabled:opacity-50"
                       aria-label="Revocar enlace KDS"
                     >
                       {{ revokingToken === st.id ? '...' : 'Revocar' }}
@@ -160,7 +160,7 @@
         </div>
         <button
           @click="openCreateStation"
-          class="flex items-center gap-1.5 px-3 py-2 text-xs font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors min-h-[36px]"
+          class="flex items-center gap-1.5 px-3 py-2 text-xs font-medium bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors min-h-[36px]"
         >
           <PlusIcon class="w-3.5 h-3.5" />
           Nueva
@@ -309,7 +309,7 @@
       >
         <div
           v-if="deactivateModalOpen"
-          class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+          class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-overlay-backdrop/60 backdrop-blur-sm"
           @click.self="deactivateModalOpen = false"
         >
           <Transition

--- a/pages/operaciones/mesas.vue
+++ b/pages/operaciones/mesas.vue
@@ -444,7 +444,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
         <template #header-actions>
           <button
             type="button"
-              class="h-9 px-4 rounded-lg bg-primary text-sm font-semibold text-primary-foreground hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 active:scale-[0.98] transition-all shadow-sm shadow-primary/30 whitespace-nowrap"
+              class="h-9 px-4 rounded-lg bg-primary text-sm font-semibold text-primary-foreground hover:bg-action-primary-hover-bg focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 active:scale-[0.98] transition-all shadow-sm shadow-primary/30 whitespace-nowrap"
             @click="openPanel(null)"
           >
             <span class="hidden sm:inline">{{ `+ Nueva ${singularLower}` }}</span>
@@ -564,7 +564,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
           <!-- Desktop: actions -->
           <template #cell-actions="{ row }">
             <div class="flex items-center justify-end gap-1">
-              <button :aria-label="`Editar ${row.name}`" title="Editar" class="flex items-center justify-center h-9 w-9 rounded-lg text-text-secondary hover:bg-surface-secondary hover:text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30" @click="openPanel(row)">
+              <button :aria-label="`Editar ${row.name}`" title="Editar" class="flex items-center justify-center h-9 w-9 rounded-lg text-text-secondary hover:bg-surface-secondary hover:text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30" @click="openPanel(row)">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" /></svg>
               </button>
               <button :aria-label="`Desactivar ${row.name}`" title="Desactivar" class="flex items-center justify-center h-9 w-9 rounded-lg text-text-secondary hover:bg-state-warning-bg hover:text-state-warning-text transition-colors focus:outline-none focus:ring-2 focus:ring-state-warning-border" @click="openDeactivateModal(row)">
@@ -677,7 +677,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
       >
         <div
           v-if="deactivateModalOpen"
-          class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+          class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-overlay-backdrop/60 backdrop-blur-sm"
           @click.self="deactivateModalOpen = false"
         >
           <Transition
@@ -755,7 +755,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
       >
         <div
           v-if="deleteModalOpen"
-          class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+          class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-overlay-backdrop/60 backdrop-blur-sm"
           @click.self="deleteModalOpen = false"
         >
           <Transition

--- a/pages/operaciones/personalizar.vue
+++ b/pages/operaciones/personalizar.vue
@@ -225,7 +225,7 @@ const toggleOpenSale = async () => {
             :disabled="isTogglingOpenSale"
             @change="toggleOpenSale"
           />
-          <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+          <div class="w-10 h-6 bg-control-toggle-track-off rounded-full peer peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
         </label>
       </div>
 
@@ -258,7 +258,7 @@ const toggleOpenSale = async () => {
             :disabled="isTogglingGeneric"
             @change="toggleAutoSelectGeneric"
           />
-          <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+          <div class="w-10 h-6 bg-control-toggle-track-off rounded-full peer peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
         </label>
       </div>
 
@@ -336,7 +336,7 @@ const toggleOpenSale = async () => {
           <button
             type="button"
             :disabled="!hasChanges || isSavingLabel"
-            class="min-h-[44px] px-4 py-2 rounded-lg bg-primary text-primary-foreground font-medium text-sm transition-all hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed active:scale-95"
+            class="min-h-[44px] px-4 py-2 rounded-lg bg-action-primary-bg text-action-primary-text font-medium text-sm transition-all hover:bg-action-primary-hover-bg focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed active:scale-95"
             @click="saveLabel"
           >
             {{ isSavingLabel ? 'Guardando...' : 'Guardar' }}

--- a/pages/operaciones/promociones/index.vue
+++ b/pages/operaciones/promociones/index.vue
@@ -33,7 +33,7 @@
             @change="togglePromoLineOptOutSetting"
           />
           <div
-            class="relative h-6 w-10 shrink-0 overflow-hidden rounded-full bg-border peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-white after:transition-transform after:content-[''] peer-checked:after:translate-x-4"
+            class="relative h-6 w-10 shrink-0 overflow-hidden rounded-full bg-control-toggle-track-off peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:absolute after:left-0.5 after:top-0.5 after:h-5 after:w-5 after:rounded-full after:bg-control-toggle-thumb after:transition-transform after:content-[''] peer-checked:after:translate-x-4"
           />
         </label>
       </div>
@@ -141,7 +141,7 @@
                 type="button"
                 :aria-label="`Editar ${item.name}`"
                 title="Editar"
-                class="flex-shrink-0 min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
+                class="flex-shrink-0 min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 transition-colors"
                 @click="openEdit(item)"
               >
                 <PencilSquareIcon class="w-4 h-4" />
@@ -211,7 +211,7 @@
                 type="button"
                 :aria-label="`Editar ${item.name}`"
                 title="Editar"
-                class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
+                class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 transition-colors"
                 @click="openEdit(item)"
               >
                 <PencilSquareIcon class="w-4 h-4" />

--- a/pages/operaciones/propinas.vue
+++ b/pages/operaciones/propinas.vue
@@ -220,7 +220,7 @@ const saveConfig = async () => {
             :disabled="isToggling"
             @change="toggleTipEnabled"
           />
-          <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+          <div class="w-10 h-6 bg-control-toggle-track-off rounded-full peer peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
         </label>
       </div>
 
@@ -250,14 +250,14 @@ const saveConfig = async () => {
               :disabled="isTogglingTaxable"
               @change="toggleTipTaxableDefault"
             />
-            <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+            <div class="w-10 h-6 bg-control-toggle-track-off rounded-full peer peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
           </label>
         </div>
 
         <!-- Fixed informational banner (Ley 1935 framing) -->
-        <div class="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 flex gap-3">
-          <span aria-hidden="true" class="text-amber-700 mt-0.5">⚠</span>
-          <p class="text-sm text-amber-900 leading-snug">
+        <div class="rounded-xl border border-state-warning-border bg-state-warning-bg px-4 py-3 flex gap-3">
+          <span aria-hidden="true" class="text-state-warning-text mt-0.5">⚠</span>
+          <p class="text-sm text-state-warning-text leading-snug">
             En este momento las propinas se asignan directamente al mesero de la orden. La distribución entre el equipo (cocina, auxiliares, etc.) es responsabilidad del dueño.
           </p>
         </div>
@@ -342,7 +342,7 @@ const saveConfig = async () => {
               :disabled="draftPresets.length === 0"
               @change="draftPreselect = !draftPreselect"
             />
-            <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+            <div class="w-10 h-6 bg-control-toggle-track-off rounded-full peer peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
           </label>
         </div>
 
@@ -354,7 +354,7 @@ const saveConfig = async () => {
           <button
             type="button"
             :disabled="!hasChanges || isSavingConfig"
-            class="min-h-[44px] px-4 py-2 rounded-lg bg-primary text-primary-foreground font-medium text-sm transition-all hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed active:scale-95"
+            class="min-h-[44px] px-4 py-2 rounded-lg bg-action-primary-bg text-action-primary-text font-medium text-sm transition-all hover:bg-action-primary-hover-bg focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed active:scale-95"
             @click="saveConfig"
           >
             {{ isSavingConfig ? 'Guardando...' : 'Guardar cambios' }}

--- a/pages/operaciones/turnos.vue
+++ b/pages/operaciones/turnos.vue
@@ -52,7 +52,7 @@
                 type="button"
                 :aria-label="`Editar ${item.name}`"
                 title="Editar"
-                class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
+                class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 transition-colors"
                 @click="openEdit(item)"
               >
                 <PencilSquareIcon class="w-4 h-4" />
@@ -62,7 +62,7 @@
                 type="button"
                 :aria-label="`Desactivar ${item.name}`"
                 title="Desactivar"
-                class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-amber-600 hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-400/30 transition-colors"
+                class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-state-warning-text hover:bg-state-warning-bg focus:outline-none focus:ring-2 focus:ring-state-warning-border/30 transition-colors"
                 @click="requestDeactivate(item)"
               >
                 <NoSymbolIcon class="w-4 h-4" />
@@ -72,7 +72,7 @@
                 type="button"
                 :aria-label="`Reactivar ${item.name}`"
                 title="Reactivar"
-                class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-primary hover:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
+                class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-primary hover:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 transition-colors"
                 @click="reactivate(item)"
               >
                 <ArrowPathIcon class="w-4 h-4" />
@@ -104,7 +104,7 @@
               type="button"
               :aria-label="`Editar ${row.name}`"
               title="Editar"
-              class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
+              class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 transition-colors"
               @click="openEdit(row)"
             >
               <PencilSquareIcon class="w-4 h-4" />
@@ -114,7 +114,7 @@
               type="button"
               :aria-label="`Desactivar ${row.name}`"
               title="Desactivar"
-              class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-amber-600 hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-400/30 transition-colors"
+              class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-state-warning-text hover:bg-state-warning-bg focus:outline-none focus:ring-2 focus:ring-state-warning-border/30 transition-colors"
               @click="requestDeactivate(row)"
             >
               <NoSymbolIcon class="w-4 h-4" />
@@ -124,7 +124,7 @@
               type="button"
               :aria-label="`Reactivar ${row.name}`"
               title="Reactivar"
-              class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-primary hover:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-primary/30 transition-colors"
+              class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-primary hover:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 transition-colors"
               @click="reactivate(row)"
             >
               <ArrowPathIcon class="w-4 h-4" />

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -2589,7 +2589,7 @@ onUnmounted(() => {
               class="px-3 py-2.5 md:p-4 flex gap-2.5 md:gap-4 items-start group hover:bg-surface-secondary/50 theme-transition"
             >
               <!-- Order Number -->
-              <div class="flex-shrink-0 w-6 h-6 md:w-8 md:h-8 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-bold mt-0.5">
+              <div class="flex-shrink-0 w-6 h-6 md:w-8 md:h-8 rounded-full bg-action-primary-bg text-action-primary-text flex items-center justify-center text-xs font-bold mt-0.5">
                 {{ index + 1 }}
               </div>
 
@@ -2605,14 +2605,14 @@ onUnmounted(() => {
                     <h3 class="font-semibold text-text-primary text-sm leading-tight truncate">{{ item.product.name }}</h3>
                     <span
                       v-if="getLinePromoLabel(item)"
-                      class="text-[10px] bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 px-1.5 py-0.5 rounded-full font-medium flex-shrink-0"
+                      class="text-[10px] bg-state-success-bg text-state-success-text  px-1.5 py-0.5 rounded-full font-medium flex-shrink-0"
                       :title="getLinePromoTypeLabel(item) || undefined"
                     >
                       {{ getLinePromoLabel(item) }}
                     </span>
                     <span
                       v-if="getLinePromoSavings(item) > 0"
-                      class="text-[10px] text-emerald-700 dark:text-emerald-400 font-medium flex-shrink-0"
+                      class="text-[10px] text-state-success-text  font-medium flex-shrink-0"
                     >
                       - {{ formatCurrency(getLinePromoSavings(item)) }}
                     </span>
@@ -2657,7 +2657,7 @@ onUnmounted(() => {
                       :disabled="togglingPromoLineId === String(item.orderItemId ?? item.id ?? '')"
                       @change="toggleLinePromoApply(item, ($event.target as HTMLInputElement).checked)"
                     />
-                    <span class="block w-10 h-6 bg-border rounded-full peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+                    <span class="block w-10 h-6 bg-control-toggle-track-off rounded-full peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
                   </span>
                 </label>
               </div>
@@ -2682,7 +2682,7 @@ onUnmounted(() => {
             <div class="flex-1 min-w-0">
               <p class="font-semibold text-text-primary truncate">{{ selectedCustomer.name || 'Cliente sin datos' }}</p>
               <p class="text-sm text-text-secondary truncate">{{ selectedCustomer.phone_number || 'Sin teléfono' }}</p>
-              <p v-if="selectedCustomer.fiscal_id" class="text-xs text-emerald-700 dark:text-emerald-400 truncate mt-0.5 flex items-center gap-1">
+              <p v-if="selectedCustomer.fiscal_id" class="text-xs text-state-success-text  truncate mt-0.5 flex items-center gap-1">
                 <svg class="h-3.5 w-3.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
                 Factura: {{ selectedCustomer.fiscal_id_type }} {{ selectedCustomer.fiscal_id }}
               </p>
@@ -2698,7 +2698,7 @@ onUnmounted(() => {
                 />
                 <span
                   v-else
-                  class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700 border border-emerald-200"
+                  class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-state-success-bg text-state-success-text border border-state-success-border"
                 >
                   Wallet: {{ formatCurrency(walletBalanceCop) }}
                 </span>
@@ -2758,14 +2758,14 @@ onUnmounted(() => {
               <div
                 class="border rounded-xl p-2.5 md:p-4 theme-transition h-full flex flex-col items-center gap-1.5 md:gap-3 md:items-start"
                 :class="selectedPaymentMethod === group.slug
-                  ? (group.triggersCartera ? 'border-amber-500 bg-amber-50 shadow-sm dark:bg-amber-950/20' : 'border-primary bg-primary/5 shadow-sm')
-                  : (group.triggersCartera ? 'border-border hover:border-amber-400/40' : 'border-border hover:border-primary/30')"
+                  ? (group.triggersCartera ? 'border-state-warning-border bg-state-warning-bg shadow-sm ' : 'border-primary bg-primary/5 shadow-sm')
+                  : (group.triggersCartera ? 'border-border hover:border-state-warning-border/40' : 'border-border hover:border-primary/30')"
               >
                 <div class="flex items-center justify-between w-full">
                   <!-- Icon — cash -->
                   <div
                     v-if="group.slug === 'cash'"
-                    class="bg-green-100 text-green-700 w-8 h-8 md:w-10 md:h-10 rounded-full flex items-center justify-center flex-shrink-0"
+                    class="bg-state-success-bg text-state-success-text w-8 h-8 md:w-10 md:h-10 rounded-full flex items-center justify-center flex-shrink-0"
                   >
                     <svg class="h-4 w-4 md:h-6 md:w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z" />
@@ -2774,7 +2774,7 @@ onUnmounted(() => {
                   <!-- Icon — card -->
                   <div
                     v-else-if="group.slug === 'card'"
-                    class="bg-blue-100 text-blue-700 w-8 h-8 md:w-10 md:h-10 rounded-full flex items-center justify-center flex-shrink-0"
+                    class="bg-state-info-bg text-state-info-text w-8 h-8 md:w-10 md:h-10 rounded-full flex items-center justify-center flex-shrink-0"
                   >
                     <svg class="h-4 w-4 md:h-6 md:w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z" />
@@ -2793,7 +2793,7 @@ onUnmounted(() => {
                   <!-- Icon — wallet anticipo -->
                   <div
                     v-else-if="group.slug === WALLET_PAYMENT_SLUG || group.triggersWallet"
-                    class="bg-emerald-100 text-emerald-700 w-8 h-8 md:w-10 md:h-10 rounded-full flex items-center justify-center flex-shrink-0"
+                    class="bg-state-success-bg text-state-success-text w-8 h-8 md:w-10 md:h-10 rounded-full flex items-center justify-center flex-shrink-0"
                   >
                     <svg class="h-4 w-4 md:h-6 md:w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a2.25 2.25 0 0 0-2.25-2.25H15a3 3 0 1 1-6 0H5.25A2.25 2.25 0 0 0 3 12m18 0v6a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 18v-6m18 0V9M3 12V9m18 0a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 9m18 0V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v3" />
@@ -2802,7 +2802,7 @@ onUnmounted(() => {
                   <!-- Icon — credit / triggersCartera -->
                   <div
                     v-else-if="group.triggersCartera"
-                    class="bg-amber-100 text-amber-700 w-8 h-8 md:w-10 md:h-10 rounded-full flex items-center justify-center flex-shrink-0"
+                    class="bg-state-warning-bg text-state-warning-text w-8 h-8 md:w-10 md:h-10 rounded-full flex items-center justify-center flex-shrink-0"
                   >
                     <svg class="h-4 w-4 md:h-6 md:w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
@@ -2823,7 +2823,7 @@ onUnmounted(() => {
                     class="h-4 w-4 transition-all hidden md:block"
                     :class="[
                       selectedPaymentMethod === group.slug ? 'opacity-100' : 'opacity-0',
-                      group.triggersCartera ? 'text-amber-600' : 'text-primary'
+                      group.triggersCartera ? 'text-state-warning-text' : 'text-primary'
                     ]"
                     xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
                   >
@@ -2835,7 +2835,7 @@ onUnmounted(() => {
                 <div class="text-center md:text-left w-full">
                   <div
                     class="font-semibold text-xs md:text-sm leading-tight"
-                    :class="selectedPaymentMethod === group.slug && group.triggersCartera ? 'text-amber-700' : 'text-text-primary'"
+                    :class="selectedPaymentMethod === group.slug && group.triggersCartera ? 'text-state-warning-text' : 'text-text-primary'"
                   >
                     {{ group.name }}
                   </div>
@@ -2845,7 +2845,7 @@ onUnmounted(() => {
                 <div
                   v-if="selectedPaymentMethod === group.slug"
                   class="absolute top-1.5 right-1.5 w-2 h-2 rounded-full md:hidden"
-                  :class="group.triggersCartera ? 'bg-amber-500' : 'bg-primary'"
+                  :class="group.triggersCartera ? 'bg-action-warning-bg' : 'bg-primary'"
                 ></div>
               </div>
             </label>
@@ -2891,7 +2891,7 @@ onUnmounted(() => {
                 class="relative min-h-[48px] px-3 py-2.5 rounded-xl border-2 text-sm font-semibold transition-all text-center active:scale-95"
                 :class="selectedPaymentMethodId === method.id
                   ? (selectedGroup.triggersCartera
-                      ? 'border-amber-500 bg-amber-50 text-amber-700 shadow-sm'
+                      ? 'border-state-warning-border bg-state-warning-bg text-state-warning-text shadow-sm'
                       : 'border-primary bg-primary/10 text-primary shadow-sm')
                   : 'border-border bg-background text-text-secondary hover:border-primary/30 hover:text-text-primary'"
               >
@@ -2899,7 +2899,7 @@ onUnmounted(() => {
                 <span
                   v-if="selectedPaymentMethodId === method.id"
                   class="absolute top-1 right-1.5 w-1.5 h-1.5 rounded-full"
-                  :class="selectedGroup.triggersCartera ? 'bg-amber-500' : 'bg-primary'"
+                  :class="selectedGroup.triggersCartera ? 'bg-action-warning-bg' : 'bg-primary'"
                 />
               </button>
             </div>
@@ -2918,7 +2918,7 @@ onUnmounted(() => {
                   class="w-full flex items-center justify-between px-4 py-3 text-sm transition-colors active:scale-[0.99]"
                   :class="selectedPaymentMethodId === method.id
                     ? (selectedGroup.triggersCartera
-                        ? 'bg-amber-50 text-amber-700 font-semibold'
+                        ? 'bg-state-warning-bg text-state-warning-text font-semibold'
                         : 'bg-primary/8 text-primary font-semibold')
                     : 'text-text-primary hover:bg-surface-secondary/50'"
                 >
@@ -2926,7 +2926,7 @@ onUnmounted(() => {
                   <svg
                     v-if="selectedPaymentMethodId === method.id"
                     class="w-4 h-4 flex-shrink-0"
-                    :class="selectedGroup.triggersCartera ? 'text-amber-600' : 'text-primary'"
+                    :class="selectedGroup.triggersCartera ? 'text-state-warning-text' : 'text-primary'"
                     fill="none" stroke="currentColor" viewBox="0 0 24 24"
                   >
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
@@ -2940,14 +2940,14 @@ onUnmounted(() => {
           </div>
 
           <!-- Credit due date (optional) — shown only when a triggersCartera group is selected -->
-          <div v-if="selectedGroup?.triggersCartera && selectedCustomer && !isAnonymousCustomer" class="mt-3 p-3 bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 rounded-xl">
-            <label class="block text-xs font-semibold text-amber-800 dark:text-amber-300 mb-1.5">
-              Fecha límite de pago <span class="font-normal text-amber-600">(opcional)</span>
+          <div v-if="selectedGroup?.triggersCartera && selectedCustomer && !isAnonymousCustomer" class="mt-3 p-3 bg-state-warning-bg  border border-state-warning-border  rounded-xl">
+            <label class="block text-xs font-semibold text-state-warning-text  mb-1.5">
+              Fecha límite de pago <span class="font-normal text-state-warning-text">(opcional)</span>
             </label>
             <input
               v-model="creditDueDate"
               type="date"
-              class="w-full h-9 px-3 rounded-lg border border-amber-300 dark:border-amber-700 bg-white dark:bg-surface text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-amber-400"
+              class="w-full h-9 px-3 rounded-lg border border-state-warning-border  bg-white  text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-state-warning-border"
             />
           </div>
         </div>
@@ -2971,7 +2971,7 @@ onUnmounted(() => {
               :class="discountEnabled ? 'bg-primary' : 'bg-border'"
             >
               <span
-                class="pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition duration-200"
+                class="pointer-events-none inline-block h-5 w-5 rounded-full bg-control-toggle-thumb shadow transform ring-0 transition duration-200"
                 :class="discountEnabled ? 'translate-x-5' : 'translate-x-0'"
               />
             </button>
@@ -3044,7 +3044,7 @@ onUnmounted(() => {
             <input
               v-model="tipTaxable"
               type="checkbox"
-              class="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-primary/30"
+              class="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-action-primary-focus-ring/30"
               aria-label="Propina gravada con impuesto al consumo"
             />
             <span class="text-sm text-text-primary leading-snug">
@@ -3083,7 +3083,7 @@ onUnmounted(() => {
                 :disabled="!isDeliveryEligible"
                 aria-label="Activar domicilio para esta orden"
               />
-              <div class="w-11 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+              <div class="w-11 h-6 bg-control-toggle-track-off rounded-full peer peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
             </label>
           </div>
 
@@ -3219,7 +3219,7 @@ onUnmounted(() => {
                 <span>Subtotal ({{ cartItems.length }} productos)</span>
                 <span class="font-medium text-text-primary">{{ formatCurrency(cartTotal) }}</span>
               </div>
-              <div v-if="promoSavings > 0" class="flex justify-between text-sm text-emerald-700 dark:text-emerald-400">
+              <div v-if="promoSavings > 0" class="flex justify-between text-sm text-state-success-text ">
                 <span>Promoción</span>
                 <span class="font-medium">- {{ formatCurrency(promoSavings) }}</span>
               </div>
@@ -3227,7 +3227,7 @@ onUnmounted(() => {
                 v-for="(promo, promoIdx) in displayPromoBreakdown"
                 v-show="displayPromoBreakdown.length > 1"
                 :key="promo.promotion_id ?? promo.promotion_name ?? promoIdx"
-                class="flex justify-between text-xs text-emerald-700/90 dark:text-emerald-400/90 pl-3"
+                class="flex justify-between text-xs text-state-success-text/90  pl-3"
               >
                 <span>{{ promo.promotion_name }}</span>
                 <span class="font-medium">- {{ formatCurrency(promo.savings) }}</span>
@@ -3243,7 +3243,7 @@ onUnmounted(() => {
                 <span>Descuento manual</span>
                 <span class="font-medium">- {{ formatCurrency(discountAmount) }}</span>
               </div>
-              <div v-if="waroDiscountCop > 0" class="flex justify-between text-sm text-amber-700">
+              <div v-if="waroDiscountCop > 0" class="flex justify-between text-sm text-state-warning-text">
                 <span>{{ waroRewardLabel ? `WaRo: ${waroRewardLabel}` : 'Canje WaRo' }}</span>
                 <span class="font-medium">- {{ formatCurrency(waroDiscountCop) }}</span>
               </div>
@@ -3295,11 +3295,11 @@ onUnmounted(() => {
             @click="activeAccordion = activeAccordion === 'waros' ? null : 'waros'"
             class="w-full px-5 py-3.5 flex items-center gap-3 text-left hover:bg-surface-secondary/40 transition-colors min-h-[52px]"
           >
-            <svg class="h-4 w-4 text-amber-500 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <svg class="h-4 w-4 text-state-warning-icon flex-shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path fill-rule="evenodd" d="M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.006 5.404.434c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.434 2.082-5.005Z" clip-rule="evenodd" />
             </svg>
             <span class="font-semibold text-sm text-text-primary">Waros</span>
-            <span v-if="!isLoadingWaros" class="ml-auto text-sm font-bold tabular-nums text-amber-700">
+            <span v-if="!isLoadingWaros" class="ml-auto text-sm font-bold tabular-nums text-state-warning-text">
               {{ warosBalance.toLocaleString('es-CO') }}
             </span>
             <svg
@@ -3330,7 +3330,7 @@ onUnmounted(() => {
               </div>
               <div v-if="warosEarnBlockVisible" class="rounded-lg bg-surface-secondary/70 px-2 py-2 text-center">
                 <p class="text-[10px] font-medium uppercase tracking-wide text-text-tertiary">Gana</p>
-                <p class="text-sm font-bold tabular-nums leading-tight mt-0.5" :class="warosEarnEligible ? 'text-emerald-700' : 'text-text-tertiary'">
+                <p class="text-sm font-bold tabular-nums leading-tight mt-0.5" :class="warosEarnEligible ? 'text-state-success-text' : 'text-text-tertiary'">
                   <span v-if="isLoadingEstimate" class="inline-block h-4 w-8 rounded bg-surface-secondary animate-pulse" />
                   <span v-else-if="!warosEarnEligible">—</span>
                   <span v-else-if="estimatedWaros === null">—</span>
@@ -3365,7 +3365,7 @@ onUnmounted(() => {
                             :disabled="warosBalance < reward.waros_cost"
                             @change="setWaroRewardSelected(reward, ($event.target as HTMLInputElement).checked)"
                           />
-                          <span class="block w-10 h-6 bg-border rounded-full peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+                          <span class="block w-10 h-6 bg-control-toggle-track-off rounded-full peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
                         </span>
                       </span>
                     </label>
@@ -3397,7 +3397,7 @@ onUnmounted(() => {
               :class="splitMode ? 'bg-primary' : 'bg-border'"
             >
               <span
-                class="pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition duration-200"
+                class="pointer-events-none inline-block h-5 w-5 rounded-full bg-control-toggle-thumb shadow transform ring-0 transition duration-200"
                 :class="splitMode ? 'translate-x-5' : 'translate-x-0'"
               />
             </button>
@@ -3425,7 +3425,7 @@ onUnmounted(() => {
                   class="flex items-center gap-2.5 px-3 py-2 bg-surface-secondary rounded-lg text-sm"
                 >
                   <!-- Check icon -->
-                  <svg class="h-4 w-4 text-green-500 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+                  <svg class="h-4 w-4 text-state-success-icon flex-shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                     <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd" />
                   </svg>
                   <span class="text-text-secondary flex-1">#{{ idx + 1 }} · {{ p.payment_method_name }}</span>
@@ -3479,9 +3479,9 @@ onUnmounted(() => {
             <!-- Remaining counter -->
             <div
               class="flex items-center justify-between px-3 py-2.5 rounded-lg"
-              :class="splitIsComplete ? 'bg-green-50 dark:bg-green-900/20' : 'bg-primary/10'"
+              :class="splitIsComplete ? 'bg-state-success-bg ' : 'bg-primary/10'"
             >
-              <span class="text-sm font-medium flex items-center gap-1.5" :class="splitIsComplete ? 'text-green-700 dark:text-green-400' : 'text-primary'">
+              <span class="text-sm font-medium flex items-center gap-1.5" :class="splitIsComplete ? 'text-state-success-text ' : 'text-primary'">
                 <svg v-if="splitIsComplete" class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                   <path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" />
                 </svg>
@@ -3489,7 +3489,7 @@ onUnmounted(() => {
               </span>
               <span
                 class="text-sm font-bold tabular-nums"
-                :class="splitIsComplete ? 'text-green-700 dark:text-green-400' : 'text-text-primary'"
+                :class="splitIsComplete ? 'text-state-success-text ' : 'text-text-primary'"
                 aria-live="polite"
               >{{ formatCurrency(splitRemaining) }}</span>
             </div>
@@ -3525,7 +3525,7 @@ onUnmounted(() => {
               type="button"
               :disabled="isAddingPayment || !selectedPaymentMethod || requiresMethodSelection || !splitAmountToCharge || splitAmountToCharge <= 0 || !selectedCustomer || (!isKitchenServiceMode && !posStore.cartId) || !cashIsValid"
               @click="addSplitPayment"
-              class="w-full min-h-[44px] px-4 py-3 bg-primary text-primary-foreground text-sm font-semibold rounded-xl transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+              class="w-full min-h-[44px] px-4 py-3 bg-action-primary-bg text-action-primary-text text-sm font-semibold rounded-xl transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-action-primary-hover-bg focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
             >
               <UiLoadingDots v-if="isAddingPayment" size="10px" />
               <span v-else>Cobrar {{ formatCurrency(splitAmountToCharge) }} · {{ getPaymentMethodLabel(selectedPaymentMethod) }}</span>
@@ -3534,10 +3534,10 @@ onUnmounted(() => {
         </div>
 
         <!-- Error Message -->
-        <div v-if="processingError" class="bg-red-50 dark:bg-red-900/20 border-2 border-red-200 dark:border-red-800 rounded-xl p-4">
+        <div v-if="processingError" class="bg-state-danger-bg  border-2 border-state-danger-border  rounded-xl p-4">
           <div class="flex items-start gap-3">
             <span class="text-xl">⚠️</span>
-            <p class="text-sm text-red-800 dark:text-red-200">{{ processingError }}</p>
+            <p class="text-sm text-state-danger-text ">{{ processingError }}</p>
           </div>
         </div>
 
@@ -3553,15 +3553,15 @@ onUnmounted(() => {
         <div
           v-if="comandasEnabled && isCounterMode && cartItems.length > 0"
           role="status"
-          class="flex items-center gap-3 min-h-[44px] px-4 py-3 bg-amber-50 border border-amber-200 rounded-xl"
+          class="flex items-center gap-3 min-h-[44px] px-4 py-3 bg-state-warning-bg border border-state-warning-border rounded-xl"
         >
-          <div class="flex-shrink-0 bg-amber-100 p-1.5 rounded-lg">
-            <svg class="w-4 h-4 text-amber-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <div class="flex-shrink-0 bg-state-warning-bg p-1.5 rounded-lg">
+            <svg class="w-4 h-4 text-state-warning-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M15.362 5.214A8.252 8.252 0 0 1 12 21 8.25 8.25 0 0 1 6.038 7.047 8.287 8.287 0 0 0 9 9.601a8.983 8.983 0 0 1 3.361-6.867 8.21 8.21 0 0 0 3 2.48Z" />
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 18a3.75 3.75 0 0 0 .495-7.468 5.99 5.99 0 0 0-1.925 3.547 5.975 5.975 0 0 1-2.133-1.001A3.75 3.75 0 0 0 12 18Z" />
             </svg>
           </div>
-          <p class="text-sm text-amber-800 font-medium">Los ítems serán enviados a cocina al cobrar</p>
+          <p class="text-sm text-state-warning-text font-medium">Los ítems serán enviados a cocina al cobrar</p>
         </div>
 
         <!-- Action Buttons (always visible) -->
@@ -3570,7 +3570,7 @@ onUnmounted(() => {
             @click="processOrder"
             v-if="!splitMode"
             :disabled="isProcessing || !selectedCustomer || isLoadingEstimate || requiresMethodSelection || !cashIsValid"
-            class="w-full bg-primary hover:bg-primary/90 text-primary-foreground font-bold py-4 px-6 rounded-xl shadow-lg transition-all flex items-center justify-center gap-2 active:scale-95 group disabled:opacity-50 disabled:cursor-not-allowed"
+            class="w-full bg-primary hover:bg-action-primary-hover-bg text-primary-foreground font-bold py-4 px-6 rounded-xl shadow-lg transition-all flex items-center justify-center gap-2 active:scale-95 group disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <UiLoadingDots v-if="isProcessing" size="9px" />
             <svg v-else class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
@@ -3596,7 +3596,7 @@ onUnmounted(() => {
             :disabled="prefacturaDisabled"
             :title="prefacturaDisabled ? 'Calculando impuestos…' : 'Imprime una pre-cuenta para revisión del cliente. No es una factura.'"
             @click="printPrefactura"
-            class="w-full bg-surface border-2 border-border hover:border-primary hover:text-primary text-text-secondary font-semibold py-3 px-6 rounded-xl transition-all flex items-center justify-center gap-2 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-primary/30"
+            class="w-full bg-surface border-2 border-border hover:border-primary hover:text-primary text-text-secondary font-semibold py-3 px-6 rounded-xl transition-all flex items-center justify-center gap-2 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30"
             aria-label="Imprimir prefactura para revisión del cliente"
           >
             <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.8" aria-hidden="true">
@@ -3609,7 +3609,7 @@ onUnmounted(() => {
           <button
             v-if="expediterEnabled && comandasEnabled && (isMesaMode || posStore.activeTableSession)"
             type="button"
-            class="w-full bg-surface border-2 border-border hover:border-primary hover:text-primary text-text-secondary font-semibold py-3 px-6 rounded-xl transition-all flex items-center justify-center gap-2 active:scale-95 focus:outline-none focus:ring-2 focus:ring-primary/30"
+            class="w-full bg-surface border-2 border-border hover:border-primary hover:text-primary text-text-secondary font-semibold py-3 px-6 rounded-xl transition-all flex items-center justify-center gap-2 active:scale-95 focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30"
             aria-label="Ver estado de comandas"
             @click="showExpediterPanel = true"
           >
@@ -3719,7 +3719,7 @@ onUnmounted(() => {
               <span>Subtotal ({{ cartItems.length }} productos)</span>
               <span class="font-medium text-text-primary">{{ formatCurrency(cartTotal) }}</span>
             </div>
-            <div v-if="promoSavings > 0" class="flex justify-between text-sm text-emerald-700 dark:text-emerald-400">
+            <div v-if="promoSavings > 0" class="flex justify-between text-sm text-state-success-text ">
               <span>Promoción</span>
               <span class="font-medium">- {{ formatCurrency(promoSavings) }}</span>
             </div>
@@ -3727,7 +3727,7 @@ onUnmounted(() => {
               v-for="(promo, promoIdx) in displayPromoBreakdown"
               v-show="displayPromoBreakdown.length > 1"
               :key="promo.promotion_id ?? promo.promotion_name ?? promoIdx"
-              class="flex justify-between text-xs text-emerald-700/90 dark:text-emerald-400/90 pl-3"
+              class="flex justify-between text-xs text-state-success-text/90  pl-3"
             >
               <span>{{ promo.promotion_name }}</span>
               <span class="font-medium">- {{ formatCurrency(promo.savings) }}</span>
@@ -3739,11 +3739,11 @@ onUnmounted(() => {
               <span>Subtotal con promoción</span>
               <span class="font-medium text-text-primary">{{ formatCurrency(subtotalAfterPromos) }}</span>
             </div>
-            <div v-if="discountEnabled && discountAmount > 0" class="flex justify-between text-sm text-green-600 dark:text-green-400">
+            <div v-if="discountEnabled && discountAmount > 0" class="flex justify-between text-sm text-state-success-text ">
               <span>Descuento manual</span>
               <span class="font-medium">- {{ formatCurrency(discountAmount) }}</span>
             </div>
-            <div v-if="waroDiscountCop > 0" class="flex justify-between text-sm text-amber-700">
+            <div v-if="waroDiscountCop > 0" class="flex justify-between text-sm text-state-warning-text">
               <span>{{ waroRewardLabel ? `WaRo: ${waroRewardLabel}` : 'Canje WaRo' }}</span>
               <span class="font-medium">- {{ formatCurrency(waroDiscountCop) }}</span>
             </div>
@@ -3793,7 +3793,7 @@ onUnmounted(() => {
         <div class="px-5 py-4 space-y-4">
           <div class="flex items-center justify-between gap-2">
             <h3 class="font-semibold text-text-primary text-sm">Waros</h3>
-            <span v-if="!isLoadingWaros" class="text-sm font-bold tabular-nums text-amber-700">
+            <span v-if="!isLoadingWaros" class="text-sm font-bold tabular-nums text-state-warning-text">
               {{ warosBalance.toLocaleString('es-CO') }}
             </span>
           </div>
@@ -3815,7 +3815,7 @@ onUnmounted(() => {
             </div>
             <div v-if="warosEarnBlockVisible" class="rounded-lg bg-surface-secondary/70 px-2 py-2 text-center">
               <p class="text-[10px] font-medium uppercase tracking-wide text-text-tertiary">Gana</p>
-              <p class="text-sm font-bold tabular-nums leading-tight mt-0.5" :class="warosEarnEligible ? 'text-emerald-700' : 'text-text-tertiary'">
+              <p class="text-sm font-bold tabular-nums leading-tight mt-0.5" :class="warosEarnEligible ? 'text-state-success-text' : 'text-text-tertiary'">
                 <span v-if="isLoadingEstimate" class="inline-block h-4 w-8 rounded bg-surface-secondary animate-pulse" />
                 <span v-else-if="!warosEarnEligible">—</span>
                 <span v-else-if="estimatedWaros === null">—</span>
@@ -3845,7 +3845,7 @@ onUnmounted(() => {
                           :disabled="warosBalance < reward.waros_cost"
                           @change="setWaroRewardSelected(reward, ($event.target as HTMLInputElement).checked)"
                         />
-                        <span class="block w-10 h-6 bg-border rounded-full peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+                        <span class="block w-10 h-6 bg-control-toggle-track-off rounded-full peer-checked:bg-control-toggle-track-on peer-focus:ring-2 peer-focus:ring-control-toggle-focus-ring after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-control-toggle-thumb after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
                       </span>
                     </span>
                   </label>
@@ -3858,10 +3858,10 @@ onUnmounted(() => {
       </div>
 
       <!-- Error Message -->
-      <div v-if="processingError" class="bg-red-50 dark:bg-red-900/20 border-2 border-red-200 dark:border-red-800 rounded-xl p-4">
+      <div v-if="processingError" class="bg-state-danger-bg  border-2 border-state-danger-border  rounded-xl p-4">
         <div class="flex items-start gap-3">
           <span class="text-xl">⚠️</span>
-          <p class="text-sm text-red-800 dark:text-red-200">{{ processingError }}</p>
+          <p class="text-sm text-state-danger-text ">{{ processingError }}</p>
         </div>
       </div>
 
@@ -3869,15 +3869,15 @@ onUnmounted(() => {
       <div
         v-if="comandasEnabled && isCounterMode && cartItems.length > 0"
         role="status"
-        class="flex items-center gap-3 min-h-[44px] px-4 py-3 bg-amber-50 border border-amber-200 rounded-xl"
+        class="flex items-center gap-3 min-h-[44px] px-4 py-3 bg-state-warning-bg border border-state-warning-border rounded-xl"
       >
-        <div class="flex-shrink-0 bg-amber-100 p-1.5 rounded-lg">
-          <svg class="w-4 h-4 text-amber-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <div class="flex-shrink-0 bg-state-warning-bg p-1.5 rounded-lg">
+          <svg class="w-4 h-4 text-state-warning-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M15.362 5.214A8.252 8.252 0 0 1 12 21 8.25 8.25 0 0 1 6.038 7.047 8.287 8.287 0 0 0 9 9.601a8.983 8.983 0 0 1 3.361-6.867 8.21 8.21 0 0 0 3 2.48Z" />
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 18a3.75 3.75 0 0 0 .495-7.468 5.99 5.99 0 0 0-1.925 3.547 5.975 5.975 0 0 1-2.133-1.001A3.75 3.75 0 0 0 12 18Z" />
           </svg>
         </div>
-        <p class="text-sm text-amber-800 font-medium">Los ítems serán enviados a cocina al cobrar</p>
+        <p class="text-sm text-state-warning-text font-medium">Los ítems serán enviados a cocina al cobrar</p>
       </div>
 
       <!-- Issue #524 — Cash tender (mobile / tablet; desktop uses right column) -->
@@ -3894,7 +3894,7 @@ onUnmounted(() => {
           @click="processOrder"
           v-if="!splitMode"
             :disabled="isProcessing || !selectedCustomer || isLoadingEstimate || requiresMethodSelection || !cashIsValid"
-          class="w-full bg-primary hover:bg-primary/90 text-primary-foreground font-bold py-4 px-6 rounded-xl shadow-lg transition-all flex items-center justify-center gap-2 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
+          class="w-full bg-primary hover:bg-action-primary-hover-bg text-primary-foreground font-bold py-4 px-6 rounded-xl shadow-lg transition-all flex items-center justify-center gap-2 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <UiLoadingDots v-if="isProcessing" size="9px" />
           <svg v-else class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
@@ -3911,7 +3911,7 @@ onUnmounted(() => {
           :disabled="prefacturaDisabled"
           :title="prefacturaDisabled ? 'Calculando impuestos…' : 'Imprime una pre-cuenta para revisión del cliente. No es una factura.'"
           @click="printPrefactura"
-          class="w-full bg-surface border-2 border-border hover:border-primary hover:text-primary text-text-secondary font-semibold py-3 px-6 rounded-xl transition-all flex items-center justify-center gap-2 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-primary/30"
+          class="w-full bg-surface border-2 border-border hover:border-primary hover:text-primary text-text-secondary font-semibold py-3 px-6 rounded-xl transition-all flex items-center justify-center gap-2 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30"
           aria-label="Imprimir prefactura para revisión del cliente"
         >
           <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.8" aria-hidden="true">
@@ -3947,7 +3947,7 @@ onUnmounted(() => {
         aria-modal="true"
         aria-labelledby="void-payment-title"
       >
-        <div class="absolute inset-0 bg-black/50" @click="closeVoidPaymentModal" />
+        <div class="absolute inset-0 bg-overlay-backdrop/50" @click="closeVoidPaymentModal" />
         <div class="relative bg-surface rounded-2xl shadow-xl border border-border w-full max-w-md p-6">
           <div class="flex items-center gap-3 mb-4">
             <div class="w-12 h-12 rounded-full flex items-center justify-center bg-destructive/10">
@@ -3965,7 +3965,7 @@ onUnmounted(() => {
 
           <p
             v-if="voidPaymentTarget.payment_method === 'cash'"
-            class="flex items-start gap-2 text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded-lg p-3 mb-4"
+            class="flex items-start gap-2 text-sm text-state-warning-text bg-state-warning-bg border border-state-warning-border rounded-lg p-3 mb-4"
           >
             <svg class="w-4 h-4 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
@@ -3982,7 +3982,7 @@ onUnmounted(() => {
             rows="2"
             :disabled="isVoidingPayment === voidPaymentTarget.id"
             placeholder="Ej: cobro registrado por error"
-            class="w-full px-3 py-2 bg-surface-secondary border border-border rounded-lg text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:opacity-50"
+            class="w-full px-3 py-2 bg-surface-secondary border border-border rounded-lg text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 disabled:opacity-50"
           />
 
           <p v-if="voidPaymentError" class="mt-3 text-sm text-destructive flex items-start gap-2">
@@ -4003,7 +4003,7 @@ onUnmounted(() => {
               type="button"
               :disabled="isVoidingPayment === voidPaymentTarget.id"
               @click="confirmVoidPayment"
-              class="flex-1 min-h-[44px] px-4 py-2.5 rounded-lg bg-destructive text-white text-sm font-semibold hover:bg-destructive/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
+              class="flex-1 min-h-[44px] px-4 py-2.5 rounded-lg bg-action-destructive-bg text-action-destructive-text text-sm font-semibold hover:bg-action-destructive-hover-bg disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
             >
               <UiLoadingDots v-if="isVoidingPayment === voidPaymentTarget.id" size="8px" />
               <span v-else>Eliminar pago</span>
@@ -4019,15 +4019,15 @@ onUnmounted(() => {
         class="fixed inset-0 z-50 flex items-center justify-center p-4"
       >
         <!-- Backdrop -->
-        <div class="absolute inset-0 bg-black/50"></div>
+        <div class="absolute inset-0 bg-overlay-backdrop/50"></div>
 
         <!-- Modal -->
         <div class="relative bg-surface rounded-2xl shadow-xl border border-border w-full max-w-md p-6">
           <!-- Icon -->
           <div class="flex justify-center mb-4">
-            <div class="w-16 h-16 rounded-full flex items-center justify-center bg-green-100 dark:bg-green-900/30">
+            <div class="w-16 h-16 rounded-full flex items-center justify-center bg-state-success-bg ">
               <svg
-                class="w-8 h-8 text-green-600 dark:text-green-400"
+                class="w-8 h-8 text-state-success-text "
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -4046,12 +4046,12 @@ onUnmounted(() => {
           </p>
 
           <!-- Credit notice banner -->
-          <div v-if="orderResult?.payment_method === 'credit'" class="mb-4 px-4 py-3 bg-amber-50 border border-amber-200 rounded-xl space-y-2">
+          <div v-if="orderResult?.payment_method === 'credit'" class="mb-4 px-4 py-3 bg-state-warning-bg border border-state-warning-border rounded-xl space-y-2">
             <div class="flex items-start gap-2">
-              <svg class="h-4 w-4 text-amber-600 flex-shrink-0 mt-0.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <svg class="h-4 w-4 text-state-warning-text flex-shrink-0 mt-0.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
               </svg>
-              <p class="text-xs text-amber-800">Para registrar abonos, accede al perfil del cliente donde encontrarás el estado de su cartera, historial de pagos y saldo pendiente.</p>
+              <p class="text-xs text-state-warning-text">Para registrar abonos, accede al perfil del cliente donde encontrarás el estado de su cartera, historial de pagos y saldo pendiente.</p>
             </div>
           </div>
 
@@ -4073,16 +4073,16 @@ onUnmounted(() => {
               :key="promo.promotion_id ?? promo.promotion_name"
               class="flex items-center justify-between"
             >
-              <span class="text-sm text-emerald-700 dark:text-emerald-400">{{ promo.promotion_name }}</span>
-              <span class="text-sm font-medium text-emerald-700 dark:text-emerald-400">-{{ formatCurrency(promo.savings) }}</span>
+              <span class="text-sm text-state-success-text ">{{ promo.promotion_name }}</span>
+              <span class="text-sm font-medium text-state-success-text ">-{{ formatCurrency(promo.savings) }}</span>
             </div>
             <div v-if="orderResult.discount_amount" class="flex items-center justify-between">
               <span class="text-sm text-primary">Descuento manual</span>
               <span class="text-sm font-medium text-primary">-{{ formatCurrency(orderResult.discount_amount) }}</span>
             </div>
             <div v-if="orderResultWaroDiscountCop > 0" class="flex items-center justify-between">
-              <span class="text-sm text-amber-700">{{ orderResultWaroLineLabel }}</span>
-              <span class="text-sm font-medium text-amber-700">-{{ formatCurrency(orderResultWaroDiscountCop) }}</span>
+              <span class="text-sm text-state-warning-text">{{ orderResultWaroLineLabel }}</span>
+              <span class="text-sm font-medium text-state-warning-text">-{{ formatCurrency(orderResultWaroDiscountCop) }}</span>
             </div>
             <div v-if="orderResult.standard_tax && orderResult.standard_tax > 0" class="flex items-center justify-between">
               <span class="text-sm text-text-secondary">{{ orderResult.standard_tax_label ?? 'Impuesto' }}</span>
@@ -4181,7 +4181,7 @@ onUnmounted(() => {
                 />
               </div>
 
-              <p v-if="fiscalWizardError" class="text-xs text-red-600 dark:text-red-400">{{ fiscalWizardError }}</p>
+              <p v-if="fiscalWizardError" class="text-xs text-state-danger-text ">{{ fiscalWizardError }}</p>
 
               <div class="flex gap-2 pt-1">
                 <button
@@ -4196,7 +4196,7 @@ onUnmounted(() => {
                   type="button"
                   :disabled="!fiscalWizardCanSubmit || fiscalWizardSaving"
                   @click="submitFiscalAndInvoice"
-                  class="flex-1 min-h-[44px] px-3 py-2 text-sm bg-primary text-primary-foreground font-semibold rounded-lg hover:bg-primary/90 active:scale-95 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                  class="flex-1 min-h-[44px] px-3 py-2 text-sm bg-action-primary-bg text-action-primary-text font-semibold rounded-lg hover:bg-action-primary-hover-bg active:scale-95 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
                 >
                   <svg v-if="fiscalWizardSaving" class="h-4 w-4 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -4216,23 +4216,23 @@ onUnmounted(() => {
             <!-- Success — show ONLY invoice number -->
             <div
               v-else-if="invoiceResult?.prefix && invoiceResult?.invoice_number"
-              class="rounded-lg border border-green-200 bg-green-50 p-3 text-center"
+              class="rounded-lg border border-state-success-border bg-state-success-bg p-3 text-center"
             >
-              <p class="text-xs font-semibold text-green-800">Factura generada</p>
-              <p class="text-sm font-semibold text-green-700 mt-1">
+              <p class="text-xs font-semibold text-state-success-text">Factura generada</p>
+              <p class="text-sm font-semibold text-state-success-text mt-1">
                 {{ invoiceResult.prefix }}-{{ invoiceResult.invoice_number }}
               </p>
             </div>
 
             <!-- Error -->
-            <div v-else-if="invoiceError" class="rounded-lg border border-red-200 bg-red-50 p-3 space-y-2">
-              <div class="flex items-center gap-2 text-red-700">
+            <div v-else-if="invoiceError" class="rounded-lg border border-state-danger-border bg-state-danger-bg p-3 space-y-2">
+              <div class="flex items-center gap-2 text-state-danger-text">
                 <svg class="h-4 w-4 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" /></svg>
                 <span class="text-sm font-medium">{{ invoiceError }}</span>
               </div>
               <button
                 @click="requestInvoice"
-                class="text-xs font-medium text-red-600 hover:underline"
+                class="text-xs font-medium text-state-danger-text hover:underline"
               >
                 Reintentar
               </button>
@@ -4252,7 +4252,7 @@ onUnmounted(() => {
                   <button
                     @click="sendReceiptEmail"
                     :disabled="!receiptEmail || isSendingEmail"
-                    class="shrink-0 min-h-[36px] px-4 py-1.5 rounded-lg text-sm font-semibold transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed bg-primary text-primary-foreground hover:bg-primary/90"
+                    class="shrink-0 min-h-[36px] px-4 py-1.5 rounded-lg text-sm font-semibold transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed bg-action-primary-bg text-action-primary-text hover:bg-action-primary-hover-bg"
                   >
                     <span v-if="isSendingEmail">Enviando...</span>
                     <span v-else>Confirmar envío</span>
@@ -4262,7 +4262,7 @@ onUnmounted(() => {
 
               <!-- When email was sent (from profile or manual) -->
               <template v-else-if="emailSent">
-                <div class="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-green-700">
+                <div class="flex items-center gap-2 rounded-lg border border-state-success-border bg-state-success-bg px-3 py-2 text-state-success-text">
                   <svg class="h-4 w-4 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
                   <span class="text-sm font-medium">Recibo enviado a {{ receiptEmail }}</span>
                 </div>
@@ -4308,7 +4308,7 @@ onUnmounted(() => {
           <!-- Accept Button -->
           <button
             @click="closeSuccessModal"
-            class="w-full py-3 px-4 bg-primary text-primary-foreground rounded-lg font-medium hover:bg-primary/90 transition-colors"
+            class="w-full py-3 px-4 bg-action-primary-bg text-action-primary-text rounded-lg font-medium hover:bg-action-primary-hover-bg transition-colors"
           >
             Nueva Venta
           </button>

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -1523,22 +1523,22 @@ onUnmounted(() => {
       </div>
 
       <!-- Barra Banner (bar session — behaves as normal POS) -->
-      <div v-else-if="posStore.activeTableSession?.isBar" class="bg-surface border border-amber-300/40 rounded-2xl mb-4 p-3.5 shadow-sm">
+      <div v-else-if="posStore.activeTableSession?.isBar" class="bg-surface border border-state-warning-border/40 rounded-2xl mb-4 p-3.5 shadow-sm">
         <div class="flex items-center gap-3">
-          <div class="bg-amber-50 p-2.5 rounded-xl flex-shrink-0">
-            <svg class="w-4 h-4 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <div class="bg-state-warning-bg p-2.5 rounded-xl flex-shrink-0">
+            <svg class="w-4 h-4 text-state-warning-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9.75 3.104v5.714a2.25 2.25 0 0 1-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 0 1 4.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0 1 12 15a9.065 9.065 0 0 0-6.23-.693L5 14.5m14.8.8 1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0 1 12 21a48.25 48.25 0 0 1-8.135-.687c-1.718-.293-2.3-2.379-1.067-3.61L5 14.5" />
             </svg>
           </div>
           <div class="flex-1 min-w-0 flex items-center gap-2 flex-wrap">
-            <span class="text-[10px] font-bold text-amber-600 uppercase tracking-widest flex-shrink-0">Barra</span>
+            <span class="text-[10px] font-bold text-state-warning-text uppercase tracking-widest flex-shrink-0">Barra</span>
             <span class="w-px h-3 bg-border flex-shrink-0" aria-hidden="true" />
             <span class="text-xs text-text-secondary">
               {{ comandasEnabled ? 'Agregar y enviar a cocina antes de cobrar' : 'Venta directa en barra' }}
             </span>
             <template v-if="comandasEnabled && unfiredCount > 0">
               <span class="w-px h-3 bg-border flex-shrink-0" aria-hidden="true" />
-              <span class="flex items-center gap-1 text-xs font-semibold text-red-600 flex-shrink-0">
+              <span class="flex items-center gap-1 text-xs font-semibold text-state-danger-text flex-shrink-0">
                 {{ unfiredCount }} {{ unfiredCount === 1 ? 'ítem' : 'ítems' }} sin enviar
               </span>
             </template>
@@ -1573,11 +1573,11 @@ onUnmounted(() => {
               </p>
               <p
                 v-if="comandasEnabled && unfiredCount > 0"
-                class="flex items-center gap-1 text-xs font-semibold text-red-600 mt-1.5"
+                class="flex items-center gap-1 text-xs font-semibold text-state-danger-text mt-1.5"
               >
                 <span class="relative flex h-2 w-2">
                   <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
-                  <span class="relative inline-flex rounded-full h-2 w-2 bg-red-500" />
+                  <span class="relative inline-flex rounded-full h-2 w-2 bg-state-danger-icon" />
                 </span>
                 {{ unfiredCount }} {{ unfiredCount === 1 ? 'ítem' : 'ítems' }} sin enviar
               </p>
@@ -1669,22 +1669,22 @@ onUnmounted(() => {
           {{ tabError }}
         </p>
         <!-- Tab success (fire to kitchen) -->
-        <p v-if="tabSuccess" class="mt-2 text-xs text-emerald-700 bg-emerald-50 rounded-lg px-3 py-1.5 border border-emerald-200">
+        <p v-if="tabSuccess" class="mt-2 text-xs text-state-success-text bg-state-success-bg rounded-lg px-3 py-1.5 border border-state-success-border">
           {{ tabSuccess }}
         </p>
       </div>
 
       <!-- Customer Header (when customer is identified and no mesa mode) -->
-      <div v-else-if="posStore.currentCustomer" class="bg-crocus-600/5 border border-crocus-500/25 rounded-xl mb-4 p-4">
+      <div v-else-if="posStore.currentCustomer" class="bg-badge-primary-bg border border-badge-primary-border rounded-xl mb-4 p-4">
         <div class="flex items-start justify-between gap-3">
           <div class="flex items-center gap-3 min-w-0">
-            <div class="bg-crocus-600/10 p-3 rounded-xl border border-crocus-500/20 flex-shrink-0">
-              <svg class="w-5 h-5 text-crocus-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div class="bg-badge-primary-bg p-3 rounded-xl border border-badge-primary-border flex-shrink-0">
+              <svg class="w-5 h-5 text-badge-primary-text" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
               </svg>
             </div>
             <div class="min-w-0">
-              <p class="text-[10px] font-bold text-crocus-600 uppercase tracking-widest">
+              <p class="text-[10px] font-bold text-badge-primary-text uppercase tracking-widest">
                 Cliente Actual
               </p>
               <p class="text-base font-bold text-text-primary leading-tight truncate">
@@ -1705,7 +1705,7 @@ onUnmounted(() => {
                 />
                 <span
                   v-else
-                  class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700 border border-emerald-200"
+                  class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-state-success-bg text-state-success-text border border-state-success-border"
                 >
                   Wallet: {{ formatCurrency(posWalletBalance) }}
                 </span>
@@ -1716,7 +1716,7 @@ onUnmounted(() => {
                 />
                 <span
                   v-else
-                  class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-amber-50 text-amber-700 border border-amber-200"
+                  class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-state-warning-bg text-state-warning-text border border-state-warning-border"
                 >
                   WaRos: {{ posWarosBalance.toLocaleString('es-CO') }} pts
                 </span>
@@ -1725,7 +1725,7 @@ onUnmounted(() => {
           </div>
           <button
             type="button"
-            class="flex-shrink-0 text-xs font-semibold text-crocus-700 hover:text-crocus-800 px-3 py-2 rounded-lg border border-crocus-500/30 hover:bg-crocus-600/10 transition-colors min-h-[44px]"
+            class="flex-shrink-0 text-xs font-semibold text-badge-primary-text hover:text-badge-primary-text px-3 py-2 rounded-lg border border-badge-primary-border hover:bg-badge-primary-bg transition-colors min-h-[44px]"
             @click="showCustomerModal = true"
           >
             Cambiar
@@ -1737,7 +1737,7 @@ onUnmounted(() => {
       <div v-else class="mb-4">
         <button
           type="button"
-          class="w-full flex items-center justify-center gap-2 min-h-[44px] px-4 py-3 rounded-xl border-2 border-dashed border-crocus-500/40 text-crocus-700 font-semibold text-sm hover:bg-crocus-600/5 transition-colors"
+          class="w-full flex items-center justify-center gap-2 min-h-[44px] px-4 py-3 rounded-xl border-2 border-dashed border-badge-primary-border text-badge-primary-text font-semibold text-sm hover:bg-badge-primary-bg transition-colors"
           @click="showCustomerModal = true"
         >
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1769,7 +1769,7 @@ onUnmounted(() => {
             :key="cat"
             class="px-3.5 py-1.5 rounded-xl text-sm font-medium whitespace-nowrap theme-transition"
             :class="selectedCategory === cat
-              ? 'bg-text-primary text-white shadow-md'
+              ? 'bg-action-primary-bg text-action-primary-text shadow-md'
               : 'bg-surface border border-border text-text-secondary hover:border-border hover:text-text-primary hover:bg-surface-secondary'"
             @click="selectedCategory = cat"
           >
@@ -1888,8 +1888,8 @@ onUnmounted(() => {
         type="button"
         :aria-label="readyComandasCount > 0 ? `Estado de comandas — ${readyComandasCount} listas` : 'Estado de comandas'"
         :title="readyComandasCount > 0 ? `${readyComandasCount} comanda${readyComandasCount === 1 ? '' : 's'} lista${readyComandasCount === 1 ? '' : 's'}` : 'Estado de comandas'"
-        class="relative inline-flex items-center gap-2 h-11 rounded-lg border-2 border-surface-secondary bg-white text-text-primary text-sm font-medium hover:bg-surface-secondary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary mr-1.5 md:mr-2 px-2.5 sm:px-3 md:px-4"
-        :class="readyComandasCount > 0 ? 'ring-1 ring-emerald-300/60' : ''"
+        class="relative inline-flex items-center gap-2 h-11 rounded-lg border-2 border-surface-secondary bg-action-secondary-bg text-action-secondary-text text-sm font-medium hover:bg-action-secondary-hover-bg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-action-secondary-focus-ring mr-1.5 md:mr-2 px-2.5 sm:px-3 md:px-4"
+        :class="readyComandasCount > 0 ? 'ring-1 ring-state-success-border/60' : ''"
         @click="showExpediterPanel = true"
       >
         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -1901,13 +1901,13 @@ onUnmounted(() => {
         <!-- Count badge: numeric on sm+, dot indicator on mobile -->
         <span
           v-if="readyComandasCount > 0"
-          class="hidden sm:inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full bg-emerald-500 text-white text-[11px] font-bold tabular-nums"
+          class="hidden sm:inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full bg-action-success-bg text-action-success-text text-[11px] font-bold tabular-nums"
         >
           {{ readyComandasCount }}
         </span>
         <span
           v-if="readyComandasCount > 0"
-          class="sm:hidden absolute -top-1 -right-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-emerald-500 px-1 text-[10px] font-bold text-white tabular-nums ring-2 ring-surface"
+          class="sm:hidden absolute -top-1 -right-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-badge-success-bg px-1 text-[10px] font-bold text-badge-success-text tabular-nums ring-2 ring-surface"
           aria-hidden="true"
         >
           {{ readyComandasCount > 9 ? '9+' : readyComandasCount }}

--- a/pages/pos/producto/[id].vue
+++ b/pages/pos/producto/[id].vue
@@ -768,7 +768,7 @@ onUnmounted(() => {
                 </span>
                 <span
                   v-if="productPromoBadge"
-                  class="text-xs font-semibold bg-emerald-500/90 text-white px-2 py-0.5 rounded-full"
+                  class="text-xs font-semibold bg-badge-success-bg text-badge-success-text px-2 py-0.5 rounded-full"
                   :title="productPromoBadge.title || productPromoBadge.label"
                 >
                   {{ productPromoBadge.label }}
@@ -824,7 +824,7 @@ onUnmounted(() => {
             <label class="flex items-start gap-3 cursor-pointer">
               <input
                 type="checkbox"
-                class="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-primary/30"
+                class="mt-1 h-4 w-4 rounded border-border text-primary focus:ring-action-primary-focus-ring/30"
                 :checked="wizardPending"
                 @change="enableWizard"
               />
@@ -1032,7 +1032,7 @@ onUnmounted(() => {
               <button
                 v-if="wizardStep < quantity - 1"
                 type="button"
-                class="flex-[2] bg-primary hover:bg-primary/90 text-primary-foreground font-bold py-3 rounded-xl"
+                class="flex-[2] bg-primary hover:bg-action-primary-hover-bg text-primary-foreground font-bold py-3 rounded-xl"
                 @click="goToNextStep"
               >
                 Siguiente →
@@ -1041,7 +1041,7 @@ onUnmounted(() => {
                 v-else
                 @click="addToCart"
                 :disabled="isAdding"
-                class="flex-[2] bg-primary hover:bg-primary/90 text-primary-foreground font-bold py-3 rounded-xl disabled:opacity-50"
+                class="flex-[2] bg-primary hover:bg-action-primary-hover-bg text-primary-foreground font-bold py-3 rounded-xl disabled:opacity-50"
               >
                 Agregar {{ quantity }} ítems
               </button>
@@ -1051,7 +1051,7 @@ onUnmounted(() => {
             v-else
             @click="addToCart"
             :disabled="isAdding"
-            class="w-full bg-primary hover:bg-primary/90 text-primary-foreground font-bold py-3 md:py-4 px-4 md:px-6 rounded-xl shadow-lg transition-all flex items-center justify-center gap-2 active:scale-95 text-sm md:text-base disabled:opacity-50 disabled:cursor-not-allowed"
+            class="w-full bg-primary hover:bg-action-primary-hover-bg text-primary-foreground font-bold py-3 md:py-4 px-4 md:px-6 rounded-xl shadow-lg transition-all flex items-center justify-center gap-2 active:scale-95 text-sm md:text-base disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <template v-if="isAdding">
               <svg class="animate-spin h-4 md:h-5 w-4 md:w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -1124,7 +1124,7 @@ onUnmounted(() => {
             <button
               v-if="wizardStep < quantity - 1"
               type="button"
-              class="flex-[2] bg-primary hover:bg-primary/90 text-primary-foreground font-bold py-3 rounded-xl"
+              class="flex-[2] bg-primary hover:bg-action-primary-hover-bg text-primary-foreground font-bold py-3 rounded-xl"
               @click="goToNextStep"
             >
               Siguiente →
@@ -1133,7 +1133,7 @@ onUnmounted(() => {
               v-else
               @click="addToCart"
               :disabled="isAdding"
-              class="flex-[2] bg-primary hover:bg-primary/90 text-primary-foreground font-bold py-3 rounded-xl disabled:opacity-50"
+              class="flex-[2] bg-primary hover:bg-action-primary-hover-bg text-primary-foreground font-bold py-3 rounded-xl disabled:opacity-50"
             >
               Agregar {{ quantity }} ítems
             </button>
@@ -1143,7 +1143,7 @@ onUnmounted(() => {
           v-else
           @click="addToCart"
           :disabled="isAdding"
-          class="w-full bg-primary hover:bg-primary/90 text-primary-foreground font-bold py-3 md:py-4 px-4 md:px-6 rounded-xl shadow-lg transition-all flex items-center justify-center gap-2 active:scale-95 text-sm md:text-base disabled:opacity-50 disabled:cursor-not-allowed"
+          class="w-full bg-primary hover:bg-action-primary-hover-bg text-primary-foreground font-bold py-3 md:py-4 px-4 md:px-6 rounded-xl shadow-lg transition-all flex items-center justify-center gap-2 active:scale-95 text-sm md:text-base disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <template v-if="isAdding">
             <svg class="animate-spin h-4 md:h-5 w-4 md:w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary

- Migrated operational POS, comandas, cocina, despacho, mesas and abastecimiento UI states from literal color utilities to existing semantic tokens/components.
- Collapsed purchase/direct-purchase status maps into semantic `UiStatusBadge` variants and extended `usePurchaseStatus` for `partially_received`.
- Tokenized overlays, sheet handles, toggles, warning/success/error states, action buttons, pagination controls and POS payment/checkout state surfaces.

## Search Counts

Scoped grep path set from #1182 delta:

- Before: `863`
- After: `239`

Remaining intentional/documented categories:

- `components/pos/ProductCard.vue` category palette hex colors are data-driven product/category colors.
- `pages/cocina/[id].vue` and `components/cocina/StationPanel.vue` station color defaults/user-configured station colors remain data/configurable exceptions.
- POS print black/white CSS in `pages/pos/checkout.vue` remains a print exception.
- Residual POS discount/reward success colors are operational data/result indicators and should be handled in the final audit if a more specific token is desired.

## Validation

- `git diff --cached --check`
- `npx nuxi prepare`
  - Completed successfully.
  - Existing warning observed: duplicate import `ActivePromotionRow` between `composables/useActivePromotions.ts` and `utils/promoProductMatch.ts`.

## Manual Visual Validation Scope

No local server/port opened automatically.

Suggested routes/views for manual check:

- `/pos`, `/pos/checkout`, `/pos/producto/:id`
- `/comandas`, `/cocina/:id`, `/despacho/comandas`, `/despacho/domicilios`, `/despacho/en-mesa`
- `/operaciones/mesas`, `/operaciones/comandas`, `/operaciones/propinas`, `/operaciones/personalizar`
- `/abastecimiento/compras`, `/abastecimiento/compra/:id`, `/abastecimiento/compras-directas`, `/abastecimiento/proveedores`, `/abastecimiento/stock`, `/abastecimiento/ingredientes-propios`

Closes #1182
