### PR TITLE
Increase table row contrast

### DIFF
--- a/assets/css/design-tokens.css
+++ b/assets/css/design-tokens.css
@@ -356,8 +356,8 @@
   --data-table-header-bg: var(--neutral-200);
   --data-table-header-text: var(--text-primary);
   --data-table-row-bg: var(--surface);
-  --data-table-row-alt-bg: var(--neutral-100);
-  --data-table-row-hover-bg: var(--neutral-200);
+  --data-table-row-alt-bg: var(--neutral-200);
+  --data-table-row-hover-bg: var(--neutral-300);
   --data-table-row-selected-bg: var(--crocus-50);
   --data-table-row-new-bg: var(--crocus-50);
   --data-table-border: var(--border);
@@ -547,8 +547,8 @@
   --data-table-header-bg: var(--neutral-600);
   --data-table-header-text: var(--text-primary);
   --data-table-row-bg: var(--surface);
-  --data-table-row-alt-bg: var(--neutral-700);
-  --data-table-row-hover-bg: var(--neutral-600);
+  --data-table-row-alt-bg: var(--neutral-600);
+  --data-table-row-hover-bg: var(--neutral-500);
   --data-table-row-selected-bg: var(--neutral-700);
   --data-table-row-new-bg: var(--neutral-700);
   --data-table-border: var(--border);
@@ -684,8 +684,8 @@
   --data-table-header-bg: var(--neutral-200);
   --data-table-header-text: var(--text-primary);
   --data-table-row-bg: var(--surface);
-  --data-table-row-alt-bg: var(--neutral-100);
-  --data-table-row-hover-bg: var(--neutral-200);
+  --data-table-row-alt-bg: var(--neutral-200);
+  --data-table-row-hover-bg: var(--neutral-300);
   --data-table-row-selected-bg: var(--crocus-50);
   --data-table-row-new-bg: var(--crocus-50);
   --data-table-border: var(--border);


### PR DESCRIPTION
## Summary

- Increases table zebra and hover token contrast after header contrast was fixed but row states remained too subtle.
- Keeps header token values unchanged.
- Light mode: zebra `neutral-200`, hover `neutral-300`.
- Dark mode: zebra `neutral-600`, hover `neutral-500`.

## Validation

- `git diff --check`
- Targeted token scan for `data-table-row-alt-bg` and `data-table-row-hover-bg`

Follow-up to #1195 / #1196.
