### PR TITLE
Tokenizar componentes compartidos, paneles y estados

### DIFF
--- a/components/Commons/TheLoading.vue
+++ b/components/Commons/TheLoading.vue
@@ -12,7 +12,7 @@ const props = defineProps({
     overlay ? 'h-screen' : 'h-full'
   ]">
     <div class="loader"></div>
-    <div class="text-4xl font-medium text-left font-principal italic">Momentico..</div>
+    <div class="text-4xl font-medium text-left font-principal italic text-text-primary">Momentico..</div>
   </div>
 </template>
 
@@ -23,8 +23,8 @@ const props = defineProps({
   height: 78px;
   border-radius: 50%;
   box-sizing: border-box;
-  background: #fff;
-  border: 8px solid #131a1d;
+  background: hsl(var(--surface));
+  border: 8px solid hsl(var(--text-primary));
   overflow: hidden;
 }
 
@@ -35,9 +35,9 @@ const props = defineProps({
   top: -50%;
   width: 100%;
   height: 100%;
-  background: #263238;
+  background: hsl(var(--text-secondary));
   z-index: 5;
-  border-bottom: 8px solid #131a1d;
+  border-bottom: 8px solid hsl(var(--text-primary));
   box-sizing: border-box;
   animation: eyeShade 3s infinite;
 }
@@ -50,7 +50,7 @@ const props = defineProps({
   width: 32px;
   z-index: 2;
   height: 32px;
-  background: #111;
+  background: hsl(var(--text-primary));
   border-radius: 50%;
   animation: eyeMove 3s infinite;
 }

--- a/components/Commons/TheLoadingOverlay.vue
+++ b/components/Commons/TheLoadingOverlay.vue
@@ -1,8 +1,8 @@
 <template>
   <Teleport to="body">
-    <div 
+    <div
       v-if="show"
-      class="loading-overlay"
+      class="fixed inset-0 z-[9999] flex items-center justify-center bg-overlay-backdrop/50 backdrop-blur-sm"
     >
       <CommonsTheLoading />
     </div>
@@ -17,19 +17,3 @@ defineProps({
   }
 });
 </script>
-
-<style scoped>
-.loading-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(4px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 9999;
-}
-</style>

--- a/components/Toast/ToastProvider.vue
+++ b/components/Toast/ToastProvider.vue
@@ -25,7 +25,7 @@
           <!-- Close button -->
           <button
             @click="remove(toast.id)"
-            class="flex-shrink-0 ml-3 p-1 hover:bg-black/10 rounded-full transition-colors"
+            class="flex-shrink-0 ml-3 p-1 hover:bg-control-action-hover-bg rounded-full transition-colors"
           >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -44,16 +44,16 @@ const { toasts, remove } = useToast()
 
 // Clases CSS para cada tipo de toast
 const toastClasses = {
-  success: 'bg-green-50 border-green-200 text-green-800',
-  error: 'bg-red-50 border-red-200 text-red-800',
-  warning: 'bg-yellow-50 border-yellow-200 text-yellow-800',
-  info: 'bg-blue-50 border-blue-200 text-blue-800'
+  success: 'bg-state-success-bg border-state-success-border text-state-success-text',
+  error: 'bg-state-danger-bg border-state-danger-border text-state-danger-text',
+  warning: 'bg-state-warning-bg border-state-warning-border text-state-warning-text',
+  info: 'bg-state-info-bg border-state-info-border text-state-info-text'
 }
 
 // Iconos para cada tipo
 const toastIcons = {
   success: () => h('svg', {
-    class: 'text-green-600',
+    class: 'text-state-success-icon',
     fill: 'currentColor',
     viewBox: '0 0 20 20'
   }, h('path', {
@@ -63,7 +63,7 @@ const toastIcons = {
   })),
   
   error: () => h('svg', {
-    class: 'text-red-600',
+    class: 'text-state-danger-icon',
     fill: 'currentColor',
     viewBox: '0 0 20 20'
   }, h('path', {
@@ -73,7 +73,7 @@ const toastIcons = {
   })),
   
   warning: () => h('svg', {
-    class: 'text-yellow-600',
+    class: 'text-state-warning-icon',
     fill: 'currentColor',
     viewBox: '0 0 20 20'
   }, h('path', {
@@ -83,7 +83,7 @@ const toastIcons = {
   })),
   
   info: () => h('svg', {
-    class: 'text-blue-600',
+    class: 'text-state-info-icon',
     fill: 'currentColor',
     viewBox: '0 0 20 20'
   }, h('path', {

--- a/components/ui/AdvancedFiltersBar.vue
+++ b/components/ui/AdvancedFiltersBar.vue
@@ -176,6 +176,6 @@ const emit = defineEmits<{
 }
 .dp-custom-menu {
   border-radius: 0.75rem !important;
-  box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1) !important;
+  box-shadow: 0 10px 15px -3px hsl(var(--foreground) / 0.1), 0 4px 6px -4px hsl(var(--foreground) / 0.1) !important;
 }
 </style>

--- a/components/ui/ConfirmActionModal.vue
+++ b/components/ui/ConfirmActionModal.vue
@@ -10,7 +10,7 @@
     >
       <div
         v-if="modelValue"
-        class="fixed inset-0 z-[80] flex items-center justify-center p-4 bg-black/50"
+        class="fixed inset-0 z-[80] flex items-center justify-center p-4 bg-overlay-backdrop/50"
         role="alertdialog"
         aria-modal="true"
         :aria-labelledby="titleId"
@@ -36,7 +36,7 @@
                 :class="[
                   'w-16 h-16 rounded-full flex items-center justify-center',
                   variant === 'destructive'
-                    ? 'bg-amber-100 dark:bg-amber-900/30'
+                    ? 'bg-state-warning-bg'
                     : 'bg-primary/10',
                 ]"
               >
@@ -44,7 +44,7 @@
                   :class="[
                     'w-8 h-8',
                     variant === 'destructive'
-                      ? 'text-amber-600 dark:text-amber-400'
+                      ? 'text-state-warning-icon'
                       : 'text-primary',
                   ]"
                   aria-hidden="true"

--- a/components/ui/ErrorAlertModal.vue
+++ b/components/ui/ErrorAlertModal.vue
@@ -10,7 +10,7 @@
     >
       <div
         v-if="modelValue"
-        class="fixed inset-0 z-[80] flex items-center justify-center p-4 bg-black/50"
+        class="fixed inset-0 z-[80] flex items-center justify-center p-4 bg-overlay-backdrop/50"
         role="alertdialog"
         aria-modal="true"
         :aria-labelledby="titleId"
@@ -32,8 +32,8 @@
             @click.stop
           >
             <div class="flex justify-center mb-4">
-              <div class="w-16 h-16 rounded-full flex items-center justify-center bg-red-100 dark:bg-red-900/30">
-                <ExclamationTriangleIcon class="w-8 h-8 text-red-600 dark:text-red-400" aria-hidden="true" />
+              <div class="w-16 h-16 rounded-full flex items-center justify-center bg-state-danger-bg">
+                <ExclamationTriangleIcon class="w-8 h-8 text-state-danger-icon" aria-hidden="true" />
               </div>
             </div>
 
@@ -46,7 +46,7 @@
 
             <div
               v-if="dependents && dependents.length > 0"
-              class="bg-red-50 dark:bg-red-900/20 border border-red-100 dark:border-red-900/40 rounded-lg px-4 py-3 mb-6 space-y-2"
+              class="bg-state-danger-bg border border-state-danger-border rounded-lg px-4 py-3 mb-6 space-y-2"
             >
               <div
                 v-for="dep in dependents"
@@ -54,7 +54,7 @@
                 class="flex items-center justify-between"
               >
                 <span class="text-sm font-medium text-text-primary">{{ dep.label }}</span>
-                <span class="text-sm font-bold text-red-700 dark:text-red-300">{{ dep.count }}</span>
+                <span class="text-sm font-bold text-state-danger-text">{{ dep.count }}</span>
               </div>
             </div>
 

--- a/components/ui/Modal.vue
+++ b/components/ui/Modal.vue
@@ -10,7 +10,7 @@
     >
       <div
         v-if="modelValue"
-        class="fixed inset-0 z-[60] flex items-end sm:items-center justify-center bg-black/50 p-0 sm:p-4"
+        class="fixed inset-0 z-[60] flex items-end sm:items-center justify-center bg-overlay-backdrop/50 p-0 sm:p-4"
         @click="closeModal"
       >
         <Transition
@@ -23,20 +23,20 @@
         >
           <div
             v-if="modelValue"
-            class="bg-surface w-full sm:max-w-md flex flex-col shadow-xl rounded-t-2xl sm:rounded-2xl max-h-[90vh]"
+            class="bg-modal-surface-bg w-full sm:max-w-md flex flex-col shadow-xl rounded-t-2xl sm:rounded-2xl max-h-[90vh]"
             :class="maxHeightClass"
             @click.stop
           >
             <!-- Header -->
-            <div class="flex-shrink-0 border-b border-border px-6 py-4 flex items-center justify-between rounded-t-2xl sm:rounded-t-2xl">
-              <h3 class="text-lg font-semibold text-text-primary">{{ title }}</h3>
+            <div class="flex-shrink-0 border-b border-modal-header-border px-6 py-4 flex items-center justify-between rounded-t-2xl sm:rounded-t-2xl">
+              <h3 class="text-lg font-semibold text-modal-surface-text">{{ title }}</h3>
               <button
                 type="button"
-                class="min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-surface-secondary rounded-lg transition-colors"
+                class="min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-icon-button-neutral-hover-bg focus:outline-none focus:ring-2 focus:ring-icon-button-focus-ring rounded-lg transition-colors"
                 aria-label="Cerrar"
                 @click="closeModal"
               >
-                <XMarkIcon class="w-5 h-5 text-text-secondary" />
+                <XMarkIcon class="w-5 h-5 text-icon-button-neutral-text" />
               </button>
             </div>
 
@@ -46,7 +46,7 @@
             </div>
 
             <!-- Footer (optional, sticky) -->
-            <div v-if="$slots.footer" class="flex-shrink-0 border-t border-border rounded-b-2xl">
+            <div v-if="$slots.footer" class="flex-shrink-0 border-t border-modal-footer-border rounded-b-2xl">
               <slot name="footer" />
             </div>
           </div>

--- a/components/ui/Skeleton.vue
+++ b/components/ui/Skeleton.vue
@@ -51,9 +51,9 @@ const shapeClasses = computed(() => {
 
 const variantClasses = computed(() => {
   const variants = {
-    default: 'bg-gray-200/60 dark:bg-gray-700/60',
-    light: 'bg-gray-100/80 dark:bg-gray-600/40',
-    profile: 'bg-white/20 backdrop-blur-sm'
+    default: 'bg-muted/70',
+    light: 'bg-muted/45',
+    profile: 'bg-surface/20 backdrop-blur-sm'
   }
   return variants[props.variant] || variants.default
 })

--- a/components/ui/SubmitBusyOverlay.vue
+++ b/components/ui/SubmitBusyOverlay.vue
@@ -61,7 +61,7 @@ const hintId = computed(() => props.hint ? `${labelId.value}-hint` : undefined)
         >
           <div class="relative flex flex-col items-center gap-5 text-center">
             <div
-              class="inline-flex items-center gap-2 rounded-full border border-crocus-200 bg-crocus-100/90 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-crocus-700"
+              class="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-primary"
             >
               Submit busy
             </div>

--- a/components/ui/badge/Badge.vue
+++ b/components/ui/badge/Badge.vue
@@ -27,8 +27,8 @@ const badgeVariants = cva(
         warning: 'rounded-full border-transparent bg-warning text-warning-foreground hover:bg-warning/80 px-2.5 py-0.5',
         info: 'rounded-full border-transparent bg-info text-info-foreground hover:bg-info/80 px-2.5 py-0.5',
         profile: 'rounded-md border border-border bg-surface text-text-secondary hover:bg-surface-secondary px-3 py-1',
-        titan: 'rounded-md border border-titan-400 bg-titan-200 text-titan-800 hover:bg-titan-300 px-3 py-1',
-        crocus: 'rounded-md border border-crocus-400 bg-crocus-100 text-crocus-800 hover:bg-crocus-200 px-3 py-1'
+        titan: 'rounded-md border border-badge-neutral-border bg-badge-neutral-bg text-badge-neutral-text hover:bg-muted px-3 py-1',
+        crocus: 'rounded-md border border-primary bg-primary/10 text-primary hover:bg-primary/15 px-3 py-1'
       },
     },
     defaultVariants: {

--- a/components/ui/button/Button.vue
+++ b/components/ui/button/Button.vue
@@ -15,8 +15,8 @@ const buttonVariants = cva(
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
-        'titan-outline': 'border border-titan-400 bg-transparent text-titan-800 hover:bg-titan-100 dark:border-titan-600 dark:text-titan-300 dark:hover:bg-titan-800/20',
-        'crocus-outline': 'border border-crocus-400 bg-transparent text-crocus-800 hover:bg-crocus-100 dark:border-crocus-300 dark:text-crocus-200 dark:hover:bg-crocus-900/20',
+        'titan-outline': 'border border-border bg-transparent text-text-secondary hover:bg-surface-secondary hover:text-text-primary',
+        'crocus-outline': 'border border-primary bg-transparent text-primary hover:bg-primary/10',
       },
       size: {
         default: 'h-10 px-4 py-2',

--- a/components/ui/navigation/Navigation.vue
+++ b/components/ui/navigation/Navigation.vue
@@ -20,8 +20,8 @@ const props = defineProps({
         <NuxtLink 
           :to="item.href"
           :class="cn(
-            'text-sm text-gray-300 hover:text-white transition-colors',
-            item.active && 'text-white font-medium'
+            'text-sm text-text-tertiary hover:text-text-primary transition-colors',
+            item.active && 'text-text-primary font-medium'
           )"
         >
           {{ item.label }}

--- a/components/ui/stats/Stats.vue
+++ b/components/ui/stats/Stats.vue
@@ -42,7 +42,7 @@ const statsVariants = cva(
   {
     variants: {
       variant: {
-        default: "border-gray-800",
+        default: "border-border",
         compact: "",
         cards: "grid gap-4",
         balance: "grid gap-4"

--- a/components/ui/toast/Toast.vue
+++ b/components/ui/toast/Toast.vue
@@ -11,7 +11,7 @@
       v-if="visible"
       :class="[
         'flex items-start gap-3 px-4 py-3 rounded-lg shadow-lg backdrop-blur-sm border max-w-sm min-w-[300px]',
-        'bg-card/95 border-border ring-1 ring-white/10',
+        'bg-card/95 border-border ring-1 ring-border/40',
         variantClasses,
         sizeClasses
       ]"
@@ -27,7 +27,7 @@
       </div>
       <button
         @click="close"
-        class="flex-shrink-0 p-1 rounded-md hover:bg-white/10 transition-colors"
+        class="flex-shrink-0 p-1 rounded-md hover:bg-control-action-hover-bg transition-colors"
       >
         <Icon name="heroicons:x-mark" class="w-4 h-4" />
       </button>
@@ -77,10 +77,10 @@ const visible = ref(false)
 
 const variantClasses = computed(() => {
   const variants = {
-    success: 'border-green-500/30',
-    error: 'border-red-500/30', 
-    warning: 'border-yellow-500/30',
-    info: 'border-blue-500/30'
+    success: 'border-state-success-border',
+    error: 'border-state-danger-border',
+    warning: 'border-state-warning-border',
+    info: 'border-state-info-border'
   }
   return variants[props.type]
 })
@@ -106,20 +106,32 @@ const iconName = computed(() => {
 
 const iconClasses = computed(() => {
   const classes = {
-    success: 'text-green-400',
-    error: 'text-red-400',
-    warning: 'text-yellow-400',
-    info: 'text-blue-400'
+    success: 'text-state-success-icon',
+    error: 'text-state-danger-icon',
+    warning: 'text-state-warning-icon',
+    info: 'text-state-info-icon'
   }
   return `w-5 h-5 flex-shrink-0 ${classes[props.type]}`
 })
 
 const titleClasses = computed(() => {
-  return `font-medium text-${props.type === 'success' ? 'green' : props.type === 'error' ? 'red' : props.type === 'warning' ? 'yellow' : 'blue'}-100`
+  const classes = {
+    success: 'text-state-success-text',
+    error: 'text-state-danger-text',
+    warning: 'text-state-warning-text',
+    info: 'text-state-info-text'
+  }
+  return `font-medium ${classes[props.type]}`
 })
 
 const messageClasses = computed(() => {
-  return `text-${props.type === 'success' ? 'green' : props.type === 'error' ? 'red' : props.type === 'warning' ? 'yellow' : 'blue'}-200 ${props.title ? 'text-xs' : ''}`
+  const classes = {
+    success: 'text-state-success-text',
+    error: 'text-state-danger-text',
+    warning: 'text-state-warning-text',
+    info: 'text-state-info-text'
+  }
+  return `${classes[props.type]} ${props.title ? 'text-xs' : ''}`
 })
 
 const close = () => {


### PR DESCRIPTION
## Summary
- Tokenized shared modal/alert overlays, modal surfaces, close buttons, loading overlays, skeletons, toasts, badges, buttons, navigation, and small shared filter/stat primitives.
- Replaced direct shared UI colors with existing semantic tokens such as `overlay-*`, `modal-*`, `icon-button-*`, `state-*`, `badge-*`, `muted`, `surface`, `text-*`, and `primary`.
- Left chart/event/category gradients and usage-bar visual palettes untouched as intentional data/visual exceptions for the final audit.

## Counts
- Primitive shared scope before: `82` matches from the delta research (`components/ui components/Commons --glob "*.vue"`).
- Comparable expanded scope after (`components/ui components/Commons components/Toast --glob "*.vue"`): `52` matches.
- Touched files after: `0` direct color matches for the issue regex.

## Validation
- `git diff --check`
- `npm run postinstall` (`nuxt prepare`) passed. Warning observed: duplicated import `ActivePromotionRow` between `useActivePromotions.ts` and `promoProductMatch.ts` appears unrelated/pre-existing.

## Manual visual validation scope
- Modal/dialog overlay and close button states.
- Confirm/error alert modal icon and callout states.
- Toast variants.
- Loading overlay and custom loader.
- Skeleton variants.
- Shared filter datepicker menu shadow, navigation links, stats default border, button/badge legacy variants.

Closes #1185