### PR TITLE
Restore table contrast tokens

### DIFF
--- a/.wr/1195.yaml
+++ b/.wr/1195.yaml
@@ -1,0 +1,42 @@
+issue: 1195
+title: "Restaurar contraste visual en tablas componentizadas"
+repo: warocol.com
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/warocol.com
+stack: nuxt
+branch: wr-1195-table-contrast
+
+paths:
+  - components/ui/data-table/index.vue
+  - components/ui/ResponsiveDataView.vue
+  - assets/css/design-tokens.css
+  - tailwind.config.js
+
+ac:
+  - Desktop table headers have a clearly differentiated data-table token surface.
+  - Alternating rows show a perceptible zebra without breaking dark mode or custom rowClass.
+  - Row hover is visible and consistent in UiResponsiveDataView/UiDataTable.
+  - Manual smoke scope is listed for 2-3 representative list/table routes.
+  - No API/data/layout/column redesign.
+
+out_of_scope:
+  - Backend/API changes.
+  - Migrating raw tables that do not use UiDataTable.
+  - Business-column or route-layout redesigns.
+
+hints:
+  entry: "components/ui/data-table/index.vue"
+  pattern: "assets/css/design-tokens.css data-table tokens currently make header, zebra, and hover too similar."
+  tests: "git diff --check; targeted rg for direct colors in touched component/tokens."
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits:
+    - full build/typecheck unless explicitly requested
+    - dev server unless explicitly requested
+
+next:
+  after_pr: "none"

--- a/assets/css/design-tokens.css
+++ b/assets/css/design-tokens.css
@@ -353,11 +353,11 @@
 
   /* === COMPONENT TOKENS: DATA TABLE === */
   --data-table-container-bg: var(--surface);
-  --data-table-header-bg: var(--surface-secondary);
-  --data-table-header-text: var(--text-secondary);
+  --data-table-header-bg: var(--neutral-200);
+  --data-table-header-text: var(--text-primary);
   --data-table-row-bg: var(--surface);
-  --data-table-row-alt-bg: var(--surface-secondary);
-  --data-table-row-hover-bg: var(--surface-secondary);
+  --data-table-row-alt-bg: var(--neutral-100);
+  --data-table-row-hover-bg: var(--neutral-200);
   --data-table-row-selected-bg: var(--crocus-50);
   --data-table-row-new-bg: var(--crocus-50);
   --data-table-border: var(--border);
@@ -544,11 +544,11 @@
 
   /* === COMPONENT TOKENS OSCUROS: DATA TABLE === */
   --data-table-container-bg: var(--surface);
-  --data-table-header-bg: var(--surface-secondary);
-  --data-table-header-text: var(--text-secondary);
+  --data-table-header-bg: var(--neutral-600);
+  --data-table-header-text: var(--text-primary);
   --data-table-row-bg: var(--surface);
-  --data-table-row-alt-bg: var(--surface-secondary);
-  --data-table-row-hover-bg: var(--surface-tertiary);
+  --data-table-row-alt-bg: var(--neutral-700);
+  --data-table-row-hover-bg: var(--neutral-600);
   --data-table-row-selected-bg: var(--neutral-700);
   --data-table-row-new-bg: var(--neutral-700);
   --data-table-border: var(--border);
@@ -681,11 +681,11 @@
 
   /* === COMPONENT TOKENS CLAROS: DATA TABLE === */
   --data-table-container-bg: var(--surface);
-  --data-table-header-bg: var(--surface-secondary);
-  --data-table-header-text: var(--text-secondary);
+  --data-table-header-bg: var(--neutral-200);
+  --data-table-header-text: var(--text-primary);
   --data-table-row-bg: var(--surface);
-  --data-table-row-alt-bg: var(--surface-secondary);
-  --data-table-row-hover-bg: var(--surface-secondary);
+  --data-table-row-alt-bg: var(--neutral-100);
+  --data-table-row-hover-bg: var(--neutral-200);
   --data-table-row-selected-bg: var(--crocus-50);
   --data-table-row-new-bg: var(--crocus-50);
   --data-table-border: var(--border);

--- a/components/ui/data-table/index.vue
+++ b/components/ui/data-table/index.vue
@@ -47,7 +47,7 @@ const tableHeaderVariants = cva(
     variants: {
       variant: {
         default: 'bg-data-table-header-bg border-data-table-border',
-        minimal: 'bg-data-table-container-bg border-data-table-border',
+        minimal: 'bg-data-table-header-bg border-data-table-border',
         elevated: 'bg-data-table-header-bg border-data-table-border'
       }
     },
@@ -63,7 +63,7 @@ const tableRowVariants = cva(
     variants: {
       variant: {
         default: 'border-data-table-border hover:bg-data-table-row-hover-bg',
-        minimal: 'border-data-table-border hover:bg-data-table-row-hover-bg/50',
+        minimal: 'border-data-table-border hover:bg-data-table-row-hover-bg',
         elevated: 'border-data-table-border hover:bg-data-table-row-hover-bg'
       },
       rowType: {
@@ -330,7 +330,7 @@ watch(
             :key="getRowKey(row, index)"
             :class="[
               tableRowVariants({ variant, rowType: 'normal' }),
-              rowClass?.(row) || (index % 2 === 0 ? 'bg-data-table-row-bg' : 'bg-data-table-row-alt-bg/30'),
+              rowClass?.(row) || (index % 2 === 0 ? 'bg-data-table-row-bg' : 'bg-data-table-row-alt-bg'),
               recentRowKeys.has(getRowKey(row, index)) && 'table-row-new',
               'cursor-pointer hover:bg-data-table-row-hover-bg transition-colors'
             ]"


### PR DESCRIPTION
## Summary

- Strengthens `data-table-*` tokens so table headers, zebra rows, and hover states are visibly differentiated again.
- Restores full zebra striping on alternating `UiDataTable` rows instead of rendering the alternate row at low opacity.
- Applies the visible header/hover treatment to the `minimal` table variant too, which is used by `UiResponsiveDataView` compact tables.
- Keeps `rowClass` as the override path for custom row states.

## Validation

- `git diff --check`
- Targeted scan of touched table component/tokens for stale low-opacity table classes and direct color regressions

Manual smoke scope: `UiResponsiveDataView`/`UiDataTable` list pages in finance, abastecimiento, and ventas/operaciones.

Closes #1195
