### PR TITLE
Let promotions rows use table zebra

### DIFF
--- a/pages/operaciones/promociones/index.vue
+++ b/pages/operaciones/promociones/index.vue
@@ -466,8 +466,7 @@ const filteredPromotions = computed(() => {
   return rows
 })
 
-const promoRowClass = (_row: PromotionRow, index: number) =>
-  index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'
+const promoRowClass = (_row: PromotionRow, _index: number) => ''
 
 const getRowClass = (row: PromotionRow) => {
   const index = filteredPromotions.value.findIndex((p) => p.id === row.id)


### PR DESCRIPTION
## Summary

- Fixes `/operaciones/promociones` overriding `UiDataTable` zebra/hover row styles for normal rows.
- Removes the local low-contrast `bg-surface-secondary/30` zebra fallback so the shared table component controls row striping and hover.

## Validation

- `git diff --check`
- Targeted grep confirmed the local low-contrast row override is removed.

Follow-up to table contrast work.
