### PR TITLE
Remove ventas and menu semaphore wrappers

### DIFF
--- a/components/menu/MenuCatalogFiltersBar.vue
+++ b/components/menu/MenuCatalogFiltersBar.vue
@@ -216,5 +216,9 @@ watch(
         <span class="font-semibold">Desfase costo</span>
       </label>
     </template>
+
+    <template v-if="$slots.trailing" #trailing>
+      <slot name="trailing" />
+    </template>
   </UiAdvancedFiltersBar>
 </template>

--- a/pages/menu/modificadores/index.vue
+++ b/pages/menu/modificadores/index.vue
@@ -15,9 +15,8 @@
         :show-clear="hasActiveFilters"
         @search="performSearch"
         @clear="onClearModificadoresFilters"
-      />
-      <HealthSemaphore :is-unlocked="true" title="Reglas y grupos de modificadores">
-        <template #header-actions>
+      >
+        <template #trailing>
           <button
             @click="goToCreateGroup"
             class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap"
@@ -26,15 +25,16 @@
             <span class="sm:hidden">+ Nuevo</span>
           </button>
         </template>
+      </UiAdvancedFiltersBar>
       <!-- Tabla de Grupos de Modificadores -->
       <UiResponsiveDataView
-      :columns="gruposTableColumns"
-      :data="modifierGroups"
-      empty-message="No hay grupos de modificadores registrados"
-      empty-sub-message="Crea un nuevo grupo para comenzar"
-      variant="default"
-      row-size="sm"
-    >
+        :columns="gruposTableColumns"
+        :data="modifierGroups"
+        empty-message="No hay grupos de modificadores registrados"
+        empty-sub-message="Crea un nuevo grupo para comenzar"
+        variant="default"
+        row-size="sm"
+      >
       <!-- Desktop Table Cells -->
       <template #cell-name="{ value }">
         <div class="flex items-center">
@@ -285,14 +285,12 @@
         </table>
       </div>
     </div>
-    </HealthSemaphore>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -46,7 +46,30 @@
           @search="onCatalogSearch"
           @clear="onCatalogClear"
           @filter-change="currentPage = 1"
-        />
+        >
+          <template #trailing>
+            <div class="flex flex-wrap items-center gap-2 justify-end">
+              <button
+                type="button"
+                class="px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap min-h-[44px] transition-colors"
+                :class="editMode
+                  ? 'bg-surface border-2 border-border text-text-primary hover:bg-surface-secondary'
+                  : 'btn-primary text-primary-foreground'"
+                @click="onToggleEditMode"
+              >
+                <span class="hidden sm:inline">{{ editMode ? 'Ver catálogo' : 'Modo edición' }}</span>
+                <span class="sm:hidden">{{ editMode ? 'Ver' : 'Editar' }}</span>
+              </button>
+              <NuxtLink
+                to="/menu/productos/crear"
+                class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap min-h-[44px] flex items-center"
+              >
+                <span class="hidden sm:inline">+ Nuevo producto</span>
+                <span class="sm:hidden">+ Nuevo</span>
+              </NuxtLink>
+            </div>
+          </template>
+        </MenuCatalogFiltersBar>
 
         <MenuCatalogBulkBar
           v-if="selectedIds.length > 0"
@@ -82,29 +105,6 @@
           @cancel="() => cancelEditOperation(clearSelection)"
         />
 
-        <HealthSemaphore :is-unlocked="true" :title="catalogTitle">
-          <template #header-actions>
-            <div class="flex flex-wrap items-center gap-2 justify-end">
-              <button
-                type="button"
-                class="px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap min-h-[44px] transition-colors"
-                :class="editMode
-                  ? 'bg-surface border-2 border-border text-text-primary hover:bg-surface-secondary'
-                  : 'btn-primary text-primary-foreground'"
-                @click="onToggleEditMode"
-              >
-                <span class="hidden sm:inline">{{ editMode ? 'Ver catálogo' : 'Modo edición' }}</span>
-                <span class="sm:hidden">{{ editMode ? 'Ver' : 'Editar' }}</span>
-              </button>
-              <NuxtLink
-                to="/menu/productos/crear"
-                class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap min-h-[44px] flex items-center"
-              >
-                <span class="hidden sm:inline">+ Nuevo producto</span>
-                <span class="sm:hidden">+ Nuevo</span>
-              </NuxtLink>
-            </div>
-          </template>
         <!-- Responsive Data View (Mobile Cards + Desktop Table) -->
         <UiResponsiveDataView
           :columns="productosTableColumns"
@@ -746,7 +746,6 @@
             </div>
           </div>
         </div>
-        </HealthSemaphore>
       </div>
     </div>
 
@@ -788,7 +787,6 @@
 import { onUnmounted, watch } from 'vue'
 import type { ProductTypeFilter } from '@/stores/menuFilters'
 import { useQueryCache } from '@pinia/colada'
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import { runSequentialProductPatches, runSequentialRequests, toastCatalogBulkResult, toastCatalogDeleteResult } from '@/composables/useMenuCatalogBulkSave'
 import { syncResaleIngredientName } from '@/composables/useResaleIngredientSync'
@@ -843,13 +841,6 @@ const {
 } = useMenuCatalogFilters()
 
 useHead({ title: 'Productos' })
-
-const catalogTitle = computed(() => {
-  const base = 'Catálogo y rentabilidad de productos'
-  if (productTypeFilter.value === 'resale') return `${base} — reventa`
-  if (productTypeFilter.value === 'menu') return `${base} — menú`
-  return base
-})
 
 let syncingProductTypeRoute = false
 

--- a/pages/menu/recetas/index.vue
+++ b/pages/menu/recetas/index.vue
@@ -19,16 +19,18 @@
           :show-clear="hasActiveFilters"
           @search="performSearch"
           @clear="onClearRecetasFilters"
-        />
-
-        <HealthSemaphore :is-unlocked="true" title="Estructura y costo de recetas base">
-          <template #header-actions>
-            <NuxtLink to="/menu/recetas/crear"
-              class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap">
+        >
+          <template #trailing>
+            <NuxtLink
+              to="/menu/recetas/crear"
+              class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap"
+            >
               <span class="hidden sm:inline">+ Nueva Receta Base</span>
               <span class="sm:hidden">+ Nueva</span>
             </NuxtLink>
           </template>
+        </UiAdvancedFiltersBar>
+
         <!-- Tabla de Recetas -->
         <UiResponsiveDataView
           :columns="recetasTableColumns"
@@ -259,7 +261,6 @@
             </table>
           </div>
         </div>
-        </HealthSemaphore>
       </div>
     </div>
   </div>
@@ -268,7 +269,6 @@
 <script setup lang="ts">
 import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import { ref, computed, onMounted, onUnmounted, inject, watch } from 'vue'
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 

--- a/pages/ventas/ordenes.vue
+++ b/pages/ventas/ordenes.vue
@@ -2,8 +2,6 @@
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 
 useHead({ title: 'Órdenes - Ventas' })
 
@@ -546,8 +544,8 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
       </div>
 
       <!-- Responsive Data View -->
-      <HealthSemaphore v-else :is-unlocked="true" title="Historial de Ventas">
       <UiResponsiveDataView
+        v-else
         :columns="ordersTableColumns"
         :data="orders"
         :sort-field="sortField"
@@ -709,7 +707,6 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
           />
         </template>
       </UiResponsiveDataView>
-      </HealthSemaphore>
 
       <!-- Pagination -->
       <div v-if="ordersTotal > 0" class="flex items-center justify-end px-1 py-2">

--- a/pages/ventas/productos.vue
+++ b/pages/ventas/productos.vue
@@ -3,8 +3,6 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { formatDistanceToNow } from 'date-fns'
 import { es } from 'date-fns/locale'
 import MetricCard from '~/components/shared/MetricCard.vue'
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 
 useHead({ title: 'Productos - Ventas' })
 
@@ -221,50 +219,49 @@ onUnmounted(() => {
       </div>
 
       <!-- Table -->
-      <HealthSemaphore v-else :is-unlocked="true" title="Productos más vendidos">
-        <UiResponsiveDataView
-          row-size="sm"
-          :columns="tableColumns"
-          :data="products"
-          :empty-message="emptyMessage"
-          :empty-sub-message="emptySubMessage"
-          variant="default"
-        >
-          <!-- Mobile card -->
-          <template #card="{ item, index }">
-            <div
-              class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-surface-secondary"
-              :class="index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'"
-            >
-              <div class="flex-1 min-w-0">
-                <p class="text-sm font-bold text-text-primary">{{ item.product_name }}</p>
-                <p class="text-xs text-text-secondary mt-0.5">{{ item.category_name ?? 'Sin categoría' }}</p>
-              </div>
-              <div class="flex flex-col items-end gap-0.5 flex-shrink-0">
-                <span class="text-sm font-bold text-primary tabular-nums">{{ formatCurrency(item.total_revenue) }}</span>
-                <span class="text-xs text-text-secondary">{{ item.quantity_sold }} uds.</span>
-              </div>
+      <UiResponsiveDataView
+        v-else
+        row-size="sm"
+        :columns="tableColumns"
+        :data="products"
+        :empty-message="emptyMessage"
+        :empty-sub-message="emptySubMessage"
+        variant="default"
+      >
+        <!-- Mobile card -->
+        <template #card="{ item, index }">
+          <div
+            class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-surface-secondary"
+            :class="index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'"
+          >
+            <div class="flex-1 min-w-0">
+              <p class="text-sm font-bold text-text-primary">{{ item.product_name }}</p>
+              <p class="text-xs text-text-secondary mt-0.5">{{ item.category_name ?? 'Sin categoría' }}</p>
             </div>
-          </template>
+            <div class="flex flex-col items-end gap-0.5 flex-shrink-0">
+              <span class="text-sm font-bold text-primary tabular-nums">{{ formatCurrency(item.total_revenue) }}</span>
+              <span class="text-xs text-text-secondary">{{ item.quantity_sold }} uds.</span>
+            </div>
+          </div>
+        </template>
 
-          <!-- Desktop cells -->
-          <template #cell-product_name="{ value }">
-            <span class="text-sm font-bold text-text-primary">{{ value }}</span>
-          </template>
+        <!-- Desktop cells -->
+        <template #cell-product_name="{ value }">
+          <span class="text-sm font-bold text-text-primary">{{ value }}</span>
+        </template>
 
-          <template #cell-category_name="{ value }">
-            <span class="text-sm text-text-secondary">{{ value ?? 'Sin categoría' }}</span>
-          </template>
+        <template #cell-category_name="{ value }">
+          <span class="text-sm text-text-secondary">{{ value ?? 'Sin categoría' }}</span>
+        </template>
 
-          <template #cell-quantity_sold="{ value }">
-            <span class="text-sm font-medium text-text-primary tabular-nums">{{ value }}</span>
-          </template>
+        <template #cell-quantity_sold="{ value }">
+          <span class="text-sm font-medium text-text-primary tabular-nums">{{ value }}</span>
+        </template>
 
-          <template #cell-total_revenue="{ value }">
-            <span class="text-sm font-bold text-primary tabular-nums">{{ formatCurrency(value) }}</span>
-          </template>
-        </UiResponsiveDataView>
-      </HealthSemaphore>
+        <template #cell-total_revenue="{ value }">
+          <span class="text-sm font-bold text-primary tabular-nums">{{ formatCurrency(value) }}</span>
+        </template>
+      </UiResponsiveDataView>
 
       <!-- Totals row -->
       <div


### PR DESCRIPTION
## Summary
- pass menu catalog actions through the shared filters bar trailing slot
- move menu listing actions into filter bars
- remove ventas/menu HealthSemaphore wrappers and unused imports

## Validation
- rg "HealthSemaphore" pages/ventas/ordenes.vue pages/ventas/productos.vue pages/menu/productos/index.vue pages/menu/recetas/index.vue pages/menu/modificadores/index.vue components/menu/MenuCatalogFiltersBar.vue
- git diff --check
- Vue SFC/template compile pass for edited files
- curl 200 checks for /menu/productos, /menu/recetas, /menu/modificadores, /ventas/ordenes, /ventas/productos

Closes #1205