### PR TITLE
Tokenizar superficies público, online y supplier

### DIFF
--- a/components/blog/BlogArticleCTA.vue
+++ b/components/blog/BlogArticleCTA.vue
@@ -25,7 +25,7 @@ const ctaContent = computed(() => useBlogCta(props.slug))
 .blog-cta-banner {
   margin-top: 3rem;
   border-radius: 0.875rem;
-  background-color: hsl(var(--crocus-600));
+  background-color: hsl(var(--primary));
 }
 
 .blog-cta-inner {
@@ -57,7 +57,7 @@ const ctaContent = computed(() => useBlogCta(props.slug))
   font-size: 1rem;
   font-weight: 700;
   line-height: 1.35;
-  color: #ffffff;
+  color: hsl(var(--action-primary-text));
   margin: 0;
 }
 
@@ -70,7 +70,7 @@ const ctaContent = computed(() => useBlogCta(props.slug))
 .blog-cta-body {
   font-size: 0.875rem;
   line-height: 1.55;
-  color: hsl(var(--crocus-100));
+  color: hsl(var(--badge-primary-hover-bg));
   margin: 0;
 }
 
@@ -81,9 +81,9 @@ const ctaContent = computed(() => useBlogCta(props.slug))
   border-radius: 0.5rem;
   font-size: 0.875rem;
   font-weight: 600;
-  color: #ffffff;
-  background-color: #ffffff;
-  color: hsl(var(--crocus-700));
+  color: hsl(var(--action-primary-text));
+  background-color: hsl(var(--surface));
+  color: hsl(var(--action-primary-hover-bg));
   border: none;
   cursor: pointer;
   white-space: nowrap;
@@ -92,7 +92,7 @@ const ctaContent = computed(() => useBlogCta(props.slug))
 }
 
 .blog-cta-button:hover {
-  background-color: hsl(var(--crocus-50));
+  background-color: hsl(var(--badge-primary-bg));
 }
 
 .blog-cta-button:active {
@@ -100,7 +100,7 @@ const ctaContent = computed(() => useBlogCta(props.slug))
 }
 
 .blog-cta-button:focus-visible {
-  outline: 2px solid #ffffff;
+  outline: 2px solid hsl(var(--action-primary-text));
   outline-offset: 3px;
 }
 </style>

--- a/components/blog/BlogArticleContent.vue
+++ b/components/blog/BlogArticleContent.vue
@@ -103,14 +103,14 @@ onMounted(() => {
 
 <template>
   <div>
-  <!-- Barra de progreso fija en el top — 2px, crocus-600 -->
+  <!-- Fixed top reading progress bar -->
   <div
     class="reading-progress-bar"
     :style="{ width: readingProgress + '%' }"
     aria-hidden="true"
   />
 
-  <div class="w-full bg-titan-100 py-6 sm:py-10 lg:py-14">
+  <div class="w-full bg-surface-secondary py-6 sm:py-10 lg:py-14">
     <div class="article-container">
 
       <!-- Breadcrumb -->
@@ -131,7 +131,7 @@ onMounted(() => {
         <slot name="cta" />
 
         <!-- Separador antes del autor -->
-        <hr class="my-12 border-0 h-px bg-gradient-to-r from-transparent via-titan-300 to-transparent">
+        <hr class="my-12 border-0 h-px bg-gradient-to-r from-transparent via-border to-transparent">
 
         <!-- Author Card -->
         <slot name="author" />
@@ -148,7 +148,7 @@ onMounted(() => {
   top: 0;
   left: 0;
   height: 2px;
-  background-color: hsl(var(--crocus-600));
+  background-color: hsl(var(--primary));
   z-index: 9999;
   transition: width 80ms linear;
   pointer-events: none;
@@ -161,12 +161,12 @@ onMounted(() => {
   gap: 1rem;
   padding: 1rem;
   margin: 2rem 0 1.75rem;
-  border: 1px solid hsl(var(--crocus-200));
+  border: 1px solid hsl(var(--badge-primary-border));
   border-radius: 0.5rem;
   background:
-    linear-gradient(135deg, hsl(var(--crocus-50)), #ffffff 58%),
-    hsl(var(--titan-50));
-  box-shadow: 0 10px 28px hsl(var(--ebony-900) / 0.08);
+    linear-gradient(135deg, hsl(var(--badge-primary-bg)), hsl(var(--surface)) 58%),
+    hsl(var(--surface));
+  box-shadow: 0 10px 28px hsl(var(--overlay-backdrop-bg) / 0.08);
 }
 
 :deep([data-mid-cta-content]) {
@@ -180,8 +180,8 @@ onMounted(() => {
   padding: 0 0.5rem;
   margin-bottom: 0.5rem;
   border-radius: 999px;
-  background-color: hsl(var(--crocus-100));
-  color: hsl(var(--crocus-800));
+  background-color: hsl(var(--badge-primary-hover-bg));
+  color: hsl(var(--action-primary-active-bg));
   font-size: 0.6875rem;
   font-weight: 700;
   line-height: 1;
@@ -189,7 +189,7 @@ onMounted(() => {
 
 :deep([data-mid-cta-headline]) {
   margin: 0;
-  color: hsl(var(--ebony-900));
+  color: hsl(var(--text-primary));
   font-size: 0.9375rem;
   font-weight: 750;
   line-height: 1.35;
@@ -197,7 +197,7 @@ onMounted(() => {
 
 :deep([data-mid-cta-body]) {
   margin: 0.25rem 0 0;
-  color: hsl(var(--ebony-600));
+  color: hsl(var(--text-secondary));
   font-size: 0.8125rem;
   font-weight: 500;
   line-height: 1.45;
@@ -209,8 +209,8 @@ onMounted(() => {
   padding: 0.5rem 0.875rem;
   border: none;
   border-radius: 0.4375rem;
-  background-color: hsl(var(--crocus-600));
-  color: #ffffff;
+  background-color: hsl(var(--primary));
+  color: hsl(var(--action-primary-text));
   cursor: pointer;
   font-family: inherit;
   font-size: 0.8125rem;
@@ -221,7 +221,7 @@ onMounted(() => {
 }
 
 :deep([data-blog-cta-btn]:hover) {
-  background-color: hsl(var(--crocus-700));
+  background-color: hsl(var(--action-primary-hover-bg));
 }
 
 :deep([data-blog-cta-btn]:active) {
@@ -229,7 +229,7 @@ onMounted(() => {
 }
 
 :deep([data-blog-cta-btn]:focus-visible) {
-  outline: 2px solid hsl(var(--crocus-300));
+  outline: 2px solid hsl(var(--focus-ring-subtle));
   outline-offset: 3px;
 }
 

--- a/components/blog/BlogArticleGrid.vue
+++ b/components/blog/BlogArticleGrid.vue
@@ -43,15 +43,15 @@ const getGradientClass = (index: number) => props.gradientClasses[index % props.
 <template>
   <section class="mb-10 lg:mb-20">
     <div class="flex items-center gap-3 mb-6 sm:mb-10">
-      <div class="w-1 h-5 bg-ebony-300 rounded-full"></div>
-      <span class="text-xs font-bold uppercase tracking-[0.2em] text-ebony-400">Más Artículos</span>
+      <div class="w-1 h-5 bg-border rounded-full"></div>
+      <span class="text-xs font-bold uppercase tracking-[0.2em] text-text-tertiary">Más Artículos</span>
     </div>
 
     <div v-if="props.articles.length > 0" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 lg:gap-7">
       <article
         v-for="(article, index) in props.articles"
         :key="article.id"
-        class="group bg-white rounded-2xl overflow-hidden border border-titan-200 hover:border-crocus-400 transition-colors duration-300 flex flex-col h-full"
+        class="group bg-surface rounded-2xl overflow-hidden border border-border hover:border-badge-primary-border transition-colors duration-300 flex flex-col h-full"
       >
         <NuxtLink :to="`/blog/${article.slug}`" class="relative h-40 sm:h-48 lg:h-52 overflow-hidden flex-shrink-0">
           <img
@@ -63,7 +63,7 @@ const getGradientClass = (index: number) => props.gradientClasses[index % props.
           <div v-else :class="['absolute inset-0', getGradientClass(index + 1)]"></div>
           <div class="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent"></div>
 
-          <span class="absolute bottom-3.5 right-3.5 inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-black/50 text-white text-[10px] font-medium backdrop-blur-sm">
+          <span class="absolute bottom-3.5 right-3.5 inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-overlay-backdrop/50 text-action-primary-text text-[10px] font-medium backdrop-blur-sm">
             <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
             </svg>
@@ -73,38 +73,38 @@ const getGradientClass = (index: number) => props.gradientClasses[index % props.
 
         <div class="p-4 sm:p-5 lg:p-6 flex flex-col flex-1">
           <NuxtLink :to="`/blog/${article.slug}`" class="block mb-3 flex-1">
-            <h3 class="text-lg font-bold text-ebony-900 leading-snug group-hover:text-crocus-700 transition-colors duration-200 line-clamp-2">
+            <h3 class="text-lg font-bold text-text-primary leading-snug group-hover:text-badge-primary-text transition-colors duration-200 line-clamp-2">
               {{ article.title }}
             </h3>
           </NuxtLink>
 
-          <p class="text-ebony-400 text-sm leading-relaxed mb-5 line-clamp-2">
+          <p class="text-text-tertiary text-sm leading-relaxed mb-5 line-clamp-2">
             {{ article.description }}
           </p>
 
-          <div class="flex items-center justify-between pt-4 border-t border-titan-200 mt-auto">
+          <div class="flex items-center justify-between pt-4 border-t border-border mt-auto">
             <div class="flex items-center gap-2.5">
               <img
                 v-if="article.author_avatar"
                 :src="article.author_avatar"
                 :alt="article.author_name || 'Autor'"
-                class="w-7 h-7 rounded-full object-cover ring-1 ring-titan-200"
+                class="w-7 h-7 rounded-full object-cover ring-1 ring-border"
               />
-              <div v-else class="w-7 h-7 rounded-full bg-crocus-50 flex items-center justify-center ring-1 ring-crocus-200">
-                <span class="text-crocus-600 text-[10px] font-bold">{{ article.author_name?.charAt(0) || 'W' }}</span>
+              <div v-else class="w-7 h-7 rounded-full bg-badge-primary-bg flex items-center justify-center ring-1 ring-badge-primary-border">
+                <span class="text-badge-primary-text text-[10px] font-bold">{{ article.author_name?.charAt(0) || 'W' }}</span>
               </div>
               <div>
-                <p class="text-xs font-semibold text-ebony-800 leading-none">{{ article.author_name || 'Waro Colombia' }}</p>
-                <p class="text-[10px] text-ebony-400 mt-0.5">{{ formatDate(article.created_at) }}</p>
+                <p class="text-xs font-semibold text-text-primary leading-none">{{ article.author_name || 'Waro Colombia' }}</p>
+                <p class="text-[10px] text-text-tertiary mt-0.5">{{ formatDate(article.created_at) }}</p>
               </div>
             </div>
 
             <NuxtLink
               :to="`/blog/${article.slug}`"
-              class="w-8 h-8 rounded-full bg-titan-100 hover:bg-crocus-600 flex items-center justify-center transition-colors duration-200 group/btn"
+              class="w-8 h-8 rounded-full bg-surface-secondary hover:bg-action-primary-bg flex items-center justify-center transition-colors duration-200 group/btn"
               aria-label="Leer artículo"
             >
-              <svg class="w-3.5 h-3.5 text-ebony-500 group-hover/btn:text-white transition-colors duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-3.5 h-3.5 text-text-secondary group-hover/btn:text-action-primary-text transition-colors duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/>
               </svg>
             </NuxtLink>
@@ -113,14 +113,14 @@ const getGradientClass = (index: number) => props.gradientClasses[index % props.
       </article>
     </div>
 
-    <div v-else-if="props.showEmpty" class="text-center py-24 bg-white rounded-2xl border border-dashed border-titan-400 shadow-sm">
-      <div class="w-16 h-16 rounded-2xl bg-crocus-50 flex items-center justify-center mx-auto mb-4">
-        <svg class="w-8 h-8 text-crocus-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <div v-else-if="props.showEmpty" class="text-center py-24 bg-surface rounded-2xl border border-dashed border-border shadow-sm">
+      <div class="w-16 h-16 rounded-2xl bg-badge-primary-bg flex items-center justify-center mx-auto mb-4">
+        <svg class="w-8 h-8 text-badge-primary-text" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
         </svg>
       </div>
-      <h3 class="text-lg font-bold text-ebony-900 mb-2">No hay artículos disponibles</h3>
-      <p class="text-sm text-ebony-400">Pronto publicaremos nuevo contenido.</p>
+      <h3 class="text-lg font-bold text-text-primary mb-2">No hay artículos disponibles</h3>
+      <p class="text-sm text-text-tertiary">Pronto publicaremos nuevo contenido.</p>
     </div>
   </section>
 </template>

--- a/components/blog/BlogArticleHero.vue
+++ b/components/blog/BlogArticleHero.vue
@@ -29,8 +29,8 @@ const formattedDate = computed(() => formatDate(props.publishedDate))
 </script>
 
 <template>
-  <!-- Light surface hero — superficie blanca elevada sobre titan-100 -->
-  <div class="w-full bg-white relative overflow-hidden border-b border-titan-200 shadow-sm pt-8 pb-8 sm:pt-12 sm:pb-12 lg:pt-20 lg:pb-20">
+  <!-- Light elevated article hero over the content surface -->
+  <div class="w-full bg-surface relative overflow-hidden border-b border-border shadow-sm pt-8 pb-8 sm:pt-12 sm:pb-12 lg:pt-20 lg:pb-20">
 
     <!-- Textura food emoji — misma técnica que blog index y home -->
     <div class="food-bg" aria-hidden="true">
@@ -64,7 +64,7 @@ const formattedDate = computed(() => formatDate(props.publishedDate))
 
           <!-- Title -->
           <h1
-            class="text-3xl sm:text-4xl md:text-5xl font-black leading-[1.1] tracking-tight text-ebony-900"
+            class="text-3xl sm:text-4xl md:text-5xl font-black leading-[1.1] tracking-tight text-text-primary"
             itemprop="headline"
           >
             {{ title }}
@@ -75,25 +75,25 @@ const formattedDate = computed(() => formatDate(props.publishedDate))
             <!-- Avatar -->
             <div
               v-if="author.profilePicture"
-              class="w-9 h-9 rounded-full overflow-hidden ring-2 ring-titan-200 flex-shrink-0"
+              class="w-9 h-9 rounded-full overflow-hidden ring-2 ring-border flex-shrink-0"
             >
               <img :src="author.profilePicture" :alt="author.name" class="w-full h-full object-cover">
             </div>
             <div
               v-else
-              class="w-9 h-9 rounded-full bg-crocus-100 flex items-center justify-center flex-shrink-0"
+              class="w-9 h-9 rounded-full bg-badge-primary-bg flex items-center justify-center flex-shrink-0"
             >
-              <span class="text-crocus-700 text-sm font-bold">{{ author.name?.charAt(0) || 'W' }}</span>
+              <span class="text-badge-primary-text text-sm font-bold">{{ author.name?.charAt(0) || 'W' }}</span>
             </div>
 
             <!-- Meta text -->
-            <div class="flex flex-wrap items-center gap-1.5 text-sm text-ebony-500">
-              <span class="font-semibold text-ebony-700" itemprop="author">{{ author.name }}</span>
-              <span class="text-titan-500">·</span>
+            <div class="flex flex-wrap items-center gap-1.5 text-sm text-text-secondary">
+              <span class="font-semibold text-text-primary" itemprop="author">{{ author.name }}</span>
+              <span class="text-text-tertiary">·</span>
               <time :datetime="new Date(publishedDate).toISOString()" itemprop="datePublished">
                 {{ formattedDate }}
               </time>
-              <span class="text-titan-500">·</span>
+              <span class="text-text-tertiary">·</span>
               <span>{{ readingTime }} min de lectura</span>
             </div>
           </div>
@@ -103,7 +103,7 @@ const formattedDate = computed(() => formatDate(props.publishedDate))
         <div class="hidden lg:block lg:col-span-5 lg:pt-14">
           <p
             v-if="description"
-            class="text-base lg:text-lg leading-relaxed text-ebony-600 border-l-2 border-crocus-300 pl-5"
+            class="text-base lg:text-lg leading-relaxed text-text-secondary border-l-2 border-badge-primary-border pl-5"
             itemprop="description"
           >
             {{ description }}

--- a/components/blog/BlogArticleImage.vue
+++ b/components/blog/BlogArticleImage.vue
@@ -9,8 +9,8 @@ const props = defineProps<Props>()
 </script>
 
 <template>
-  <!-- Transición suave: superficie blanca del hero → titan-100 del content -->
-  <div class="w-full bg-titan-100">
+  <!-- Soft transition from article hero surface to content surface -->
+  <div class="w-full bg-surface-secondary">
     <div class="article-container py-6 lg:py-8">
       <!-- Imagen con esquinas redondeadas, sin texto encima -->
       <div class="w-full aspect-video max-h-[480px] overflow-hidden rounded-xl shadow-sm">
@@ -25,7 +25,7 @@ const props = defineProps<Props>()
       <!-- Caption opcional -->
       <p
         v-if="caption"
-        class="mt-3 text-sm text-ebony-400 text-center italic"
+        class="mt-3 text-sm text-text-tertiary text-center italic"
       >
         {{ caption }}
       </p>

--- a/components/blog/BlogAuthorCard.vue
+++ b/components/blog/BlogAuthorCard.vue
@@ -29,7 +29,7 @@ const locationText = computed(() => {
 
 <template>
   <div
-    class="w-full lg:max-w-3xl p-6 lg:p-8 flex flex-col gap-6 bg-white border-2 border-crocus-600/30 rounded shadow-sm hover:border-crocus-600/80 transition-colors duration-300"
+    class="w-full lg:max-w-3xl p-6 lg:p-8 flex flex-col gap-6 bg-surface border-2 border-badge-primary-border/30 rounded shadow-sm hover:border-badge-primary-border/80 transition-colors duration-300"
     itemscope
     itemtype="https://schema.org/Person"
   >
@@ -37,7 +37,7 @@ const locationText = computed(() => {
     <div class="flex items-start gap-6">
       <!-- Avatar -->
       <div class="flex-shrink-0">
-        <div class="w-16 h-16 lg:w-20 lg:h-20 rounded-xl overflow-hidden ring-2 ring-titan-200">
+        <div class="w-16 h-16 lg:w-20 lg:h-20 rounded-xl overflow-hidden ring-2 ring-border">
           <img
             :src="author.profilePicture"
             :alt="`${author.name} profile picture`"
@@ -51,14 +51,14 @@ const locationText = computed(() => {
       <div class="flex flex-col gap-2 flex-1">
         <div>
           <h3
-            class="text-xl lg:text-2xl font-semibold text-ebony-900"
+            class="text-xl lg:text-2xl font-semibold text-text-primary"
             itemprop="name"
           >
             {{ author.name }}
           </h3>
           <p
             v-if="author.userName"
-            class="text-sm lg:text-base text-ebony-500"
+            class="text-sm lg:text-base text-text-secondary"
           >
             @{{ author.userName }}
           </p>
@@ -67,7 +67,7 @@ const locationText = computed(() => {
         <!-- Location -->
         <div v-if="locationText" class="flex items-center gap-2">
           <svg
-            class="w-4 h-4 lg:w-5 lg:h-5 text-ebony-400"
+            class="w-4 h-4 lg:w-5 lg:h-5 text-text-tertiary"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -79,7 +79,7 @@ const locationText = computed(() => {
               d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
             />
           </svg>
-          <p class="text-sm lg:text-base text-ebony-600 capitalize">
+          <p class="text-sm lg:text-base text-text-secondary capitalize">
             <span itemprop="addressLocality">{{ author.city }}</span>
             <span v-if="author.city && author.country">, </span>
             <span itemprop="addressCountry">{{ author.country }}</span>
@@ -91,7 +91,7 @@ const locationText = computed(() => {
     <!-- Description -->
     <div v-if="author.description" class="w-full">
       <p
-        class="text-base lg:text-lg text-ebony-600 leading-relaxed"
+        class="text-base lg:text-lg text-text-secondary leading-relaxed"
         itemprop="description"
       >
         {{ author.description }}
@@ -101,7 +101,7 @@ const locationText = computed(() => {
     <!-- Social Links -->
     <div
       v-if="author.socialLinks && Object.keys(author.socialLinks).length > 0"
-      class="flex gap-4 pt-2 border-t border-titan-200"
+      class="flex gap-4 pt-2 border-t border-border"
     >
       <!-- Twitter -->
       <a
@@ -109,7 +109,7 @@ const locationText = computed(() => {
         :href="author.socialLinks.twitter"
         target="_blank"
         rel="noopener noreferrer"
-        class="text-ebony-500 hover:text-crocus-600 transition-colors"
+        class="text-text-secondary hover:text-badge-primary-text transition-colors"
         aria-label="Twitter profile"
       >
         <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
@@ -123,7 +123,7 @@ const locationText = computed(() => {
         :href="author.socialLinks.linkedin"
         target="_blank"
         rel="noopener noreferrer"
-        class="text-ebony-500 hover:text-crocus-600 transition-colors"
+        class="text-text-secondary hover:text-badge-primary-text transition-colors"
         aria-label="LinkedIn profile"
       >
         <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
@@ -137,7 +137,7 @@ const locationText = computed(() => {
         :href="author.socialLinks.website"
         target="_blank"
         rel="noopener noreferrer"
-        class="text-ebony-500 hover:text-crocus-600 transition-colors"
+        class="text-text-secondary hover:text-badge-primary-text transition-colors"
         aria-label="Personal website"
       >
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/components/blog/BlogBreadcrumb.vue
+++ b/components/blog/BlogBreadcrumb.vue
@@ -43,7 +43,7 @@ const breadcrumbs = computed<BreadcrumbItem[]>(() => {
       <NuxtLink
         v-if="index === 0"
         :to="item.path || '/'"
-        class="text-ebony-500 hover:text-crocus-600 transition-colors"
+        class="text-text-secondary hover:text-badge-primary-text transition-colors"
         aria-label="Inicio"
       >
         <svg
@@ -59,7 +59,7 @@ const breadcrumbs = computed<BreadcrumbItem[]>(() => {
       <template v-else>
         <!-- Separator -->
         <svg
-          class="w-5 h-5 text-ebony-400"
+          class="w-5 h-5 text-text-tertiary"
           fill="currentColor"
           viewBox="0 0 20 20"
         >
@@ -74,13 +74,13 @@ const breadcrumbs = computed<BreadcrumbItem[]>(() => {
         <NuxtLink
           v-if="item.path"
           :to="item.path"
-          class="text-ebony-600 hover:text-crocus-600 capitalize transition-colors whitespace-nowrap"
+          class="text-text-secondary hover:text-badge-primary-text capitalize transition-colors whitespace-nowrap"
         >
           {{ item.label }}
         </NuxtLink>
         <span
           v-else
-          class="text-ebony-900 capitalize whitespace-nowrap font-medium"
+          class="text-text-primary capitalize whitespace-nowrap font-medium"
           aria-current="page"
         >
           {{ item.label }}

--- a/components/blog/BlogCard.vue
+++ b/components/blog/BlogCard.vue
@@ -25,7 +25,7 @@ const props = withDefaults(defineProps<Props>(), {
 const { formatDate } = useArticle()
 
 const gradientClasses = {
-  purple: 'bg-gradient-to-br from-blue-400 via-crocus-500 to-purple-400',
+  purple: 'bg-gradient-to-br from-badge-info-bg via-badge-primary-text to-badge-primary-bg',
   blue: 'bg-gradient-to-br from-blue-300 via-blue-500 to-cyan-400',
   orange: 'bg-gradient-to-br from-orange-300 via-orange-500 to-pink-400',
   dark: 'bg-gradient-to-br from-gray-600 via-gray-700 to-gray-500',
@@ -35,13 +35,13 @@ const gradientClasses = {
 
 <template>
   <article
-    class="group relative bg-white rounded-2xl overflow-hidden shadow-sm hover:shadow-xl transition-all duration-300 hover:-translate-y-1"
+    class="group relative bg-surface rounded-2xl overflow-hidden shadow-sm hover:shadow-xl transition-all duration-300 hover:-translate-y-1"
   >
     <NuxtLink :to="`/blog/${slug}`" class="block">
       <!-- Bookmark Icon -->
       <div class="absolute top-6 right-6 z-10">
-        <div class="w-10 h-10 bg-white rounded-lg flex items-center justify-center shadow-md opacity-0 group-hover:opacity-100 transition-opacity">
-          <svg class="w-5 h-5 text-ebony-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <div class="w-10 h-10 bg-surface rounded-lg flex items-center justify-center shadow-md opacity-0 group-hover:opacity-100 transition-opacity">
+          <svg class="w-5 h-5 text-text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
           </svg>
         </div>
@@ -55,12 +55,12 @@ const gradientClasses = {
         ]"
       >
         <!-- Dark overlay for better text contrast -->
-        <div class="absolute inset-0 bg-black/20" />
+        <div class="absolute inset-0 bg-overlay-backdrop/20" />
 
         <p
           v-if="imageText"
-          class="relative z-10 text-white text-3xl font-bold text-center px-8 leading-tight drop-shadow-lg"
-          style="text-shadow: 0 2px 8px rgba(0,0,0,0.3)"
+          class="relative z-10 text-action-primary-text text-3xl font-bold text-center px-8 leading-tight drop-shadow-lg"
+          style="text-shadow: 0 2px 8px hsl(var(--overlay-backdrop-bg) / 0.3)"
         >
           {{ imageText }}
         </p>
@@ -69,12 +69,12 @@ const gradientClasses = {
       <!-- Card Body -->
       <div class="p-8">
         <!-- Title -->
-        <h3 class="text-2xl font-bold text-ebony-900 mb-4 leading-tight group-hover:text-crocus-600 transition-colors">
+        <h3 class="text-2xl font-bold text-text-primary mb-4 leading-tight group-hover:text-badge-primary-text transition-colors">
           {{ title }}
         </h3>
 
         <!-- Excerpt -->
-        <p class="text-base text-ebony-600 leading-relaxed line-clamp-3 mb-6">
+        <p class="text-base text-text-secondary leading-relaxed line-clamp-3 mb-6">
           {{ excerpt }}
         </p>
 
@@ -89,7 +89,7 @@ const gradientClasses = {
             >
 
             <!-- Author Info -->
-            <div class="flex items-center gap-1.5 text-sm text-ebony-600">
+            <div class="flex items-center gap-1.5 text-sm text-text-secondary">
               <span class="font-normal">by</span>
               <span class="font-semibold">{{ author.name }}</span>
               <span class="font-normal">in</span>
@@ -98,7 +98,7 @@ const gradientClasses = {
           </div>
 
           <!-- Reading Time -->
-          <div class="flex items-center gap-1.5 text-sm text-ebony-500">
+          <div class="flex items-center gap-1.5 text-sm text-text-secondary">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <circle cx="12" cy="12" r="10" stroke-width="2" />
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6l4 2" />

--- a/components/blog/BlogFeaturedArticleCard.vue
+++ b/components/blog/BlogFeaturedArticleCard.vue
@@ -38,11 +38,11 @@ const getReadingTime = (description: string) => {
 <template>
   <section class="mb-10 sm:mb-14 lg:mb-20">
     <div class="flex items-center gap-3 mb-5 sm:mb-8">
-      <div class="w-1 h-5 bg-crocus-600 rounded-full"></div>
-      <span class="text-xs font-bold uppercase tracking-[0.2em] text-ebony-400">Destacado</span>
+      <div class="w-1 h-5 bg-action-primary-bg rounded-full"></div>
+      <span class="text-xs font-bold uppercase tracking-[0.2em] text-text-tertiary">Destacado</span>
     </div>
 
-    <article class="group relative bg-white rounded-2xl overflow-hidden border border-titan-200 hover:border-crocus-400 transition-colors duration-300 grid lg:grid-cols-[1.1fr_1fr]">
+    <article class="group relative bg-surface rounded-2xl overflow-hidden border border-border hover:border-badge-primary-border transition-colors duration-300 grid lg:grid-cols-[1.1fr_1fr]">
       <NuxtLink :to="`/blog/${article.slug}`" class="relative overflow-hidden min-h-[13rem] sm:min-h-[18rem] lg:min-h-[26rem]">
         <img
           v-if="article.cover"
@@ -55,26 +55,26 @@ const getReadingTime = (description: string) => {
       </NuxtLink>
 
       <div class="p-5 sm:p-8 lg:p-12 xl:p-14 flex flex-col justify-center">
-        <div class="flex items-center gap-2 mb-3 sm:mb-5 text-xs text-ebony-400 font-medium">
-          <svg class="w-3.5 h-3.5 text-crocus-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <div class="flex items-center gap-2 mb-3 sm:mb-5 text-xs text-text-tertiary font-medium">
+          <svg class="w-3.5 h-3.5 text-badge-primary-text" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
           </svg>
           {{ getReadingTime(article.description) }} min de lectura
         </div>
 
         <NuxtLink :to="`/blog/${article.slug}`">
-          <h2 class="text-xl sm:text-2xl lg:text-3xl xl:text-4xl font-bold mb-3 sm:mb-5 text-ebony-900 leading-tight group-hover:text-crocus-700 transition-colors duration-300">
+          <h2 class="text-xl sm:text-2xl lg:text-3xl xl:text-4xl font-bold mb-3 sm:mb-5 text-text-primary leading-tight group-hover:text-badge-primary-text transition-colors duration-300">
             {{ article.title }}
           </h2>
         </NuxtLink>
 
-        <p class="text-ebony-500 text-sm sm:text-base lg:text-lg leading-relaxed mb-5 sm:mb-8 line-clamp-2 sm:line-clamp-3">
+        <p class="text-text-secondary text-sm sm:text-base lg:text-lg leading-relaxed mb-5 sm:mb-8 line-clamp-2 sm:line-clamp-3">
           {{ article.description }}
         </p>
 
         <NuxtLink
           :to="`/blog/${article.slug}`"
-          class="inline-flex items-center gap-2 self-start px-5 py-2.5 bg-crocus-600 hover:bg-crocus-700 text-white text-sm font-semibold rounded-full transition-all duration-200 hover:gap-3 mb-4 sm:mb-8"
+          class="inline-flex items-center gap-2 self-start px-5 py-2.5 bg-action-primary-bg hover:bg-action-primary-hover-bg text-action-primary-text text-sm font-semibold rounded-full transition-all duration-200 hover:gap-3 mb-4 sm:mb-8"
         >
           Leer artículo
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -82,19 +82,19 @@ const getReadingTime = (description: string) => {
           </svg>
         </NuxtLink>
 
-        <div class="flex items-center gap-3 pt-6 border-t border-titan-200">
+        <div class="flex items-center gap-3 pt-6 border-t border-border">
           <img
             v-if="article.author_avatar"
             :src="article.author_avatar"
             :alt="article.author_name || 'Autor'"
-            class="w-9 h-9 rounded-full object-cover ring-2 ring-titan-200"
+            class="w-9 h-9 rounded-full object-cover ring-2 ring-border"
           />
-          <div v-else class="w-9 h-9 rounded-full bg-crocus-100 flex items-center justify-center ring-2 ring-titan-200">
-            <span class="text-crocus-600 text-sm font-bold">{{ article.author_name?.charAt(0) || 'W' }}</span>
+          <div v-else class="w-9 h-9 rounded-full bg-badge-primary-bg flex items-center justify-center ring-2 ring-border">
+            <span class="text-badge-primary-text text-sm font-bold">{{ article.author_name?.charAt(0) || 'W' }}</span>
           </div>
           <div>
-            <p class="text-sm font-semibold text-ebony-900 leading-none mb-0.5">{{ article.author_name || 'Waro Colombia' }}</p>
-            <p class="text-xs text-ebony-400">{{ formatDate(article.created_at) }}</p>
+            <p class="text-sm font-semibold text-text-primary leading-none mb-0.5">{{ article.author_name || 'Waro Colombia' }}</p>
+            <p class="text-xs text-text-tertiary">{{ formatDate(article.created_at) }}</p>
           </div>
         </div>
       </div>

--- a/components/blog/BlogFilters.vue
+++ b/components/blog/BlogFilters.vue
@@ -25,8 +25,8 @@ const handleFilterClick = (filter: string) => {
       :class="[
         'px-4 py-2 rounded-full text-sm font-medium transition-all',
         activeFilter === filter
-          ? 'bg-ebony-900 text-white'
-          : 'bg-transparent text-ebony-600 hover:bg-titan-100 hover:text-ebony-900'
+          ? 'bg-action-primary-bg text-action-primary-text'
+          : 'bg-transparent text-text-secondary hover:bg-surface-secondary hover:text-text-primary'
       ]"
       @click="handleFilterClick(filter)"
     >

--- a/components/blog/BlogHero.vue
+++ b/components/blog/BlogHero.vue
@@ -11,14 +11,14 @@ const props = defineProps<Props>()
 <template>
   <NuxtLink
     :to="link || '#'"
-    class="block relative bg-gradient-to-br from-crocus-500 via-crocus-600 to-crocus-700 rounded-2xl overflow-hidden min-h-3xl transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl hover:shadow-crocus-500/30 cursor-pointer"
+    class="block relative bg-gradient-to-br from-badge-primary-text via-action-primary-bg to-action-primary-hover-bg rounded-2xl overflow-hidden min-h-3xl transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl hover:shadow-action-primary-bg/30 cursor-pointer"
   >
     <!-- Dark overlay for better contrast -->
-    <div class="absolute inset-0 bg-black/10" />
+    <div class="absolute inset-0 bg-overlay-backdrop-subtle/10" />
 
     <!-- Decorative Element -->
     <div
-      class="absolute top-0 left-0 w-2/5 h-full bg-gradient-to-b from-crocus-400 to-crocus-600 opacity-80"
+      class="absolute top-0 left-0 w-2/5 h-full bg-gradient-to-b from-badge-primary-border to-action-primary-bg opacity-80"
       style="clip-path: polygon(0 0, 100% 0, 70% 100%, 0 100%)"
     />
 
@@ -26,15 +26,15 @@ const props = defineProps<Props>()
     <div class="relative z-10 h-full flex items-center justify-center text-center p-12">
       <div>
         <h1
-          class="text-6xl lg:text-8xl font-bold text-white leading-tight tracking-tight mb-4 drop-shadow-2xl"
-          style="text-shadow: 0 4px 12px rgba(0,0,0,0.4)"
+          class="text-6xl lg:text-8xl font-bold text-action-primary-text leading-tight tracking-tight mb-4 drop-shadow-2xl"
+          style="text-shadow: 0 4px 12px hsl(var(--overlay-backdrop-bg) / 0.4)"
         >
           {{ title }}
         </h1>
         <p
           v-if="subtitle"
-          class="text-2xl lg:text-3xl font-medium text-white/95 drop-shadow-lg"
-          style="text-shadow: 0 2px 8px rgba(0,0,0,0.3)"
+          class="text-2xl lg:text-3xl font-medium text-action-primary-text/95 drop-shadow-lg"
+          style="text-shadow: 0 2px 8px hsl(var(--overlay-backdrop-bg) / 0.3)"
         >
           {{ subtitle }}
         </p>

--- a/components/blog/BlogPagination.vue
+++ b/components/blog/BlogPagination.vue
@@ -11,10 +11,10 @@ const emit = defineEmits<{
 
 <template>
   <div v-if="totalPages > 1" class="flex justify-center mt-12 mb-4">
-    <nav class="flex items-center gap-1.5 bg-white p-1.5 rounded-xl shadow-sm border border-titan-200">
+    <nav class="flex items-center gap-1.5 bg-surface p-1.5 rounded-xl shadow-sm border border-border">
       <button
         :disabled="currentPage === 1"
-        class="p-2 rounded-lg hover:bg-titan-100 text-ebony-500 disabled:opacity-40 disabled:hover:bg-transparent transition-colors"
+        class="p-2 rounded-lg hover:bg-surface-secondary text-text-secondary disabled:opacity-40 disabled:hover:bg-transparent transition-colors"
         aria-label="Página anterior"
         @click="emit('page', currentPage - 1)"
       >
@@ -29,8 +29,8 @@ const emit = defineEmits<{
         :class="[
           'w-9 h-9 rounded-lg text-sm font-medium transition-all',
           currentPage === page
-            ? 'bg-crocus-600 text-white shadow-sm'
-            : 'text-ebony-500 hover:bg-titan-100'
+            ? 'bg-action-primary-bg text-action-primary-text shadow-sm'
+            : 'text-text-secondary hover:bg-surface-secondary'
         ]"
         @click="emit('page', page)"
       >
@@ -39,7 +39,7 @@ const emit = defineEmits<{
 
       <button
         :disabled="currentPage === totalPages"
-        class="p-2 rounded-lg hover:bg-titan-100 text-ebony-500 disabled:opacity-40 disabled:hover:bg-transparent transition-colors"
+        class="p-2 rounded-lg hover:bg-surface-secondary text-text-secondary disabled:opacity-40 disabled:hover:bg-transparent transition-colors"
         aria-label="Página siguiente"
         @click="emit('page', currentPage + 1)"
       >

--- a/components/blog/BlogSearchBar.vue
+++ b/components/blog/BlogSearchBar.vue
@@ -8,10 +8,10 @@ const searchQuery = defineModel<string>('modelValue', { default: '' })
       v-model="searchQuery"
       type="text"
       placeholder="Buscar en el blog..."
-      class="w-full px-5 py-4 pl-12 bg-titan-50 border border-titan-300 rounded-xl text-ebony-900 text-base font-normal placeholder:text-ebony-400 focus:outline-none focus:border-crocus-500 focus:ring-4 focus:ring-crocus-500/10 transition-all"
+      class="w-full px-5 py-4 pl-12 bg-surface-secondary border border-border rounded-xl text-text-primary text-base font-normal placeholder:text-text-tertiary focus:outline-none focus:border-form-control-focus-border focus:ring-4 focus:ring-form-control-focus-ring transition-all"
     >
     <svg
-      class="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-ebony-500 pointer-events-none"
+      class="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-text-secondary pointer-events-none"
       fill="none"
       stroke="currentColor"
       viewBox="0 0 24 24"

--- a/components/directory/DirectoryView.vue
+++ b/components/directory/DirectoryView.vue
@@ -70,15 +70,15 @@ useHead({
       />
       <div class="absolute inset-0 bg-foreground/50" />
       <div class="relative max-w-6xl mx-auto text-center w-full px-4 py-12">
-        <h1 class="text-4xl md:text-5xl font-bold mb-4 tracking-tight text-white">
+        <h1 class="text-4xl md:text-5xl font-bold mb-4 tracking-tight text-action-primary-text">
           Restaurantes en {{ cityName }}
         </h1>
-        <p class="text-lg md:text-xl text-white/90 mb-6 max-w-2xl mx-auto">
+        <p class="text-lg md:text-xl text-action-primary-text/90 mb-6 max-w-2xl mx-auto">
           Descubre los mejores restaurantes de la ciudad
         </p>
         <span
           v-if="!pending && restaurants.length > 0"
-          class="inline-block px-4 py-1.5 bg-white/20 backdrop-blur-sm rounded-full text-sm font-semibold text-white"
+          class="inline-block px-4 py-1.5 bg-surface/20 backdrop-blur-sm rounded-full text-sm font-semibold text-action-primary-text"
         >
           {{ restaurants.length }} restaurante{{ restaurants.length !== 1 ? 's' : '' }}
         </span>
@@ -100,7 +100,7 @@ useHead({
         <h2 class="text-2xl font-bold text-foreground mb-4">Error al cargar restaurantes</h2>
         <p class="text-muted-foreground mb-6">{{ error }}</p>
         <button
-          class="px-6 py-3 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+          class="px-6 py-3 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors"
           @click="refreshNuxtData(`restaurants-${props.citySlug}`)"
         >
           Reintentar
@@ -168,7 +168,7 @@ useHead({
           </div>
 
           <div class="p-6">
-            <h3 class="text-lg font-semibold text-foreground mb-2 group-hover:text-primary transition-colors">
+            <h3 class="text-lg font-semibold text-foreground mb-2 group-hover:text-badge-primary-text transition-colors">
               {{ (restaurant as any).display_name }}
             </h3>
 
@@ -189,7 +189,7 @@ useHead({
             </div>
 
             <div class="mt-4 pt-4 border-t border-border">
-              <span class="inline-flex items-center gap-1.5 px-4 py-1.5 bg-primary/10 text-primary rounded-xl text-sm font-semibold group-hover:bg-primary group-hover:text-primary-foreground transition-colors">
+              <span class="inline-flex items-center gap-1.5 px-4 py-1.5 bg-badge-primary-bg text-badge-primary-text rounded-xl text-sm font-semibold group-hover:bg-primary group-hover:text-badge-primary-text-foreground transition-colors">
                 Ver menú
                 <ChevronRightIcon class="w-4 h-4" aria-hidden="true" />
               </span>
@@ -207,7 +207,7 @@ useHead({
         <p class="text-muted-foreground mb-6">Estamos sumando restaurantes en esta ciudad. Pronto vas a encontrar opciones aquí.</p>
         <NuxtLink
           to="/"
-          class="inline-flex items-center gap-2 px-6 py-3 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+          class="inline-flex items-center gap-2 px-6 py-3 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors"
         >
           Ver otras ciudades
           <ChevronRightIcon class="w-4 h-4" aria-hidden="true" />

--- a/components/online/AddressForm.vue
+++ b/components/online/AddressForm.vue
@@ -13,7 +13,7 @@
           class="py-3 px-4 border-2 rounded-lg text-sm font-semibold text-center cursor-pointer transition-all"
           :class="formData.address_type === type.value
             ? 'bg-primary border-primary text-primary-foreground'
-            : 'bg-background border-border text-muted-foreground hover:border-primary hover:text-primary'"
+            : 'bg-background border-border text-muted-foreground hover:border-action-outline-focus-ring hover:text-action-outline-hover-text'"
           @click="formData.address_type = type.value"
         >
           {{ type.icon }} {{ type.label }}
@@ -31,8 +31,8 @@
         v-model="formData.address_line1"
         type="text"
         class="w-full h-10 px-3 rounded-md border border-input bg-background text-sm text-foreground
-               placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring
-               focus:border-ring transition-all"
+               placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-form-control-focus-ring
+               focus:border-form-control-focus-border transition-all"
         placeholder="Calle 100 # 20-30"
         required
       />
@@ -48,8 +48,8 @@
         v-model="formData.address_line2"
         type="text"
         class="w-full h-10 px-3 rounded-md border border-input bg-background text-sm text-foreground
-               placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring
-               focus:border-ring transition-all"
+               placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-form-control-focus-ring
+               focus:border-form-control-focus-border transition-all"
         placeholder="Apto 501, Torre B (opcional)"
       />
     </div>
@@ -65,8 +65,8 @@
           v-model="formData.city"
           type="text"
           class="w-full h-10 px-3 rounded-md border border-input bg-background text-sm text-foreground
-                 placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring
-                 focus:border-ring transition-all"
+                 placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-form-control-focus-ring
+                 focus:border-form-control-focus-border transition-all"
           placeholder="Bogotá"
           required
         />
@@ -81,8 +81,8 @@
           v-model="formData.state"
           type="text"
           class="w-full h-10 px-3 rounded-md border border-input bg-background text-sm text-foreground
-                 placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring
-                 focus:border-ring transition-all"
+                 placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-form-control-focus-ring
+                 focus:border-form-control-focus-border transition-all"
           placeholder="Cundinamarca"
           required
         />
@@ -99,8 +99,8 @@
         v-model="formData.postal_code"
         type="text"
         class="w-full h-10 px-3 rounded-md border border-input bg-background text-sm text-foreground
-               placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring
-               focus:border-ring transition-all"
+               placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-form-control-focus-ring
+               focus:border-form-control-focus-border transition-all"
         placeholder="110111"
         maxlength="10"
       />
@@ -115,8 +115,8 @@
         id="delivery_notes"
         v-model="formData.delivery_notes"
         class="w-full px-3 py-2 rounded-md border border-input bg-background text-sm text-foreground
-               placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring
-               focus:border-ring transition-all resize-y min-h-[80px] font-[inherit]"
+               placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-form-control-focus-ring
+               focus:border-form-control-focus-border transition-all resize-y min-h-[80px] font-[inherit]"
         placeholder="Ej: Portería con citófono - timbre 501, entregar al portero"
         rows="3"
         maxlength="500"
@@ -146,7 +146,7 @@
       <button
         type="button"
         class="sm:w-auto w-full py-3 px-6 text-sm font-semibold rounded-lg transition-all
-               bg-muted text-muted-foreground hover:bg-muted/80
+               bg-action-secondary-bg text-action-secondary-text hover:bg-action-secondary-hover-bg
                disabled:opacity-50 disabled:cursor-not-allowed"
         @click="$emit('cancel')"
         :disabled="loading"
@@ -156,7 +156,7 @@
       <button
         type="submit"
         class="sm:w-auto w-full py-3 px-6 text-sm font-semibold rounded-lg transition-all
-               bg-primary text-primary-foreground hover:bg-primary/90
+               bg-action-primary-bg text-action-primary-text hover:bg-action-primary-hover-bg
                disabled:opacity-50 disabled:cursor-not-allowed"
         :disabled="loading || !isFormValid"
       >

--- a/components/online/AddressSelector.vue
+++ b/components/online/AddressSelector.vue
@@ -9,8 +9,8 @@
         :key="address.id"
         class="relative flex flex-col sm:flex-row gap-3 p-4 bg-background border-2 border-border rounded-xl
                text-left cursor-pointer transition-all duration-200 w-full
-               hover:border-primary hover:shadow-sm"
-        :class="{ 'border-primary bg-primary/10': selectedId === address.id }"
+               hover:border-action-outline-focus-ring hover:shadow-sm"
+        :class="{ 'border-action-primary-border bg-badge-primary-bg': selectedId === address.id }"
         @click="$emit('select', address.id)"
       >
         <!-- Selection Indicator -->
@@ -28,8 +28,8 @@
             <span
               class="text-xs font-semibold px-2.5 py-1 rounded-xl"
               :class="{
-                'bg-blue-100 text-blue-800': address.address_type === 'home',
-                'bg-yellow-100 text-yellow-800': address.address_type === 'work',
+                'bg-badge-info-bg text-badge-info-text': address.address_type === 'home',
+                'bg-badge-warning-bg text-badge-warning-text': address.address_type === 'work',
                 'bg-muted text-muted-foreground': address.address_type === 'other',
               }"
             >
@@ -37,7 +37,7 @@
             </span>
             <span
               v-if="address.is_default"
-              class="text-[11px] font-bold px-2 py-0.5 rounded-full bg-green-500 text-white"
+              class="text-[11px] font-bold px-2 py-0.5 rounded-full bg-badge-success-bg text-badge-success-text"
             >
               Predeterminada
             </span>
@@ -64,7 +64,7 @@
         <div v-if="!readonly" class="flex gap-1.5 items-start" @click.stop>
           <button
             class="min-h-[44px] min-w-[44px] flex items-center justify-center bg-background border border-border rounded-lg
-                   transition-all text-primary hover:bg-primary/10 hover:border-primary"
+                   transition-all text-icon-button-primary-text hover:bg-icon-button-primary-hover-bg hover:border-action-outline-focus-ring"
             @click="$emit('edit', address.id)"
             aria-label="Editar dirección"
           >
@@ -83,7 +83,7 @@
           </button>
           <button
             class="min-h-[44px] min-w-[44px] flex items-center justify-center bg-background border border-border rounded-lg
-                   transition-all text-destructive hover:bg-destructive/10 hover:border-destructive"
+                   transition-all text-icon-button-destructive-text hover:bg-icon-button-destructive-hover-bg hover:border-action-destructive-border"
             @click="$emit('delete', address.id)"
             aria-label="Eliminar dirección"
           >
@@ -116,7 +116,7 @@
       class="w-full flex items-center justify-center gap-2 py-3.5 px-5
              bg-background border-2 border-dashed border-border rounded-xl
              text-primary text-sm font-semibold cursor-pointer transition-all
-             hover:border-primary hover:bg-primary/10"
+             hover:border-action-outline-focus-ring hover:bg-action-outline-hover-bg"
       @click="$emit('add-new')"
     >
       <svg

--- a/components/online/CartBottomBar.vue
+++ b/components/online/CartBottomBar.vue
@@ -1,7 +1,7 @@
 <template>
   <Teleport to="body">
     <Transition name="bar-slide">
-      <div v-if="cartStore.itemCount > 0 && acceptsOnlineOrders" class="cart-bottom-bar bg-white border-t border-border shadow-2xl">
+      <div v-if="cartStore.itemCount > 0 && acceptsOnlineOrders" class="cart-bottom-bar bg-surface border-t border-border shadow-2xl">
         <!-- Inner container — aligned with body content
              (max-w-7xl mx-auto px-4 — same shape PublicMenu and
              RestaurantHeader use). Previous `md:px-16 2xl:px-[30rem]`

--- a/components/online/CartDrawer.vue
+++ b/components/online/CartDrawer.vue
@@ -35,7 +35,7 @@
           </h2>
 
           <button
-            class="w-10 h-10 flex items-center justify-center bg-muted rounded-lg text-muted-foreground hover:bg-border hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            class="w-10 h-10 flex items-center justify-center bg-icon-button-neutral-bg rounded-lg text-icon-button-neutral-text hover:bg-icon-button-neutral-hover-bg hover:text-icon-button-neutral-hover-text transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring"
             aria-label="Cerrar carrito"
             @click="close"
           >
@@ -73,7 +73,7 @@
           <h3 class="text-base font-bold text-foreground mb-1">Tu carrito está vacío</h3>
           <p class="text-sm text-muted-foreground mb-4">Agrega productos para comenzar tu pedido</p>
           <button
-            class="px-8 py-3 bg-primary text-primary-foreground rounded-lg font-semibold hover:opacity-90 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            class="px-8 py-3 bg-primary text-primary-foreground rounded-lg font-semibold hover:opacity-90 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring"
             @click="close"
           >
             Explorar Menú
@@ -124,14 +124,14 @@
                 <div v-if="confirmClear" key="confirm" class="flex items-center gap-2 justify-center py-1">
                   <span class="text-sm text-muted-foreground">¿Vaciar carrito?</span>
                   <button
-                    class="px-3 py-1.5 text-sm font-semibold bg-destructive text-destructive-foreground rounded-lg hover:opacity-90 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    class="px-3 py-1.5 text-sm font-semibold bg-destructive text-destructive-foreground rounded-lg hover:opacity-90 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring"
                     :disabled="cartStore.isLoading"
                     @click="confirmAndClearCart"
                   >
                     Sí, vaciar
                   </button>
                   <button
-                    class="px-3 py-1.5 text-sm font-semibold bg-muted text-foreground rounded-lg hover:bg-border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    class="px-3 py-1.5 text-sm font-semibold bg-action-secondary-bg text-action-secondary-text rounded-lg hover:bg-action-secondary-hover-bg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring"
                     @click="confirmClear = false"
                   >
                     Cancelar
@@ -140,7 +140,7 @@
                 <button
                   v-else
                   key="trigger"
-                  class="w-full py-2 text-sm font-semibold text-destructive hover:bg-destructive/5 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  class="w-full py-2 text-sm font-semibold text-action-destructive-text hover:bg-action-destructive-hover-bg rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring"
                   @click="confirmClear = true"
                 >
                   Vaciar Carrito

--- a/components/online/CartItem.vue
+++ b/components/online/CartItem.vue
@@ -38,7 +38,7 @@
         <div class="flex items-center gap-1.5 bg-muted rounded-lg p-1">
           <button
             class="w-8 h-8 flex items-center justify-center bg-background rounded-md text-muted-foreground
-                   hover:bg-primary hover:text-primary-foreground transition-colors
+                   hover:bg-action-primary-bg hover:text-action-primary-text transition-colors
                    disabled:opacity-50 disabled:cursor-not-allowed
                    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             :disabled="loading"
@@ -64,7 +64,7 @@
 
           <button
             class="w-8 h-8 flex items-center justify-center bg-background rounded-md text-muted-foreground
-                   hover:bg-primary hover:text-primary-foreground transition-colors
+                   hover:bg-action-primary-bg hover:text-action-primary-text transition-colors
                    disabled:opacity-50 disabled:cursor-not-allowed
                    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             :disabled="loading || restaurantClosed"
@@ -92,7 +92,7 @@
         <!-- Remove button -->
         <button
           class="w-8 h-8 flex items-center justify-center bg-transparent border border-border rounded-md text-destructive
-                 hover:bg-destructive/10 hover:border-destructive transition-colors
+                 hover:bg-icon-button-destructive-hover-bg hover:border-action-destructive-border transition-colors
                  disabled:opacity-50 disabled:cursor-not-allowed
                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           :disabled="loading"

--- a/components/online/CartSummary.vue
+++ b/components/online/CartSummary.vue
@@ -38,7 +38,7 @@
     </div>
 
     <!-- Minimum order warning -->
-    <div v-if="normalizedMinimumOrder > subtotal" class="flex flex-col items-center text-center text-sm p-2.5 rounded-lg bg-amber-50 border border-amber-300 text-amber-900 mb-3">
+    <div v-if="normalizedMinimumOrder > subtotal" class="flex flex-col items-center text-center text-sm p-2.5 rounded-lg bg-state-warning-bg border border-state-warning-border text-state-warning-text mb-3">
       <span class="flex items-center gap-1.5">
         <svg class="w-4 h-4 flex-shrink-0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.732 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />

--- a/components/online/OTPInput.vue
+++ b/components/online/OTPInput.vue
@@ -13,7 +13,7 @@
         class="w-11 h-14 sm:w-[52px] sm:h-16 text-2xl sm:text-3xl font-bold text-center
                rounded-xl border-2 transition-all duration-200
                border-border bg-background text-foreground
-               focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/10
+               focus:outline-none focus:border-form-control-focus-border focus:ring-2 focus:ring-form-control-focus-ring
                disabled:bg-muted disabled:text-muted-foreground disabled:cursor-not-allowed"
         :class="{
           'border-primary bg-primary/10': digits[index] !== '' && !hasError,

--- a/components/online/ProductDetailDrawer.vue
+++ b/components/online/ProductDetailDrawer.vue
@@ -663,7 +663,7 @@ onMounted(() => {
   z-index: 101;
   display: flex;
   flex-direction: column;
-  box-shadow: -4px 0 20px rgba(0, 0, 0, 0.15);
+  box-shadow: -4px 0 20px hsl(var(--overlay-backdrop-bg) / 0.15);
   overflow: hidden;
 }
 
@@ -1065,7 +1065,7 @@ onMounted(() => {
   border-radius: 50%;
   background: hsl(var(--card));
   transition: transform 0.2s ease;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  box-shadow: 0 1px 3px hsl(var(--overlay-backdrop-bg) / 0.2);
 }
 
 .toggle-switch.on .toggle-knob {
@@ -1242,7 +1242,7 @@ onMounted(() => {
     max-width: 100%;
     max-height: 92vh;
     border-radius: 20px 20px 0 0;
-    box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 -4px 20px hsl(var(--overlay-backdrop-bg) / 0.15);
   }
 
   .product-slide-enter-from,

--- a/components/online/checkout/StepConfirm.vue
+++ b/components/online/checkout/StepConfirm.vue
@@ -56,7 +56,7 @@
 
     <!-- Verified email -->
     <div class="flex items-center gap-3 p-4 rounded-xl border border-border bg-card">
-      <svg class="w-5 h-5 text-green-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <svg class="w-5 h-5 text-state-success-icon flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
       </svg>
       <div class="text-sm">
@@ -136,17 +136,17 @@
         <!-- Saldo actual -->
         <div class="flex items-center justify-between px-4 py-3.5">
           <p class="text-xs font-semibold text-text-secondary uppercase tracking-wider">Saldo actual</p>
-          <p class="text-lg font-bold text-slate-800 tabular-nums">
+          <p class="text-lg font-bold text-text-primary tabular-nums">
             {{ warosBalance !== null ? warosBalance.toLocaleString('es-CO') : '—' }}
           </p>
         </div>
 
         <!-- Ganarás con este pedido -->
-        <div v-if="warosEstimate !== null" class="flex items-center justify-between px-4 py-3.5 bg-emerald-50">
-          <p class="text-xs font-semibold text-emerald-700 uppercase tracking-wider">Ganarás con este pedido</p>
+        <div v-if="warosEstimate !== null" class="flex items-center justify-between px-4 py-3.5 bg-state-success-bg">
+          <p class="text-xs font-semibold text-state-success-text uppercase tracking-wider">Ganarás con este pedido</p>
           <p
             class="text-lg font-extrabold tabular-nums"
-            :class="warosEstimate > 0 ? 'text-emerald-600' : 'text-slate-300'"
+            :class="warosEstimate > 0 ? 'text-state-success-text' : 'text-text-tertiary'"
           >
             {{ warosEstimate > 0 ? `+${warosEstimate.toLocaleString('es-CO')}` : '—' }}
           </p>
@@ -185,12 +185,12 @@
     <Transition name="fade">
       <div
         v-if="showSuccessModal"
-        class="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-5"
+        class="fixed inset-0 bg-overlay-backdrop-strong/60 backdrop-blur-sm z-50 flex items-center justify-center p-5"
       >
         <div class="bg-background rounded-2xl p-8 max-w-sm w-full text-center shadow-2xl">
           <!-- Check icon -->
-          <div class="w-20 h-20 rounded-full bg-green-100 flex items-center justify-center mx-auto mb-5">
-            <svg class="w-10 h-10 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div class="w-20 h-20 rounded-full bg-state-success-bg flex items-center justify-center mx-auto mb-5">
+            <svg class="w-10 h-10 text-state-success-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
             </svg>
           </div>
@@ -204,13 +204,13 @@
           <!-- Pickup PIN -->
           <div
             v-if="confirmedOrder?.pickup_pin || otpAuthStore.pickupPin"
-            class="bg-amber-50 border-2 border-amber-300 rounded-xl p-5 mb-5"
+            class="bg-state-warning-bg border-2 border-state-warning-border rounded-xl p-5 mb-5"
           >
-            <p class="text-xs font-semibold text-amber-800 mb-2 uppercase tracking-wide">Tu PIN de recogida</p>
-            <p class="text-4xl font-extrabold text-amber-900 tracking-[0.2em] mb-2">
+            <p class="text-xs font-semibold text-state-warning-text mb-2 uppercase tracking-wide">Tu PIN de recogida</p>
+            <p class="text-4xl font-extrabold text-state-warning-text tracking-[0.2em] mb-2">
               {{ confirmedOrder?.pickup_pin || otpAuthStore.pickupPin }}
             </p>
-            <p class="text-xs text-amber-700">Muestra este PIN al recoger tu pedido</p>
+            <p class="text-xs text-state-warning-text">Muestra este PIN al recoger tu pedido</p>
           </div>
 
           <!-- ETA message -->

--- a/components/online/checkout/StepDeliveryInfo.vue
+++ b/components/online/checkout/StepDeliveryInfo.vue
@@ -40,7 +40,7 @@
       <template v-else>
         <div
           v-if="addressFormValid"
-          class="flex items-center justify-between gap-2 p-3 rounded-md bg-green-50 border border-green-200 text-green-800 text-sm font-medium"
+          class="flex items-center justify-between gap-2 p-3 rounded-md bg-state-success-bg border border-state-success-border text-state-success-text text-sm font-medium"
         >
           <div class="flex items-center gap-2">
             <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -50,7 +50,7 @@
           </div>
           <button
             type="button"
-            class="text-xs font-medium text-green-700 underline hover:text-green-900 flex-shrink-0"
+            class="text-xs font-medium text-state-success-text underline hover:text-state-success-icon flex-shrink-0"
             @click="addressFormValid = false"
           >
             Cambiar
@@ -98,7 +98,7 @@
           class="flex items-center gap-3 p-4 rounded-xl border-2 transition-all duration-200 text-left"
           :class="!isScheduled
             ? 'border-primary bg-primary/10 text-primary'
-            : 'border-border bg-card text-foreground hover:border-primary/50'"
+            : 'border-border bg-card text-foreground hover:border-action-outline-focus-ring'"
           @click="isScheduled = false"
         >
           <svg class="w-7 h-7 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -119,7 +119,7 @@
           class="flex items-center gap-3 p-4 rounded-xl border-2 transition-all duration-200 text-left"
           :class="isScheduled
             ? 'border-primary bg-primary/10 text-primary'
-            : 'border-border bg-card text-foreground hover:border-primary/50'"
+            : 'border-border bg-card text-foreground hover:border-action-outline-focus-ring'"
           @click="isScheduled = true"
         >
           <svg class="w-7 h-7 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/components/online/checkout/StepIdentity.vue
+++ b/components/online/checkout/StepIdentity.vue
@@ -11,8 +11,8 @@
 
     <!-- Already verified -->
     <div v-else-if="subStep === 'verified'" class="flex flex-col items-center gap-3 py-6 text-center">
-      <div class="w-16 h-16 rounded-full bg-green-100 flex items-center justify-center">
-        <Icon name="heroicons:check-circle" class="w-9 h-9 text-green-600" />
+      <div class="w-16 h-16 rounded-full bg-state-success-bg flex items-center justify-center">
+        <Icon name="heroicons:check-circle" class="w-9 h-9 text-state-success-icon" />
       </div>
       <div>
         <p class="font-semibold text-foreground">Identidad verificada</p>
@@ -58,7 +58,7 @@
         <div
           v-for="warning in customerWarnings"
           :key="warning"
-          class="flex items-start gap-2 p-3 rounded-md bg-yellow-50 border border-yellow-200 text-yellow-800 text-sm"
+          class="flex items-start gap-2 p-3 rounded-md bg-state-warning-bg border border-state-warning-border text-state-warning-text text-sm"
         >
           <Icon name="heroicons:information-circle" class="w-4 h-4 flex-shrink-0 mt-0.5" />
           {{ warning }}
@@ -91,7 +91,7 @@
         </p>
       </div>
 
-      <div v-if="countdown > 0" class="text-center text-sm font-medium text-amber-600">
+      <div v-if="countdown > 0" class="text-center text-sm font-medium text-state-warning-text">
         <Icon name="heroicons:clock" class="w-4 h-4 inline mr-1" />
         Reenviar disponible en {{ countdown }}s
       </div>

--- a/components/online/checkout/StepOrderType.vue
+++ b/components/online/checkout/StepOrderType.vue
@@ -17,7 +17,7 @@
         :class="[
           cartStore.orderType === type.value
             ? 'border-primary bg-primary/10 text-primary'
-            : 'border-border bg-card text-foreground hover:border-primary/50',
+            : 'border-border bg-card text-foreground hover:border-action-outline-focus-ring',
           !isAvailable(type.value) && 'opacity-40 cursor-not-allowed pointer-events-none'
         ]"
         :disabled="!isAvailable(type.value)"

--- a/components/public/HomeHero.vue
+++ b/components/public/HomeHero.vue
@@ -42,7 +42,7 @@ h1 {
   margin-bottom: 24px;
   text-transform: uppercase;
   line-height: 0.95;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  text-shadow: 0 2px 4px hsl(var(--overlay-backdrop-bg) / 0.1);
 }
 
 .subtitle {
@@ -80,7 +80,7 @@ h1 {
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px hsl(var(--overlay-backdrop-bg) / 0.1);
   min-width: 160px;
 }
 
@@ -94,7 +94,7 @@ h1 {
   background: hsl(262, 83%, 58%);
   color: white;
   transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(141, 54, 235, 0.2);
+  box-shadow: 0 6px 20px hsl(var(--action-primary-bg) / 0.2);
 }
 
 @media (max-width: 768px) {

--- a/components/public/PublicMenu.vue
+++ b/components/public/PublicMenu.vue
@@ -11,7 +11,7 @@
             class="px-4 py-2 min-h-[44px] rounded-xl font-medium whitespace-nowrap transition-all duration-200"
             :class="selectedCategory === category.id
               ? 'bg-primary text-primary-foreground'
-              : 'bg-muted text-foreground hover:bg-secondary'"
+              : 'bg-action-secondary-bg text-action-secondary-text hover:bg-action-secondary-hover-bg'"
           >
             {{ category.name }}
             <span class="ml-2 text-xs opacity-75">

--- a/components/public/PublicProductCard.vue
+++ b/components/public/PublicProductCard.vue
@@ -11,7 +11,7 @@
     @keydown.space.prevent="handleClick"
   >
     <!-- Product Image/Emoji -->
-    <div class="relative h-48 bg-gradient-to-br from-gray-100 to-gray-200 overflow-hidden">
+    <div class="relative h-48 bg-gradient-to-br from-surface-secondary to-surface-tertiary overflow-hidden">
       <img
         v-if="product.image_url && product.image_url.startsWith('http')"
         :src="product.image_url"
@@ -24,7 +24,7 @@
 
       <!-- Availability badge -->
       <div v-if="!product.is_available" class="absolute top-3 right-3">
-        <span class="px-3 py-1 text-xs font-semibold bg-red-500 text-white rounded-full">
+        <span class="px-3 py-1 text-xs font-semibold bg-state-danger-action-bg text-state-danger-action-text rounded-full">
           No disponible
         </span>
       </div>
@@ -61,7 +61,7 @@
           v-if="!isInCart"
           @click.stop="handleClick"
           :disabled="!product.is_available || restaurantClosed"
-          class="w-11 h-11 flex items-center justify-center rounded-xl bg-primary text-primary-foreground text-xl font-bold hover:bg-primary/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-none"
+          class="w-11 h-11 flex items-center justify-center rounded-xl bg-action-primary-bg text-action-primary-text text-xl font-bold hover:bg-action-primary-hover-bg transition-colors disabled:opacity-40 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-action-primary-focus-ring focus-visible:outline-none"
           aria-label="Agregar al carrito"
         >+</button>
 
@@ -70,7 +70,7 @@
           <button
             @click="decrease"
             :disabled="cartStore.isLoading"
-            class="w-10 h-10 flex items-center justify-center rounded-xl bg-muted hover:bg-red-100 text-foreground hover:text-red-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed text-lg font-bold"
+            class="w-10 h-10 flex items-center justify-center rounded-xl bg-icon-button-neutral-bg hover:bg-icon-button-destructive-hover-bg text-icon-button-neutral-text hover:text-icon-button-destructive-text transition-colors disabled:opacity-40 disabled:cursor-not-allowed text-lg font-bold"
             aria-label="Quitar uno"
           >−</button>
           <span class="min-w-[1.5rem] text-center font-bold text-foreground text-sm">
@@ -79,7 +79,7 @@
           <button
             @click="increase"
             :disabled="cartStore.isLoading || !product.is_available || restaurantClosed"
-            class="w-10 h-10 flex items-center justify-center rounded-xl bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed text-lg font-bold focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-none"
+            class="w-10 h-10 flex items-center justify-center rounded-xl bg-action-primary-bg text-action-primary-text hover:bg-action-primary-hover-bg transition-colors disabled:opacity-40 disabled:cursor-not-allowed text-lg font-bold focus-visible:ring-2 focus-visible:ring-action-primary-focus-ring focus-visible:outline-none"
             aria-label="Agregar uno más"
           >+</button>
         </div>
@@ -112,7 +112,7 @@
     @keydown.space.prevent="handleClick"
   >
     <!-- Left: square image 96×96 -->
-    <div class="relative w-24 h-24 flex-shrink-0 bg-gradient-to-br from-gray-100 to-gray-200 overflow-hidden">
+    <div class="relative w-24 h-24 flex-shrink-0 bg-gradient-to-br from-surface-secondary to-surface-tertiary overflow-hidden">
       <img
         v-if="product.image_url && product.image_url.startsWith('http')"
         :src="product.image_url"
@@ -124,8 +124,8 @@
       </div>
 
       <!-- Availability badge (horizontal) -->
-      <div v-if="!product.is_available" class="absolute inset-0 flex items-center justify-center bg-black/40">
-        <span class="px-1.5 py-0.5 text-xs font-semibold bg-red-500 text-white rounded-full text-center leading-tight">
+      <div v-if="!product.is_available" class="absolute inset-0 flex items-center justify-center bg-overlay-backdrop/40">
+        <span class="px-1.5 py-0.5 text-xs font-semibold bg-state-danger-action-bg text-state-danger-action-text rounded-full text-center leading-tight">
           No disponible
         </span>
       </div>
@@ -163,7 +163,7 @@
           v-if="!isInCart"
           @click.stop="handleClick"
           :disabled="!product.is_available || restaurantClosed"
-          class="w-11 h-11 flex items-center justify-center rounded-xl bg-primary text-primary-foreground text-lg font-bold hover:bg-primary/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-none"
+          class="w-11 h-11 flex items-center justify-center rounded-xl bg-action-primary-bg text-action-primary-text text-lg font-bold hover:bg-action-primary-hover-bg transition-colors disabled:opacity-40 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-action-primary-focus-ring focus-visible:outline-none"
           aria-label="Agregar al carrito"
         >+</button>
 
@@ -172,7 +172,7 @@
           <button
             @click="decrease"
             :disabled="cartStore.isLoading"
-            class="w-11 h-11 flex items-center justify-center rounded-xl bg-muted hover:bg-red-100 text-foreground hover:text-red-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed text-base font-bold"
+            class="w-11 h-11 flex items-center justify-center rounded-xl bg-icon-button-neutral-bg hover:bg-icon-button-destructive-hover-bg text-icon-button-neutral-text hover:text-icon-button-destructive-text transition-colors disabled:opacity-40 disabled:cursor-not-allowed text-base font-bold"
             aria-label="Quitar uno"
           >−</button>
           <span class="min-w-[1.25rem] text-center font-bold text-foreground text-sm">
@@ -181,7 +181,7 @@
           <button
             @click="increase"
             :disabled="cartStore.isLoading || !product.is_available || restaurantClosed"
-            class="w-11 h-11 flex items-center justify-center rounded-xl bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed text-base font-bold focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-none"
+            class="w-11 h-11 flex items-center justify-center rounded-xl bg-action-primary-bg text-action-primary-text hover:bg-action-primary-hover-bg transition-colors disabled:opacity-40 disabled:cursor-not-allowed text-base font-bold focus-visible:ring-2 focus-visible:ring-action-primary-focus-ring focus-visible:outline-none"
             aria-label="Agregar uno más"
           >+</button>
         </div>

--- a/components/public/RestaurantHeader.vue
+++ b/components/public/RestaurantHeader.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="w-full">
     <!-- Banner / Hero -->
-    <div class="relative h-48 md:h-64 gradient-crocus overflow-hidden">
+    <div class="relative h-48 md:h-64 bg-gradient-to-br from-badge-primary-text via-action-primary-bg to-action-primary-hover-bg overflow-hidden">
       <img
         v-if="restaurant.banner_url && restaurant.banner_url.startsWith('http')"
         :src="restaurant.banner_url"
@@ -13,7 +13,7 @@
       </div>
 
       <!-- Overlay gradient -->
-      <div class="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
+      <div class="absolute inset-0 bg-gradient-to-t from-overlay-backdrop-strong/60 to-transparent" />
     </div>
 
     <!-- Restaurant Info -->

--- a/components/supplier/SupplierPortalBottomNav.vue
+++ b/components/supplier/SupplierPortalBottomNav.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- Bottom Navigation - Solo Mobile -->
-  <nav class="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-titan-300 shadow-lg z-50 safe-area-bottom">
+  <nav class="md:hidden fixed bottom-0 left-0 right-0 bg-shell-mobile-bg border-t border-shell-mobile-border shadow-lg z-50 safe-area-bottom">
     <div class="flex items-center justify-around px-2 py-2">
 
       <!-- Órdenes de Compra -->
@@ -11,14 +11,14 @@
         <div
           class="w-10 h-10 flex items-center justify-center rounded-full transition-all duration-200"
           :class="activePage === 'purchases'
-            ? 'bg-crocus-100'
-            : 'hover:bg-titan-100'"
+            ? 'bg-badge-primary-bg'
+            : 'hover:bg-shell-icon-hover-bg'"
         >
           <svg
             class="w-5 h-5 transition-colors"
             :class="activePage === 'purchases'
-              ? 'text-crocus-600'
-              : 'text-titan-500'"
+              ? 'text-badge-primary-text'
+              : 'text-shell-icon-text'"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -30,8 +30,8 @@
         <span
           class="text-xs font-medium transition-colors"
           :class="activePage === 'purchases'
-            ? 'text-crocus-700 font-semibold'
-            : 'text-titan-600'"
+            ? 'text-badge-primary-text font-semibold'
+            : 'text-text-secondary'"
         >
           Órdenes
         </span>
@@ -45,14 +45,14 @@
         <div
           class="w-10 h-10 flex items-center justify-center rounded-full transition-all duration-200"
           :class="activePage === 'billing'
-            ? 'bg-crocus-100'
-            : 'hover:bg-titan-100'"
+            ? 'bg-badge-primary-bg'
+            : 'hover:bg-shell-icon-hover-bg'"
         >
           <svg
             class="w-5 h-5 transition-colors"
             :class="activePage === 'billing'
-              ? 'text-crocus-600'
-              : 'text-titan-500'"
+              ? 'text-badge-primary-text'
+              : 'text-shell-icon-text'"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -64,8 +64,8 @@
         <span
           class="text-xs font-medium transition-colors"
           :class="activePage === 'billing'
-            ? 'text-crocus-700 font-semibold'
-            : 'text-titan-600'"
+            ? 'text-badge-primary-text font-semibold'
+            : 'text-text-secondary'"
         >
           Facturación
         </span>
@@ -77,12 +77,12 @@
         @click="onRefresh"
         class="flex flex-col items-center gap-0.5 flex-1 group"
       >
-        <div class="w-10 h-10 flex items-center justify-center rounded-full transition-all duration-200 hover:bg-titan-100">
-          <svg class="w-5 h-5 transition-transform group-hover:rotate-180 duration-300 text-titan-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <div class="w-10 h-10 flex items-center justify-center rounded-full transition-all duration-200 hover:bg-shell-icon-hover-bg">
+          <svg class="w-5 h-5 transition-transform group-hover:rotate-180 duration-300 text-shell-icon-text" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
           </svg>
         </div>
-        <span class="text-xs font-medium transition-colors text-titan-600">
+        <span class="text-xs font-medium transition-colors text-text-secondary">
           Refrescar
         </span>
       </button>
@@ -92,12 +92,12 @@
         @click="showSupplierModal = true"
         class="flex flex-col items-center gap-0.5 flex-1 group"
       >
-        <div class="w-10 h-10 flex items-center justify-center rounded-full transition-all duration-200 hover:bg-titan-100">
-          <svg class="w-5 h-5 transition-colors text-titan-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <div class="w-10 h-10 flex items-center justify-center rounded-full transition-all duration-200 hover:bg-shell-icon-hover-bg">
+          <svg class="w-5 h-5 transition-colors text-shell-icon-text" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
         </div>
-        <span class="text-xs font-medium transition-colors text-titan-600">
+        <span class="text-xs font-medium transition-colors text-text-secondary">
           Info
         </span>
       </button>
@@ -110,54 +110,54 @@
         <!-- Supplier Info -->
         <div class="space-y-4">
           <!-- Company Name -->
-          <div class="px-4 py-3 bg-crocus-50 rounded-lg border border-crocus-200">
+          <div class="px-4 py-3 bg-badge-primary-bg rounded-lg border border-badge-primary-border">
             <div class="flex items-center gap-3">
-              <div class="w-10 h-10 bg-crocus-600 rounded-full flex items-center justify-center">
-                <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <div class="w-10 h-10 bg-shell-account-avatar-bg rounded-full flex items-center justify-center">
+                <svg class="w-6 h-6 text-shell-account-text" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
                 </svg>
               </div>
               <div>
-                <div class="text-xs text-crocus-700 font-medium">Empresa</div>
-                <div class="font-semibold text-sm text-ebony-800">{{ supplierName || 'Proveedor' }}</div>
+                <div class="text-xs text-badge-primary-text font-medium">Empresa</div>
+                <div class="font-semibold text-sm text-text-primary">{{ supplierName || 'Proveedor' }}</div>
               </div>
             </div>
           </div>
 
           <!-- Contact Info -->
           <div v-if="supplierEmail || supplierPhone" class="space-y-2">
-            <div v-if="supplierEmail" class="flex items-center gap-3 px-4 py-2 bg-titan-50 rounded-lg">
-              <svg class="w-5 h-5 text-titan-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div v-if="supplierEmail" class="flex items-center gap-3 px-4 py-2 bg-surface-secondary rounded-lg">
+              <svg class="w-5 h-5 text-shell-icon-text" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
               </svg>
               <div>
-                <div class="text-xs text-titan-600">Email</div>
-                <div class="text-sm text-ebony-800">{{ supplierEmail }}</div>
+                <div class="text-xs text-text-secondary">Email</div>
+                <div class="text-sm text-text-primary">{{ supplierEmail }}</div>
               </div>
             </div>
 
-            <div v-if="supplierPhone" class="flex items-center gap-3 px-4 py-2 bg-titan-50 rounded-lg">
-              <svg class="w-5 h-5 text-titan-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div v-if="supplierPhone" class="flex items-center gap-3 px-4 py-2 bg-surface-secondary rounded-lg">
+              <svg class="w-5 h-5 text-shell-icon-text" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
               </svg>
               <div>
-                <div class="text-xs text-titan-600">Teléfono</div>
-                <div class="text-sm text-ebony-800">{{ supplierPhone }}</div>
+                <div class="text-xs text-text-secondary">Teléfono</div>
+                <div class="text-sm text-text-primary">{{ supplierPhone }}</div>
               </div>
             </div>
           </div>
         </div>
 
         <!-- Help -->
-        <div class="pt-4 border-t border-titan-300">
-          <div class="px-4 py-3 bg-blue-50 rounded-lg border border-blue-200">
+        <div class="pt-4 border-t border-border">
+          <div class="px-4 py-3 bg-state-info-bg rounded-lg border border-state-info-border">
             <div class="flex items-start gap-3">
-              <svg class="w-5 h-5 text-blue-600 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-state-info-icon flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
               <div>
-                <div class="text-sm font-medium text-blue-900">¿Necesitas ayuda?</div>
-                <div class="text-xs text-blue-700 mt-1">
+                <div class="text-sm font-medium text-state-info-text">¿Necesitas ayuda?</div>
+                <div class="text-xs text-state-info-text mt-1">
                   Si tienes alguna pregunta, contacta a tu administrador o escribe a
                   <a href="mailto:hola@warolabs.com" class="font-medium underline">hola@warolabs.com</a>
                 </div>

--- a/components/supplier/SupplierPortalSidebar.vue
+++ b/components/supplier/SupplierPortalSidebar.vue
@@ -2,10 +2,10 @@
   <UiBaseSidebar>
     <!-- Supplier Selector -->
     <template #selector>
-      <div class="px-3 py-2 border border-ebony-700 rounded-lg text-sm bg-ebony-800">
+      <div class="px-3 py-2 border border-nav-divider rounded-lg text-sm bg-nav-surface-border">
         <div class="flex items-center gap-2">
-          <div class="w-2 h-2 bg-crocus-500 rounded-full"></div>
-          <span class="font-medium text-white">{{ supplierName || 'Proveedor' }}</span>
+          <div class="w-2 h-2 bg-shell-account-indicator-bg rounded-full"></div>
+          <span class="font-medium text-nav-icon-active">{{ supplierName || 'Proveedor' }}</span>
         </div>
       </div>
     </template>
@@ -17,11 +17,11 @@
         :class="[
           'flex items-center gap-3 px-3 py-2 rounded-lg transition-all font-medium group',
           activePage === 'purchases'
-            ? 'bg-crocus-600/20 text-crocus-400'
-            : 'text-titan-400 hover:bg-ebony-800 hover:text-white'
+            ? 'bg-nav-surface-border text-nav-icon-active'
+            : 'text-nav-label-idle hover:bg-nav-surface-border hover:text-nav-label-hover'
         ]"
       >
-        <svg :class="['w-5 h-5', activePage === 'purchases' ? 'text-crocus-500' : 'text-titan-500 group-hover:text-titan-300']" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+        <svg :class="['w-5 h-5', activePage === 'purchases' ? 'text-nav-icon-active' : 'text-nav-icon-idle group-hover:text-nav-icon-hover']" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
         </svg>
         <span>Órdenes de Compra</span>
@@ -32,11 +32,11 @@
         :class="[
           'flex items-center gap-3 px-3 py-2 rounded-lg transition-all font-medium group',
           activePage === 'billing'
-            ? 'bg-crocus-600/20 text-crocus-400'
-            : 'text-titan-400 hover:bg-ebony-800 hover:text-white'
+            ? 'bg-nav-surface-border text-nav-icon-active'
+            : 'text-nav-label-idle hover:bg-nav-surface-border hover:text-nav-label-hover'
         ]"
       >
-        <svg :class="['w-5 h-5', activePage === 'billing' ? 'text-crocus-500' : 'text-titan-500 group-hover:text-titan-300']" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+        <svg :class="['w-5 h-5', activePage === 'billing' ? 'text-nav-icon-active' : 'text-nav-icon-idle group-hover:text-nav-icon-hover']" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z" />
         </svg>
         <span>Facturación</span>
@@ -45,17 +45,17 @@
 
     <!-- Supplier Contact Info -->
     <template #footer>
-      <div class="flex items-start gap-3 p-3 rounded-lg hover:bg-ebony-800 cursor-pointer transition-colors">
+      <div class="flex items-start gap-3 p-3 rounded-lg hover:bg-nav-surface-border cursor-pointer transition-colors">
         <div class="relative flex-shrink-0">
-          <div class="w-10 h-10 bg-crocus-600 rounded-full flex items-center justify-center font-semibold text-white">
+          <div class="w-10 h-10 bg-shell-account-avatar-bg rounded-full flex items-center justify-center font-semibold text-shell-account-text">
             {{ getInitials(supplierName) }}
           </div>
-          <span class="absolute bottom-0 right-0 w-2.5 h-2.5 bg-green-500 border-2 border-ebony-900 rounded-full"></span>
+          <span class="absolute bottom-0 right-0 w-2.5 h-2.5 bg-shell-account-indicator-bg border-2 border-nav-surface-bg rounded-full"></span>
         </div>
         <div class="min-w-0 flex-1">
-          <div class="font-semibold text-sm text-white truncate">{{ supplierName || 'Proveedor' }}</div>
-          <div class="text-xs text-titan-400 truncate" v-if="supplierEmail">{{ supplierEmail }}</div>
-          <div class="text-xs text-titan-400 truncate" v-if="supplierPhone">{{ supplierPhone }}</div>
+          <div class="font-semibold text-sm text-nav-icon-active truncate">{{ supplierName || 'Proveedor' }}</div>
+          <div class="text-xs text-nav-label-idle truncate" v-if="supplierEmail">{{ supplierEmail }}</div>
+          <div class="text-xs text-nav-label-idle truncate" v-if="supplierPhone">{{ supplierPhone }}</div>
         </div>
       </div>
     </template>

--- a/layouts/docs.vue
+++ b/layouts/docs.vue
@@ -182,7 +182,7 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  background: #fff;
+  background: hsl(var(--surface));
   font-family: 'Lato', sans-serif;
 }
 
@@ -191,9 +191,9 @@ onMounted(() => {
   position: sticky;
   top: 0;
   z-index: 50;
-  background: #fff;
-  border-bottom: 1px solid hsl(var(--titan-200));
-  box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+  background: hsl(var(--surface));
+  border-bottom: 1px solid hsl(var(--border));
+  box-shadow: 0 1px 3px hsl(var(--overlay-backdrop-bg) / 0.04);
 }
 
 .docs-header-inner {
@@ -226,9 +226,9 @@ onMounted(() => {
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: hsl(var(--ebony-500));
-  background: hsl(var(--titan-100));
-  border: 1px solid hsl(var(--titan-200));
+  color: hsl(var(--text-secondary));
+  background: hsl(var(--surface-secondary));
+  border: 1px solid hsl(var(--border));
   padding: 2px 8px;
   border-radius: 4px;
 }
@@ -248,33 +248,33 @@ onMounted(() => {
   left: 14px;
   width: 16px;
   height: 16px;
-  color: hsl(var(--ebony-400));
+  color: hsl(var(--text-tertiary));
   pointer-events: none;
 }
 
 .docs-search-input {
   width: 100%;
   padding: 8px 48px 8px 40px;
-  border: 1px solid hsl(var(--titan-200));
+  border: 1px solid hsl(var(--border));
   border-radius: 999px;
-  background: hsl(var(--titan-50));
+  background: hsl(var(--surface));
   font-size: 13.5px;
-  color: hsl(var(--ebony-600));
+  color: hsl(var(--text-secondary));
   outline: none;
   cursor: default;
   font-family: inherit;
 }
 .docs-search-input::placeholder {
-  color: hsl(var(--ebony-400));
+  color: hsl(var(--text-tertiary));
 }
 
 .docs-search-kbd {
   position: absolute;
   right: 12px;
   font-size: 11px;
-  color: hsl(var(--ebony-400));
-  background: hsl(var(--titan-100));
-  border: 1px solid hsl(var(--titan-200));
+  color: hsl(var(--text-tertiary));
+  background: hsl(var(--surface-secondary));
+  border: 1px solid hsl(var(--border));
   padding: 1px 6px;
   border-radius: 4px;
   letter-spacing: 0.02em;
@@ -291,27 +291,27 @@ onMounted(() => {
 .docs-header-link {
   font-size: 13.5px;
   font-weight: 600;
-  color: hsl(var(--ebony-600));
+  color: hsl(var(--text-secondary));
   text-decoration: none;
 }
 .docs-header-link:hover {
-  color: hsl(var(--crocus-600));
+  color: hsl(var(--primary));
 }
 
 .docs-header-cta {
   font-size: 13px;
   font-weight: 700;
-  color: hsl(var(--crocus-600));
+  color: hsl(var(--primary));
   background: transparent;
-  border: 2px solid hsl(var(--crocus-600));
+  border: 2px solid hsl(var(--primary));
   padding: 6px 18px;
   border-radius: 8px;
   cursor: pointer;
   font-family: inherit;
 }
 .docs-header-cta:hover {
-  background: hsl(var(--crocus-600));
-  color: #fff;
+  background: hsl(var(--primary));
+  color: hsl(var(--action-primary-text));
 }
 
 /* ─── Body ───────────────────────────────────────────── */
@@ -325,7 +325,7 @@ onMounted(() => {
 .docs-sidebar {
   width: 256px;
   flex-shrink: 0;
-  background: hsl(var(--titan-100));
+  background: hsl(var(--surface-secondary));
   display: flex;
   flex-direction: column;
   position: sticky;
@@ -335,12 +335,12 @@ onMounted(() => {
   overflow-y: auto;
   overflow-x: hidden;
   scrollbar-width: thin;
-  scrollbar-color: hsl(var(--titan-200)) transparent;
+  scrollbar-color: hsl(var(--border)) transparent;
 }
 .docs-sidebar::-webkit-scrollbar { width: 4px; }
 .docs-sidebar::-webkit-scrollbar-track { background: transparent; }
 .docs-sidebar::-webkit-scrollbar-thumb {
-  background: hsl(var(--titan-200));
+  background: hsl(var(--border));
   border-radius: 10px;
 }
 
@@ -352,10 +352,10 @@ onMounted(() => {
 /* ─── Nav card ───────────────────────────────────────── */
 .docs-nav-card {
   margin: 20px 12px 0;
-  background: #fff;
-  border: 1px solid hsl(var(--titan-200));
+  background: hsl(var(--surface));
+  border: 1px solid hsl(var(--border));
   border-radius: 10px;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+  box-shadow: 0 1px 4px hsl(var(--overlay-backdrop-bg) / 0.04);
   overflow: hidden;
 }
 
@@ -372,7 +372,7 @@ onMounted(() => {
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: hsl(var(--ebony-400));
+  color: hsl(var(--text-tertiary));
   padding: 10px 12px 4px;
   margin-top: 4px;
 }
@@ -388,18 +388,18 @@ onMounted(() => {
   border-radius: 8px;
   font-size: 14px;
   font-weight: 400;
-  color: hsl(var(--ebony-600));
+  color: hsl(var(--text-secondary));
   text-decoration: none;
   line-height: 1.4;
   transition: background 0.1s, color 0.1s;
 }
 .docs-nav-item:hover {
-  background: hsl(var(--titan-100));
-  color: hsl(var(--ebony-900));
+  background: hsl(var(--surface-secondary));
+  color: hsl(var(--text-primary));
 }
 .docs-nav-item.active {
-  background: hsl(var(--crocus-50));
-  color: hsl(var(--crocus-700));
+  background: hsl(var(--badge-primary-bg));
+  color: hsl(var(--action-primary-hover-bg));
   font-weight: 600;
 }
 
@@ -411,24 +411,24 @@ onMounted(() => {
 }
 .docs-nav-item.active .docs-nav-item-icon {
   opacity: 1;
-  color: hsl(var(--crocus-600));
+  color: hsl(var(--primary));
 }
 
 /* ─── Sidebar footer ─────────────────────────────────── */
 .docs-sidebar-footer {
   padding: 14px 20px 18px;
-  border-top: 1px solid hsl(var(--titan-100));
+  border-top: 1px solid hsl(var(--surface-secondary));
   margin-top: auto;
 }
 
 .docs-back-link {
   font-size: 12.5px;
   font-weight: 500;
-  color: hsl(var(--ebony-400));
+  color: hsl(var(--text-tertiary));
   text-decoration: none;
 }
 .docs-back-link:hover {
-  color: hsl(var(--crocus-600));
+  color: hsl(var(--primary));
 }
 
 /* ─── Mobile index button ────────────────────────────── */
@@ -444,15 +444,15 @@ onMounted(() => {
     padding: 7px 14px;
     font-size: 13px;
     font-weight: 600;
-    color: hsl(var(--crocus-600));
-    background: hsl(var(--crocus-50));
-    border: 1px solid hsl(var(--crocus-200));
+    color: hsl(var(--primary));
+    background: hsl(var(--badge-primary-bg));
+    border: 1px solid hsl(var(--badge-primary-border));
     border-radius: 8px;
     cursor: pointer;
     font-family: inherit;
   }
   .docs-mobile-index-btn:hover {
-    background: hsl(var(--crocus-100));
+    background: hsl(var(--badge-primary-hover-bg));
   }
 }
 
@@ -480,29 +480,29 @@ onMounted(() => {
   width: 52px;
   height: 52px;
   border-radius: 50%;
-  background: hsl(var(--titan-100));
+  background: hsl(var(--surface-secondary));
   display: flex;
   align-items: center;
   justify-content: center;
-  color: hsl(var(--ebony-500));
+  color: hsl(var(--text-secondary));
   border: 1.5px solid transparent;
   transition: background 0.12s, color 0.12s, border-color 0.12s;
 }
 
 .sheet-grid-item--active .sheet-grid-icon {
-  background: hsl(var(--crocus-50));
-  color: hsl(var(--crocus-600));
-  border-color: hsl(var(--crocus-300));
+  background: hsl(var(--badge-primary-bg));
+  color: hsl(var(--primary));
+  border-color: hsl(var(--focus-ring-subtle));
 }
 
 .sheet-grid-item:active .sheet-grid-icon {
-  background: hsl(var(--titan-200));
+  background: hsl(var(--border));
 }
 
 .sheet-grid-label {
   font-size: 10px;
   font-weight: 500;
-  color: hsl(var(--ebony-500));
+  color: hsl(var(--text-secondary));
   text-align: center;
   line-height: 1.3;
   letter-spacing: 0.01em;
@@ -510,7 +510,7 @@ onMounted(() => {
 }
 
 .sheet-grid-item--active .sheet-grid-label {
-  color: hsl(var(--crocus-600));
+  color: hsl(var(--primary));
   font-weight: 600;
 }
 
@@ -526,7 +526,7 @@ onMounted(() => {
   flex: 1;
   min-width: 0;
   padding: 24px 24px 64px 32px;
-  background: hsl(var(--titan-100));
+  background: hsl(var(--surface-secondary));
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -543,7 +543,7 @@ onMounted(() => {
 @media (max-width: 639px) {
   .docs-main {
     padding: 0 0 calc(48px + 58px);
-    background: #fff;
+    background: hsl(var(--surface));
     align-items: stretch;
   }
 }
@@ -554,7 +554,7 @@ onMounted(() => {
   flex-shrink: 0;
   display: none;
   padding: 20px 12px 0;
-  background: hsl(var(--titan-100));
+  background: hsl(var(--surface-secondary));
 }
 
 @media (min-width: 1280px) {
@@ -566,14 +566,14 @@ onMounted(() => {
 .docs-toc-inner {
   position: sticky;
   top: calc(58px + 20px);
-  background: #fff;
-  border: 1px solid hsl(var(--titan-200));
+  background: hsl(var(--surface));
+  border: 1px solid hsl(var(--border));
   border-radius: 10px;
   padding: 14px 16px 16px;
   max-height: calc(100vh - 120px);
   overflow-y: auto;
   scrollbar-width: none;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+  box-shadow: 0 1px 4px hsl(var(--overlay-backdrop-bg) / 0.04);
 }
 .docs-toc-inner::-webkit-scrollbar { display: none; }
 
@@ -582,24 +582,24 @@ onMounted(() => {
   font-weight: 700;
   letter-spacing: 0.09em;
   text-transform: uppercase;
-  color: hsl(var(--ebony-400));
+  color: hsl(var(--text-tertiary));
   margin-bottom: 10px;
   padding-bottom: 9px;
-  border-bottom: 1px solid hsl(var(--titan-100));
+  border-bottom: 1px solid hsl(var(--surface-secondary));
 }
 
 /* Rail izquierdo continuo */
 .docs-toc-rail {
   display: flex;
   flex-direction: column;
-  border-left: 1.5px solid hsl(var(--titan-200));
+  border-left: 1.5px solid hsl(var(--border));
 }
 
 .docs-toc-link {
   display: block;
   font-size: 14px;
   font-weight: 400;
-  color: hsl(var(--ebony-600));
+  color: hsl(var(--text-secondary));
   text-decoration: none;
   padding: 6px 8px 6px 12px;
   border-radius: 0 6px 6px 0;
@@ -612,18 +612,18 @@ onMounted(() => {
 .docs-toc-link--h3 {
   padding-left: 22px;
   font-size: 13px;
-  color: hsl(var(--ebony-500));
+  color: hsl(var(--text-secondary));
 }
 
 .docs-toc-link:hover {
-  color: hsl(var(--crocus-600));
-  border-left-color: hsl(var(--crocus-300));
+  color: hsl(var(--primary));
+  border-left-color: hsl(var(--focus-ring-subtle));
 }
 
 .docs-toc-link--active {
-  background: hsl(var(--crocus-50));
-  color: hsl(var(--crocus-700));
+  background: hsl(var(--badge-primary-bg));
+  color: hsl(var(--action-primary-hover-bg));
   font-weight: 600;
-  border-left-color: hsl(var(--crocus-500));
+  border-left-color: hsl(var(--primary));
 }
 </style>

--- a/layouts/supplier-portal.vue
+++ b/layouts/supplier-portal.vue
@@ -14,11 +14,11 @@
     <!-- Main Content Area -->
     <div class="flex-1 flex flex-col overflow-hidden">
       <!-- Header -->
-      <header class="bg-white border-b border-titan-300 px-4 md:px-8 py-4 flex-shrink-0">
+      <header class="bg-shell-header-bg border-b border-shell-header-border px-4 md:px-8 py-4 flex-shrink-0">
         <div class="flex items-center justify-between">
           <div>
-            <h1 class="text-2xl md:text-3xl font-bold text-ebony-800">{{ pageTitle }}</h1>
-            <p class="text-xs md:text-sm text-ebony-400 mt-1">{{ currentDateTime }}</p>
+            <h1 class="text-2xl md:text-3xl font-bold text-shell-title-text">{{ pageTitle }}</h1>
+            <p class="text-xs md:text-sm text-shell-subtitle-text mt-1">{{ currentDateTime }}</p>
           </div>
           <div class="flex items-center gap-2 md:gap-3">
             <!-- Refresh Button - Always show when there's a refresh handler -->
@@ -26,7 +26,7 @@
               v-if="refreshHandler"
               @click="handleRefresh"
               :disabled="isRefreshing"
-              class="hidden md:flex h-[42px] px-4 py-2 bg-background border-2 border-border rounded-lg text-text-primary hover:bg-surface-secondary hover:border-primary transition-all focus:outline-none focus:ring-2 focus:ring-primary group disabled:opacity-50 disabled:cursor-not-allowed"
+              class="hidden md:flex h-[42px] px-4 py-2 bg-shell-action-bg border-2 border-shell-action-border rounded-lg text-shell-action-text hover:bg-shell-action-hover-bg hover:border-shell-action-focus-ring transition-all focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring group disabled:opacity-50 disabled:cursor-not-allowed"
               title="Refrescar"
             >
               <svg
@@ -45,7 +45,7 @@
             <button
               v-if="showBackButton"
               @click="goBack"
-              class="px-4 py-2 bg-background border-2 border-border rounded-lg text-text-primary hover:bg-surface-secondary hover:border-primary transition-all text-sm font-medium"
+              class="px-4 py-2 bg-shell-action-bg border-2 border-shell-action-border rounded-lg text-shell-action-text hover:bg-shell-action-hover-bg hover:border-shell-action-focus-ring transition-all text-sm font-medium"
             >
               Volver
             </button>
@@ -196,13 +196,13 @@ const supplier = useState<any>('supplier-portal-supplier', () => null)
 <style scoped>
 /* Main Content */
 main {
-  background: hsl(220, 14%, 97%);
+  background: hsl(var(--background));
 }
 
 /* Footer Styles */
 .footer-main {
-  background: hsla(0, 0%, 100%, 0.95);
-  border-top: 1px solid hsl(220, 11%, 90%);
+  background: hsl(var(--surface) / 0.95);
+  border-top: 1px solid hsl(var(--border));
   padding: 16px 40px;
 }
 
@@ -222,12 +222,12 @@ main {
   align-items: center;
   gap: 8px;
   font-size: 14px;
-  color: hsl(220, 13%, 46%);
+  color: hsl(var(--text-secondary));
 }
 
 .footer-copyright {
   font-size: 14px;
-  color: hsl(220, 13%, 46%);
+  color: hsl(var(--text-secondary));
 }
 
 .footer-links {
@@ -235,17 +235,17 @@ main {
   align-items: center;
   gap: 12px;
   font-size: 14px;
-  color: hsl(220, 13%, 46%);
+  color: hsl(var(--text-secondary));
 }
 
 .footer-links a {
   text-decoration: none;
-  color: hsl(220, 13%, 46%);
+  color: hsl(var(--text-secondary));
   transition: color 0.3s;
 }
 
 .footer-links a:hover {
-  color: hsl(262, 83%, 58%);
+  color: hsl(var(--primary));
 }
 
 /* Responsive */

--- a/pages/[tenant]/mesa/[token]/index.vue
+++ b/pages/[tenant]/mesa/[token]/index.vue
@@ -84,7 +84,7 @@ const handleCheckout = async () => {
     </div>
   </div>
 
-  <div v-else-if="resolve" class="min-h-screen bg-gray-50 pb-24">
+  <div v-else-if="resolve" class="min-h-screen bg-background pb-24">
     <div class="bg-card border-b border-border">
       <div class="max-w-7xl mx-auto px-4 py-6">
         <p class="text-xs font-semibold uppercase tracking-wide text-primary mb-1">Pedido en mesa</p>

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -184,7 +184,7 @@ useHead({
 </script>
 
 <template>
-  <div class="bg-white">
+  <div class="bg-surface">
     <!-- Loading State -->
     <div v-if="pending" class="flex items-center justify-center min-h-screen">
       <CommonsTheCustomLoader size="large" />
@@ -193,11 +193,11 @@ useHead({
     <!-- Error State -->
     <div v-else-if="fetchError" class="flex items-center justify-center min-h-screen">
       <div class="text-center px-4">
-        <p class="text-2xl font-bold text-ebony-900 mb-2">Error al cargar el artículo</p>
-        <p class="text-lg text-ebony-600 mb-4">{{ fetchError.message }}</p>
+        <p class="text-2xl font-bold text-text-primary mb-2">Error al cargar el artículo</p>
+        <p class="text-lg text-text-secondary mb-4">{{ fetchError.message }}</p>
         <NuxtLink
           to="/blog"
-          class="text-lg text-crocus-600 hover:text-crocus-700 underline"
+          class="text-lg text-badge-primary-text hover:text-badge-primary-text underline"
         >
           Volver al blog
         </NuxtLink>
@@ -266,10 +266,10 @@ useHead({
     <!-- Not Found State -->
     <div v-else class="flex items-center justify-center min-h-screen">
       <div class="text-center px-4">
-        <p class="text-2xl font-bold text-ebony-900 mb-2">Artículo no encontrado</p>
+        <p class="text-2xl font-bold text-text-primary mb-2">Artículo no encontrado</p>
         <NuxtLink
           to="/blog"
-          class="text-lg text-crocus-600 hover:text-crocus-700 underline"
+          class="text-lg text-badge-primary-text hover:text-badge-primary-text underline"
         >
           Volver al blog
         </NuxtLink>

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -109,11 +109,11 @@ const goToPage = (page: number) => {
 
 // Gradient classes for article images (fallback when no cover)
 const gradientClasses = [
-  'bg-gradient-to-br from-crocus-200 via-crocus-100 to-titan-200',
-  'bg-gradient-to-br from-ebony-200 via-titan-200 to-crocus-100',
-  'bg-gradient-to-br from-crocus-100 via-titan-300 to-ebony-100',
-  'bg-gradient-to-br from-titan-300 via-crocus-100 to-titan-200',
-  'bg-gradient-to-br from-ebony-100 via-crocus-50 to-titan-300'
+  'bg-gradient-to-br from-badge-primary-border via-badge-primary-bg to-surface-tertiary',
+  'bg-gradient-to-br from-surface-tertiary via-border to-badge-primary-bg',
+  'bg-gradient-to-br from-badge-primary-bg via-surface-tertiary to-surface-secondary',
+  'bg-gradient-to-br from-surface-tertiary via-badge-primary-bg to-border',
+  'bg-gradient-to-br from-surface-secondary via-badge-primary-bg to-surface-tertiary'
 ]
 
 const getGradientClass = (index: number) => gradientClasses[index % gradientClasses.length]
@@ -153,47 +153,47 @@ useHead({
 </script>
 
 <template>
-  <div class="min-h-screen bg-titan-100 flex flex-col font-sans">
+  <div class="min-h-screen bg-surface-secondary flex flex-col font-sans">
 
     <!-- ════════════════════════════════════════
          HERO SECTION
          Fondo blanco con dot-grid sutil + gradiente lateral púrpura
     ════════════════════════════════════════ -->
-    <section class="relative bg-white overflow-hidden border-b border-titan-200">
+    <section class="relative bg-surface overflow-hidden border-b border-border">
       <!-- Dot grid background -->
       <div class="dot-grid" aria-hidden="true"></div>
       <!-- Gradiente de color lateral izquierdo -->
-      <div class="absolute inset-y-0 left-0 w-1/2 bg-gradient-to-r from-crocus-50/60 to-transparent pointer-events-none" aria-hidden="true"></div>
+      <div class="absolute inset-y-0 left-0 w-1/2 bg-gradient-to-r from-badge-primary-bg/60 to-transparent pointer-events-none" aria-hidden="true"></div>
       <!-- Accent blob superior derecho -->
-      <div class="absolute -top-32 -right-32 w-96 h-96 bg-crocus-100/40 rounded-full blur-3xl pointer-events-none" aria-hidden="true"></div>
+      <div class="absolute -top-32 -right-32 w-96 h-96 bg-badge-primary-bg/40 rounded-full blur-3xl pointer-events-none" aria-hidden="true"></div>
 
       <div class="relative z-10 max-w-5xl mx-auto px-5 lg:px-12 pt-16 pb-12 lg:pt-28 lg:pb-24 text-center">
         <!-- Eyebrow badge -->
         <div class="inline-flex items-center gap-2 mb-5 lg:mb-7">
-          <span class="w-5 h-px bg-crocus-400"></span>
-          <span class="text-xs font-bold uppercase tracking-[0.25em] text-crocus-600">Blog & Recursos</span>
-          <span class="w-5 h-px bg-crocus-400"></span>
+          <span class="w-5 h-px bg-badge-primary-border"></span>
+          <span class="text-xs font-bold uppercase tracking-[0.25em] text-badge-primary-text">Blog & Recursos</span>
+          <span class="w-5 h-px bg-badge-primary-border"></span>
         </div>
 
         <!-- Título con typewriter -->
-        <h1 class="font-quantico text-[1.85rem] sm:text-4xl lg:text-[4.5rem] font-black mb-5 lg:mb-7 text-ebony-900 tracking-tight leading-tight lg:leading-[1] uppercase">
+        <h1 class="font-quantico text-[1.85rem] sm:text-4xl lg:text-[4.5rem] font-black mb-5 lg:mb-7 text-text-primary tracking-tight leading-tight lg:leading-[1] uppercase">
           {{ displayedTitle }}
         </h1>
 
         <!-- Subtítulo -->
-        <p class="text-sm sm:text-base text-ebony-500 leading-relaxed font-light">
+        <p class="text-sm sm:text-base text-text-secondary leading-relaxed font-light">
           Guías prácticas y estrategias probadas para controlar costos, optimizar inventarios y tomar decisiones con datos.
         </p>
 
         <!-- Stats pill -->
-        <div class="inline-flex flex-wrap justify-center items-center gap-3 sm:gap-6 mt-6 lg:mt-10 px-4 sm:px-6 py-2.5 sm:py-3 bg-titan-100 rounded-full border border-titan-300 text-xs sm:text-sm text-ebony-500">
+        <div class="inline-flex flex-wrap justify-center items-center gap-3 sm:gap-6 mt-6 lg:mt-10 px-4 sm:px-6 py-2.5 sm:py-3 bg-surface-secondary rounded-full border border-border text-xs sm:text-sm text-text-secondary">
           <span class="flex items-center gap-1.5">
-            <svg class="w-4 h-4 text-crocus-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            <svg class="w-4 h-4 text-badge-primary-text" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
             Contenido para restaurantes
           </span>
-          <span class="w-px h-4 bg-titan-400"></span>
+          <span class="w-px h-4 bg-border"></span>
           <span class="flex items-center gap-1.5">
-            <svg class="w-4 h-4 text-crocus-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+            <svg class="w-4 h-4 text-badge-primary-text" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
             Lectura rápida
           </span>
         </div>
@@ -213,9 +213,9 @@ useHead({
       <!-- Error State -->
       <div v-else-if="fetchError" class="flex items-center justify-center min-h-[400px]">
         <div class="text-center">
-          <p class="text-xl font-semibold text-ebony-800 mb-2">Error al cargar los artículos</p>
-          <p class="text-sm text-ebony-600 mb-4">{{ fetchError.message }}</p>
-          <button @click="refresh" class="px-4 py-2 bg-crocus-600 text-white rounded-lg hover:bg-crocus-700 transition-colors">
+          <p class="text-xl font-semibold text-text-primary mb-2">Error al cargar los artículos</p>
+          <p class="text-sm text-text-secondary mb-4">{{ fetchError.message }}</p>
+          <button @click="refresh" class="px-4 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors">
             Reintentar
           </button>
         </div>
@@ -253,7 +253,7 @@ useHead({
   inset: 0;
   z-index: 0;
   pointer-events: none;
-  background-image: radial-gradient(circle, hsl(var(--titan-400)) 1px, transparent 1px);
+  background-image: radial-gradient(circle, hsl(var(--border)) 1px, transparent 1px);
   background-size: 28px 28px;
   opacity: 0.45;
   mask-image: radial-gradient(ellipse 80% 60% at 50% 50%, black 40%, transparent 100%);

--- a/pages/docs/[...slug].vue
+++ b/pages/docs/[...slug].vue
@@ -99,13 +99,13 @@ function handleClick(e: MouseEvent) {
 <template>
   <!-- Loading -->
   <div v-if="status === 'pending'" class="flex items-center justify-center min-h-[40vh]">
-    <p class="text-sm text-ebony-400">Cargando...</p>
+    <p class="text-sm text-text-tertiary">Cargando...</p>
   </div>
 
   <!-- 404 -->
   <div v-else-if="error" class="flex flex-col items-center justify-center min-h-[40vh] gap-4">
-    <p class="text-ebony-500">Documento no encontrado.</p>
-    <NuxtLink to="/docs" class="text-sm text-crocus-600 hover:underline">
+    <p class="text-text-secondary">Documento no encontrado.</p>
+    <NuxtLink to="/docs" class="text-sm text-badge-primary-text hover:underline">
       Volver al índice
     </NuxtLink>
   </div>
@@ -114,7 +114,7 @@ function handleClick(e: MouseEvent) {
   <div v-else class="doc-card" @click="handleClick">
     <article class="article-style">
       <h1>
-        {{ displayedTitle }}<span class="animate-pulse text-crocus-500 font-light">|</span>
+        {{ displayedTitle }}<span class="animate-pulse text-badge-primary-text font-light">|</span>
       </h1>
       <div v-html="renderedContent"></div>
     </article>
@@ -123,12 +123,12 @@ function handleClick(e: MouseEvent) {
 
 <style scoped>
 .doc-card {
-  background: #fff;
+  background: hsl(var(--surface));
   border: 1px solid hsl(220 13% 91%);
   border-radius: 14px;
   padding: 48px 56px 64px;
   max-width: 860px;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.04);
+  box-shadow: 0 1px 4px hsl(var(--overlay-backdrop-bg) / 0.04);
 }
 
 /* Tablet */

--- a/pages/proveedor/[token]/[purchaseId]/acciones.vue
+++ b/pages/proveedor/[token]/[purchaseId]/acciones.vue
@@ -15,7 +15,7 @@
         <h2 class="mt-4 text-xl font-bold text-text-primary">Error</h2>
         <p class="mt-2 text-text-secondary">{{ error }}</p>
         <button @click="loadPurchase"
-          class="mt-4 px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors">
+          class="mt-4 px-6 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors">
           Reintentar
         </button>
       </div>
@@ -81,7 +81,7 @@
               <h3 class="text-lg font-semibold text-text-primary">No hay acciones pendientes</h3>
               <p class="text-text-secondary mt-2">Esta orden no requiere ninguna acción de tu parte en este momento.</p>
               <button @click="navigateTo(`/proveedor/${token}/${purchaseId}`)"
-                class="mt-6 px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors">
+                class="mt-6 px-6 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors">
                 Volver al detalle
               </button>
             </div>
@@ -129,7 +129,7 @@
                 type="button"
                 @click="handleFormSubmit('completePrices')"
                 :disabled="isFormSubmitting"
-                class="w-full py-3 bg-green-500 text-white rounded-lg hover:bg-green-600 transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold shadow-lg shadow-green-500/20">
+                class="w-full py-3 bg-action-success-bg text-action-success-text rounded-lg hover:bg-action-success-hover-bg transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold shadow-lg shadow-action-success-bg/20">
                 <CommonsTheCustomLoader v-if="isFormSubmitting" size="small" />
                 <span>{{ isFormSubmitting ? 'Enviando...' : 'Enviar Cotización' }}</span>
               </button>
@@ -141,7 +141,7 @@
                 type="button"
                 @click="handleFormSubmit('invoice')"
                 :disabled="isFormSubmitting"
-                class="w-full py-3 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold shadow-lg shadow-orange-500/20">
+                class="w-full py-3 bg-action-warning-bg text-action-warning-text rounded-lg hover:bg-action-warning-hover-bg transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold shadow-lg shadow-action-warning-bg/20">
                 <CommonsTheCustomLoader v-if="isFormSubmitting" size="small" />
                 <span>{{ isFormSubmitting ? 'Registrando...' : 'Registrar Factura' }}</span>
               </button>
@@ -153,7 +153,7 @@
                 type="button"
                 @click="handleFormSubmit('ship')"
                 :disabled="isFormSubmitting"
-                class="w-full py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold shadow-lg shadow-blue-500/20">
+                class="w-full py-3 bg-action-info-bg text-action-info-text rounded-lg hover:bg-action-info-hover-bg transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold shadow-lg shadow-action-info-bg/20">
                 <CommonsTheCustomLoader v-if="isFormSubmitting" size="small" />
                 <span>{{ isFormSubmitting ? 'Registrando...' : 'Marcar como Enviado' }}</span>
               </button>
@@ -164,15 +164,15 @@
               v-if="purchase?.status === 'quotation' || canShowInvoiceForm || purchase?.status === 'invoiced'"
               type="button"
               @click="navigateTo(`/proveedor/${token}/${purchaseId}`)"
-              class="w-full py-3 border-2 border-border rounded-lg text-text-secondary hover:text-text-primary hover:bg-background transition-colors font-medium">
+              class="w-full py-3 border-2 border-action-outline-border rounded-lg text-action-outline-text hover:text-action-outline-hover-text hover:bg-action-outline-hover-bg transition-colors font-medium">
               Cancelar
             </button>
           </div>
           <!-- Action Help Text -->
-          <div class="mt-6 p-4 bg-primary/5 border border-primary/20 rounded-lg">
+          <div class="mt-6 p-4 bg-state-info-bg border border-state-info-border rounded-lg">
             <div class="flex gap-3">
               <div class="flex-shrink-0">
-                <svg class="w-5 h-5 text-primary mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-5 h-5 text-state-info-icon mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
               </div>
@@ -281,23 +281,23 @@ const headerIcon = computed(() => {
 })
 
 const headerClass = computed(() => {
-  if (purchase.value?.status === 'quotation') return 'bg-green-500/5 border-green-500/20'
-  if (canShowInvoiceForm.value) return 'bg-orange-500/5 border-orange-500/20'
-  if (purchase.value?.status === 'invoiced') return 'bg-blue-500/5 border-blue-500/20'
+  if (purchase.value?.status === 'quotation') return 'bg-state-success-bg border-state-success-border'
+  if (canShowInvoiceForm.value) return 'bg-state-warning-bg border-state-warning-border'
+  if (purchase.value?.status === 'invoiced') return 'bg-state-info-bg border-state-info-border'
   return 'bg-surface'
 })
 
 const iconBgClass = computed(() => {
-  if (purchase.value?.status === 'quotation') return 'bg-green-500/10'
-  if (canShowInvoiceForm.value) return 'bg-orange-500/10'
-  if (purchase.value?.status === 'invoiced') return 'bg-blue-500/10'
+  if (purchase.value?.status === 'quotation') return 'bg-state-success-bg'
+  if (canShowInvoiceForm.value) return 'bg-state-warning-bg'
+  if (purchase.value?.status === 'invoiced') return 'bg-state-info-bg'
   return 'bg-surface-secondary'
 })
 
 const iconColorClass = computed(() => {
-  if (purchase.value?.status === 'quotation') return 'text-green-500'
-  if (canShowInvoiceForm.value) return 'text-orange-500'
-  if (purchase.value?.status === 'invoiced') return 'text-blue-500'
+  if (purchase.value?.status === 'quotation') return 'text-state-success-icon'
+  if (canShowInvoiceForm.value) return 'text-state-warning-icon'
+  if (purchase.value?.status === 'invoiced') return 'text-state-info-icon'
   return 'text-text-secondary'
 })
 
@@ -311,14 +311,14 @@ function formatDate(dateString: string): string {
 
 function getStatusBadgeClass(status: string): string {
   const classes: Record<string, string> = {
-    'quotation': 'bg-yellow-500/10 text-yellow-600',
-    'pending': 'bg-blue-500/10 text-blue-600',
-    'confirmed': 'bg-green-500/10 text-green-600',
+    'quotation': 'bg-badge-warning-bg text-badge-warning-text',
+    'pending': 'bg-state-info-bg text-badge-info-text',
+    'confirmed': 'bg-state-success-bg text-badge-success-text',
     'preparing': 'bg-state-warning-bg text-state-warning-text',
-    'invoiced': 'bg-orange-500/10 text-orange-600',
+    'invoiced': 'bg-state-warning-bg text-badge-warning-text',
     'shipped': 'bg-cyan-500/10 text-cyan-600',
-    'received': 'bg-emerald-500/10 text-emerald-600',
-    'paid': 'bg-green-600/10 text-green-700'
+    'received': 'bg-badge-success-bg text-badge-success-text',
+    'paid': 'bg-badge-success-bg text-badge-success-text'
   }
   return classes[status] || 'bg-surface-secondary text-text-secondary'
 }

--- a/pages/proveedor/[token]/[purchaseId]/index.vue
+++ b/pages/proveedor/[token]/[purchaseId]/index.vue
@@ -15,7 +15,7 @@
         <h2 class="mt-4 text-xl font-bold text-text-primary">Error</h2>
         <p class="mt-2 text-text-secondary">{{ error }}</p>
         <button @click="navigateTo(`/proveedor/${token}`)"
-          class="mt-4 px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors">
+          class="mt-4 px-6 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors">
           Volver al listado
         </button>
       </div>
@@ -203,8 +203,8 @@
                           v-if="item.ingredient_type && item.ingredient_type !== 'food'"
                           class="px-1.5 py-0.5 text-[10px] font-medium rounded"
                           :class="{
-                            'bg-blue-100 text-blue-700': item.ingredient_type === 'service',
-                            'bg-amber-100 text-amber-700': item.ingredient_type === 'supply'
+                            'bg-badge-info-bg text-badge-info-text': item.ingredient_type === 'service',
+                            'bg-badge-warning-bg text-badge-warning-text': item.ingredient_type === 'supply'
                           }"
                         >
                           {{ item.ingredient_type === 'service' ? 'Servicio' : 'Insumo' }}
@@ -399,10 +399,10 @@ function getStatusBadgeClass(status: string): string {
     quotation: 'border-accent text-accent',
     pending: 'border-warning text-warning',
     confirmed: 'border-success text-success',
-    preparing: 'border-blue-500 text-blue-500',
-    shipped: 'border-blue-600 text-blue-600',
+    preparing: 'border-badge-info-border text-badge-info-text',
+    shipped: 'border-badge-info-border text-badge-info-text',
     received: 'border-success text-success',
-    invoiced: 'border-orange-500 text-orange-500',
+    invoiced: 'border-badge-warning-border text-badge-warning-text',
     paid: 'border-success text-success',
     cancelled: 'border-destructive text-destructive'
   }

--- a/pages/proveedor/[token]/[purchaseId]/transicion/[id].vue
+++ b/pages/proveedor/[token]/[purchaseId]/transicion/[id].vue
@@ -15,7 +15,7 @@
         <p class="mt-2 text-text-secondary">{{ error }}</p>
         <button
           @click="navigateTo(`/proveedor/${token}/${purchaseId}`)"
-          class="mt-4 px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors"
+          class="mt-4 px-6 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors"
         >
           Volver al detalle de la orden
         </button>
@@ -211,21 +211,21 @@
             <!-- Image Preview (clickable) -->
             <a v-if="isImageFile(attachment.file_name)" :href="attachment.s3_url" target="_blank"
               rel="noopener noreferrer"
-              class="relative aspect-video bg-gray-100 block cursor-pointer hover:opacity-90 transition-opacity">
+              class="relative aspect-video bg-surface-secondary block cursor-pointer hover:opacity-90 transition-opacity">
               <img :src="attachment.s3_url" :alt="attachment.file_name" class="w-full h-full object-contain"
                 loading="lazy" />
             </a>
             <!-- PDF Preview (clickable) -->
             <a v-else-if="isPdfFile(attachment.file_name)" :href="attachment.s3_url" target="_blank"
               rel="noopener noreferrer"
-              class="relative aspect-video bg-gray-100 block cursor-pointer hover:opacity-90 transition-opacity overflow-hidden">
+              class="relative aspect-video bg-surface-secondary block cursor-pointer hover:opacity-90 transition-opacity overflow-hidden">
               <embed :src="`${attachment.s3_url}#toolbar=0&navpanes=0&scrollbar=0`" type="application/pdf"
                 class="w-full h-full pointer-events-none" />
               <div class="absolute inset-0 bg-transparent"></div>
             </a>
             <!-- File Icon for other files (clickable) -->
             <a v-else :href="attachment.s3_url" target="_blank" rel="noopener noreferrer"
-              class="relative aspect-video bg-gray-100 flex items-center justify-center cursor-pointer hover:bg-gray-200 transition-colors">
+              class="relative aspect-video bg-surface-secondary flex items-center justify-center cursor-pointer hover:bg-surface-tertiary transition-colors">
               <svg class="w-20 h-20 text-text-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                   :d="getFileIcon(attachment.file_name)" />
@@ -273,7 +273,7 @@
             <button 
               @click="handleUploadFiles" 
               :disabled="isUploading"
-              class="px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center space-x-2 font-medium">
+              class="px-6 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors disabled:opacity-50 flex items-center space-x-2 font-medium">
               <CommonsTheCustomLoader v-if="isUploading" size="small" />
               <span>{{ isUploading ? 'Subiendo...' : 'Subir Archivos' }}</span>
             </button>
@@ -414,11 +414,11 @@ function getStatusBadgeClass(status: string): string {
     quotation: 'border-accent text-accent',
     pending: 'border-warning text-warning',
     confirmed: 'border-success text-success',
-    preparing: 'border-blue-500 text-blue-500',
-    shipped: 'border-blue-600 text-blue-600',
+    preparing: 'border-badge-info-border text-badge-info-text',
+    shipped: 'border-badge-info-border text-badge-info-text',
     received: 'border-state-success-border text-state-success-text',
-    verified: 'border-indigo-500 text-indigo-500',
-    invoiced: 'border-orange-500 text-orange-500',
+    verified: 'border-badge-primary-border text-badge-primary-text',
+    invoiced: 'border-badge-warning-border text-badge-warning-text',
     paid: 'border-success text-success',
     cancelled: 'border-destructive text-destructive'
   }

--- a/pages/proveedor/[token]/facturacion.vue
+++ b/pages/proveedor/[token]/facturacion.vue
@@ -20,7 +20,7 @@
     <!-- Invoices Content -->
     <div v-else class="flex flex-col gap-4">
       <!-- Filters -->
-      <div class="bg-white rounded-lg shadow-sm border border-titan-200 p-6">
+      <div class="bg-filter-surface-bg rounded-lg shadow-sm border border-filter-surface-border p-6">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
           <!-- Document Type Filter -->
           <div>
@@ -28,7 +28,7 @@
               Tipo de Documento
             </label>
             <select v-model="filters.documentType" @change="applyFilters"
-              class="w-full px-4 py-2 border border-titan-300 rounded-lg focus:ring-2 focus:ring-crocus-500 focus:border-crocus-500">
+              class="w-full px-4 py-2 border border-form-control-border bg-form-control-bg text-form-control-text rounded-lg focus:ring-2 focus:ring-form-control-focus-ring focus:border-form-control-focus-border">
               <option value="">Todos</option>
               <option value="factura">Factura</option>
               <option value="remision">Remisión</option>
@@ -41,7 +41,7 @@
               Proveedor
             </label>
             <select v-model="filters.supplierId" @change="applyFilters"
-              class="w-full px-4 py-2 border border-titan-300 rounded-lg focus:ring-2 focus:ring-crocus-500 focus:border-crocus-500">
+              class="w-full px-4 py-2 border border-form-control-border bg-form-control-bg text-form-control-text rounded-lg focus:ring-2 focus:ring-form-control-focus-ring focus:border-form-control-focus-border">
               <option value="">Todos</option>
               <option v-for="sup in uniqueSuppliers" :key="sup.id" :value="sup.id">
                 {{ sup.name }}
@@ -55,7 +55,7 @@
               Fecha Desde
             </label>
             <input v-model="filters.startDate" @change="applyFilters" type="date"
-              class="w-full px-4 py-2 border border-titan-300 rounded-lg focus:ring-2 focus:ring-crocus-500 focus:border-crocus-500" />
+              class="w-full px-4 py-2 border border-form-control-border bg-form-control-bg text-form-control-text rounded-lg focus:ring-2 focus:ring-form-control-focus-ring focus:border-form-control-focus-border" />
           </div>
 
           <!-- End Date Filter -->
@@ -64,14 +64,14 @@
               Fecha Hasta
             </label>
             <input v-model="filters.endDate" @change="applyFilters" type="date"
-              class="w-full px-4 py-2 border border-titan-300 rounded-lg focus:ring-2 focus:ring-crocus-500 focus:border-crocus-500" />
+              class="w-full px-4 py-2 border border-form-control-border bg-form-control-bg text-form-control-text rounded-lg focus:ring-2 focus:ring-form-control-focus-ring focus:border-form-control-focus-border" />
           </div>
         </div>
 
         <!-- Clear Filters Button -->
         <div class="mt-4 flex justify-end">
           <button @click="clearFilters"
-            class="px-4 py-2 text-sm text-text-secondary hover:text-text-primary border border-titan-300 rounded-lg hover:border-crocus-500 transition-all">
+            class="px-4 py-2 text-sm text-action-outline-text hover:text-action-outline-hover-text border border-action-outline-border rounded-lg hover:border-action-outline-focus-ring hover:bg-action-outline-hover-bg transition-all">
             Limpiar Filtros
           </button>
         </div>
@@ -90,11 +90,11 @@
           </div>
           <div class="flex space-x-2">
             <button @click="clearSelection"
-              class="px-4 py-2 text-sm border-2 border-border rounded-lg hover:border-destructive hover:text-destructive transition-all">
+              class="px-4 py-2 text-sm border-2 border-action-destructive-border rounded-lg text-action-destructive-text hover:bg-action-destructive-hover-bg hover:text-action-destructive-hover-text transition-all">
               Cancelar
             </button>
             <button @click="showLegalInvoiceModal = true" :disabled="!canAttachLegalInvoice"
-              class="px-4 py-2 text-sm bg-primary text-white rounded-lg hover:bg-primary/90 transition-all disabled:opacity-50 disabled:cursor-not-allowed">
+              class="px-4 py-2 text-sm bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-all disabled:opacity-50 disabled:cursor-not-allowed">
               Adjuntar Factura Legal
             </button>
           </div>
@@ -125,13 +125,13 @@
         <template #cell-select="{ row }">
           <input type="checkbox" :checked="isSelected(row.id)" @change="toggleSelection(row)"
             :disabled="row.tipo !== 'Remisión'"
-            class="w-4 h-4 text-primary border-border rounded focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed" />
+            class="w-4 h-4 text-form-control-focus-border border-form-control-border rounded focus:ring-form-control-focus-ring disabled:opacity-50 disabled:cursor-not-allowed" />
         </template>
 
         <template #cell-numero="{ value, row }">
           <div>
-            <div class="text-sm font-medium text-ebony-800">{{ value }}</div>
-            <div class="text-xs text-titan-600">OC: {{ row.purchaseNumber }}</div>
+            <div class="text-sm font-medium text-text-primary">{{ value }}</div>
+            <div class="text-xs text-text-secondary">OC: {{ row.purchaseNumber }}</div>
             <div v-if="row.legalInvoiceNumber" class="text-xs text-success mt-1">
               Factura Legal: {{ row.legalInvoiceNumber }}
             </div>
@@ -139,7 +139,7 @@
         </template>
 
         <template #cell-proveedor="{ value }">
-          <div class="text-sm font-medium text-ebony-800">{{ value }}</div>
+          <div class="text-sm font-medium text-text-primary">{{ value }}</div>
         </template>
 
         <template #cell-tipo="{ value }">
@@ -147,13 +147,13 @@
         </template>
 
         <template #cell-fecha="{ value }">
-          <span class="text-sm text-ebony-800">{{ formatDate(value) }}</span>
+          <span class="text-sm text-text-primary">{{ formatDate(value) }}</span>
         </template>
 
         <template #cell-monto="{ value, row }">
           <div>
-            <div class="text-sm font-medium text-ebony-800">{{ formatCurrency(value) }}</div>
-            <div class="text-xs text-titan-600">+{{ formatCurrency(row.taxAmount) }} IVA</div>
+            <div class="text-sm font-medium text-text-primary">{{ formatCurrency(value) }}</div>
+            <div class="text-xs text-text-secondary">+{{ formatCurrency(row.taxAmount) }} IVA</div>
           </div>
         </template>
 
@@ -166,7 +166,7 @@
 
     <!-- Legal Invoice Modal -->
     <div v-if="showLegalInvoiceModal" class="fixed inset-0 z-50 overflow-y-auto">
-      <div class="fixed inset-0 bg-black bg-opacity-50 transition-opacity" @click="closeLegalInvoiceModal"></div>
+      <div class="fixed inset-0 bg-overlay-backdrop/50 transition-opacity" @click="closeLegalInvoiceModal"></div>
 
       <div class="flex min-h-full items-center justify-center p-4">
         <div class="relative w-full max-w-2xl bg-surface rounded-xl shadow-2xl border-2 border-border">
@@ -174,7 +174,7 @@
           <div class="border-b-2 border-border p-6">
             <div class="flex items-center justify-between">
               <div class="flex items-center space-x-3">
-                <div class="bg-primary/10 p-3 rounded-lg">
+                <div class="bg-badge-primary-bg p-3 rounded-lg">
                   <svg class="w-6 h-6 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                   </svg>
@@ -205,7 +205,7 @@
                 v-model="legalInvoiceForm.number"
                 type="text"
                 required
-                class="w-full px-4 py-2 bg-background border-2 border-border rounded-lg text-text-primary focus:border-primary"
+                class="w-full px-4 py-2 bg-form-control-bg border-2 border-form-control-border rounded-lg text-form-control-text focus:border-form-control-focus-border focus:ring-2 focus:ring-form-control-focus-ring"
                 placeholder="Ej: FAC-2025-001"
               />
             </div>
@@ -219,7 +219,7 @@
                 v-model="legalInvoiceForm.date"
                 type="datetime-local"
                 required
-                class="w-full px-4 py-2 bg-background border-2 border-border rounded-lg text-text-primary focus:border-primary"
+                class="w-full px-4 py-2 bg-form-control-bg border-2 border-form-control-border rounded-lg text-form-control-text focus:border-form-control-focus-border focus:ring-2 focus:ring-form-control-focus-ring"
               />
             </div>
 
@@ -232,14 +232,14 @@
                 type="button"
                 @click="closeLegalInvoiceModal"
                 :disabled="isSubmitting"
-                class="px-6 py-2 border-2 border-border rounded-lg text-text-primary hover:bg-background transition-colors disabled:opacity-50"
+                class="px-6 py-2 border-2 border-action-outline-border rounded-lg text-action-outline-text hover:bg-action-outline-hover-bg transition-colors disabled:opacity-50"
               >
                 Cancelar
               </button>
               <button
                 type="submit"
                 :disabled="isSubmitting"
-                class="px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 flex items-center space-x-2"
+                class="px-6 py-2 bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors disabled:opacity-50 flex items-center space-x-2"
               >
                 <svg v-if="isSubmitting" class="animate-spin h-5 w-5" fill="none" viewBox="0 0 24 24">
                   <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>

--- a/pages/proveedor/[token]/index.vue
+++ b/pages/proveedor/[token]/index.vue
@@ -36,23 +36,23 @@
         <!-- Desktop Table Cells -->
         <template #cell-numero="{ value, row }">
           <div>
-            <div class="text-sm font-medium text-ebony-800">{{ value }}</div>
-            <div class="text-xs text-titan-600">{{ row.invoice_number || 'Sin factura' }}</div>
+            <div class="text-sm font-medium text-text-primary">{{ value }}</div>
+            <div class="text-xs text-text-secondary">{{ row.invoice_number || 'Sin factura' }}</div>
           </div>
         </template>
 
         <template #cell-proveedor="{ value }">
-          <div class="text-sm font-bold text-ebony-800">{{ value }}</div>
+          <div class="text-sm font-bold text-text-primary">{{ value }}</div>
         </template>
 
         <template #cell-fecha="{ value }">
-          <span class="text-sm text-ebony-800">{{ formatDate(value) }}</span>
+          <span class="text-sm text-text-primary">{{ formatDate(value) }}</span>
         </template>
 
         <template #cell-valorTotal="{ value, row }">
           <div>
-            <div class="text-sm font-medium text-ebony-800">{{ formatCurrency(value) }}</div>
-            <div class="text-xs text-titan-600">+{{ formatCurrency(row.impuestos) }} IVA</div>
+            <div class="text-sm font-medium text-text-primary">{{ formatCurrency(value) }}</div>
+            <div class="text-xs text-text-secondary">+{{ formatCurrency(row.impuestos) }} IVA</div>
           </div>
         </template>
 
@@ -65,15 +65,15 @@
         </template>
 
         <template #cell-fechaEntrega="{ value }">
-          <div class="text-sm text-ebony-800">
+          <div class="text-sm text-text-primary">
             <div v-if="value">{{ formatDate(value) }}</div>
-            <div v-else class="text-ebony-800">Sin programar</div>
+            <div v-else class="text-text-primary">Sin programar</div>
           </div>
         </template>
 
         <template #cell-actions="{ row }">
           <div class="flex justify-center space-x-2">
-            <button @click="navigateToPurchase(row)" class="text-crocus-600 hover:text-crocus-900 transition-colors"
+            <button @click="navigateToPurchase(row)" class="text-action-ghost-text hover:text-action-ghost-hover-text transition-colors"
               title="Ver orden">
               <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -317,6 +317,8 @@ module.exports = {
           },
         },
         nav: {
+          "surface-bg": "hsl(var(--nav-surface-bg) / <alpha-value>)",
+          "surface-border": "hsl(var(--nav-surface-border) / <alpha-value>)",
           "item-hover-bg": "hsl(var(--nav-item-hover-bg) / <alpha-value>)",
           "item-active-bg": "hsl(var(--nav-item-active-bg) / <alpha-value>)",
           "icon-idle": "hsl(var(--nav-icon-idle) / <alpha-value>)",


### PR DESCRIPTION
## Summary

- Tokenizes supplier portal shell/navigation, supplier pages, action/status states and modal/form surfaces.
- Tokenizes online checkout/customer-facing public restaurant controls, state blocks, overlays, address badges and generic elevation colors.
- Tokenizes active blog/docs/directory public surfaces, cards, article UI, pagination, docs CSS, and public CTAs using existing semantic tokens.
- Exposes existing nav surface tokens in Tailwind so supplier sidebar UI can use semantic nav surface classes.

## Before/after scoped counts

Using the #1184 delta grep pattern:

| Scope | Before | After |
|---|---:|---:|
| Supplier portal (`layouts/supplier-portal.vue`, `components/supplier`, `pages/proveedor`) | 182 | 63 |
| Online/public restaurant (`layouts/public-restaurant.vue`, `components/public`, `components/online`, checkout/mesa pages) | 134 | 88 |
| Blog/docs/directory (`layouts/blog.vue`, `layouts/docs.vue`, `pages/blog`, `pages/docs`, `components/blog`, `components/directory`) | 123 | 32 |

Remaining broad-pattern hits are mostly semantic `hover:*` / `focus:*` token utilities, issue-number comments that match the hex regex, and documented brand exceptions below.

## Documented exceptions

- Public social links intentionally keep external brand hover colors in `components/public/RestaurantHeader.vue`: WhatsApp `#25D366`, Facebook `#1877F2`, Instagram `#E1306C`.
- User/tenant-provided restaurant media, logos and banners remain data/content inputs.

## Validation

- `git diff --check` passed.
- `nuxt prepare` generated `.nuxt` types successfully using the existing local `node_modules` via a temporary symlink, then cleanup removed generated files and the symlink. It emitted an existing duplicate import warning for `ActivePromotionRow`.
- No local dev server or ports were opened.

## Manual visual validation scope

Please spot-check supplier portal desktop/mobile nav, supplier order detail/actions/facturacion, online checkout identity/delivery/confirm/address flows, public restaurant product cards/header, blog index/article pages, and docs layout/article routes.

Closes #1184
