### PR TITLE
Tokenizar gestión, billing y finanzas

### DIFF
--- a/components/Finanzas/CierrePanel.vue
+++ b/components/Finanzas/CierrePanel.vue
@@ -9,7 +9,7 @@
       leave-from-class="opacity-100"
       leave-to-class="opacity-0"
     >
-      <div v-if="modelValue" class="fixed inset-0 z-40 bg-black/40" @click="close" aria-hidden="true" />
+      <div v-if="modelValue" class="fixed inset-0 z-40 bg-overlay-backdrop/40" @click="close" aria-hidden="true" />
     </Transition>
 
     <!-- Panel -->
@@ -25,7 +25,7 @@
       >
         <!-- Mobile drag handle -->
         <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
-          <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+          <div class="w-10 h-1 rounded-full bg-surface-tertiary" aria-hidden="true" />
         </div>
 
         <!-- Header -->
@@ -115,7 +115,7 @@
                 </div>
                 <div class="flex justify-between px-6 py-2.5 text-sm font-semibold">
                   <span class="text-text-primary">Diferencia</span>
-                  <span :class="detail.cashDifference >= 0 ? 'text-emerald-600' : 'text-destructive'">
+                  <span :class="detail.cashDifference >= 0 ? 'text-state-success-text' : 'text-destructive'">
                     {{ detail.cashDifference >= 0 ? '+' : '' }}{{ formatCurrency(detail.cashDifference) }}
                   </span>
                 </div>
@@ -170,7 +170,7 @@
               <button
                 @click="handleDelete"
                 :disabled="deleting"
-                class="min-h-[44px] flex-1 px-4 py-2 rounded-lg bg-destructive text-white text-sm font-semibold hover:bg-destructive/90 transition-colors disabled:opacity-50"
+                class="min-h-[44px] flex-1 px-4 py-2 rounded-lg bg-action-destructive-bg text-action-destructive-text text-sm font-semibold hover:bg-action-destructive-hover-bg transition-colors disabled:opacity-50"
               >
                 {{ deleting ? 'Eliminando...' : 'Sí, eliminar' }}
               </button>

--- a/components/Finanzas/PLStatement.vue
+++ b/components/Finanzas/PLStatement.vue
@@ -226,7 +226,7 @@ const prevPeriodLabel = computed(() => {
           <span class="text-text-secondary">Total:</span>
           <span
             class="font-bold tabular-nums"
-            :class="current.primeCost.status === 'ok' ? 'text-emerald-600' : 'text-amber-600'"
+            :class="current.primeCost.status === 'ok' ? 'text-state-success-text' : 'text-state-warning-text'"
           >
             {{ formatPct(current.primeCost.totalPct) }}
           </span>
@@ -564,14 +564,14 @@ const prevPeriodLabel = computed(() => {
         <span class="flex-1 text-base font-bold text-text-primary">Ingreso neto</span>
         <span
           class="w-36 text-right tabular-nums text-base font-bold"
-          :class="isNegative(current.netIncome) ? 'text-destructive' : 'text-emerald-600'"
+          :class="isNegative(current.netIncome) ? 'text-destructive' : 'text-state-success-text'"
         >
           {{ formatCurrency(current.netIncome) }}
         </span>
         <span
           v-if="hasPrevious"
           class="w-36 text-right tabular-nums text-base font-bold"
-          :class="isNegative(previous!.netIncome) ? 'text-destructive' : 'text-emerald-600'"
+          :class="isNegative(previous!.netIncome) ? 'text-destructive' : 'text-state-success-text'"
         >
           {{ formatCurrency(previous!.netIncome) }}
         </span>
@@ -603,7 +603,7 @@ const prevPeriodLabel = computed(() => {
             <span class="text-text-secondary">Total:</span>
             <span
               class="font-bold tabular-nums"
-              :class="current.primeCost.status === 'ok' ? 'text-emerald-600' : 'text-amber-600'"
+              :class="current.primeCost.status === 'ok' ? 'text-state-success-text' : 'text-state-warning-text'"
             >
               {{ formatPct(current.primeCost.totalPct) }}
             </span>

--- a/components/Finanzas/contabilidad/AjustarSaldoPanel.vue
+++ b/components/Finanzas/contabilidad/AjustarSaldoPanel.vue
@@ -254,7 +254,7 @@ const submit = async () => {
     >
       <div
         v-if="modelValue"
-        class="fixed inset-0 z-40 bg-black/40"
+        class="fixed inset-0 z-40 bg-overlay-backdrop/40"
         aria-hidden="true"
         @click="close"
       />
@@ -273,7 +273,7 @@ const submit = async () => {
       >
         <!-- Mobile drag handle -->
         <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
-          <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+          <div class="w-10 h-1 rounded-full bg-surface-tertiary" aria-hidden="true" />
         </div>
 
         <!-- Header -->
@@ -345,15 +345,15 @@ const submit = async () => {
             v-if="sign !== 'zero'"
             class="rounded-xl px-4 py-3 border-2"
             :class="sign === 'positive'
-              ? 'border-emerald-200 bg-emerald-50 dark:border-emerald-800/40 dark:bg-emerald-950/20'
-              : 'border-amber-200 bg-amber-50 dark:border-amber-800/40 dark:bg-amber-950/20'"
+              ? 'border-state-success-border bg-state-success-bg'
+              : 'border-state-warning-border bg-state-warning-bg'"
           >
             <p class="text-xs uppercase tracking-wider font-medium mb-1"
-               :class="sign === 'positive' ? 'text-emerald-700 dark:text-emerald-400' : 'text-amber-700 dark:text-amber-400'">
+               :class="sign === 'positive' ? 'text-state-success-text' : 'text-state-warning-text'">
               Diferencia
             </p>
             <p class="text-2xl font-bold flex items-center gap-2"
-               :class="sign === 'positive' ? 'text-emerald-700 dark:text-emerald-400' : 'text-amber-700 dark:text-amber-400'">
+               :class="sign === 'positive' ? 'text-state-success-text' : 'text-state-warning-text'">
               <svg v-if="sign === 'positive'" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 10l7-7m0 0l7 7m-7-7v18" />
               </svg>
@@ -363,7 +363,7 @@ const submit = async () => {
               {{ sign === 'positive' ? '+' : '−' }} {{ formatCOP(Math.abs(diferencia)) }}
             </p>
             <p class="text-xs leading-snug mt-1"
-               :class="sign === 'positive' ? 'text-emerald-700/80 dark:text-emerald-400/80' : 'text-amber-700/80 dark:text-amber-400/80'">
+               :class="sign === 'positive' ? 'text-state-success-text/80' : 'text-state-warning-text/80'">
               {{ sign === 'positive'
                 ? 'Tu cuenta tiene más plata que lo que dicen los libros.'
                 : 'Tu cuenta tiene menos plata que lo que dicen los libros.' }}
@@ -417,7 +417,7 @@ const submit = async () => {
             </p>
             <p
               v-if="selectedMotivo.pendingReview"
-              class="text-xs text-amber-700 dark:text-amber-400 leading-snug mt-2 flex items-start gap-1.5"
+              class="text-xs text-state-warning-text leading-snug mt-2 flex items-start gap-1.5"
             >
               <svg class="w-3.5 h-3.5 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
@@ -445,7 +445,7 @@ const submit = async () => {
           <button
             type="button"
             :disabled="!canSubmit"
-            class="flex-1 min-h-[44px] rounded-lg bg-primary text-white text-sm font-bold transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/30 active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            class="flex-1 min-h-[44px] rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-bold transition-colors hover:bg-action-primary-hover-bg focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 active:scale-[0.98] disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-2"
             @click="submit"
           >
             <UiLoadingDots v-if="submitting" size="8px" color="currentColor" />

--- a/components/Finanzas/contabilidad/AsientoDetailPanel.vue
+++ b/components/Finanzas/contabilidad/AsientoDetailPanel.vue
@@ -179,7 +179,7 @@ watch(
     >
       <div
         v-if="modelValue"
-        class="fixed inset-0 z-40 bg-black/40"
+        class="fixed inset-0 z-40 bg-overlay-backdrop/40"
         aria-hidden="true"
         @click="close"
       />
@@ -196,7 +196,7 @@ watch(
                md:inset-y-0 md:right-0 md:bottom-auto md:left-auto md:inset-x-auto md:rounded-none md:w-full md:max-w-lg md:max-h-none md:h-full"
       >
         <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
-          <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+          <div class="w-10 h-1 rounded-full bg-surface-tertiary" aria-hidden="true" />
         </div>
 
         <!-- Header -->
@@ -261,7 +261,7 @@ watch(
               />
               <span
                 v-if="entry.pendingReview"
-                class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 text-xs font-medium dark:bg-amber-950/30 dark:text-amber-400"
+                class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-badge-warning-bg text-badge-warning-text text-xs font-medium"
               >
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />

--- a/components/analytics/AlertsSection.vue
+++ b/components/analytics/AlertsSection.vue
@@ -28,54 +28,54 @@ const getIcon = (type: string) => {
   }
 };
 
-// Color classes based on alert type
+// Semantic classes based on alert type
 const getColorClasses = (type: string) => {
   switch (type) {
     case 'critical':
       return {
-        bg: 'bg-red-50',
-        border: 'border-red-100',
-        iconBg: 'bg-white',
-        iconText: 'text-red-500',
-        titleText: 'text-red-700',
-        descText: 'text-red-600/80',
-        actionText: 'text-red-700'
+        bg: 'bg-state-danger-bg',
+        border: 'border-state-danger-border',
+        iconBg: 'bg-surface',
+        iconText: 'text-state-danger-icon',
+        titleText: 'text-state-danger-text',
+        descText: 'text-state-danger-text/80',
+        actionText: 'text-state-danger-text'
       };
     case 'warning':
       return {
-        bg: 'bg-orange-50',
-        border: 'border-orange-100',
-        iconBg: 'bg-white',
-        iconText: 'text-orange-500',
-        titleText: 'text-orange-700',
-        descText: 'text-orange-600/80',
-        actionText: 'text-orange-700'
+        bg: 'bg-state-warning-bg',
+        border: 'border-state-warning-border',
+        iconBg: 'bg-surface',
+        iconText: 'text-state-warning-icon',
+        titleText: 'text-state-warning-text',
+        descText: 'text-state-warning-text/80',
+        actionText: 'text-state-warning-text'
       };
     default:
       return {
-        bg: 'bg-blue-50',
-        border: 'border-blue-100',
-        iconBg: 'bg-white',
-        iconText: 'text-blue-500',
-        titleText: 'text-blue-700',
-        descText: 'text-blue-600/80',
-        actionText: 'text-blue-700'
+        bg: 'bg-state-info-bg',
+        border: 'border-state-info-border',
+        iconBg: 'bg-surface',
+        iconText: 'text-state-info-icon',
+        titleText: 'text-state-info-text',
+        descText: 'text-state-info-text/80',
+        actionText: 'text-state-info-text'
       };
   }
 };
 </script>
 
 <template>
-  <section class="bg-white p-6 rounded-2xl border border-slate-200 shadow-sm opacity-100 transition-opacity duration-300">
+  <section class="bg-surface p-6 rounded-2xl border border-border shadow-sm opacity-100 transition-opacity duration-300">
     <h3 class="text-lg font-bold flex items-center gap-2 mb-4">
-      <span class="w-2 h-6 bg-red-500 rounded-full"></span>
+      <span class="w-2 h-6 bg-state-danger-icon rounded-full"></span>
       Alertas
     </h3>
 
     <div v-if="!alerts || alerts.length === 0" class="text-center py-8">
-      <Info :size="48" class="text-slate-300 mx-auto mb-3" />
-      <p class="text-slate-500 text-sm">No hay alertas en este momento</p>
-      <p class="text-slate-400 text-xs mt-1">Todo está funcionando correctamente ✅</p>
+      <Info :size="48" class="text-text-tertiary mx-auto mb-3" />
+      <p class="text-text-secondary text-sm">No hay alertas en este momento</p>
+      <p class="text-text-tertiary text-xs mt-1">Todo está funcionando correctamente ✅</p>
     </div>
 
     <div v-else class="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/components/analytics/InvoiceModal.vue
+++ b/components/analytics/InvoiceModal.vue
@@ -12,32 +12,32 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div v-if="show" class="fixed inset-0 bg-slate-900/60 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-    <div class="bg-white rounded-3xl w-full max-w-md overflow-hidden shadow-2xl animate-in fade-in zoom-in duration-300">
+  <div v-if="show" class="fixed inset-0 bg-overlay-backdrop/60 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+    <div class="bg-modal-surface-bg text-modal-surface-text rounded-3xl w-full max-w-md overflow-hidden shadow-2xl animate-in fade-in zoom-in duration-300">
       <div class="p-6 text-center">
-        <div class="w-20 h-20 bg-indigo-50 rounded-2xl flex items-center justify-center mx-auto mb-4 border-2 border-dashed border-indigo-200">
-          <Camera class="text-indigo-400" :size="40" />
+        <div class="w-20 h-20 bg-state-info-bg rounded-2xl flex items-center justify-center mx-auto mb-4 border-2 border-dashed border-state-info-border">
+          <Camera class="text-state-info-icon" :size="40" />
         </div>
         <h3 class="text-xl font-bold mb-2">Escanear con IA</h3>
-        <p class="text-slate-500 text-sm mb-6">
+        <p class="text-text-secondary text-sm mb-6">
           Toma una foto de tu factura de proveedor. Extraeremos automáticamente productos, precios y actualizaremos tu stock.
         </p>
         <div class="space-y-3">
           <button 
             @click="emit('confirm')"
-            class="w-full bg-indigo-600 text-white py-4 rounded-2xl font-bold hover:bg-indigo-700 transition-all shadow-lg"
+            class="w-full bg-action-info-bg text-action-info-text py-4 rounded-2xl font-bold hover:bg-action-info-hover-bg transition-all shadow-lg"
           >
             Simular Carga de Foto
           </button>
           <button 
             @click="emit('close')"
-            class="w-full bg-white text-slate-400 py-3 font-medium hover:text-slate-600"
+            class="w-full bg-action-ghost-bg text-action-ghost-text py-3 font-medium hover:text-action-ghost-hover-text"
           >
             Cancelar
           </button>
         </div>
       </div>
-      <div class="bg-slate-50 p-4 text-[10px] text-slate-400 text-center uppercase tracking-widest font-bold border-t border-slate-100">
+      <div class="bg-surface-secondary p-4 text-[10px] text-text-tertiary text-center uppercase tracking-widest font-bold border-t border-modal-footer-border">
         Procesado por Motor IA RestoGrowth
       </div>
     </div>

--- a/components/analytics/MenuProfitabilityTable.vue
+++ b/components/analytics/MenuProfitabilityTable.vue
@@ -65,15 +65,15 @@ const tableColumns: MatrixColumn[] = [
 const getCategoryStyles = (category: string) => {
   switch (category) {
     case 'Star':
-      return { bg: 'bg-green-100', text: 'text-green-700', icon: Star, label: 'Excelente' }
+      return { bg: 'bg-state-success-bg', text: 'text-state-success-text', icon: Star, label: 'Excelente' }
     case 'Plowhorse':
-      return { bg: 'bg-blue-100', text: 'text-blue-700', icon: Shield, label: 'Popular' }
+      return { bg: 'bg-state-info-bg', text: 'text-state-info-text', icon: Shield, label: 'Popular' }
     case 'Puzzle':
-      return { bg: 'bg-orange-100', text: 'text-orange-700', icon: Puzzle, label: 'Potencial' }
+      return { bg: 'bg-state-warning-bg', text: 'text-state-warning-text', icon: Puzzle, label: 'Potencial' }
     case 'Dog':
-      return { bg: 'bg-red-100', text: 'text-red-700', icon: AlertTriangle, label: 'Crítico' }
+      return { bg: 'bg-state-danger-bg', text: 'text-state-danger-text', icon: AlertTriangle, label: 'Crítico' }
     default:
-      return { bg: 'bg-slate-100', text: 'text-slate-700', icon: Star, label: 'Unknown' }
+      return { bg: 'bg-status-chip-bg', text: 'text-status-chip-text', icon: Star, label: 'Unknown' }
   }
 }
 
@@ -226,7 +226,7 @@ const totals = computed(() => {
         <div class="text-right">
           <span
             v-if="marginRealPct(marginRow(row)) !== null"
-            :class="(marginRealPct(marginRow(row)) ?? 0) >= 40 ? 'text-green-600 font-bold' : 'text-text-primary'"
+            :class="(marginRealPct(marginRow(row)) ?? 0) >= 40 ? 'text-state-success-text font-bold' : 'text-text-primary'"
           >
             {{ marginRealPct(marginRow(row))!.toFixed(1) }}%
           </span>
@@ -266,7 +266,7 @@ const totals = computed(() => {
       </template>
 
       <template #cell-total_profit="{ value }">
-        <div class="text-right text-green-600 font-bold">{{ value ? formatCurrency(value) : '—' }}</div>
+        <div class="text-right text-state-success-text font-bold">{{ value ? formatCurrency(value) : '—' }}</div>
       </template>
     </UiResponsiveDataView>
   </div>

--- a/components/analytics/SalesChart.vue
+++ b/components/analytics/SalesChart.vue
@@ -75,6 +75,7 @@ const chartOptions = computed(() => ({
       opacityTo: 0.30,
     },
   },
+  // Chart palette exception: Apex requires literal series/axis colors.
   colors: ['#f59e0b', '#4f46e5'],
   xaxis: {
     categories: data.value.map(d => d.name),
@@ -121,18 +122,18 @@ const chartOptions = computed(() => ({
     <!-- Legend -->
     <div class="flex justify-end gap-6 text-xs font-medium mb-2 px-2">
       <div class="flex items-center gap-2">
-        <span class="w-3 h-3 rounded-full bg-indigo-600"></span>
-        <span class="text-slate-700 whitespace-nowrap">{{ currentLabel }}</span>
+        <span class="w-3 h-3 rounded-full bg-state-info-icon"></span>
+        <span class="text-text-primary whitespace-nowrap">{{ currentLabel }}</span>
       </div>
       <div class="flex items-center gap-2">
-        <span class="w-3 h-3 rounded-full bg-amber-500"></span>
-        <span class="text-slate-700 whitespace-nowrap">{{ comparisonLabel }}</span>
+        <span class="w-3 h-3 rounded-full bg-state-warning-icon"></span>
+        <span class="text-text-primary whitespace-nowrap">{{ comparisonLabel }}</span>
       </div>
     </div>
 
     <div class="h-[250px]">
       <div v-if="loading" class="flex items-center justify-center h-full">
-        <div class="w-6 h-6 border-2 border-indigo-500 border-t-transparent rounded-full animate-spin" />
+        <div class="w-6 h-6 border-2 border-state-info-icon border-t-transparent rounded-full animate-spin" />
       </div>
       <apexchart
         v-else

--- a/components/payments/PaymentForm.vue
+++ b/components/payments/PaymentForm.vue
@@ -111,13 +111,13 @@
         <div class="mt-6 pt-6 border-t-2 border-border">
           <div class="flex justify-between items-end mb-6">
             <span class="text-text-secondary font-medium">Total a Pagar</span>
-            <span class="text-2xl font-bold text-emerald-500">{{ formatCurrency(totalAmount) }}</span>
+            <span class="text-2xl font-bold text-state-success-text">{{ formatCurrency(totalAmount) }}</span>
           </div>
 
           <!-- Actions -->
           <div class="space-y-3">
             <button type="submit" :disabled="loading"
-              class="w-full py-3 bg-emerald-500 text-white rounded-lg hover:bg-emerald-600 transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold shadow-lg shadow-emerald-500/20">
+              class="w-full py-3 bg-action-success-bg text-action-success-text rounded-lg hover:bg-action-success-hover-bg transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold shadow-lg shadow-primary/20">
               <CommonsTheCustomLoader v-if="loading" size="small" />
               <span>{{ loading ? 'Procesando...' : 'Confirmar Pago' }}</span>
             </button>

--- a/components/payments/PaymentMethodSelector.vue
+++ b/components/payments/PaymentMethodSelector.vue
@@ -21,10 +21,10 @@
           :class="[
             modelValue.slug === group.slug
               ? (group.triggersCartera
-                  ? 'border-amber-500 bg-amber-50 shadow-sm dark:bg-amber-950/20'
+                  ? 'border-state-warning-border bg-state-warning-bg shadow-sm'
                   : 'border-primary bg-primary/5 shadow-sm')
               : (group.triggersCartera
-                  ? 'border-border hover:border-amber-400/40'
+                  ? 'border-border hover:border-state-warning-border/40'
                   : 'border-border hover:border-primary/30'),
             disabled ? 'opacity-50 cursor-not-allowed' : '',
           ]"
@@ -33,7 +33,7 @@
             <!-- Per-slug icon -->
             <div
               v-if="group.slug === 'cash'"
-              class="bg-green-100 text-green-700 w-8 h-8 md:w-9 md:h-9 rounded-full flex items-center justify-center flex-shrink-0"
+              class="bg-state-success-bg text-state-success-icon w-8 h-8 md:w-9 md:h-9 rounded-full flex items-center justify-center flex-shrink-0"
             >
               <svg class="h-4 w-4 md:h-5 md:w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z" />
@@ -41,7 +41,7 @@
             </div>
             <div
               v-else-if="group.slug === 'card'"
-              class="bg-blue-100 text-blue-700 w-8 h-8 md:w-9 md:h-9 rounded-full flex items-center justify-center flex-shrink-0"
+              class="bg-state-info-bg text-state-info-icon w-8 h-8 md:w-9 md:h-9 rounded-full flex items-center justify-center flex-shrink-0"
             >
               <svg class="h-4 w-4 md:h-5 md:w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z" />
@@ -57,7 +57,7 @@
             </div>
             <div
               v-else-if="group.triggersCartera"
-              class="bg-amber-100 text-amber-700 w-8 h-8 md:w-9 md:h-9 rounded-full flex items-center justify-center flex-shrink-0"
+              class="bg-state-warning-bg text-state-warning-icon w-8 h-8 md:w-9 md:h-9 rounded-full flex items-center justify-center flex-shrink-0"
             >
               <svg class="h-4 w-4 md:h-5 md:w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
@@ -77,7 +77,7 @@
               class="h-4 w-4 transition-all hidden md:block"
               :class="[
                 modelValue.slug === group.slug ? 'opacity-100' : 'opacity-0',
-                group.triggersCartera ? 'text-amber-600' : 'text-primary',
+                group.triggersCartera ? 'text-state-warning-icon' : 'text-primary',
               ]"
               xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
               aria-hidden="true"
@@ -90,7 +90,7 @@
           <div class="text-center md:text-left w-full">
             <div
               class="font-semibold text-xs md:text-sm leading-tight"
-              :class="modelValue.slug === group.slug && group.triggersCartera ? 'text-amber-700' : 'text-text-primary'"
+              :class="modelValue.slug === group.slug && group.triggersCartera ? 'text-state-warning-text' : 'text-text-primary'"
             >
               {{ group.name }}
             </div>
@@ -100,7 +100,7 @@
           <div
             v-if="modelValue.slug === group.slug"
             class="absolute top-1.5 right-1.5 w-2 h-2 rounded-full md:hidden"
-            :class="group.triggersCartera ? 'bg-amber-500' : 'bg-primary'"
+            :class="group.triggersCartera ? 'bg-state-warning-icon' : 'bg-primary'"
           />
         </div>
       </label>
@@ -146,7 +146,7 @@
           class="relative min-h-[48px] px-3 py-2.5 rounded-xl border-2 text-sm font-semibold transition-all text-center active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
           :class="modelValue.id === method.id
             ? (selectedGroup.triggersCartera
-                ? 'border-amber-500 bg-amber-50 text-amber-700 shadow-sm'
+                ? 'border-state-warning-border bg-state-warning-bg text-state-warning-text shadow-sm'
                 : 'border-primary bg-primary/10 text-primary shadow-sm')
             : 'border-border bg-background text-text-secondary hover:border-primary/30 hover:text-text-primary'"
           @click="onMethodToggle(method.id)"
@@ -155,7 +155,7 @@
           <span
             v-if="modelValue.id === method.id"
             class="absolute top-1 right-1.5 w-1.5 h-1.5 rounded-full"
-            :class="selectedGroup.triggersCartera ? 'bg-amber-500' : 'bg-primary'"
+            :class="selectedGroup.triggersCartera ? 'bg-state-warning-icon' : 'bg-primary'"
           />
         </button>
       </div>
@@ -171,7 +171,7 @@
             class="w-full flex items-center justify-between px-4 py-3 text-sm transition-colors active:scale-[0.99] disabled:opacity-50 disabled:cursor-not-allowed"
             :class="modelValue.id === method.id
               ? (selectedGroup.triggersCartera
-                  ? 'bg-amber-50 text-amber-700 font-semibold'
+                  ? 'bg-state-warning-bg text-state-warning-text font-semibold'
                   : 'bg-primary/8 text-primary font-semibold')
               : 'text-text-primary hover:bg-surface-secondary/50'"
             @click="onMethodToggle(method.id)"
@@ -180,7 +180,7 @@
             <svg
               v-if="modelValue.id === method.id"
               class="w-4 h-4 flex-shrink-0"
-              :class="selectedGroup.triggersCartera ? 'text-amber-600' : 'text-primary'"
+              :class="selectedGroup.triggersCartera ? 'text-state-warning-icon' : 'text-primary'"
               fill="none" stroke="currentColor" viewBox="0 0 24 24"
               aria-hidden="true"
             >

--- a/pages/billing/confirmacion.vue
+++ b/pages/billing/confirmacion.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="page-layout">
     <div class="max-w-md mx-auto flex items-center justify-center min-h-[400px]">
-      <p v-if="debugError" class="text-xs text-red-500 absolute top-4 left-4 right-4 break-all">{{ debugError }}</p>
+      <p v-if="debugError" class="text-xs text-form-control-error absolute top-4 left-4 right-4 break-all">{{ debugError }}</p>
       <!-- Loading -->
       <div v-if="isLoading" class="text-center space-y-4">
         <div class="flex justify-center">
@@ -16,8 +16,8 @@
       <!-- Approved -->
       <div v-else-if="isApproved" class="text-center space-y-5">
         <div class="flex justify-center">
-          <div class="w-16 h-16 rounded-full bg-green-100 flex items-center justify-center">
-            <svg class="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div class="w-16 h-16 rounded-full bg-state-success-bg flex items-center justify-center">
+            <svg class="w-8 h-8 text-state-success-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
             </svg>
           </div>
@@ -37,8 +37,8 @@
       <!-- Pending -->
       <div v-else-if="isPending" class="text-center space-y-5">
         <div class="flex justify-center">
-          <div class="w-16 h-16 rounded-full bg-yellow-100 flex items-center justify-center">
-            <svg class="w-8 h-8 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div class="w-16 h-16 rounded-full bg-state-warning-bg flex items-center justify-center">
+            <svg class="w-8 h-8 text-state-warning-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           </div>
@@ -58,8 +58,8 @@
       <!-- Failure / other -->
       <div v-else class="text-center space-y-5">
         <div class="flex justify-center">
-          <div class="w-16 h-16 rounded-full bg-red-100 flex items-center justify-center">
-            <svg class="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div class="w-16 h-16 rounded-full bg-state-danger-bg flex items-center justify-center">
+            <svg class="w-8 h-8 text-state-danger-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>
           </div>

--- a/pages/facturacion/audit.vue
+++ b/pages/facturacion/audit.vue
@@ -101,8 +101,8 @@ const reasonLabel = (reason: string) => {
 }
 
 const reasonClass = (reason: string) => {
-  if (reason === 'matias_ya_validado') return 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
-  if (reason?.startsWith('matias_')) return 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+  if (reason === 'matias_ya_validado') return 'bg-state-warning-bg text-state-warning-text'
+  if (reason?.startsWith('matias_')) return 'bg-state-danger-bg text-state-danger-text'
   return 'bg-surface-secondary text-text-secondary'
 }
 </script>

--- a/pages/facturacion/index.vue
+++ b/pages/facturacion/index.vue
@@ -248,15 +248,15 @@ const docTypeShort: Record<string, string> = {
 }
 
 const progressColor = (percent: number) => {
-  if (percent >= 90) return 'bg-red-500'
-  if (percent >= 70) return 'bg-amber-500'
-  return 'bg-green-500'
+  if (percent >= 90) return 'bg-state-danger-icon'
+  if (percent >= 70) return 'bg-state-warning-icon'
+  return 'bg-state-success-icon'
 }
 
 const progressTextColor = (percent: number) => {
-  if (percent >= 90) return 'text-red-600 dark:text-red-400'
-  if (percent >= 70) return 'text-amber-600 dark:text-amber-400'
-  return 'text-emerald-700 dark:text-emerald-400'
+  if (percent >= 90) return 'text-state-danger-text'
+  if (percent >= 70) return 'text-state-warning-text'
+  return 'text-state-success-text'
 }
 
 const resolutionColumns = [
@@ -381,63 +381,63 @@ const taxLevels = [
       <!-- Dev flag disabled — only WARO team can flip this -->
       <div
         v-if="!readinessChecks.dev_flag_enabled"
-        class="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-700/40 dark:bg-amber-900/20"
+        class="flex items-start gap-3 rounded-lg border border-state-warning-border bg-state-warning-bg p-4"
         role="status"
       >
-        <ExclamationTriangleIcon class="w-5 h-5 text-amber-700 dark:text-amber-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
+        <ExclamationTriangleIcon class="w-5 h-5 text-state-warning-icon flex-shrink-0 mt-0.5" aria-hidden="true" />
         <div class="flex-1">
-          <p class="text-sm font-semibold text-amber-900 dark:text-amber-200">Cuenta no habilitada para facturación electrónica</p>
-          <p class="text-xs text-amber-800 dark:text-amber-300 mt-0.5">Tu cuenta aún no está habilitada por el equipo de WARO. Contáctanos para activarla.</p>
+          <p class="text-sm font-semibold text-state-warning-text">Cuenta no habilitada para facturación electrónica</p>
+          <p class="text-xs text-state-warning-text/90 mt-0.5">Tu cuenta aún no está habilitada por el equipo de WARO. Contáctanos para activarla.</p>
         </div>
       </div>
 
       <!-- Fiscal data incomplete -->
       <div
         v-if="!readinessChecks.fiscal_data_complete"
-        class="flex items-start gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-700/40 dark:bg-blue-900/20"
+        class="flex items-start gap-3 rounded-lg border border-state-info-border bg-state-info-bg p-4"
         role="status"
       >
-        <InformationCircleIcon class="w-5 h-5 text-blue-700 dark:text-blue-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
+        <InformationCircleIcon class="w-5 h-5 text-state-info-icon flex-shrink-0 mt-0.5" aria-hidden="true" />
         <div class="flex-1">
-          <p class="text-sm font-semibold text-blue-900 dark:text-blue-200">Faltan datos fiscales</p>
-          <p class="text-xs text-blue-800 dark:text-blue-300 mt-0.5">Completa NIT, razón social, teléfono y email en la sección <span class="font-medium">Datos Fiscales del Negocio</span>.</p>
+          <p class="text-sm font-semibold text-state-info-text">Faltan datos fiscales</p>
+          <p class="text-xs text-state-info-text/90 mt-0.5">Completa NIT, razón social, teléfono y email en la sección <span class="font-medium">Datos Fiscales del Negocio</span>.</p>
         </div>
       </div>
 
       <!-- No active DIAN resolution -->
       <div
         v-if="!readinessChecks.active_resolution"
-        class="flex items-start gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-700/40 dark:bg-blue-900/20"
+        class="flex items-start gap-3 rounded-lg border border-state-info-border bg-state-info-bg p-4"
         role="status"
       >
-        <InformationCircleIcon class="w-5 h-5 text-blue-700 dark:text-blue-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
+        <InformationCircleIcon class="w-5 h-5 text-state-info-icon flex-shrink-0 mt-0.5" aria-hidden="true" />
         <div class="flex-1">
-          <p class="text-sm font-semibold text-blue-900 dark:text-blue-200">Sin resolución DIAN vigente</p>
-          <p class="text-xs text-blue-800 dark:text-blue-300 mt-0.5">Configura una resolución activa con numeración disponible en la sección <span class="font-medium">Resolución DIAN</span>.</p>
+          <p class="text-sm font-semibold text-state-info-text">Sin resolución DIAN vigente</p>
+          <p class="text-xs text-state-info-text/90 mt-0.5">Configura una resolución activa con numeración disponible en la sección <span class="font-medium">Resolución DIAN</span>.</p>
         </div>
       </div>
 
       <!-- No taxes configured (4th check — added in plan amendment) -->
       <div
         v-if="!readinessChecks.taxes_configured"
-        class="flex items-start gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-700/40 dark:bg-blue-900/20"
+        class="flex items-start gap-3 rounded-lg border border-state-info-border bg-state-info-bg p-4"
         role="status"
       >
-        <InformationCircleIcon class="w-5 h-5 text-blue-700 dark:text-blue-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
+        <InformationCircleIcon class="w-5 h-5 text-state-info-icon flex-shrink-0 mt-0.5" aria-hidden="true" />
         <div class="flex-1">
-          <p class="text-sm font-semibold text-blue-900 dark:text-blue-200">No hay impuestos configurados</p>
-          <p class="text-xs text-blue-800 dark:text-blue-300 mt-0.5">Activa <span class="font-medium">INC</span> o <span class="font-medium">IVA</span> en la sección <span class="font-medium">Configuración fiscal</span> para poder emitir facturas.</p>
+          <p class="text-sm font-semibold text-state-info-text">No hay impuestos configurados</p>
+          <p class="text-xs text-state-info-text/90 mt-0.5">Activa <span class="font-medium">INC</span> o <span class="font-medium">IVA</span> en la sección <span class="font-medium">Configuración fiscal</span> para poder emitir facturas.</p>
         </div>
       </div>
 
       <!-- All four checks passed — ready to invoice -->
       <div
         v-if="isInvoicingReady"
-        class="flex items-center gap-3 rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-700/40 dark:bg-green-900/20"
+        class="flex items-center gap-3 rounded-lg border border-state-success-border bg-state-success-bg p-3"
         role="status"
       >
-        <CheckCircleIcon class="w-5 h-5 text-green-700 dark:text-green-400 flex-shrink-0" aria-hidden="true" />
-        <p class="text-sm font-medium text-green-900 dark:text-green-200">Tu cuenta está lista para emitir facturas electrónicas.</p>
+        <CheckCircleIcon class="w-5 h-5 text-state-success-icon flex-shrink-0" aria-hidden="true" />
+        <p class="text-sm font-medium text-state-success-text">Tu cuenta está lista para emitir facturas electrónicas.</p>
       </div>
     </div>
 
@@ -450,7 +450,7 @@ const taxLevels = [
         </h3>
         <button
           @click="openNewResolution"
-          class="min-h-[44px] px-3 py-2 text-sm font-semibold rounded-lg bg-primary text-white hover:bg-primary/90 transition-colors flex items-center gap-1"
+          class="min-h-[44px] px-3 py-2 text-sm font-semibold rounded-lg bg-action-primary-bg text-action-primary-text hover:bg-action-primary-hover-bg transition-colors flex items-center gap-1"
         >
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" /></svg>
           Agregar
@@ -461,22 +461,22 @@ const taxLevels = [
       <NuxtLink
         v-if="hasRecentGaps"
         to="/facturacion/audit"
-        class="block mb-4 rounded-lg border border-amber-200 bg-amber-50 p-3 hover:bg-amber-100/70 transition-colors dark:border-amber-700/40 dark:bg-amber-900/20 dark:hover:bg-amber-900/30"
+        class="block mb-4 rounded-lg border border-state-warning-border bg-state-warning-bg p-3 hover:bg-state-warning-bg/80 transition-colors"
       >
         <div class="flex items-start gap-3">
-          <ExclamationTriangleIcon class="w-5 h-5 text-amber-700 dark:text-amber-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
+          <ExclamationTriangleIcon class="w-5 h-5 text-state-warning-icon flex-shrink-0 mt-0.5" aria-hidden="true" />
           <div class="flex-1 min-w-0">
-            <p class="text-sm font-semibold text-amber-900 dark:text-amber-200">
+            <p class="text-sm font-semibold text-state-warning-text">
               Números quemados detectados en tu numeración
             </p>
-            <p class="text-xs text-amber-800 dark:text-amber-300 mt-0.5 leading-snug">
+            <p class="text-xs text-state-warning-text/90 mt-0.5 leading-snug">
               <span class="font-semibold tabular-nums">{{ gapsSummary?.last_24h ?? 0 }}</span> en 24h ·
               <span class="font-semibold tabular-nums">{{ gapsSummary?.last_7d ?? 0 }}</span> en 7d ·
               <span class="font-semibold tabular-nums">{{ gapsSummary?.last_30d ?? 0 }}</span> en 30d.
               DIAN no permite reutilizarlos — revisa la bitácora.
             </p>
           </div>
-          <svg class="w-4 h-4 text-amber-700 dark:text-amber-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <svg class="w-4 h-4 text-state-warning-icon flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
           </svg>
         </div>
@@ -487,7 +487,7 @@ const taxLevels = [
         <DocumentTextIcon class="w-10 h-10 mx-auto text-text-tertiary mb-2" />
         <p class="text-sm text-text-secondary">Sin resoluciones DIAN configuradas</p>
         <p class="text-xs text-text-tertiary mt-1">Configura la resolución que registraste en el portal de Matias (número, prefijo, rango)</p>
-        <button @click="openNewResolution" class="mt-3 min-h-[44px] px-4 py-2 text-sm font-medium rounded-lg bg-primary text-white hover:bg-primary/90 transition-colors">
+        <button @click="openNewResolution" class="mt-3 min-h-[44px] px-4 py-2 text-sm font-medium rounded-lg bg-action-primary-bg text-action-primary-text hover:bg-action-primary-hover-bg transition-colors">
           Configurar resolución
         </button>
       </div>
@@ -497,19 +497,19 @@ const taxLevels = [
         <h4 class="text-sm font-bold text-text-primary">{{ editingResolutionId ? 'Editar resolución' : 'Nueva resolución' }}</h4>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div class="flex flex-col gap-1">
-            <label class="text-xs font-medium text-text-secondary">Número de resolución <span class="text-red-500">*</span></label>
+            <label class="text-xs font-medium text-text-secondary">Número de resolución <span class="text-form-control-error">*</span></label>
             <input v-model="resolutionForm.resolution_number" type="text" placeholder="18764074347312" class="min-h-[44px] px-3 py-2 border border-border rounded-lg text-sm bg-background focus:outline-none focus:ring-2 focus:ring-primary" />
           </div>
           <div class="flex flex-col gap-1">
-            <label class="text-xs font-medium text-text-secondary">Prefijo <span class="text-red-500">*</span></label>
+            <label class="text-xs font-medium text-text-secondary">Prefijo <span class="text-form-control-error">*</span></label>
             <input v-model="resolutionForm.prefix" type="text" placeholder="LZT" maxlength="10" class="min-h-[44px] px-3 py-2 border border-border rounded-lg text-sm bg-background focus:outline-none focus:ring-2 focus:ring-primary uppercase" />
           </div>
           <div class="flex flex-col gap-1">
-            <label class="text-xs font-medium text-text-secondary">Rango desde <span class="text-red-500">*</span></label>
+            <label class="text-xs font-medium text-text-secondary">Rango desde <span class="text-form-control-error">*</span></label>
             <input v-model.number="resolutionForm.from_number" type="number" min="1" class="min-h-[44px] px-3 py-2 border border-border rounded-lg text-sm bg-background focus:outline-none focus:ring-2 focus:ring-primary" />
           </div>
           <div class="flex flex-col gap-1">
-            <label class="text-xs font-medium text-text-secondary">Rango hasta <span class="text-red-500">*</span></label>
+            <label class="text-xs font-medium text-text-secondary">Rango hasta <span class="text-form-control-error">*</span></label>
             <input v-model.number="resolutionForm.to_number" type="number" min="1" class="min-h-[44px] px-3 py-2 border border-border rounded-lg text-sm bg-background focus:outline-none focus:ring-2 focus:ring-primary" />
           </div>
           <!-- warocol.com#589 — `current_number` solo visible al editar.
@@ -543,11 +543,11 @@ const taxLevels = [
             </select>
           </div>
           <div class="flex flex-col gap-1">
-            <label class="text-xs font-medium text-text-secondary">Fecha desde <span class="text-red-500">*</span></label>
+            <label class="text-xs font-medium text-text-secondary">Fecha desde <span class="text-form-control-error">*</span></label>
             <input v-model="resolutionForm.date_from" type="date" class="min-h-[44px] px-3 py-2 border border-border rounded-lg text-sm bg-background focus:outline-none focus:ring-2 focus:ring-primary" />
           </div>
           <div class="flex flex-col gap-1">
-            <label class="text-xs font-medium text-text-secondary">Fecha hasta <span class="text-red-500">*</span></label>
+            <label class="text-xs font-medium text-text-secondary">Fecha hasta <span class="text-form-control-error">*</span></label>
             <input v-model="resolutionForm.date_to" type="date" class="min-h-[44px] px-3 py-2 border border-border rounded-lg text-sm bg-background focus:outline-none focus:ring-2 focus:ring-primary" />
           </div>
         </div>
@@ -558,7 +558,7 @@ const taxLevels = [
           <button
             @click="saveResolution"
             :disabled="isSavingResolution || !resolutionForm.prefix || !resolutionForm.resolution_number || !resolutionForm.date_from || !resolutionForm.date_to || isCurrentNumberInvalid"
-            class="min-h-[44px] px-4 py-2 text-sm font-medium rounded-lg bg-primary text-white hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+            class="min-h-[44px] px-4 py-2 text-sm font-medium rounded-lg bg-action-primary-bg text-action-primary-text hover:bg-action-primary-hover-bg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
           >
             <CheckIcon v-if="!isSavingResolution" class="w-4 h-4" aria-hidden="true" />
             <span>{{ isSavingResolution ? 'Guardando...' : (editingResolutionId ? 'Actualizar' : 'Crear resolución') }}</span>
@@ -624,7 +624,7 @@ const taxLevels = [
           <div class="inline-flex items-center gap-2 justify-center">
             <span
               class="text-xs font-semibold"
-              :class="row.is_active ? 'text-emerald-700 dark:text-emerald-400' : 'text-text-secondary'"
+              :class="row.is_active ? 'text-state-success-text' : 'text-text-secondary'"
             >
               {{ row.is_active ? 'Activa' : 'Inactiva' }}
             </span>
@@ -674,7 +674,7 @@ const taxLevels = [
                 </button>
                 <span
                   class="text-xs font-semibold"
-                  :class="row.is_active ? 'text-emerald-700 dark:text-emerald-400' : 'text-text-secondary'"
+                  :class="row.is_active ? 'text-state-success-text' : 'text-text-secondary'"
                 >
                   {{ row.is_active ? 'Activa' : 'Inactiva' }}
                 </span>
@@ -725,7 +725,7 @@ const taxLevels = [
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <!-- NIT -->
         <div class="flex flex-col gap-1">
-          <label for="fiscal-nit" class="text-sm font-medium text-text-primary">NIT <span class="text-red-500">*</span></label>
+          <label for="fiscal-nit" class="text-sm font-medium text-text-primary">NIT <span class="text-form-control-error">*</span></label>
           <input
             id="fiscal-nit"
             v-model="fiscalForm.nit"
@@ -737,7 +737,7 @@ const taxLevels = [
 
         <!-- Razón social -->
         <div class="flex flex-col gap-1">
-          <label for="fiscal-name" class="text-sm font-medium text-text-primary">Razón social <span class="text-red-500">*</span></label>
+          <label for="fiscal-name" class="text-sm font-medium text-text-primary">Razón social <span class="text-form-control-error">*</span></label>
           <input
             id="fiscal-name"
             v-model="fiscalForm.business_name"
@@ -837,7 +837,7 @@ const taxLevels = [
         <button
           @click="saveFiscalData"
           :disabled="isSavingFiscal || !fiscalForm.nit || !fiscalForm.business_name"
-          class="px-4 py-2 text-sm font-medium bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 min-h-[44px]"
+          class="px-4 py-2 text-sm font-medium bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 min-h-[44px]"
         >
           <CheckIcon v-if="!isSavingFiscal" class="w-4 h-4" aria-hidden="true" />
           <span>{{ isSavingFiscal ? 'Guardando...' : 'Guardar datos fiscales' }}</span>
@@ -908,7 +908,7 @@ const taxLevels = [
           type="button"
           @click="savePrintSettings"
           :disabled="isSavingFiscal"
-          class="px-4 py-2 text-sm font-medium bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 min-h-[44px]"
+          class="px-4 py-2 text-sm font-medium bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 min-h-[44px]"
         >
           <CheckIcon v-if="!isSavingFiscal" class="w-4 h-4" aria-hidden="true" />
           <span>{{ isSavingFiscal ? 'Guardando...' : 'Guardar personalización' }}</span>
@@ -1046,7 +1046,7 @@ const taxLevels = [
         <button
           @click="saveTaxConfig"
           :disabled="isSavingTax"
-          class="px-4 py-2 text-sm font-medium bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 min-h-[44px]"
+          class="px-4 py-2 text-sm font-medium bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 min-h-[44px]"
         >
           <CheckIcon v-if="!isSavingTax" class="w-4 h-4" aria-hidden="true" />
           <span>{{ isSavingTax ? 'Guardando...' : 'Guardar configuración' }}</span>
@@ -1065,7 +1065,7 @@ const taxLevels = [
         <!-- Environment -->
         <div class="flex items-center justify-between py-1">
           <span class="text-sm text-text-secondary">Entorno</span>
-          <span class="inline-flex items-center gap-1 text-xs font-bold px-2.5 py-1 rounded-full bg-amber-100 text-amber-700">
+          <span class="inline-flex items-center gap-1 text-xs font-bold px-2.5 py-1 rounded-full bg-badge-warning-bg text-badge-warning-text">
             <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" /></svg>
             {{ facturacionStatus?.environment || 'No configurado' }}
           </span>

--- a/pages/finanzas/arqueo/[id].vue
+++ b/pages/finanzas/arqueo/[id].vue
@@ -46,13 +46,13 @@
             <!-- Diferencia -->
             <div class="flex items-center gap-3">
               <div class="bg-background p-2 sm:p-3 rounded-lg border border-border flex-shrink-0">
-                <svg class="w-6 h-6 sm:w-8 sm:h-8" :class="cierre.cashDifference >= 0 ? 'text-emerald-600' : 'text-destructive'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-6 h-6 sm:w-8 sm:h-8" :class="cierre.cashDifference >= 0 ? 'text-state-success-text' : 'text-destructive'" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
               </div>
               <div>
                 <p class="text-xs font-medium text-text-secondary uppercase tracking-wide">Diferencia caja</p>
-                <p class="text-base font-semibold" :class="cierre.cashDifference >= 0 ? 'text-emerald-600' : 'text-destructive'">
+                <p class="text-base font-semibold" :class="cierre.cashDifference >= 0 ? 'text-state-success-text' : 'text-destructive'">
                   {{ cierre.cashDifference >= 0 ? '+' : '' }}{{ formatCurrency(cierre.cashDifference) }}
                 </p>
               </div>
@@ -136,7 +136,7 @@
             </div>
             <div class="flex justify-between px-4 py-2.5 text-sm font-semibold">
               <span>Diferencia</span>
-              <span :class="cierre.cashDifference >= 0 ? 'text-emerald-600' : 'text-destructive'">
+              <span :class="cierre.cashDifference >= 0 ? 'text-state-success-text' : 'text-destructive'">
                 {{ cierre.cashDifference >= 0 ? '+' : '' }}{{ formatCurrency(cierre.cashDifference) }}
               </span>
             </div>

--- a/pages/finanzas/arqueo/apertura.vue
+++ b/pages/finanzas/arqueo/apertura.vue
@@ -9,8 +9,8 @@
     />
 
     <div v-if="openSuccess" class="flex flex-col items-center justify-center py-16 gap-6 text-center">
-      <div class="w-16 h-16 rounded-full bg-emerald-100 flex items-center justify-center">
-        <svg class="w-9 h-9 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div class="w-16 h-16 rounded-full bg-state-success-bg flex items-center justify-center">
+        <svg class="w-9 h-9 text-state-success-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
       </div>
@@ -104,7 +104,7 @@
 
         <div
           v-if="isShiftOpen(existingShift)"
-          class="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2.5 text-sm text-emerald-800"
+          class="rounded-lg border border-state-success-border bg-state-success-bg px-3 py-2.5 text-sm text-state-success-text"
         >
           Este turno ya está abierto con fondo {{ formatCurrency(existingShift.openingCash) }}.
           <NuxtLink v-if="closeLink" :to="closeLink" class="font-semibold underline ml-1">Ir al cierre</NuxtLink>

--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -61,7 +61,7 @@
           <NuxtLink
             v-if="openTablesCount > 0"
             to="/mesas"
-            class="h-10 px-3 rounded-lg border-2 border-amber-300 bg-amber-50 text-xs font-medium text-amber-700 hover:bg-amber-100 transition-colors flex items-center gap-1.5"
+            class="h-10 px-3 rounded-lg border-2 border-state-warning-border bg-state-warning-bg text-xs font-medium text-state-warning-text hover:bg-state-warning-bg/80 transition-colors flex items-center gap-1.5"
           >
             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
@@ -250,7 +250,7 @@
   <!-- Delete confirmation modal -->
   <Teleport to="body">
     <div v-if="showDeleteModal" class="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div class="absolute inset-0 bg-black/50" @click="closeDeleteModal" />
+      <div class="absolute inset-0 bg-overlay-backdrop/50" @click="closeDeleteModal" />
       <div class="relative bg-surface rounded-xl shadow-xl w-full max-w-sm p-6">
         <div class="text-center">
           <div class="mx-auto mb-4 w-12 h-12 rounded-full bg-destructive/10 flex items-center justify-center">
@@ -273,7 +273,7 @@
             <button
               @click="handleDelete"
               :disabled="deleting"
-              class="flex-1 min-h-[44px] px-4 py-2 bg-destructive text-white rounded-lg text-sm font-semibold hover:bg-destructive/90 transition-colors disabled:opacity-50"
+              class="flex-1 min-h-[44px] px-4 py-2 bg-action-destructive-bg text-action-destructive-text rounded-lg text-sm font-semibold hover:bg-action-destructive-hover-bg transition-colors disabled:opacity-50"
             >
               {{ deleting ? 'Eliminando...' : 'Eliminar' }}
             </button>

--- a/pages/finanzas/arqueo/nuevo.vue
+++ b/pages/finanzas/arqueo/nuevo.vue
@@ -10,8 +10,8 @@
 
     <!-- ── SUCCESS ────────────────────────────────────────────────────────── -->
     <div v-if="cierreSuccess" class="flex flex-col items-center justify-center py-16 gap-6 text-center">
-      <div class="w-16 h-16 rounded-full bg-emerald-100 flex items-center justify-center">
-        <svg class="w-9 h-9 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div class="w-16 h-16 rounded-full bg-state-success-bg flex items-center justify-center">
+        <svg class="w-9 h-9 text-state-success-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
       </div>
@@ -46,7 +46,7 @@
         </div>
         <div class="flex justify-between px-4 py-2.5 text-sm">
           <span class="text-text-secondary">Diferencia</span>
-          <span class="font-semibold" :class="(successData?.cashDifference ?? 0) >= 0 ? 'text-emerald-600' : 'text-destructive'">
+          <span class="font-semibold" :class="(successData?.cashDifference ?? 0) >= 0 ? 'text-state-success-text' : 'text-destructive'">
             {{ (successData?.cashDifference ?? 0) >= 0 ? '+' : '' }}{{ formatCurrency(successData?.cashDifference) }}
           </span>
         </div>
@@ -233,21 +233,21 @@
           </div>
 
           <!-- Mesas abiertas: bloquear o continuar -->
-          <div v-if="xPreviewData.openTablesCount > 0" class="bg-surface border-2 border-amber-300 rounded-lg p-4 flex items-start gap-3">
-            <div class="w-10 h-10 rounded-lg bg-amber-100 border border-amber-200 flex items-center justify-center flex-shrink-0">
-              <svg class="w-5 h-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <div v-if="xPreviewData.openTablesCount > 0" class="bg-surface border-2 border-state-warning-border rounded-lg p-4 flex items-start gap-3">
+            <div class="w-10 h-10 rounded-lg bg-state-warning-bg border border-state-warning-border flex items-center justify-center flex-shrink-0">
+              <svg class="w-5 h-5 text-state-warning-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
               </svg>
             </div>
             <div class="flex-1 min-w-0">
-              <p class="text-sm font-semibold text-amber-800">{{ xPreviewData.openTablesCount }} {{ xPreviewData.openTablesCount === 1 ? tableSingular.toLowerCase() : tablePlural.toLowerCase() }} con cuenta abierta</p>
-              <p class="text-xs text-amber-700 mt-0.5">Cierra todas las {{ tablePlural.toLowerCase() }} en el POS antes de registrar el arqueo.</p>
+              <p class="text-sm font-semibold text-state-warning-text">{{ xPreviewData.openTablesCount }} {{ xPreviewData.openTablesCount === 1 ? tableSingular.toLowerCase() : tablePlural.toLowerCase() }} con cuenta abierta</p>
+              <p class="text-xs text-state-warning-text/90 mt-0.5">Cierra todas las {{ tablePlural.toLowerCase() }} en el POS antes de registrar el arqueo.</p>
               <div class="flex flex-wrap gap-2 mt-3">
-                <NuxtLink to="/pos" target="_blank" class="inline-flex items-center gap-1.5 min-h-[36px] px-4 py-1.5 rounded-lg bg-amber-600 text-white text-xs font-semibold hover:bg-amber-700 transition-colors">
+                <NuxtLink to="/pos" target="_blank" class="inline-flex items-center gap-1.5 min-h-[36px] px-4 py-1.5 rounded-lg bg-action-warning-bg text-action-warning-text text-xs font-semibold hover:bg-action-warning-hover-bg transition-colors">
                   <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" /></svg>
                   Ir al POS
                 </NuxtLink>
-                <button @click="refetchXPreview()" class="inline-flex items-center gap-1.5 min-h-[36px] px-4 py-1.5 rounded-lg border border-amber-300 bg-amber-50 text-amber-700 text-xs font-medium hover:bg-amber-100 transition-colors">
+                <button @click="refetchXPreview()" class="inline-flex items-center gap-1.5 min-h-[36px] px-4 py-1.5 rounded-lg border border-state-warning-border bg-state-warning-bg text-state-warning-text text-xs font-medium hover:bg-state-warning-bg/80 transition-colors">
                   <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" /></svg>
                   Verificar de nuevo
                 </button>
@@ -256,7 +256,7 @@
           </div>
           <div
             v-if="!shiftOpenForWindow"
-            class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 mb-3"
+            class="rounded-lg border border-state-warning-border bg-state-warning-bg px-4 py-3 text-sm text-state-warning-text mb-3"
           >
             Debes abrir el turno y declarar el fondo de caja antes de cerrar.
             <NuxtLink :to="aperturaLink" class="font-semibold underline ml-1">Abrir turno</NuxtLink>
@@ -477,7 +477,7 @@
                 <span
                   class="text-xs font-semibold px-2 py-0.5 rounded-full"
                   :class="methodDiff(method) >= 0
-                    ? 'bg-emerald-50 text-emerald-700 border border-emerald-200'
+                    ? 'bg-state-success-bg text-state-success-text border border-state-success-border'
                     : 'bg-destructive/10 text-destructive border border-destructive/20'"
                 >
                   {{ methodDiff(method) >= 0 ? '+' : '' }}{{ formatCurrency(methodDiff(method)) }}
@@ -570,18 +570,18 @@
             <!-- Diferencia — accent row -->
             <div
               class="px-3 py-2.5 border-t-2 flex items-center justify-between"
-              :class="cashDiff >= 0 ? 'bg-emerald-50 border-emerald-200' : 'bg-destructive/5 border-destructive/20'"
+              :class="cashDiff >= 0 ? 'bg-state-success-bg border-state-success-border' : 'bg-destructive/5 border-destructive/20'"
             >
               <div class="flex items-center gap-1.5">
-                <svg v-if="cashDiff >= 0" class="w-3.5 h-3.5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <svg v-if="cashDiff >= 0" class="w-3.5 h-3.5 text-state-success-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
                 </svg>
                 <svg v-else class="w-3.5 h-3.5 text-destructive" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                 </svg>
-                <span class="text-xs font-semibold" :class="cashDiff >= 0 ? 'text-emerald-700' : 'text-destructive'">Diferencia</span>
+                <span class="text-xs font-semibold" :class="cashDiff >= 0 ? 'text-state-success-text' : 'text-destructive'">Diferencia</span>
               </div>
-              <span class="text-sm font-bold" :class="cashDiff >= 0 ? 'text-emerald-700' : 'text-destructive'">
+              <span class="text-sm font-bold" :class="cashDiff >= 0 ? 'text-state-success-text' : 'text-destructive'">
                 {{ cashDiff >= 0 ? '+' : '' }}{{ formatCurrency(cashDiff) }}
               </span>
             </div>
@@ -673,10 +673,10 @@
           <!-- Diferencia caja -->
           <div
             class="rounded-lg border-2 px-3 py-2.5"
-            :class="cashDiff >= 0 ? 'bg-emerald-50 border-emerald-200' : 'bg-destructive/5 border-destructive/20'"
+            :class="cashDiff >= 0 ? 'bg-state-success-bg border-state-success-border' : 'bg-destructive/5 border-destructive/20'"
           >
-            <p class="text-xs mb-0.5" :class="cashDiff >= 0 ? 'text-emerald-700' : 'text-destructive'">Diferencia caja</p>
-            <p class="text-base font-bold" :class="cashDiff >= 0 ? 'text-emerald-700' : 'text-destructive'">
+            <p class="text-xs mb-0.5" :class="cashDiff >= 0 ? 'text-state-success-text' : 'text-destructive'">Diferencia caja</p>
+            <p class="text-base font-bold" :class="cashDiff >= 0 ? 'text-state-success-text' : 'text-destructive'">
               {{ cashDiff >= 0 ? '+' : '' }}{{ formatCurrency(cashDiff) }}
             </p>
           </div>
@@ -686,18 +686,18 @@
         <div class="flex items-start gap-3 p-3 rounded-lg border mb-3 transition-colors"
           :class="confirmArmed
             ? 'bg-destructive/10 border-destructive/30'
-            : 'bg-amber-50 border-amber-200'"
+            : 'bg-state-warning-bg border-state-warning-border'"
         >
           <svg class="w-4 h-4 flex-shrink-0 mt-0.5 transition-colors"
-            :class="confirmArmed ? 'text-destructive' : 'text-amber-600'"
+            :class="confirmArmed ? 'text-destructive' : 'text-state-warning-icon'"
             fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
           </svg>
           <div>
-            <p class="text-sm font-semibold transition-colors" :class="confirmArmed ? 'text-destructive' : 'text-amber-800'">
+            <p class="text-sm font-semibold transition-colors" :class="confirmArmed ? 'text-destructive' : 'text-state-warning-text'">
               {{ confirmArmed ? 'Confirma para cerrar definitivamente' : 'Esta acción no se puede deshacer' }}
             </p>
-            <p class="text-xs mt-0.5 transition-colors" :class="confirmArmed ? 'text-destructive/80' : 'text-amber-700'">
+            <p class="text-xs mt-0.5 transition-colors" :class="confirmArmed ? 'text-destructive/80' : 'text-state-warning-text/90'">
               El cierre Z quedará registrado y el período se bloqueará.
             </p>
           </div>
@@ -724,7 +724,7 @@
             :disabled="isSubmitting || !shiftOpenForWindow"
             class="min-h-[44px] px-6 py-2 rounded-lg text-sm font-semibold transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
             :class="confirmArmed
-              ? 'bg-destructive text-white hover:bg-destructive/90 ring-2 ring-destructive/30'
+              ? 'bg-action-destructive-bg text-action-destructive-text hover:bg-action-destructive-hover-bg ring-2 ring-action-destructive-focus-ring/30'
               : 'bg-primary text-primary-foreground hover:bg-primary/90'"
           >
             <svg v-if="isSubmitting" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
@@ -967,10 +967,10 @@ const GROUP_LABELS: Record<string, string> = {
 }
 
 const GROUP_COLORS: Record<string, { dot: string; badge: string }> = {
-  cash:    { dot: 'bg-emerald-500', badge: 'bg-emerald-50 text-emerald-700 border border-emerald-200' },
-  card:    { dot: 'bg-blue-500',    badge: 'bg-blue-50 text-blue-700 border border-blue-200'         },
+  cash:    { dot: 'bg-state-success-icon', badge: 'bg-state-success-bg text-state-success-text border border-state-success-border' },
+  card:    { dot: 'bg-state-info-icon',    badge: 'bg-state-info-bg text-state-info-text border border-state-info-border'         },
   digital: { dot: 'bg-state-info-icon',  badge: 'bg-state-info-bg text-state-info-text border border-state-info-border'   },
-  credit:  { dot: 'bg-amber-500',   badge: 'bg-amber-50 text-amber-700 border border-amber-200'      },
+  credit:  { dot: 'bg-state-warning-icon',   badge: 'bg-state-warning-bg text-state-warning-text border border-state-warning-border'      },
 }
 
 interface BreakdownRowRaw { group_slug: string; method_name: string; total: number }
@@ -1033,8 +1033,8 @@ const methodDiff = (method: BreakdownMethod) =>
   (parseInt(methodAmounts.value[method.key]) || 0) - method.total
 
 const diffResultClass = computed(() => {
-  if (cashDiff.value >= 0) return 'border-emerald-200 bg-emerald-50 text-emerald-800'
-  if (Math.abs(cashDiff.value) < (previewData.value?.cashExpected ?? 1) * 0.02) return 'border-amber-200 bg-amber-50 text-amber-800'
+  if (cashDiff.value >= 0) return 'border-state-success-border bg-state-success-bg text-state-success-text'
+  if (Math.abs(cashDiff.value) < (previewData.value?.cashExpected ?? 1) * 0.02) return 'border-state-warning-border bg-state-warning-bg text-state-warning-text'
   return 'border-destructive/30 bg-destructive/5 text-destructive'
 })
 

--- a/pages/finanzas/arqueo/x.vue
+++ b/pages/finanzas/arqueo/x.vue
@@ -106,7 +106,7 @@
             <span class="text-text-secondary">{{ tablePlural }} abiertas</span>
             <span
               class="font-medium"
-              :class="previewData.openTablesCount > 0 ? 'text-amber-600 font-semibold' : 'text-text-primary'"
+              :class="previewData.openTablesCount > 0 ? 'text-state-warning-text font-semibold' : 'text-text-primary'"
             >
               {{ previewData.openTablesCount }}
             </span>
@@ -260,10 +260,10 @@ const GROUP_LABELS: Record<string, string> = {
 }
 
 const GROUP_COLORS: Record<string, { dot: string; badge: string }> = {
-  cash:    { dot: 'bg-emerald-500', badge: 'bg-emerald-50 text-emerald-700' },
-  card:    { dot: 'bg-blue-500',    badge: 'bg-blue-50 text-blue-700'       },
+  cash:    { dot: 'bg-state-success-icon', badge: 'bg-state-success-bg text-state-success-text' },
+  card:    { dot: 'bg-state-info-icon',    badge: 'bg-state-info-bg text-state-info-text'       },
   digital: { dot: 'bg-state-info-icon',  badge: 'bg-state-info-bg text-state-info-text'   },
-  credit:  { dot: 'bg-amber-500',   badge: 'bg-amber-50 text-amber-700'     },
+  credit:  { dot: 'bg-state-warning-icon',   badge: 'bg-state-warning-bg text-state-warning-text'     },
 }
 
 interface BreakdownRowRaw { group_slug: string; method_name: string; total: number }

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -2,7 +2,7 @@
   <div class="page-layout">
 
     <!-- Loading overlay durante submit -->
-    <div v-if="isSubmitting" class="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <div v-if="isSubmitting" class="fixed inset-0 bg-overlay-backdrop/50 flex items-center justify-center z-50">
       <div class="bg-background rounded-xl p-6 flex flex-col items-center gap-3 shadow-xl">
         <CommonsTheCustomLoader size="large" />
         <p class="text-base font-semibold text-text-primary">Registrando arqueo...</p>
@@ -11,8 +11,8 @@
 
     <!-- ── SUCCESS ────────────────────────────────────────────────────────── -->
     <div v-if="cierreSuccess" class="flex flex-col items-center justify-center py-16 gap-6 text-center">
-      <div class="w-16 h-16 rounded-full bg-emerald-100 flex items-center justify-center">
-        <svg class="w-9 h-9 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div class="w-16 h-16 rounded-full bg-state-success-bg flex items-center justify-center">
+        <svg class="w-9 h-9 text-state-success-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
       </div>
@@ -47,7 +47,7 @@
         </div>
         <div class="flex justify-between px-4 py-2.5 text-sm">
           <span class="text-text-secondary">Diferencia</span>
-          <span class="font-semibold" :class="(successData?.cashDifference ?? 0) >= 0 ? 'text-emerald-600' : 'text-destructive'">
+          <span class="font-semibold" :class="(successData?.cashDifference ?? 0) >= 0 ? 'text-state-success-text' : 'text-destructive'">
             {{ (successData?.cashDifference ?? 0) >= 0 ? '+' : '' }}{{ formatCurrency(successData?.cashDifference) }}
           </span>
         </div>
@@ -107,7 +107,7 @@
 
         <p
           v-if="arqueoWindowMode === 'template' && shiftTemplates.length === 0 && !templatesLoading"
-          class="text-xs text-amber-700 whitespace-nowrap flex-shrink-0"
+          class="text-xs text-state-warning-text whitespace-nowrap flex-shrink-0"
         >
           Sin turnos activos
         </p>
@@ -203,7 +203,7 @@
               <input type="text" v-model="startTimeInput" placeholder="HH:MM" maxlength="5" inputmode="numeric"
                 @input="onTimeInput($event, 'start')" @focus="showDrop.start = true" @blur="hideDrop('start')"
                 class="h-10 w-20 px-2 text-sm font-mono rounded-lg border-2 bg-background text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/40 text-center"
-                :class="isMultiDay && !startTimeInput ? 'border-amber-400' : 'border-border'" />
+                :class="isMultiDay && !startTimeInput ? 'border-state-warning-border' : 'border-border'" />
               <ul v-if="showDrop.start && filteredTimes(startTimeInput).length" class="absolute z-50 top-full left-0 mt-1 w-24 max-h-44 overflow-y-auto bg-surface border border-border rounded-lg shadow-lg py-1">
                 <li v-for="t in filteredTimes(startTimeInput)" :key="t" @mousedown.prevent="pickTime('start', t)" class="px-3 py-1 text-sm font-mono text-text-primary hover:bg-background cursor-pointer">{{ t }}</li>
               </ul>
@@ -215,7 +215,7 @@
               <input type="text" v-model="endTimeInput" placeholder="HH:MM" maxlength="5" inputmode="numeric"
                 @input="onTimeInput($event, 'end')" @focus="showDrop.end = true" @blur="hideDrop('end')"
                 class="h-10 w-20 px-2 text-sm font-mono rounded-lg border-2 bg-background text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/40 text-center"
-                :class="isMultiDay && !endTimeInput ? 'border-amber-400' : 'border-border'" />
+                :class="isMultiDay && !endTimeInput ? 'border-state-warning-border' : 'border-border'" />
               <ul v-if="showDrop.end && filteredTimes(endTimeInput).length" class="absolute z-50 top-full left-0 mt-1 w-24 max-h-44 overflow-y-auto bg-surface border border-border rounded-lg shadow-lg py-1">
                 <li v-for="t in filteredTimes(endTimeInput)" :key="t" @mousedown.prevent="pickTime('end', t)" class="px-3 py-1 text-sm font-mono text-text-primary hover:bg-background cursor-pointer">{{ t }}</li>
               </ul>
@@ -256,7 +256,7 @@
               <div class="flex justify-between px-4 py-2.5 text-sm font-semibold"><span class="text-text-primary">Esperado en caja</span><span>{{ formatCurrency(xPreviewData.cashExpected) }}</span></div>
               <div class="flex justify-between px-4 py-2.5 text-sm">
                 <span class="text-text-secondary">{{ tablePlural }} abiertas</span>
-                <span class="font-medium" :class="xPreviewData.openTablesCount > 0 ? 'text-amber-600 font-semibold' : 'text-text-primary'">{{ xPreviewData.openTablesCount }}</span>
+                <span class="font-medium" :class="xPreviewData.openTablesCount > 0 ? 'text-state-warning-text font-semibold' : 'text-text-primary'">{{ xPreviewData.openTablesCount }}</span>
               </div>
             </div>
           </div>
@@ -274,7 +274,7 @@
 
         <div
           v-if="requiresShiftOpen && !shiftOpenForWindow"
-          class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+          class="rounded-lg border border-state-warning-border bg-state-warning-bg px-4 py-3 text-sm text-state-warning-text"
         >
           Debes abrir el turno y declarar el fondo de caja antes de cerrar.
           <NuxtLink :to="aperturaLink" class="font-semibold underline ml-1">Abrir turno</NuxtLink>
@@ -403,26 +403,26 @@
       <!-- ── Step content ─────────────────────────────────────────────────── -->
 
       <!-- Step 1: Cuentas abiertas (bloqueador — solo visible si hay mesas abiertas) -->
-      <div v-if="currentStep === 1" class="bg-surface border-2 border-amber-300 rounded-lg p-3 sm:p-4">
+      <div v-if="currentStep === 1" class="bg-surface border-2 border-state-warning-border rounded-lg p-3 sm:p-4">
         <div v-if="previewLoading" class="flex justify-center py-6">
           <CommonsTheCustomLoader size="large" />
         </div>
         <div v-else-if="previewData" class="flex items-start gap-3">
-          <div class="w-10 h-10 rounded-lg bg-amber-100 border border-amber-200 flex items-center justify-center flex-shrink-0">
-            <svg class="w-5 h-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <div class="w-10 h-10 rounded-lg bg-state-warning-bg border border-state-warning-border flex items-center justify-center flex-shrink-0">
+            <svg class="w-5 h-5 text-state-warning-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
           </div>
           <div class="flex-1 min-w-0">
-            <p class="text-sm font-semibold text-amber-800">
+            <p class="text-sm font-semibold text-state-warning-text">
               {{ previewData.openTablesCount }} {{ previewData.openTablesCount === 1 ? tableSingular.toLowerCase() : tablePlural.toLowerCase() }} con cuenta abierta
             </p>
-            <p class="text-xs text-amber-700 mt-0.5">Cierra todas las {{ tablePlural.toLowerCase() }} en el POS antes de registrar el arqueo.</p>
+            <p class="text-xs text-state-warning-text/90 mt-0.5">Cierra todas las {{ tablePlural.toLowerCase() }} en el POS antes de registrar el arqueo.</p>
             <div class="flex flex-wrap gap-2 mt-3">
               <NuxtLink
                 to="/pos"
                 target="_blank"
-                class="inline-flex items-center gap-1.5 min-h-[36px] px-4 py-1.5 rounded-lg bg-amber-600 text-white text-xs font-semibold hover:bg-amber-700 transition-colors"
+                class="inline-flex items-center gap-1.5 min-h-[36px] px-4 py-1.5 rounded-lg bg-action-warning-bg text-action-warning-text text-xs font-semibold hover:bg-action-warning-hover-bg transition-colors"
               >
                 <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
@@ -431,7 +431,7 @@
               </NuxtLink>
               <button
                 @click="refetchPreview()"
-                class="inline-flex items-center gap-1.5 min-h-[36px] px-4 py-1.5 rounded-lg border border-amber-300 bg-amber-50 text-amber-700 text-xs font-medium hover:bg-amber-100 transition-colors"
+                class="inline-flex items-center gap-1.5 min-h-[36px] px-4 py-1.5 rounded-lg border border-state-warning-border bg-state-warning-bg text-state-warning-text text-xs font-medium hover:bg-state-warning-bg/80 transition-colors"
               >
                 <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
@@ -645,7 +645,7 @@
                 <span
                   class="text-xs font-semibold px-2 py-0.5 rounded-full"
                   :class="methodDiff(method) >= 0
-                    ? 'bg-emerald-50 text-emerald-700 border border-emerald-200'
+                    ? 'bg-state-success-bg text-state-success-text border border-state-success-border'
                     : 'bg-destructive/10 text-destructive border border-destructive/20'"
                 >
                   {{ methodDiff(method) >= 0 ? '+' : '' }}{{ formatCurrency(methodDiff(method)) }}
@@ -738,18 +738,18 @@
             <!-- Diferencia — accent row -->
             <div
               class="px-3 py-2.5 border-t-2 flex items-center justify-between"
-              :class="cashDiff >= 0 ? 'bg-emerald-50 border-emerald-200' : 'bg-destructive/5 border-destructive/20'"
+              :class="cashDiff >= 0 ? 'bg-state-success-bg border-state-success-border' : 'bg-destructive/5 border-destructive/20'"
             >
               <div class="flex items-center gap-1.5">
-                <svg v-if="cashDiff >= 0" class="w-3.5 h-3.5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <svg v-if="cashDiff >= 0" class="w-3.5 h-3.5 text-state-success-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
                 </svg>
                 <svg v-else class="w-3.5 h-3.5 text-destructive" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
                 </svg>
-                <span class="text-xs font-semibold" :class="cashDiff >= 0 ? 'text-emerald-700' : 'text-destructive'">Diferencia</span>
+                <span class="text-xs font-semibold" :class="cashDiff >= 0 ? 'text-state-success-text' : 'text-destructive'">Diferencia</span>
               </div>
-              <span class="text-sm font-bold" :class="cashDiff >= 0 ? 'text-emerald-700' : 'text-destructive'">
+              <span class="text-sm font-bold" :class="cashDiff >= 0 ? 'text-state-success-text' : 'text-destructive'">
                 {{ cashDiff >= 0 ? '+' : '' }}{{ formatCurrency(cashDiff) }}
               </span>
             </div>
@@ -841,10 +841,10 @@
           <!-- Diferencia caja -->
           <div
             class="rounded-lg border-2 px-3 py-2.5"
-            :class="cashDiff >= 0 ? 'bg-emerald-50 border-emerald-200' : 'bg-destructive/5 border-destructive/20'"
+            :class="cashDiff >= 0 ? 'bg-state-success-bg border-state-success-border' : 'bg-destructive/5 border-destructive/20'"
           >
-            <p class="text-xs mb-0.5" :class="cashDiff >= 0 ? 'text-emerald-700' : 'text-destructive'">Diferencia caja</p>
-            <p class="text-base font-bold" :class="cashDiff >= 0 ? 'text-emerald-700' : 'text-destructive'">
+            <p class="text-xs mb-0.5" :class="cashDiff >= 0 ? 'text-state-success-text' : 'text-destructive'">Diferencia caja</p>
+            <p class="text-base font-bold" :class="cashDiff >= 0 ? 'text-state-success-text' : 'text-destructive'">
               {{ cashDiff >= 0 ? '+' : '' }}{{ formatCurrency(cashDiff) }}
             </p>
           </div>
@@ -871,18 +871,18 @@
         <div class="flex items-start gap-3 p-3 rounded-lg border mb-3 transition-colors"
           :class="confirmArmed
             ? 'bg-destructive/10 border-destructive/30'
-            : 'bg-amber-50 border-amber-200'"
+            : 'bg-state-warning-bg border-state-warning-border'"
         >
           <svg class="w-4 h-4 flex-shrink-0 mt-0.5 transition-colors"
-            :class="confirmArmed ? 'text-destructive' : 'text-amber-600'"
+            :class="confirmArmed ? 'text-destructive' : 'text-state-warning-icon'"
             fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
           </svg>
           <div>
-            <p class="text-sm font-semibold transition-colors" :class="confirmArmed ? 'text-destructive' : 'text-amber-800'">
+            <p class="text-sm font-semibold transition-colors" :class="confirmArmed ? 'text-destructive' : 'text-state-warning-text'">
               {{ confirmArmed ? 'Confirma para cerrar definitivamente' : 'Esta acción no se puede deshacer' }}
             </p>
-            <p class="text-xs mt-0.5 transition-colors" :class="confirmArmed ? 'text-destructive/80' : 'text-amber-700'">
+            <p class="text-xs mt-0.5 transition-colors" :class="confirmArmed ? 'text-destructive/80' : 'text-state-warning-text/90'">
               El cierre Z quedará registrado y el período se bloqueará.
             </p>
           </div>
@@ -909,7 +909,7 @@
             :disabled="isSubmitting"
             class="min-h-[44px] px-6 py-2 rounded-lg text-sm font-semibold transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
             :class="confirmArmed
-              ? 'bg-destructive text-white hover:bg-destructive/90 ring-2 ring-destructive/30'
+              ? 'bg-action-destructive-bg text-action-destructive-text hover:bg-action-destructive-hover-bg ring-2 ring-action-destructive-focus-ring/30'
               : 'bg-primary text-primary-foreground hover:bg-primary/90'"
           >
             <svg v-if="isSubmitting" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
@@ -1361,10 +1361,10 @@ const GROUP_LABELS: Record<string, string> = {
 }
 
 const GROUP_COLORS: Record<string, { dot: string; badge: string }> = {
-  cash:    { dot: 'bg-emerald-500', badge: 'bg-emerald-50 text-emerald-700 border border-emerald-200' },
-  card:    { dot: 'bg-blue-500',    badge: 'bg-blue-50 text-blue-700 border border-blue-200'         },
+  cash:    { dot: 'bg-state-success-icon', badge: 'bg-state-success-bg text-state-success-text border border-state-success-border' },
+  card:    { dot: 'bg-state-info-icon',    badge: 'bg-state-info-bg text-state-info-text border border-state-info-border'         },
   digital: { dot: 'bg-state-info-icon',  badge: 'bg-state-info-bg text-state-info-text border border-state-info-border'   },
-  credit:  { dot: 'bg-amber-500',   badge: 'bg-amber-50 text-amber-700 border border-amber-200'      },
+  credit:  { dot: 'bg-state-warning-icon',   badge: 'bg-state-warning-bg text-state-warning-text border border-state-warning-border'      },
 }
 
 interface BreakdownRowRaw { group_slug: string; method_name: string; total: number }
@@ -1424,8 +1424,8 @@ const methodDiff = (method: BreakdownMethod) =>
   (parseInt(methodAmounts.value[method.key]) || 0) - method.total
 
 const diffResultClass = computed(() => {
-  if (cashDiff.value >= 0) return 'border-emerald-200 bg-emerald-50 text-emerald-800'
-  if (Math.abs(cashDiff.value) < (previewData.value?.cashExpected ?? 1) * 0.02) return 'border-amber-200 bg-amber-50 text-amber-800'
+  if (cashDiff.value >= 0) return 'border-state-success-border bg-state-success-bg text-state-success-text'
+  if (Math.abs(cashDiff.value) < (previewData.value?.cashExpected ?? 1) * 0.02) return 'border-state-warning-border bg-state-warning-bg text-state-warning-text'
   return 'border-destructive/30 bg-destructive/5 text-destructive'
 })
 

--- a/pages/finanzas/cartera.vue
+++ b/pages/finanzas/cartera.vue
@@ -79,40 +79,40 @@ const { data: agingData, refetch: refetchAging } = useQuery({
 const agingBuckets = computed(() => agingData.value?.data ?? [])
 
 const agingDots = [
-  'bg-emerald-500',
-  'bg-amber-500',
-  'bg-orange-500',
-  'bg-red-500',
+  'bg-state-success-icon',
+  'bg-state-warning-icon',
+  'bg-state-warning-icon',
+  'bg-state-danger-icon',
 ]
 
 const agingColors = [
   {
-    bg: 'bg-emerald-50 dark:bg-emerald-950/30',
-    border: 'border-emerald-200 dark:border-emerald-800',
-    text: 'text-emerald-700 dark:text-emerald-400',
-    amount: 'text-emerald-800 dark:text-emerald-300',
-    active: 'ring-2 ring-emerald-400 dark:ring-emerald-500',
+    bg: 'bg-state-success-bg',
+    border: 'border-state-success-border',
+    text: 'text-state-success-text',
+    amount: 'text-state-success-text',
+    active: 'ring-2 ring-state-success-icon',
   },
   {
-    bg: 'bg-amber-50 dark:bg-amber-950/30',
-    border: 'border-amber-200 dark:border-amber-800',
-    text: 'text-amber-700 dark:text-amber-400',
-    amount: 'text-amber-800 dark:text-amber-300',
-    active: 'ring-2 ring-amber-400 dark:ring-amber-500',
+    bg: 'bg-state-warning-bg',
+    border: 'border-state-warning-border',
+    text: 'text-state-warning-text',
+    amount: 'text-state-warning-text',
+    active: 'ring-2 ring-state-warning-icon',
   },
   {
-    bg: 'bg-orange-50 dark:bg-orange-950/30',
-    border: 'border-orange-200 dark:border-orange-800',
-    text: 'text-orange-700 dark:text-orange-400',
-    amount: 'text-orange-800 dark:text-orange-300',
-    active: 'ring-2 ring-orange-400 dark:ring-orange-500',
+    bg: 'bg-state-warning-bg',
+    border: 'border-state-warning-border',
+    text: 'text-state-warning-text',
+    amount: 'text-state-warning-text',
+    active: 'ring-2 ring-state-warning-icon',
   },
   {
-    bg: 'bg-red-50 dark:bg-red-950/30',
-    border: 'border-red-200 dark:border-red-800',
-    text: 'text-red-700 dark:text-red-400',
-    amount: 'text-red-800 dark:text-red-300',
-    active: 'ring-2 ring-red-400 dark:ring-red-500',
+    bg: 'bg-state-danger-bg',
+    border: 'border-state-danger-border',
+    text: 'text-state-danger-text',
+    amount: 'text-state-danger-text',
+    active: 'ring-2 ring-state-danger-icon',
   },
 ]
 
@@ -284,12 +284,12 @@ onUnmounted(() => {
               </p>
             </div>
             <div class="flex flex-col items-end gap-1 flex-shrink-0">
-              <span class="text-sm font-bold" :class="item.status === 'overdue' ? 'text-red-700 dark:text-red-400' : 'text-amber-700 dark:text-amber-400'">
+              <span class="text-sm font-bold" :class="item.status === 'overdue' ? 'text-state-danger-text' : 'text-state-warning-text'">
                 {{ formatCurrency(item.total_outstanding) }}
               </span>
               <span
                 class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold"
-                :class="item.status === 'overdue' ? 'bg-red-100 text-red-800 dark:bg-red-950/40 dark:text-red-400' : 'bg-amber-100 text-amber-800 dark:bg-amber-950/40 dark:text-amber-400'"
+                :class="item.status === 'overdue' ? 'bg-state-danger-bg text-state-danger-text' : 'bg-state-warning-bg text-state-warning-text'"
               >
                 {{ item.status === 'overdue' ? 'VENCIDA' : 'Al día' }}
               </span>

--- a/pages/finanzas/contabilidad/asientos/index.vue
+++ b/pages/finanzas/contabilidad/asientos/index.vue
@@ -456,7 +456,7 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
     <!-- ── Void reason modal ───────────────────────────────────────────────── -->
     <Teleport to="body">
       <div v-if="showVoidModal" class="fixed inset-0 z-[70] flex items-center justify-center p-4">
-        <div class="absolute inset-0 bg-black/50" @click="closeVoidModal" />
+        <div class="absolute inset-0 bg-overlay-backdrop/50" @click="closeVoidModal" />
         <div class="relative bg-surface rounded-xl shadow-xl w-full max-w-sm p-6">
           <div class="text-center mb-4">
             <div class="mx-auto mb-3 w-12 h-12 rounded-full bg-destructive/10 flex items-center justify-center">
@@ -494,7 +494,7 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
             <button
               type="button"
               :disabled="voiding || !voidReason.trim()"
-              class="flex-1 min-h-[44px] px-4 py-2 bg-destructive text-white rounded-lg text-sm font-semibold hover:bg-destructive/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              class="flex-1 min-h-[44px] px-4 py-2 bg-action-destructive-bg text-action-destructive-text rounded-lg text-sm font-semibold hover:bg-action-destructive-hover-bg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
               @click="handleVoid"
             >
               <svg v-if="voiding" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">

--- a/pages/finanzas/contabilidad/balance-comprobacion.vue
+++ b/pages/finanzas/contabilidad/balance-comprobacion.vue
@@ -349,7 +349,7 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
         <!-- isBalanced badge -->
         <span
           v-if="isBalanced && rows.length > 0"
-          class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-700 border border-green-200"
+          class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold bg-badge-success-bg text-badge-success-text border border-badge-success-border"
         >
           <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />
@@ -474,7 +474,7 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
                     <span class="text-sm font-bold text-text-primary">TOTALES</span>
                     <span
                       v-if="isBalanced"
-                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-green-100 text-green-700"
+                      class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-badge-success-bg text-badge-success-text"
                     >
                       <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7" />

--- a/pages/finanzas/contabilidad/cuentas/[id].vue
+++ b/pages/finanzas/contabilidad/cuentas/[id].vue
@@ -34,12 +34,12 @@ const CLASS_VARIANTS: Record<string, string> = {
   '4': 'success', '5': 'destructive', '6': 'warning',
 }
 const CLASS_BG: Record<string, string> = {
-  '1': 'bg-primary/10', '2': 'bg-amber-100', '3': 'bg-status-chip-bg',
-  '4': 'bg-green-100',  '5': 'bg-red-100',   '6': 'bg-amber-100',
+  '1': 'bg-primary/10', '2': 'bg-state-warning-bg', '3': 'bg-status-chip-bg',
+  '4': 'bg-state-success-bg',  '5': 'bg-state-danger-bg',   '6': 'bg-state-warning-bg',
 }
 const CLASS_TEXT: Record<string, string> = {
-  '1': 'text-primary',   '2': 'text-amber-600',  '3': 'text-status-chip-text',
-  '4': 'text-green-600', '5': 'text-red-600',     '6': 'text-amber-600',
+  '1': 'text-primary',   '2': 'text-state-warning-text',  '3': 'text-status-chip-text',
+  '4': 'text-state-success-text', '5': 'text-state-danger-text',     '6': 'text-state-warning-text',
 }
 const pucLevel = (code: string) => {
   const len = code.length
@@ -777,7 +777,7 @@ const openEntryDetail = (entry: { id: string }) => {
     >
       <div
         v-if="showCreatePanel"
-        class="fixed inset-0 z-40 bg-black/40"
+        class="fixed inset-0 z-40 bg-overlay-backdrop/40"
         aria-hidden="true"
         @click="closeCreatePanel"
       />

--- a/pages/finanzas/contabilidad/cuentas/index.vue
+++ b/pages/finanzas/contabilidad/cuentas/index.vue
@@ -99,12 +99,12 @@ const CLASS_VARIANTS: Record<string, string> = {
   '4': 'success',  '5': 'destructive', '6': 'warning',
 }
 const CLASS_BG: Record<string, string> = {
-  '1': 'bg-primary/10',  '2': 'bg-amber-100',  '3': 'bg-status-chip-bg',
-  '4': 'bg-green-100',   '5': 'bg-red-100',    '6': 'bg-amber-100',
+  '1': 'bg-primary/10',  '2': 'bg-state-warning-bg',  '3': 'bg-status-chip-bg',
+  '4': 'bg-state-success-bg',   '5': 'bg-state-danger-bg',    '6': 'bg-state-warning-bg',
 }
 const CLASS_TEXT: Record<string, string> = {
-  '1': 'text-primary',   '2': 'text-amber-700', '3': 'text-status-chip-text',
-  '4': 'text-green-700', '5': 'text-red-700',   '6': 'text-amber-700',
+  '1': 'text-primary',   '2': 'text-state-warning-text', '3': 'text-status-chip-text',
+  '4': 'text-state-success-text', '5': 'text-state-danger-text',   '6': 'text-state-warning-text',
 }
 
 const pucLevel = (code: string): { label: string; variant: string } => {

--- a/pages/finanzas/gastos/[id]/index.vue
+++ b/pages/finanzas/gastos/[id]/index.vue
@@ -616,10 +616,10 @@
                 <td class="py-3 px-4">
                   <span
                     :class="{
-                      'bg-green-100 text-green-800': instance.status === 'paid',
-                      'bg-yellow-100 text-yellow-800': instance.status === 'pending',
-                      'bg-gray-100 text-gray-800': instance.status === 'skipped',
-                      'bg-red-100 text-red-800': instance.status === 'cancelled'
+                      'bg-state-success-bg text-state-success-text': instance.status === 'paid',
+                      'bg-state-warning-bg text-state-warning-text': instance.status === 'pending',
+                      'bg-status-chip-bg text-status-chip-text': instance.status === 'skipped',
+                      'bg-state-danger-bg text-state-danger-text': instance.status === 'cancelled'
                     }"
                     class="px-2 py-1 rounded-full text-xs font-medium"
                   >
@@ -649,7 +649,7 @@
                     <button
                       v-if="instance.status === 'pending'"
                       @click="markAsPaid(instance)"
-                      class="text-green-600 hover:text-green-700"
+                      class="text-state-success-text hover:text-state-success-text/80"
                       title="Marcar como pagado"
                     >
                       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/pages/finanzas/gastos/[id]/instancia.vue
+++ b/pages/finanzas/gastos/[id]/instancia.vue
@@ -351,8 +351,8 @@ watch(expenseData, (data) => {
             </div>
 
             <!-- Error message -->
-            <div v-if="error" class="mt-6 p-4 bg-red-50 border-2 border-red-200 rounded-lg">
-              <p class="text-sm text-red-600 font-medium">{{ error }}</p>
+            <div v-if="error" class="mt-6 p-4 bg-state-danger-bg border-2 border-state-danger-border rounded-lg">
+              <p class="text-sm text-state-danger-text font-medium">{{ error }}</p>
             </div>
 
             <!-- Actions -->

--- a/pages/finanzas/gastos/instancias/[id].vue
+++ b/pages/finanzas/gastos/instancias/[id].vue
@@ -37,10 +37,10 @@
           <div class="flex items-center gap-3">
             <span
               :class="{
-                'bg-green-100 text-green-800': instance.status === 'paid',
-                'bg-yellow-100 text-yellow-800': instance.status === 'pending',
-                'bg-gray-100 text-gray-800': instance.status === 'skipped',
-                'bg-red-100 text-red-800': instance.status === 'cancelled'
+                'bg-state-success-bg text-state-success-text': instance.status === 'paid',
+                'bg-state-warning-bg text-state-warning-text': instance.status === 'pending',
+                'bg-status-chip-bg text-status-chip-text': instance.status === 'skipped',
+                'bg-state-danger-bg text-state-danger-text': instance.status === 'cancelled'
               }"
               class="px-4 py-2 rounded-full text-sm font-semibold"
             >
@@ -227,7 +227,7 @@
                 type="button"
                 @click="uploadFiles"
                 :disabled="isUploading"
-                class="w-full px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 disabled:opacity-50 text-sm font-medium"
+                class="w-full px-4 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg disabled:opacity-50 text-sm font-medium"
               >
                 {{ isUploading ? 'Subiendo...' : `Subir ${selectedFiles.length} archivo(s)` }}
               </button>
@@ -243,7 +243,7 @@
           <button
             @click="markAsPaid"
             :disabled="isSubmitting"
-            class="px-6 py-3 bg-emerald-500 text-white rounded-lg hover:bg-emerald-600 transition-colors disabled:opacity-50 font-semibold flex items-center gap-2"
+            class="px-6 py-3 bg-action-success-bg text-action-success-text rounded-lg hover:bg-action-success-hover-bg transition-colors disabled:opacity-50 font-semibold flex items-center gap-2"
           >
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />

--- a/pages/finanzas/metodos-pago/[groupId].vue
+++ b/pages/finanzas/metodos-pago/[groupId].vue
@@ -97,7 +97,7 @@
               :disabled="savingId === item.id"
               class="text-xs px-2.5 py-1.5 rounded border transition-colors min-h-[32px] disabled:opacity-50"
               :class="item.isActive
-                ? 'border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100'
+                ? 'border-state-success-border bg-state-success-bg text-state-success-text hover:bg-state-success-bg/80'
                 : 'border-border bg-background text-text-secondary hover:text-text-primary'"
               @click.stop="toggleActive(item)"
             >
@@ -145,7 +145,7 @@
           :disabled="savingId === row.id"
           class="text-xs px-2.5 py-1.5 rounded border transition-colors min-h-[32px] disabled:opacity-50 disabled:cursor-not-allowed"
           :class="row.isActive
-            ? 'border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100'
+            ? 'border-state-success-border bg-state-success-bg text-state-success-text hover:bg-state-success-bg/80'
             : 'border-border bg-background text-text-secondary hover:text-text-primary'"
           :aria-label="row.isActive ? `Desactivar ${row.name}` : `Activar ${row.name}`"
           @click.stop="toggleActive(row)"
@@ -194,7 +194,7 @@
     >
       <div
         v-if="showPanel"
-        class="fixed inset-0 z-40 bg-black/40"
+        class="fixed inset-0 z-40 bg-overlay-backdrop/40"
         aria-hidden="true"
         @click="closePanel"
       />
@@ -309,9 +309,9 @@
           <!-- Warning: group has no default account configured -->
           <div
             v-else-if="panelMode === 'create' && group?.slug !== 'cash' && !group?.glAccountCode"
-            class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-800/40 dark:bg-amber-950/20"
+            class="rounded-lg border border-state-warning-border bg-state-warning-bg px-4 py-3"
           >
-            <p class="text-xs text-amber-700 dark:text-amber-400 leading-snug flex items-start gap-1.5">
+            <p class="text-xs text-state-warning-text leading-snug flex items-start gap-1.5">
               <svg class="w-3.5 h-3.5 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
               </svg>

--- a/pages/gestion/billing/index.vue
+++ b/pages/gestion/billing/index.vue
@@ -449,7 +449,7 @@ watch(() => currentTenant.value?.id, loadAll)
       :aria-label="wizardStep === 1 ? 'Seleccionar plan' : 'Confirmar pago'"
     >
       <!-- Backdrop -->
-      <div class="absolute inset-0 bg-black/50 backdrop-blur-sm" @click="showModal = false" />
+      <div class="absolute inset-0 bg-overlay-backdrop/50 backdrop-blur-sm" @click="showModal = false" />
 
       <!-- Modal -->
       <div :class="['relative bg-surface rounded-2xl shadow-xl border border-border w-full max-h-[90vh] overflow-y-auto transition-all', wizardStep === 1 && activePlans.length > 1 ? 'max-w-2xl' : 'max-w-md']">


### PR DESCRIPTION
## Summary

- Migrates billing confirmation, billing modal backdrop, invoice modal, payment selector, facturación states, finance/accounting panels, cartera, gastos, and arqueo flows from direct UI color utilities to semantic tokens.
- Keeps financial intent mapping explicit: success/paid/balanced, warning/pending/open tables/range burn, danger/rejected/overdue/cancelled, and info/config states.
- Documents the `SalesChart` Apex palette as a chart/data visualization exception while tokenizing its legend and loader UI.

## Search Counts

Scoped command from the research comment:

```bash
rg "(bg|text|border|ring|divide|from|to|via)-(white|black|slate|gray|zinc|red|green|yellow|amber|blue|indigo|purple|pink|orange|titan|crocus)-|#[0-9A-Fa-f]{3,8}|rgba?\(" pages/gestion/billing pages/billing pages/pagos pages/facturacion pages/finanzas components/analytics components/Finanzas components/payments components/billing -g '*.vue' --count-matches
```

Before: `394`
After: `37`

Remaining hits are documented/intentional categories: issue IDs in comments, placeholder examples, custom scrollbar/box-shadow rgba in existing CSS, and Apex chart palette literals in `components/analytics/SalesChart.vue`.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `npx nuxt prepare` passed; it emitted existing npm config warnings and an existing duplicate auto-import warning for `ActivePromotionRow`.

## Manual Visual Validation

User/manual scope: `/gestion/billing`, `/billing/confirmacion`, `/pagos`, `/facturacion`, `/finanzas/metodos-pago`, `/finanzas/cartera`, `/finanzas/arqueo/nuevo`, `/finanzas/arqueo/z`, and representative contabilidad pages.

Closes #1183
