### PR TITLE
Let menu product rows use table zebra

### DIFF
--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -1378,18 +1378,17 @@ const costDriftProductIds = computed(() => {
 
 const bannerDismissed = ref(false)
 
-const catalogRowBaseClass = (row: { id: string }, index: number) => {
+const catalogRowBaseClass = (row: { id: string }) => {
   if (costIssueProductIds.value.has(row.id)) return 'bg-status-critical-bg'
   if (costDriftProductIds.value.has(row.id)) return 'bg-status-warning-bg/40'
-  return index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'
+  return ''
 }
 
-const catalogRowClass = (row: { id: string }, index: number) =>
-  catalogRowSelectionClass(row.id, catalogRowBaseClass(row, index))
+const catalogRowClass = (row: { id: string }, _index?: number) =>
+  catalogRowSelectionClass(row.id, catalogRowBaseClass(row))
 
 const getRowClass = (row: any): string => {
-  const index = displayProducts.value.findIndex((p: { id: string }) => p.id === row.id)
-  return catalogRowClass(row, index >= 0 ? index : 0)
+  return catalogRowClass(row)
 }
 
 // Inject refresh handler setter from layout


### PR DESCRIPTION
## Summary

- Fixes `/menu/productos` overriding `UiDataTable` zebra/hover row styles for normal product rows.
- Keeps cost issue and cost drift row highlights intact.
- Keeps selected-row styling intact through `catalogRowSelectionClass`.

## Why

The central table tokens were working, but this page always returned a `rowClass` for normal rows (`bg-surface` / `bg-surface-secondary/30`). In `UiDataTable`, any returned `rowClass` replaces the component zebra fallback.

## Validation

- `git diff --check`
- Targeted grep confirmed the local `bg-surface-secondary/30` row override is removed.

Follow-up to #1195 / #1196 / #1197.
