### PR TITLE
Tokenize final color audit surfaces

### DIFF
--- a/docs/engineering/visual-token-color-audit.md
+++ b/docs/engineering/visual-token-color-audit.md
@@ -2,6 +2,8 @@
 
 Issue: #1172
 Epic: #1173
+Final audit: #1186
+Current epic: #1179
 
 ## Search Counts
 
@@ -13,6 +15,16 @@ Search scope excludes `node_modules`, lock files, build output, `.nuxt`, `public
 | 6-digit hex colors | 145 | 145 | Mostly token comments, data visualization palettes, social brands, and user-configurable color fallbacks. |
 | Crocus brand hex values | 1 | 1 | `#7C3AED` remains in a POS product category palette. |
 
+### Final Audit Counts (#1186)
+
+Scope: `pages`, `components`, `layouts`, and `composables`; excludes `node_modules`, `.nuxt`, `.output`, `dist`, and `public`.
+
+| Search | Before | After | Notes |
+|---|---:|---:|---|
+| Direct Tailwind color utilities | 1619 | 1527 | Supplier portal chrome/nav is covered by shell tokens in current `main`; payroll liquidation UI now uses semantic tokens. Remaining matches require module triage or documented exception categories below. |
+| Hex / `rgb(a)` literals | 541 | 534 | Remaining literals are primarily print CSS, data/chart palettes, user-configurable colors, content styling, or token source comments. |
+| Hover/focus/active/disabled color states | 229 | 202 | Payroll liquidation form/action states now use tokenized hover/focus roles; remaining states need PR-sized surface triage or exception documentation. |
+
 ## Converted
 
 - Supplier and purchase preparation statuses now use semantic warning state tokens instead of purple utilities.
@@ -22,6 +34,8 @@ Search scope excludes `node_modules`, lock files, build output, `.nuxt`, `public
 - WaRos checkout balance card now uses primary/surface/border tokens instead of violet utilities.
 - Accounting class color helpers now use status chip tokens for the third class family.
 - Auth logo, cierre period badges, loyalty frequency rule styling, and brand-avatar comments no longer use purple/violet literals.
+- Supplier portal header, footer, mobile bottom navigation, modal info panel, and desktop sidebar now use `surface`, `border`, `text-*`, `primary`, `nav-*`, and `state-info-*` tokens instead of direct titan/crocus/blue/white utilities.
+- Payroll liquidation form, preview, confirmation, success, form-control, and action states now use `surface`, `border`, `text-*`, `form-control-*`, `state-*`, and `action-*` tokens.
 
 ## Intentional Exceptions
 
@@ -29,9 +43,12 @@ Search scope excludes `node_modules`, lock files, build output, `.nuxt`, `public
 - User-configurable station colors: kitchen station dots, station forms, inherited station colors, and station fallback hex values preserve operator-selected colors.
 - Third-party brand colors: WhatsApp, Facebook, and Instagram hover colors keep their external brand identity.
 - Chart colors: analytics chart series and grid colors are chart configuration, not page chrome.
-- Print/content CSS: print tickets, docs layout surfaces, and article CTA hard white/black values are scoped rendering contexts.
+- Print/content CSS: print tickets, receipts, docs layout surfaces, city/blog article imagery overlays, and article CTA hard white/black values are scoped rendering contexts.
 - Token comments: primitive token files document source hex values for maintainability.
+- Static/legacy utilities that remain in active modules must be triaged per PR-sized surface before conversion; do not bulk-replace direct colors where the value represents data, external brand identity, print output, or operator configuration.
 
 ## Follow-Up Rule
 
 New UI state colors should use semantic tokens such as `state-*`, `status-*`, `status-chip-*`, `data-table-*`, `control-*`, or `primary`, not direct `purple-*`, `violet-*`, or brand hex utilities.
+
+Manual visual validation scope for #1186: supplier portal desktop/mobile navigation, supplier info bottom sheet, and payroll liquidation form/preview/confirmation/success states.

--- a/pages/equipo/salarios/[id]/prestaciones/liquidacion.vue
+++ b/pages/equipo/salarios/[id]/prestaciones/liquidacion.vue
@@ -154,21 +154,21 @@ fetchPaymentMethods()
 
     <!-- Header -->
     <div class="flex items-center gap-3">
-      <NuxtLink :to="`/equipo/salarios/${employeeId}`" class="text-gray-500 hover:text-gray-700">
+      <NuxtLink :to="`/equipo/salarios/${employeeId}`" class="text-text-secondary hover:text-text-primary">
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
         </svg>
       </NuxtLink>
       <div>
-        <h1 class="text-xl font-semibold text-gray-900">Liquidación de contrato</h1>
-        <p v-if="employee" class="text-sm text-gray-500">{{ employee.full_name }}</p>
+        <h1 class="text-xl font-semibold text-text-primary">Liquidación de contrato</h1>
+        <p v-if="employee" class="text-sm text-text-secondary">{{ employee.full_name }}</p>
       </div>
     </div>
 
     <!-- Already liquidated -->
     <template v-if="existing">
-      <div class="rounded-xl border border-gray-200 bg-white p-6 space-y-4">
-        <div class="flex items-center gap-2 text-amber-700 bg-amber-50 rounded-lg px-4 py-3 text-sm font-medium">
+      <div class="rounded-xl border border-border bg-surface p-6 space-y-4">
+        <div class="flex items-center gap-2 text-state-warning-text bg-state-warning-bg rounded-lg px-4 py-3 text-sm font-medium">
           <svg class="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
@@ -176,44 +176,44 @@ fetchPaymentMethods()
         </div>
         <dl class="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
           <div>
-            <dt class="text-gray-500">Causa</dt>
+            <dt class="text-text-secondary">Causa</dt>
             <dd class="font-medium">{{ causeLabels[existing.cause] ?? existing.cause }}</dd>
           </div>
           <div>
-            <dt class="text-gray-500">Fecha retiro</dt>
+            <dt class="text-text-secondary">Fecha retiro</dt>
             <dd class="font-medium">{{ formatDate(existing.termination_date) }}</dd>
           </div>
           <div>
-            <dt class="text-gray-500">Días trabajados</dt>
+            <dt class="text-text-secondary">Días trabajados</dt>
             <dd class="font-medium">{{ existing.days_worked }}</dd>
           </div>
           <div>
-            <dt class="text-gray-500">Salario base</dt>
+            <dt class="text-text-secondary">Salario base</dt>
             <dd class="font-medium">{{ formatCOP(existing.base_salary) }}</dd>
           </div>
           <div>
-            <dt class="text-gray-500">Cesantías</dt>
+            <dt class="text-text-secondary">Cesantías</dt>
             <dd class="font-medium">{{ formatCOP(existing.cesantias_amount) }}</dd>
           </div>
           <div>
-            <dt class="text-gray-500">Prima</dt>
+            <dt class="text-text-secondary">Prima</dt>
             <dd class="font-medium">{{ formatCOP(existing.prima_amount) }}</dd>
           </div>
           <div>
-            <dt class="text-gray-500">Vacaciones</dt>
+            <dt class="text-text-secondary">Vacaciones</dt>
             <dd class="font-medium">{{ formatCOP(existing.vacaciones_amount) }}</dd>
           </div>
           <div>
-            <dt class="text-gray-500">Int. cesantías</dt>
+            <dt class="text-text-secondary">Int. cesantías</dt>
             <dd class="font-medium">{{ formatCOP(existing.int_cesantias_amount) }}</dd>
           </div>
           <div v-if="Number(existing.indemnizacion_amount) > 0">
-            <dt class="text-gray-500">Indemnización</dt>
-            <dd class="font-medium text-red-600">{{ formatCOP(existing.indemnizacion_amount) }}</dd>
+            <dt class="text-text-secondary">Indemnización</dt>
+            <dd class="font-medium text-state-danger-text">{{ formatCOP(existing.indemnizacion_amount) }}</dd>
           </div>
           <div class="col-span-2 border-t pt-3">
-            <dt class="text-gray-500">Total liquidación</dt>
-            <dd class="text-lg font-bold text-gray-900">{{ formatCOP(existing.total_amount) }}</dd>
+            <dt class="text-text-secondary">Total liquidación</dt>
+            <dd class="text-lg font-bold text-text-primary">{{ formatCOP(existing.total_amount) }}</dd>
           </div>
         </dl>
       </div>
@@ -221,27 +221,27 @@ fetchPaymentMethods()
 
     <!-- Phase: form -->
     <template v-else-if="phase === 'form'">
-      <div class="rounded-xl border border-gray-200 bg-white p-6 space-y-5">
+      <div class="rounded-xl border border-border bg-surface p-6 space-y-5">
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div class="flex flex-col gap-1">
-            <label class="text-sm font-medium text-gray-700">Fecha inicio contrato *</label>
+            <label class="text-sm font-medium text-text-secondary">Fecha inicio contrato *</label>
             <input v-model="form.contract_start_date" type="date"
-              class="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 min-h-[44px]" />
+              class="rounded-lg border border-form-control-border px-3 py-2 text-sm focus:ring-2 focus:ring-form-control-focus-ring focus:border-form-control-focus-border min-h-[44px]" />
           </div>
           <div class="flex flex-col gap-1">
-            <label class="text-sm font-medium text-gray-700">Fecha retiro *</label>
+            <label class="text-sm font-medium text-text-secondary">Fecha retiro *</label>
             <input v-model="form.termination_date" type="date"
-              class="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 min-h-[44px]" />
+              class="rounded-lg border border-form-control-border px-3 py-2 text-sm focus:ring-2 focus:ring-form-control-focus-ring focus:border-form-control-focus-border min-h-[44px]" />
           </div>
           <div class="flex flex-col gap-1">
-            <label class="text-sm font-medium text-gray-700">Salario base mensual *</label>
+            <label class="text-sm font-medium text-text-secondary">Salario base mensual *</label>
             <input v-model="form.base_salary" type="number" min="0" step="1000" placeholder="1300000"
-              class="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 min-h-[44px]" />
+              class="rounded-lg border border-form-control-border px-3 py-2 text-sm focus:ring-2 focus:ring-form-control-focus-ring focus:border-form-control-focus-border min-h-[44px]" />
           </div>
           <div class="flex flex-col gap-1">
-            <label class="text-sm font-medium text-gray-700">Tipo de contrato *</label>
+            <label class="text-sm font-medium text-text-secondary">Tipo de contrato *</label>
             <select v-model="form.employment_type"
-              class="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 min-h-[44px]">
+              class="rounded-lg border border-form-control-border px-3 py-2 text-sm focus:ring-2 focus:ring-form-control-focus-ring focus:border-form-control-focus-border min-h-[44px]">
               <option value="">Seleccionar...</option>
               <option value="employee">Empleado (contrato laboral)</option>
               <option value="daily">Jornalero</option>
@@ -249,9 +249,9 @@ fetchPaymentMethods()
             </select>
           </div>
           <div class="flex flex-col gap-1 sm:col-span-2">
-            <label class="text-sm font-medium text-gray-700">Causa de terminación *</label>
+            <label class="text-sm font-medium text-text-secondary">Causa de terminación *</label>
             <select v-model="form.cause"
-              class="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 min-h-[44px]">
+              class="rounded-lg border border-form-control-border px-3 py-2 text-sm focus:ring-2 focus:ring-form-control-focus-ring focus:border-form-control-focus-border min-h-[44px]">
               <option value="sin_justa_causa">Sin justa causa (empleador termina sin causa)</option>
               <option value="justa_causa">Con justa causa (falta grave del empleado)</option>
               <option value="renuncia">Renuncia voluntaria</option>
@@ -259,7 +259,7 @@ fetchPaymentMethods()
           </div>
         </div>
 
-        <p v-if="previewError" class="flex items-center gap-1 text-sm text-red-600">
+        <p v-if="previewError" class="flex items-center gap-1 text-sm text-state-danger-text">
           <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
@@ -267,7 +267,7 @@ fetchPaymentMethods()
         </p>
 
         <button @click="calculatePreview" :disabled="previewLoading"
-          class="w-full rounded-lg bg-blue-600 px-4 py-3 text-sm font-semibold text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px]">
+          class="w-full rounded-lg bg-action-info-bg px-4 py-3 text-sm font-semibold text-action-info-text hover:bg-action-info-hover-bg focus:ring-2 focus:ring-action-info-focus-ring active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px]">
           <span v-if="previewLoading">Calculando...</span>
           <span v-else>Calcular liquidación</span>
         </button>
@@ -276,46 +276,46 @@ fetchPaymentMethods()
 
     <!-- Phase: preview -->
     <template v-else-if="phase === 'preview'">
-      <div class="rounded-xl border border-gray-200 bg-white p-6 space-y-5">
-        <h2 class="text-base font-semibold text-gray-900">Desglose de liquidación</h2>
+      <div class="rounded-xl border border-border bg-surface p-6 space-y-5">
+        <h2 class="text-base font-semibold text-text-primary">Desglose de liquidación</h2>
 
         <dl class="space-y-3 text-sm">
           <div class="flex justify-between">
-            <dt class="text-gray-500">Días trabajados</dt>
+            <dt class="text-text-secondary">Días trabajados</dt>
             <dd class="font-medium">{{ breakdown?.days_worked }}</dd>
           </div>
           <div class="flex justify-between">
-            <dt class="text-gray-500">Cesantías</dt>
+            <dt class="text-text-secondary">Cesantías</dt>
             <dd class="font-medium">{{ formatCOP(breakdown?.cesantias_amount) }}</dd>
           </div>
           <div class="flex justify-between">
-            <dt class="text-gray-500">Prima de servicios</dt>
+            <dt class="text-text-secondary">Prima de servicios</dt>
             <dd class="font-medium">{{ formatCOP(breakdown?.prima_amount) }}</dd>
           </div>
           <div class="flex justify-between">
-            <dt class="text-gray-500">Vacaciones</dt>
+            <dt class="text-text-secondary">Vacaciones</dt>
             <dd class="font-medium">{{ formatCOP(breakdown?.vacaciones_amount) }}</dd>
           </div>
           <div class="flex justify-between">
-            <dt class="text-gray-500">Intereses sobre cesantías</dt>
+            <dt class="text-text-secondary">Intereses sobre cesantías</dt>
             <dd class="font-medium">{{ formatCOP(breakdown?.int_cesantias_amount) }}</dd>
           </div>
           <div v-if="Number(breakdown?.indemnizacion_amount) > 0" class="flex justify-between">
-            <dt class="text-gray-500">Indemnización (sin justa causa)</dt>
-            <dd class="font-medium text-red-600">{{ formatCOP(breakdown?.indemnizacion_amount) }}</dd>
+            <dt class="text-text-secondary">Indemnización (sin justa causa)</dt>
+            <dd class="font-medium text-state-danger-text">{{ formatCOP(breakdown?.indemnizacion_amount) }}</dd>
           </div>
           <div class="flex justify-between border-t pt-3">
-            <dt class="font-semibold text-gray-900">Total a pagar</dt>
-            <dd class="text-lg font-bold text-gray-900">{{ formatCOP(breakdown?.total_amount) }}</dd>
+            <dt class="font-semibold text-text-primary">Total a pagar</dt>
+            <dd class="text-lg font-bold text-text-primary">{{ formatCOP(breakdown?.total_amount) }}</dd>
           </div>
         </dl>
 
         <!-- Payment fields -->
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 border-t pt-4">
           <div class="flex flex-col gap-1">
-            <label class="text-sm font-medium text-gray-700">Método de pago</label>
+            <label class="text-sm font-medium text-text-secondary">Método de pago</label>
             <select v-model="form.payment_method"
-              class="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 min-h-[44px]">
+              class="rounded-lg border border-form-control-border px-3 py-2 text-sm focus:ring-2 focus:ring-form-control-focus-ring focus:border-form-control-focus-border min-h-[44px]">
               <option value="">Sin especificar</option>
               <template v-for="group in paymentGroups">
                 <option v-if="group.methods.length === 0" :key="group.id" :value="group.slug">{{ group.name }}</option>
@@ -324,24 +324,24 @@ fetchPaymentMethods()
             </select>
           </div>
           <div class="flex flex-col gap-1">
-            <label class="text-sm font-medium text-gray-700">Fecha de pago</label>
+            <label class="text-sm font-medium text-text-secondary">Fecha de pago</label>
             <input v-model="form.payment_date" type="date"
-              class="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 min-h-[44px]" />
+              class="rounded-lg border border-form-control-border px-3 py-2 text-sm focus:ring-2 focus:ring-form-control-focus-ring focus:border-form-control-focus-border min-h-[44px]" />
           </div>
           <div class="flex flex-col gap-1 sm:col-span-2">
-            <label class="text-sm font-medium text-gray-700">Notas (opcional)</label>
+            <label class="text-sm font-medium text-text-secondary">Notas (opcional)</label>
             <textarea v-model="form.notes" rows="2" placeholder="Observaciones adicionales..."
-              class="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 resize-none" />
+              class="rounded-lg border border-form-control-border px-3 py-2 text-sm focus:ring-2 focus:ring-form-control-focus-ring focus:border-form-control-focus-border resize-none" />
           </div>
         </div>
 
         <div class="flex gap-3">
           <button @click="backToForm"
-            class="flex-1 rounded-lg border border-gray-300 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-gray-400 transition-all min-h-[44px]">
+            class="flex-1 rounded-lg border border-action-secondary-border px-4 py-3 text-sm font-medium text-action-secondary-text hover:bg-action-secondary-hover-bg focus:ring-2 focus:ring-action-secondary-focus-ring transition-all min-h-[44px]">
             Volver
           </button>
           <button @click="goToConfirm"
-            class="flex-1 rounded-lg bg-red-600 px-4 py-3 text-sm font-semibold text-white hover:bg-red-700 focus:ring-2 focus:ring-red-500 active:scale-[0.98] transition-all min-h-[44px]">
+            class="flex-1 rounded-lg bg-action-destructive-bg px-4 py-3 text-sm font-semibold text-action-destructive-text hover:bg-action-destructive-hover-bg focus:ring-2 focus:ring-action-destructive-focus-ring active:scale-[0.98] transition-all min-h-[44px]">
             Continuar
           </button>
         </div>
@@ -350,14 +350,14 @@ fetchPaymentMethods()
 
     <!-- Phase: confirm (danger gate) -->
     <template v-else-if="phase === 'confirm'">
-      <div class="rounded-xl border-2 border-red-300 bg-red-50 p-6 space-y-4">
+      <div class="rounded-xl border-2 border-state-danger-border bg-state-danger-bg p-6 space-y-4">
         <div class="flex items-start gap-3">
-          <svg class="w-6 h-6 text-red-600 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-6 h-6 text-state-danger-icon flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
           </svg>
           <div>
-            <h2 class="text-base font-bold text-red-800">Confirmar liquidación — acción irreversible</h2>
-            <p class="mt-1 text-sm text-red-700">
+            <h2 class="text-base font-bold text-state-danger-text">Confirmar liquidación — acción irreversible</h2>
+            <p class="mt-1 text-sm text-state-danger-text">
               Esta acción registrará la liquidación de <strong>{{ employee?.full_name }}</strong> por
               <strong>{{ formatCOP(breakdown?.total_amount) }}</strong> ({{ causeLabels[form.cause] }})
               y marcará al empleado como retirado. No se puede deshacer.
@@ -365,7 +365,7 @@ fetchPaymentMethods()
           </div>
         </div>
 
-        <p v-if="submitError" class="flex items-center gap-1 text-sm text-red-700 font-medium">
+        <p v-if="submitError" class="flex items-center gap-1 text-sm text-state-danger-text font-medium">
           <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
@@ -374,11 +374,11 @@ fetchPaymentMethods()
 
         <div class="flex gap-3">
           <button @click="phase = 'preview'"
-            class="flex-1 rounded-lg border border-red-300 px-4 py-3 text-sm font-medium text-red-700 hover:bg-red-100 focus:ring-2 focus:ring-red-400 transition-all min-h-[44px]">
+            class="flex-1 rounded-lg border border-state-danger-border px-4 py-3 text-sm font-medium text-state-danger-text hover:bg-state-danger-bg focus:ring-2 focus:ring-action-destructive-focus-ring transition-all min-h-[44px]">
             Cancelar
           </button>
           <button @click="submitLiquidacion" :disabled="submitLoading"
-            class="flex-1 rounded-lg bg-red-700 px-4 py-3 text-sm font-bold text-white hover:bg-red-800 focus:ring-2 focus:ring-red-600 active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px]">
+            class="flex-1 rounded-lg bg-action-destructive-bg px-4 py-3 text-sm font-bold text-action-destructive-text hover:bg-action-destructive-hover-bg focus:ring-2 focus:ring-action-destructive-focus-ring active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px]">
             <span v-if="submitLoading">Registrando...</span>
             <span v-else>Sí, registrar liquidación</span>
           </button>
@@ -388,13 +388,13 @@ fetchPaymentMethods()
 
     <!-- Phase: done -->
     <template v-else-if="phase === 'done'">
-      <div class="rounded-xl border border-green-200 bg-green-50 p-6 flex items-center gap-3">
-        <svg class="w-8 h-8 text-green-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div class="rounded-xl border border-state-success-border bg-state-success-bg p-6 flex items-center gap-3">
+        <svg class="w-8 h-8 text-state-success-icon flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
         <div>
-          <p class="text-base font-semibold text-green-800">Liquidación registrada exitosamente</p>
-          <p class="text-sm text-green-700 mt-0.5">El empleado ha sido marcado como retirado y el asiento contable fue generado.</p>
+          <p class="text-base font-semibold text-state-success-text">Liquidación registrada exitosamente</p>
+          <p class="text-sm text-state-success-text mt-0.5">El empleado ha sido marcado como retirado y el asiento contable fue generado.</p>
         </div>
       </div>
     </template>


### PR DESCRIPTION
## Summary

- Tokenized payroll liquidation form, preview, confirmation, success, form-control, and action states.
- Preserved supplier portal tokenization already present on current `main` after rebase.
- Updated `docs/engineering/visual-token-color-audit.md` with #1186 final audit counts, remaining exception categories, and manual validation scope.

## Before / After Counts

Scope: `pages`, `components`, `layouts`, `composables`; excludes `node_modules`, `.nuxt`, `.output`, `dist`, and `public`.

| Search | Before | After |
|---|---:|---:|
| Direct Tailwind color utilities | 1619 | 1527 |
| Hex / `rgb(a)` literals | 541 | 534 |
| Hover/focus/active/disabled color states | 229 | 202 |

Touched liquidation file now returns no matches for the audit utility / hex-rgb / interaction-state patterns.

## Validation

- `git diff --check`
- Final `rg` count commands for direct utilities, hex/rgb, and interaction-state utilities
- Touched-file audit-pattern scan

No dev server was opened. Manual visual validation scope: supplier portal desktop/mobile navigation, supplier info bottom sheet, and payroll liquidation form/preview/confirmation/success states.

Closes #1186
