### PR TITLE
Fix table zebra on orders and chart tokens

### DIFF
--- a/components/analytics/SalesChart.vue
+++ b/components/analytics/SalesChart.vue
@@ -41,6 +41,21 @@ const formatValue = (value: number): string => {
   return `$${Math.round(value)}`;
 };
 
+const hslToken = (name: string, fallback: string, seen = new Set<string>()): string => {
+  if (!import.meta.client) return fallback;
+  if (seen.has(name)) return fallback;
+  seen.add(name);
+
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+
+  const alias = value.match(/^var\((--[^)]+)\)$/);
+  if (alias) return hslToken(alias[1], fallback, seen);
+
+  return value ? `hsl(${value})` : fallback;
+};
+
 const series = computed(() => [
   {
     name: props.comparisonLabel,
@@ -75,25 +90,27 @@ const chartOptions = computed(() => ({
       opacityTo: 0.30,
     },
   },
-  // Chart palette exception: Apex requires literal series/axis colors.
-  colors: ['#f59e0b', '#4f46e5'],
+  colors: [
+    hslToken('--state-warning-icon', '#d97706'),
+    hslToken('--state-info-icon', '#2563eb'),
+  ],
   xaxis: {
     categories: data.value.map(d => d.name),
-    axisBorder: { color: '#e2e8f0' },
+    axisBorder: { color: hslToken('--data-table-border', '#e2e8f0') },
     axisTicks: { show: false },
     labels: {
-      style: { colors: '#64748b', fontSize: '11px' },
+      style: { colors: hslToken('--data-table-cell-muted', '#64748b'), fontSize: '11px' },
     },
     tooltip: { enabled: false },
   },
   yaxis: {
     labels: {
-      style: { colors: '#64748b', fontSize: '11px' },
+      style: { colors: hslToken('--data-table-cell-muted', '#64748b'), fontSize: '11px' },
       formatter: formatValue,
     },
   },
   grid: {
-    borderColor: '#f1f5f9',
+    borderColor: hslToken('--data-table-border', '#f1f5f9'),
     strokeDashArray: 4,
     xaxis: { lines: { show: false } },
     yaxis: { lines: { show: true } },
@@ -102,7 +119,7 @@ const chartOptions = computed(() => ({
   dataLabels: { enabled: false },
   markers: {
     size: [4, 6],
-    strokeColors: '#fff',
+    strokeColors: hslToken('--data-table-container-bg', '#fff'),
     strokeWidth: 2,
     hover: { size: 7 },
   },

--- a/pages/despacho/en-mesa/index.vue
+++ b/pages/despacho/en-mesa/index.vue
@@ -209,8 +209,8 @@ const viewRequest = (request: TableQrRequestRow) => {
         >
           <template #card="{ item, index }">
             <div
-              class="flex items-center gap-3 py-3 px-3 border-b border-border cursor-pointer transition-colors hover:bg-surface-secondary"
-              :class="index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'"
+              class="flex items-center gap-3 py-3 px-3 border-b border-data-table-border cursor-pointer transition-colors hover:bg-data-table-row-hover-bg"
+              :class="index % 2 === 0 ? 'bg-data-table-row-bg' : 'bg-data-table-row-alt-bg'"
               @click="viewRequest(item)"
             >
               <div class="flex-1 min-w-0">

--- a/pages/ventas/ordenes.vue
+++ b/pages/ventas/ordenes.vue
@@ -188,12 +188,12 @@ const clearSelection = () => {
 
 const orderRowClass = (row: { id: string }, index: number) => {
   if (selectedIds.value.includes(row.id)) return 'bg-primary/10'
-  return index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'
+  return index % 2 === 0 ? 'bg-data-table-row-bg' : 'bg-data-table-row-alt-bg'
 }
 
 const getRowClass = (row: { id: string }) => {
-  const index = orders.value.findIndex((o: { id: string }) => o.id === row.id)
-  return orderRowClass(row, index >= 0 ? index : 0)
+  if (selectedIds.value.includes(row.id)) return 'bg-primary/10'
+  return ''
 }
 
 const bulkUpdateStatus = () => {
@@ -565,7 +565,7 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
           <div
             v-if="item"
             @click="viewOrderDetails(item)"
-            class="flex items-center gap-3 py-3 px-3 border-b border-border cursor-pointer transition-colors hover:bg-surface-secondary"
+            class="flex items-center gap-3 py-3 px-3 border-b border-border cursor-pointer transition-colors hover:bg-data-table-row-hover-bg"
             :class="orderRowClass(item, index)"
           >
             <!-- Left: order info -->


### PR DESCRIPTION
## Summary
- let `/ventas/ordenes` desktop rows use the shared table zebra fallback unless selected
- move order and table-QR mobile card stripes to data-table zebra/hover tokens
- resolve `/analitica/ventas` Apex chart colors from CSS tokens with SSR fallbacks

## Verification
- npm run build
- git diff --check
