### PR TITLE
Remove abastecimiento semaphore wrappers

### DIFF
--- a/components/inventario/StockInventoryView.vue
+++ b/components/inventario/StockInventoryView.vue
@@ -74,18 +74,17 @@
       </template>
     </UiAdvancedFiltersBar>
 
-    <HealthSemaphore :is-unlocked="true" title="Stock de Inventario">
-      <UiResponsiveDataView
-        row-size="sm"
-        :columns="stockTableColumns"
-        :data="inventory"
-        :sort-field="sortField"
-        :sort-direction="sortDirection"
-        :empty-message="copy.emptyMessage"
-        empty-sub-message="Comienza recibiendo compras en Abastecimiento"
-        variant="default"
-        @sort="$emit('sort', $event)"
-      >
+    <UiResponsiveDataView
+      row-size="sm"
+      :columns="stockTableColumns"
+      :data="inventory"
+      :sort-field="sortField"
+      :sort-direction="sortDirection"
+      :empty-message="copy.emptyMessage"
+      empty-sub-message="Comienza recibiendo compras en Abastecimiento"
+      variant="default"
+      @sort="$emit('sort', $event)"
+    >
         <template #card="{ item, index }">
           <div
             class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-surface-secondary"
@@ -208,44 +207,40 @@
             </button>
           </div>
         </template>
-      </UiResponsiveDataView>
+    </UiResponsiveDataView>
 
-      <div
-        v-if="total > itemsPerPage"
-        class="mt-4 bg-white px-4 py-3 flex items-center justify-between border border-titan-200 rounded-lg"
-      >
-        <p class="text-sm text-titan-700">
-          Mostrando <span class="font-medium">{{ startItem }}</span> a
-          <span class="font-medium">{{ endItem }}</span> de
-          <span class="font-medium">{{ total }}</span>
-        </p>
-        <div class="flex gap-2">
-          <button
-            type="button"
-            :disabled="!canGoPrevious"
-            class="px-4 py-2 border border-titan-300 text-sm rounded-md disabled:opacity-50"
-            @click="$emit('previous-page')"
-          >
-            Anterior
-          </button>
-          <button
-            type="button"
-            :disabled="!canGoNext"
-            class="px-4 py-2 border border-titan-300 text-sm rounded-md disabled:opacity-50"
-            @click="$emit('next-page')"
-          >
-            Siguiente
-          </button>
-        </div>
+    <div
+      v-if="total > itemsPerPage"
+      class="mt-4 bg-white px-4 py-3 flex items-center justify-between border border-titan-200 rounded-lg"
+    >
+      <p class="text-sm text-titan-700">
+        Mostrando <span class="font-medium">{{ startItem }}</span> a
+        <span class="font-medium">{{ endItem }}</span> de
+        <span class="font-medium">{{ total }}</span>
+      </p>
+      <div class="flex gap-2">
+        <button
+          type="button"
+          :disabled="!canGoPrevious"
+          class="px-4 py-2 border border-titan-300 text-sm rounded-md disabled:opacity-50"
+          @click="$emit('previous-page')"
+        >
+          Anterior
+        </button>
+        <button
+          type="button"
+          :disabled="!canGoNext"
+          class="px-4 py-2 border border-titan-300 text-sm rounded-md disabled:opacity-50"
+          @click="$emit('next-page')"
+        >
+          Siguiente
+        </button>
       </div>
-    </HealthSemaphore>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
-
 interface StockStats {
   total_ingredients: number
   critical_count: number

--- a/pages/abastecimiento/ajustes/index.vue
+++ b/pages/abastecimiento/ajustes/index.vue
@@ -58,7 +58,6 @@
       </UiAdvancedFiltersBar>
 
       <!-- Responsive Data View -->
-      <HealthSemaphore :is-unlocked="true" title="Historial de ajustes">
       <UiResponsiveDataView
         :columns="adjustmentsTableColumns"
         :data="sortedAdjustments"
@@ -140,7 +139,6 @@
           <span class="text-sm text-text-primary">{{ value || 'Sistema' }}</span>
         </template>
       </UiResponsiveDataView>
-      </HealthSemaphore>
     </div>
   </div>
 </template>
@@ -148,7 +146,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 

--- a/pages/abastecimiento/calidad-datos.vue
+++ b/pages/abastecimiento/calidad-datos.vue
@@ -84,7 +84,6 @@
       </div>
 
       <!-- Orders Table -->
-      <HealthSemaphore :is-unlocked="true" title="Órdenes con Anomalías">
       <UiResponsiveDataView
         :columns="tableColumns"
         :data="ordersWithAnomalies"
@@ -192,14 +191,12 @@
           </div>
         </template>
       </UiResponsiveDataView>
-      </HealthSemaphore>
 
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { useFormatters } from '~/composables/useFormatters'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'

--- a/pages/abastecimiento/compras-directas/index.vue
+++ b/pages/abastecimiento/compras-directas/index.vue
@@ -51,26 +51,26 @@
             <option v-for="opt in purchaseDateFilterOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
           </select>
         </template>
-      </UiAdvancedFiltersBar>
 
-      <!-- Responsive Data View -->
-      <HealthSemaphore :is-unlocked="true" title="Compras Directas">
-        <template #header-actions>
+        <template #trailing>
           <NuxtLink to="/abastecimiento/compras-directas/crear"
             class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap">
             <span class="hidden sm:inline">+ Nueva Compra Directa</span>
             <span class="sm:hidden">+ Nueva</span>
           </NuxtLink>
         </template>
-        <UiScanUsageBar
-          v-if="quota"
-          :quota="quota"
-          :compact="true"
-          :show-period="false"
-          :warning-level="warningLevel"
-          :scans-remaining="scansRemaining"
-          class="mb-4"
-        />
+      </UiAdvancedFiltersBar>
+
+      <!-- Responsive Data View -->
+      <UiScanUsageBar
+        v-if="quota"
+        :quota="quota"
+        :compact="true"
+        :show-period="false"
+        :warning-level="warningLevel"
+        :scans-remaining="scansRemaining"
+        class="mb-4"
+      />
       <UiResponsiveDataView
         :columns="tableColumns"
         :data="sortedPurchases"
@@ -154,7 +154,6 @@
           </div>
         </template>
       </UiResponsiveDataView>
-      </HealthSemaphore>
 
       <!-- Pagination -->
       <div v-if="purchasesData.total > itemsPerPage" class="bg-surface px-4 py-3 flex items-center justify-between border border-border rounded-lg">
@@ -223,7 +222,6 @@
 
 <script setup lang="ts">
 import { ChevronLeftIcon, ChevronRightIcon, EyeIcon } from '@heroicons/vue/24/outline'
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { onMounted, onUnmounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'

--- a/pages/abastecimiento/compras.vue
+++ b/pages/abastecimiento/compras.vue
@@ -51,17 +51,17 @@
             <option v-for="opt in purchaseDateFilterOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
           </select>
         </template>
-      </UiAdvancedFiltersBar>
 
-      <!-- Responsive Data View (Mobile Cards + Desktop Table) -->
-      <HealthSemaphore :is-unlocked="true" title="Órdenes de Compra">
-        <template #header-actions>
+        <template #trailing>
           <NuxtLink to="/abastecimiento/compra/crear"
             class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap">
             <span class="hidden sm:inline">+ Nueva Orden</span>
             <span class="sm:hidden">+ Nuevo</span>
           </NuxtLink>
         </template>
+      </UiAdvancedFiltersBar>
+
+      <!-- Responsive Data View (Mobile Cards + Desktop Table) -->
       <UiResponsiveDataView
         row-size="sm"
         :columns="ordenesTableColumns"
@@ -157,7 +157,6 @@
           </div>
         </template>
       </UiResponsiveDataView>
-      </HealthSemaphore>
 
       <!-- Pagination -->
       <div v-if="purchasesData.total > itemsPerPage" class="bg-surface px-4 py-3 flex items-center justify-between border border-border rounded-lg">
@@ -221,7 +220,6 @@
 
 <script setup lang="ts">
 import { inject } from 'vue'
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import { useFormatters } from '~/composables/useFormatters'
 import {

--- a/pages/abastecimiento/ingredientes-propios.vue
+++ b/pages/abastecimiento/ingredientes-propios.vue
@@ -50,11 +50,8 @@
             Archivados
           </button>
         </template>
-      </UiAdvancedFiltersBar>
 
-      <!-- Data View -->
-      <HealthSemaphore :is-unlocked="true" :title="WAREHOUSE_COPY.warehouseCatalog">
-        <template #header-actions>
+        <template #trailing>
           <button
             @click="openPanel(null)"
             class="btn-primary px-4 py-2 rounded-lg text-sm font-medium whitespace-nowrap"
@@ -62,6 +59,9 @@
             {{ nuevoButtonLabel }}
           </button>
         </template>
+      </UiAdvancedFiltersBar>
+
+      <!-- Data View -->
       <UiResponsiveDataView
         :columns="tableColumns"
         :data="sortedIngredients"
@@ -169,7 +169,6 @@
           </div>
         </template>
       </UiResponsiveDataView>
-      </HealthSemaphore>
     </div>
 
     <!-- Create / Edit Panel -->
@@ -238,7 +237,6 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 
 useHead({ title: WAREHOUSE_COPY.warehouseCatalog })

--- a/pages/abastecimiento/movimientos.vue
+++ b/pages/abastecimiento/movimientos.vue
@@ -34,7 +34,6 @@
         </template>
       </UiAdvancedFiltersBar>
 
-      <HealthSemaphore :is-unlocked="true" title="Movimientos de Inventario">
       <UiResponsiveDataView
         row-size="sm"
         :columns="movementsTableColumns"
@@ -124,7 +123,6 @@
           <span class="text-sm text-text-primary">{{ value || 'Sistema' }}</span>
         </template>
       </UiResponsiveDataView>
-      </HealthSemaphore>
     </div>
   </div>
 </template>
@@ -133,7 +131,6 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 
 useHead({ title: 'Movimientos' })

--- a/pages/abastecimiento/proveedores.vue
+++ b/pages/abastecimiento/proveedores.vue
@@ -42,17 +42,17 @@
             <option v-for="term in paymentTermsOptions" :key="term" :value="term">{{ term }}</option>
           </select>
         </template>
-      </UiAdvancedFiltersBar>
 
-      <!-- Responsive Data View -->
-      <HealthSemaphore :is-unlocked="true" title="Directorio de proveedores">
-        <template #header-actions>
+        <template #trailing>
           <NuxtLink to="/abastecimiento/proveedor/crear"
             class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap">
             <span class="hidden sm:inline">+ Nuevo Proveedor</span>
             <span class="sm:hidden">+ Nuevo</span>
           </NuxtLink>
         </template>
+      </UiAdvancedFiltersBar>
+
+      <!-- Responsive Data View -->
       <UiResponsiveDataView
         :columns="proveedoresTableColumns"
         :data="suppliers"
@@ -141,7 +141,6 @@
           </div>
         </template>
       </UiResponsiveDataView>
-      </HealthSemaphore>
 
       <!-- Pagination -->
       <div class="bg-surface px-4 py-3 flex items-center justify-between border border-border rounded-lg">
@@ -216,7 +215,6 @@ import {
 } from '@heroicons/vue/24/outline'
 
 import { ref, computed, watch, inject, onMounted } from 'vue'
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 
 // Tenant reactivity

--- a/pages/inventario/movimientos.vue
+++ b/pages/inventario/movimientos.vue
@@ -46,7 +46,6 @@
       </UiAdvancedFiltersBar>
 
       <!-- Responsive Data View -->
-      <HealthSemaphore :is-unlocked="true" title="Movimientos de Inventario">
       <UiResponsiveDataView
         row-size="sm"
         :columns="movementsTableColumns"
@@ -133,7 +132,6 @@
           <span class="text-sm text-text-primary">{{ value || 'Sistema' }}</span>
         </template>
       </UiResponsiveDataView>
-      </HealthSemaphore>
     </div>
   </div>
 </template>
@@ -142,8 +140,6 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { INGREDIENTS_FETCH_LIMIT } from '@/composables/useMenuIngredients'
 import { useFormatters } from '~/composables/useFormatters'
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 
 useHead({ title: 'Movimientos de Inventario' })
 


### PR DESCRIPTION
## Summary
- move abastecimiento create actions from `HealthSemaphore` headers into `UiAdvancedFiltersBar` trailing slots
- remove scoped `HealthSemaphore` wrappers/imports from abastecimiento and inventory table views
- keep the direct-purchases scan usage bar above the data view after unwrapping

## Validation
- `rg "HealthSemaphore" pages/abastecimiento pages/inventario components/inventario/StockInventoryView.vue`
- `git diff --check`
- Browser smoke: opened `http://localhost:8080/abastecimiento/compras`; Nuxt route returned 200 and no browser console/page errors were captured. The local app shell rendered blank in this session, likely due auth/bootstrap state, so no visual assertions were made.

Closes #1206