### PR TITLE
Soften table zebra contrast

### DIFF
--- a/assets/css/design-tokens.css
+++ b/assets/css/design-tokens.css
@@ -356,7 +356,7 @@
   --data-table-header-bg: var(--neutral-200);
   --data-table-header-text: var(--text-primary);
   --data-table-row-bg: var(--surface);
-  --data-table-row-alt-bg: var(--neutral-200);
+  --data-table-row-alt-bg: var(--neutral-100);
   --data-table-row-hover-bg: var(--neutral-300);
   --data-table-row-selected-bg: var(--crocus-50);
   --data-table-row-new-bg: var(--crocus-50);
@@ -547,7 +547,7 @@
   --data-table-header-bg: var(--neutral-600);
   --data-table-header-text: var(--text-primary);
   --data-table-row-bg: var(--surface);
-  --data-table-row-alt-bg: var(--neutral-600);
+  --data-table-row-alt-bg: var(--neutral-700);
   --data-table-row-hover-bg: var(--neutral-500);
   --data-table-row-selected-bg: var(--neutral-700);
   --data-table-row-new-bg: var(--neutral-700);
@@ -684,7 +684,7 @@
   --data-table-header-bg: var(--neutral-200);
   --data-table-header-text: var(--text-primary);
   --data-table-row-bg: var(--surface);
-  --data-table-row-alt-bg: var(--neutral-200);
+  --data-table-row-alt-bg: var(--neutral-100);
   --data-table-row-hover-bg: var(--neutral-300);
   --data-table-row-selected-bg: var(--crocus-50);
   --data-table-row-new-bg: var(--crocus-50);


### PR DESCRIPTION
## Summary

- Softens zebra striping after the stronger row tokens proved too saturated in real tables.
- Keeps table headers and hover states more visible than zebra rows.
- Light mode: zebra `neutral-100`, hover `neutral-300`.
- Dark mode: zebra `neutral-700`, hover `neutral-500`.

## Rationale

UX/table guidance favors subtle neutral zebra striping; it should help tracking rows without competing with content or hover/selected states.

## Validation

- `git diff --check`
- Targeted token scan for data-table header/zebra/hover values
