### PR TITLE
Remove semaphore wrappers from operaciones and despacho

### DIFF
--- a/components/ui/AdvancedFiltersBar.vue
+++ b/components/ui/AdvancedFiltersBar.vue
@@ -1,81 +1,88 @@
 <template>
   <div class="advanced-filters-bar flex flex-wrap items-center gap-2 w-full">
-    <!-- Search -->
-    <div
-      v-if="showSearch"
-      class="relative w-full min-w-[12rem] max-w-full sm:w-auto sm:max-w-xs shrink-0"
-    >
-      <button
-        type="button"
-        class="absolute left-3 top-1/2 transform -translate-y-1/2 text-text-secondary hover:text-primary transition-colors cursor-pointer"
-        aria-label="Buscar"
-        @click="emit('search')"
+    <div class="advanced-filters-bar__controls flex min-w-0 flex-1 flex-wrap items-center gap-2">
+      <!-- Search -->
+      <div
+        v-if="showSearch"
+        class="relative w-full min-w-[12rem] max-w-full sm:w-auto sm:max-w-xs shrink-0"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+        <button
+          type="button"
+          class="absolute left-3 top-1/2 transform -translate-y-1/2 text-text-secondary hover:text-primary transition-colors cursor-pointer"
+          aria-label="Buscar"
+          @click="emit('search')"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+          </svg>
+        </button>
+        <input
+          :value="search"
+          :placeholder="searchPlaceholder"
+          class="w-full h-10 pl-9 pr-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
+          @input="emit('update:search', ($event.target as HTMLInputElement).value)"
+          @keydown.enter="emit('search')"
+        />
+      </div>
+
+      <!-- Search field -->
+      <UiFilterSelect
+        v-if="showSearch && searchFields.length > 0"
+        :model-value="searchField"
+        placeholder="Campo"
+        :options="searchFields"
+        always-active
+        hide-placeholder
+        aria-label="Campo de búsqueda"
+        @update:model-value="emit('update:searchField', $event)"
+      />
+
+      <!-- Date range — fixed width so flex-wrap does not stretch to full row -->
+      <div
+        v-if="showDateRange"
+        class="advanced-filters-bar__date shrink-0 w-[12.5rem] sm:w-[13.5rem]"
+      >
+        <VueDatePicker
+          class="advanced-filters-bar__date-picker"
+          :model-value="dateRange"
+          range
+          :preset-dates="presetDates"
+          :enable-time-picker="false"
+          :locale="es"
+          placeholder="Rango de fechas"
+          auto-apply
+          :teleport="true"
+          :max-date="new Date()"
+          :format="formatDateRange"
+          input-class-name="dp-custom-input"
+          menu-class-name="dp-custom-menu"
+          calendar-cell-class-name="dp-custom-cell"
+          @update:model-value="emit('update:dateRange', $event)"
+        />
+      </div>
+
+      <slot name="additional-filters" />
+
+      <!-- Clear -->
+      <button
+        v-if="showClear"
+        type="button"
+        class="h-10 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-secondary hover:text-text-primary hover:border-primary transition-colors flex-shrink-0"
+        aria-label="Limpiar filtros"
+        @click="emit('clear')"
+      >
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>
       </button>
-      <input
-        :value="search"
-        :placeholder="searchPlaceholder"
-        class="w-full h-10 pl-9 pr-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
-        @input="emit('update:search', ($event.target as HTMLInputElement).value)"
-        @keydown.enter="emit('search')"
-      />
     </div>
 
-    <!-- Search field -->
-    <UiFilterSelect
-      v-if="showSearch && searchFields.length > 0"
-      :model-value="searchField"
-      placeholder="Campo"
-      :options="searchFields"
-      always-active
-      hide-placeholder
-      aria-label="Campo de búsqueda"
-      @update:model-value="emit('update:searchField', $event)"
-    />
-
-    <!-- Date range — fixed width so flex-wrap does not stretch to full row -->
     <div
-      v-if="showDateRange"
-      class="advanced-filters-bar__date shrink-0 w-[12.5rem] sm:w-[13.5rem]"
+      v-if="$slots.trailing"
+      class="advanced-filters-bar__trailing ml-auto flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto sm:flex-none"
     >
-      <VueDatePicker
-        class="advanced-filters-bar__date-picker"
-        :model-value="dateRange"
-        range
-        :preset-dates="presetDates"
-        :enable-time-picker="false"
-        :locale="es"
-        placeholder="Rango de fechas"
-        auto-apply
-        :teleport="true"
-        :max-date="new Date()"
-        :format="formatDateRange"
-        input-class-name="dp-custom-input"
-        menu-class-name="dp-custom-menu"
-        calendar-cell-class-name="dp-custom-cell"
-        @update:model-value="emit('update:dateRange', $event)"
-      />
+      <slot name="trailing" />
     </div>
-
-    <slot name="additional-filters" />
-
-    <!-- Clear -->
-    <button
-      v-if="showClear"
-      type="button"
-      class="h-10 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-secondary hover:text-text-primary hover:border-primary transition-colors flex-shrink-0"
-      aria-label="Limpiar filtros"
-      @click="emit('clear')"
-    >
-      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-      </svg>
-    </button>
-
-    <slot name="trailing" />
   </div>
 </template>
 

--- a/pages/despacho/comandas.vue
+++ b/pages/despacho/comandas.vue
@@ -3,8 +3,6 @@ import { onMounted, onUnmounted, ref, computed, watch } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 import { useActiveStationsQuery } from '@/composables/queries/useActiveStations'
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 
 definePageMeta({ layout: 'dashboard' })
 
@@ -262,6 +260,11 @@ const getComandaStatusVariant = (status: string): string => {
             aria-label="Filtrar por fecha"
           >
         </template>
+        <template #trailing>
+          <span class="text-xs font-bold text-text-secondary bg-surface-secondary px-2 py-0.5 rounded-full">
+            {{ comandas.filter(c => c.status !== 'cancelled').length }} activa{{ comandas.filter(c => c.status !== 'cancelled').length !== 1 ? 's' : '' }}
+          </span>
+        </template>
       </UiAdvancedFiltersBar>
 
       <!-- Bulk action bar -->
@@ -306,13 +309,7 @@ const getComandaStatusVariant = (status: string): string => {
         </div>
       </Transition>
 
-      <HealthSemaphore :is-unlocked="true" title="# Comanda">
-        <template #header-actions>
-          <span class="text-xs font-bold text-text-secondary bg-surface-secondary px-2 py-0.5 rounded-full">
-            {{ comandas.filter(c => c.status !== 'cancelled').length }} activa{{ comandas.filter(c => c.status !== 'cancelled').length !== 1 ? 's' : '' }}
-          </span>
-        </template>
-        <div class="[&_td]:!py-1 [&_th]:!py-1.5">
+      <div class="[&_td]:!py-1 [&_th]:!py-1.5">
         <UiResponsiveDataView
           row-size="sm"
           :columns="columns"
@@ -332,7 +329,7 @@ const getComandaStatusVariant = (status: string): string => {
               </svg>
             </span>
           </label>
-        </div>
+      </div>
       </template>
 
       <!-- Checkbox cell -->
@@ -442,7 +439,6 @@ const getComandaStatusVariant = (status: string): string => {
       </template>
         </UiResponsiveDataView>
         </div>
-      </HealthSemaphore>
     </div>
 
     <DespachoComandaDetailPanel v-model="panelOpen" :comanda="selectedComanda" @status-updated="refetchComandas" />

--- a/pages/despacho/domicilios/index.vue
+++ b/pages/despacho/domicilios/index.vue
@@ -2,8 +2,6 @@
 import { onMounted, onUnmounted, watch } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 
 definePageMeta({ layout: 'dashboard' })
 
@@ -166,7 +164,6 @@ const viewOrder = (order: any) => {
         </template>
       </UiAdvancedFiltersBar>
 
-      <HealthSemaphore :is-unlocked="true" title="Pedidos Online">
         <UiResponsiveDataView
           row-size="sm"
           :columns="columns"
@@ -229,7 +226,6 @@ const viewOrder = (order: any) => {
             <span class="text-sm text-text-secondary">{{ value ?? '—' }}</span>
           </template>
         </UiResponsiveDataView>
-      </HealthSemaphore>
     </div>
   </div>
 </template>

--- a/pages/despacho/en-mesa/index.vue
+++ b/pages/despacho/en-mesa/index.vue
@@ -2,8 +2,6 @@
 import { onMounted, onUnmounted, watch } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { formatTableQrPayment } from '~/composables/formatTableQrPayment'
 
 definePageMeta({ layout: 'dashboard' })
@@ -194,7 +192,6 @@ const viewRequest = (request: TableQrRequestRow) => {
         </template>
       </UiAdvancedFiltersBar>
 
-      <HealthSemaphore :is-unlocked="true" title="Pedidos en mesa (QR)">
         <UiResponsiveDataView
           row-size="sm"
           :columns="columns"
@@ -245,7 +242,6 @@ const viewRequest = (request: TableQrRequestRow) => {
             <span class="text-sm font-bold text-primary">{{ formatCurrency(value) }}</span>
           </template>
         </UiResponsiveDataView>
-      </HealthSemaphore>
     </div>
   </div>
 </template>

--- a/pages/operaciones/mesas.vue
+++ b/pages/operaciones/mesas.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { displayTableCode } from '~/composables/useTableDisplayCode'
 
 definePageMeta({
@@ -437,29 +436,26 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
             aria-label="Estado"
           />
         </template>
-      </UiAdvancedFiltersBar>
-
-      <!-- ══════ ACTIVE TABLES ══════ -->
-      <HealthSemaphore :is-unlocked="true" :title="`${plural} configuradas`">
-        <template #header-actions>
+        <template #trailing>
           <button
             type="button"
-              class="h-9 px-4 rounded-lg bg-primary text-sm font-semibold text-primary-foreground hover:bg-action-primary-hover-bg focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 active:scale-[0.98] transition-all shadow-sm shadow-primary/30 whitespace-nowrap"
+            class="h-9 px-4 rounded-lg bg-primary text-sm font-semibold text-primary-foreground hover:bg-action-primary-hover-bg focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 active:scale-[0.98] transition-all shadow-sm shadow-primary/30 whitespace-nowrap"
             @click="openPanel(null)"
           >
             <span class="hidden sm:inline">{{ `+ Nueva ${singularLower}` }}</span>
             <span class="sm:hidden">+ Nueva</span>
           </button>
         </template>
+      </UiAdvancedFiltersBar>
 
-        <UiResponsiveDataView
-          :columns="tableColumns"
-          :data="activeTables"
-          :empty-message="`No hay ${pluralLower} configuradas`"
-          :empty-sub-message="`Crea tu primera ${singularLower} para empezar a gestionar el salón`"
-          variant="default"
-          row-size="sm"
-        >
+      <UiResponsiveDataView
+        :columns="tableColumns"
+        :data="activeTables"
+        :empty-message="`No hay ${pluralLower} configuradas`"
+        :empty-sub-message="`Crea tu primera ${singularLower} para empezar a gestionar el salón`"
+        variant="default"
+        row-size="sm"
+      >
           <!-- Mobile card -->
           <template #card="{ item }">
             <div class="flex items-center gap-3 py-2 px-3 border-b border-border transition-colors hover:bg-surface-secondary">
@@ -575,11 +571,10 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
               </button>
             </div>
           </template>
-        </UiResponsiveDataView>
-      </HealthSemaphore>
+      </UiResponsiveDataView>
 
       <!-- ══════ INACTIVE TABLES ══════ -->
-      <HealthSemaphore v-if="inactiveTables.length > 0" :is-unlocked="true" :title="`${plural} desactivadas`">
+      <template v-if="inactiveTables.length > 0">
         <UiResponsiveDataView
           :columns="tableColumns"
           :data="inactiveTables"
@@ -651,7 +646,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
             </div>
           </template>
         </UiResponsiveDataView>
-      </HealthSemaphore>
+      </template>
     </div>
 
     <!-- Create / Edit Panel -->

--- a/pages/operaciones/promociones/index.vue
+++ b/pages/operaciones/promociones/index.vue
@@ -69,10 +69,7 @@
             <option value="bogo">2×1 / BOGO</option>
           </select>
         </template>
-      </UiAdvancedFiltersBar>
-
-      <HealthSemaphore :is-unlocked="true" title="Promociones">
-        <template #header-actions>
+        <template #trailing>
           <button
             type="button"
             class="btn-primary px-4 py-2 rounded-lg text-sm font-medium whitespace-nowrap min-h-[44px]"
@@ -81,16 +78,17 @@
             + Nueva promoción
           </button>
         </template>
+      </UiAdvancedFiltersBar>
 
-        <UiResponsiveDataView
-          :columns="columns"
-          :data="filteredPromotions"
-          :row-class="getRowClass"
-          empty-message="No hay promociones"
-          empty-sub-message="Crea la primera para aplicarla en el POS."
-          variant="default"
-          row-size="sm"
-        >
+      <UiResponsiveDataView
+        :columns="columns"
+        :data="filteredPromotions"
+        :row-class="getRowClass"
+        empty-message="No hay promociones"
+        empty-sub-message="Crea la primera para aplicarla en el POS."
+        variant="default"
+        row-size="sm"
+      >
           <template #card="{ item, index }">
             <div
               v-if="item"
@@ -218,8 +216,7 @@
               </button>
             </div>
           </template>
-        </UiResponsiveDataView>
-      </HealthSemaphore>
+      </UiResponsiveDataView>
     </div>
 
     <PromocionesPromocionPanel
@@ -242,8 +239,6 @@
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
 import { useQuery, useQueryCache } from '@pinia/colada'
 import { PencilSquareIcon } from '@heroicons/vue/24/outline'
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import {
   formatPromoTypeLabel,
   formatPromoValue,


### PR DESCRIPTION
## Summary
- Add a right-aligned trailing action lane to `UiAdvancedFiltersBar`
- Move operaciones/despacho table actions into filter bars
- Remove `HealthSemaphore` wrappers from the #1204 listing routes

## Validation
- `rg "HealthSemaphore" pages/operaciones/promociones/index.vue pages/operaciones/mesas.vue pages/operaciones/comandas.vue pages/despacho/en-mesa/index.vue pages/despacho/comandas.vue pages/despacho/domicilios/index.vue`
- SFC parse check for touched Vue files
- `./node_modules/.bin/nuxi prepare`
- Nuxt dev route checks returned 200 for `/operaciones/promociones`, `/operaciones/mesas`, `/operaciones/comandas`, `/despacho/comandas`, `/despacho/en-mesa`, `/despacho/domicilios`

Closes #1204
