### PR TITLE
Remove finance semaphore wrappers

### DIFF
--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -146,7 +146,6 @@
       </div>
 
       <!-- ── Historial ─────────────────────────────────────────────────────── -->
-      <HealthSemaphore :is-unlocked="true" title="Historial de arqueos">
       <UiResponsiveDataView
         :data="filteredHistorial"
         :columns="historialColumns"
@@ -237,7 +236,6 @@
           </div>
         </template>
       </UiResponsiveDataView>
-      </HealthSemaphore>
 
     </div>
 
@@ -300,8 +298,6 @@ import {
   todayBogotaISO,
 } from '~/utils/bogotaDate'
 import MetricCard from '~/components/shared/MetricCard.vue'
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Arqueo de caja - Warocol' })

--- a/pages/finanzas/cierre-contable/index.vue
+++ b/pages/finanzas/cierre-contable/index.vue
@@ -26,7 +26,6 @@
     </div>
 
     <!-- Months table -->
-    <HealthSemaphore :is-unlocked="true" title="Períodos contables">
       <UiResponsiveDataView
         row-size="sm"
         :columns="columns"
@@ -107,7 +106,6 @@
           </div>
         </template>
       </UiResponsiveDataView>
-    </HealthSemaphore>
 
     <!-- Confirmation modal -->
     <Teleport to="body">
@@ -158,8 +156,6 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 
 definePageMeta({ layout: 'dashboard' })
 useHead({ title: 'Cierre contable - Warocol' })

--- a/pages/finanzas/contabilidad/asientos/index.vue
+++ b/pages/finanzas/contabilidad/asientos/index.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
 definePageMeta({ layout: 'dashboard' })
@@ -310,8 +308,7 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
       </div>
 
       <!-- Entries table -->
-      <HealthSemaphore v-else :is-unlocked="true" :title="`${totalEntries.toLocaleString('es-CO')} asientos`">
-        <div class="[&_td]:!py-1 [&_th]:!py-1.5">
+      <div v-else class="[&_td]:!py-1 [&_th]:!py-1.5">
         <UiResponsiveDataView
           row-size="sm"
           :columns="tableColumns"
@@ -398,8 +395,7 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
         </template>
 
         </UiResponsiveDataView>
-        </div>
-      </HealthSemaphore>
+      </div>
 
       <!-- Pagination -->
       <div v-if="totalEntries > 0" class="flex items-center justify-end px-1 py-2">

--- a/pages/finanzas/contabilidad/cuentas/[id].vue
+++ b/pages/finanzas/contabilidad/cuentas/[id].vue
@@ -2,8 +2,6 @@
 import { ref, computed, nextTick, onMounted, onUnmounted } from 'vue'
 import { es } from 'date-fns/locale'
 import { format as fnsFormat, startOfMonth } from 'date-fns'
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
 definePageMeta({ layout: 'dashboard' })
@@ -663,8 +661,7 @@ const openEntryDetail = (entry: { id: string }) => {
       </div>
 
       <!-- ── Ledger table ────────────────────────────────────────────────── -->
-      <HealthSemaphore :is-unlocked="true" title="Libro mayor de la cuenta">
-        <div class="[&_td]:!py-1 [&_th]:!py-1.5">
+      <div class="[&_td]:!py-1 [&_th]:!py-1.5">
           <UiResponsiveDataView
             row-size="sm"
             :columns="tableColumns"
@@ -740,8 +737,7 @@ const openEntryDetail = (entry: { id: string }) => {
               <UiStatusBadge :value="STATUS_LABELS[value] || value" format="text" :variant="STATUS_VARIANTS[value] || 'secondary'" size="sm" />
             </template>
           </UiResponsiveDataView>
-        </div>
-      </HealthSemaphore>
+      </div>
 
       <!-- Pagination -->
       <div v-if="totalEntries > PAGE_SIZE" class="flex items-center justify-end px-1 py-2">

--- a/pages/finanzas/contabilidad/cuentas/index.vue
+++ b/pages/finanzas/contabilidad/cuentas/index.vue
@@ -6,8 +6,6 @@ import { TZDate } from '@date-fns/tz'
 
 const TZ = 'America/Bogota'
 const nowCO = () => new TZDate(new Date(), TZ)
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
 definePageMeta({ layout: 'dashboard' })
@@ -338,17 +336,23 @@ onUnmounted(() => { clearRefreshHandler(refetchAll) })
         <div
           v-for="group in groupedAccounts"
           :key="group.cls"
+          class="flex flex-col gap-2"
         >
-          <HealthSemaphore :is-unlocked="true" :title="`${group.label} · ${group.items.length} ${group.items.length === 1 ? 'cuenta' : 'cuentas'}`">
-            <div class="[&_td]:!py-1 [&_th]:!py-1.5">
-              <UiResponsiveDataView
-                row-size="sm"
-                :columns="tableColumns"
-                :data="group.items"
-                empty-message="Sin cuentas en esta clase"
-                variant="default"
-                @row-click="openAccount"
-              >
+          <div class="flex items-center justify-between gap-3 px-1">
+            <p class="text-sm font-semibold text-text-primary">{{ group.label }}</p>
+            <span class="text-xs font-medium text-text-secondary">
+              {{ group.items.length }} {{ group.items.length === 1 ? 'cuenta' : 'cuentas' }}
+            </span>
+          </div>
+          <div class="[&_td]:!py-1 [&_th]:!py-1.5">
+            <UiResponsiveDataView
+              row-size="sm"
+              :columns="tableColumns"
+              :data="group.items"
+              empty-message="Sin cuentas en esta clase"
+              variant="default"
+              @row-click="openAccount"
+            >
                 <!-- Mobile card -->
                 <template #card="{ item, index }">
                   <div
@@ -513,9 +517,8 @@ onUnmounted(() => { clearRefreshHandler(refetchAll) })
                   </div>
                 </template>
 
-              </UiResponsiveDataView>
-            </div>
-          </HealthSemaphore>
+            </UiResponsiveDataView>
+          </div>
         </div>
 
         <!-- Empty state -->

--- a/pages/finanzas/gastos/index.vue
+++ b/pages/finanzas/gastos/index.vue
@@ -2,8 +2,6 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 import MetricCard from '~/components/shared/MetricCard.vue'
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 
 definePageMeta({
   layout: 'dashboard'
@@ -197,11 +195,7 @@ onUnmounted(() => { clearRefreshHandler(refetch)
             <option value="other_expense">Otro gasto</option>
           </select>
         </template>
-      </UiAdvancedFiltersBar>
-
-      <!-- Responsive Data View -->
-      <HealthSemaphore :is-unlocked="true" title="Control de Gastos">
-        <template #header-actions>
+        <template #trailing>
           <NuxtLink
             to="/finanzas/gastos/crear"
             class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap"
@@ -210,6 +204,9 @@ onUnmounted(() => { clearRefreshHandler(refetch)
             <span class="sm:hidden">+ Nuevo</span>
           </NuxtLink>
         </template>
+      </UiAdvancedFiltersBar>
+
+      <!-- Responsive Data View -->
       <UiResponsiveDataView
         row-size="sm"
         :columns="expensesTableColumns"
@@ -305,7 +302,6 @@ onUnmounted(() => { clearRefreshHandler(refetch)
           </div>
         </template>
       </UiResponsiveDataView>
-      </HealthSemaphore>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- remove HealthSemaphore table wrappers from finance and accounting listing screens
- move the gastos create action into the filter bar trailing slot
- preserve accounting dense table wrappers and add slim chart-of-accounts group headers

## Validation
- rg "HealthSemaphore" pages/finanzas/gastos/index.vue pages/finanzas/arqueo/index.vue pages/finanzas/cierre-contable/index.vue pages/finanzas/contabilidad/asientos/index.vue pages/finanzas/contabilidad/cuentas/index.vue 'pages/finanzas/contabilidad/cuentas/[id].vue' (no matches)
- parsed 6 edited Vue SFCs with @vue/compiler-sfc
- git diff --check

Closes #1207