### PR TITLE
Remove remaining semaphore wrappers

### DIFF
--- a/pages/analitica/clientes/index.vue
+++ b/pages/analitica/clientes/index.vue
@@ -5,7 +5,6 @@ import { useDebounceFn } from '@vueuse/core'
 import { es } from 'date-fns/locale';
 import { format as fnsFormat, formatDistanceToNow } from 'date-fns';
 import MetricCard from '~/components/shared/MetricCard.vue';
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 
 definePageMeta({ layout: 'dashboard' })
 
@@ -290,7 +289,7 @@ onUnmounted(() => {
         <CommonsTheCustomLoader size="medium" />
       </div>
 
-      <HealthSemaphore v-else :is-unlocked="true" title="Comportamiento y valor de clientes">
+      <template v-else>
         <UiResponsiveDataView
           row-size="sm"
           :columns="tableColumns"
@@ -426,7 +425,7 @@ onUnmounted(() => {
             </nav>
           </div>
         </div>
-      </HealthSemaphore>
+      </template>
 
     </div>
   </div>

--- a/pages/equipo/miembros/[id].vue
+++ b/pages/equipo/miembros/[id].vue
@@ -4,8 +4,6 @@ import { useRoute } from 'vue-router'
 import { es } from 'date-fns/locale'
 import { format as fnsFormat } from 'date-fns'
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 
 definePageMeta({
   layout: 'dashboard',
@@ -233,8 +231,9 @@ onUnmounted(() => clearRefreshHandler(handleRefresh))
           <CommonsTheCustomLoader size="medium" />
         </div>
 
-        <HealthSemaphore v-else :is-unlocked="true" :title="member.name">
-          <template #header-actions>
+        <div v-else class="flex flex-col gap-4">
+          <div class="flex flex-wrap items-start justify-between gap-2">
+            <h2 class="text-base font-semibold text-text-primary">{{ member.name }}</h2>
             <div class="flex items-center gap-2 flex-shrink-0">
               <span
                 v-if="member.email"
@@ -247,88 +246,87 @@ onUnmounted(() => clearRefreshHandler(handleRefresh))
                 {{ roleLabel(member.role) }}
               </span>
             </div>
-          </template>
+          </div>
 
-          <div class="flex flex-col gap-4">
-            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 md:gap-4">
-              <MetricCard
-                title="Hoy"
-                :value="todayAgg.sum"
-                format="currency"
-                variant="primary"
-                :subtitle="`Promedio: ${formatPercent(todayAgg.avg)}`"
-              />
-              <MetricCard
-                title="Últimos 7 días"
-                :value="weekAgg.sum"
-                format="currency"
-                variant="primary"
-                :subtitle="`Promedio: ${formatPercent(weekAgg.avg)}`"
-              />
-              <MetricCard
-                title="Últimos 30 días"
-                :value="monthAgg.sum"
-                format="currency"
-                variant="primary"
-                :subtitle="`Promedio: ${formatPercent(monthAgg.avg)}`"
-              />
-            </div>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 md:gap-4">
+            <MetricCard
+              title="Hoy"
+              :value="todayAgg.sum"
+              format="currency"
+              variant="primary"
+              :subtitle="`Promedio: ${formatPercent(todayAgg.avg)}`"
+            />
+            <MetricCard
+              title="Últimos 7 días"
+              :value="weekAgg.sum"
+              format="currency"
+              variant="primary"
+              :subtitle="`Promedio: ${formatPercent(weekAgg.avg)}`"
+            />
+            <MetricCard
+              title="Últimos 30 días"
+              :value="monthAgg.sum"
+              format="currency"
+              variant="primary"
+              :subtitle="`Promedio: ${formatPercent(monthAgg.avg)}`"
+            />
+          </div>
 
-            <div class="flex flex-col gap-3">
-              <p class="text-sm font-semibold text-text-primary">Últimas 10 propinas</p>
-              <UiResponsiveDataView
-                :columns="columns"
-                :data="recentTips"
-                empty-message="Sin propinas registradas"
-                empty-sub-message="Las propinas atribuidas a este mesero aparecerán aquí."
-                item-key="id"
-                row-size="sm"
-              >
-                <template #card="{ item, index }">
-                  <div :class="['flex flex-col gap-1.5 p-4 border-b border-border', index % 2 === 0 ? 'bg-surface' : 'bg-background']">
-                    <div class="flex items-center justify-between">
-                      <div class="flex items-baseline gap-2">
-                        <span class="text-xs text-text-secondary whitespace-nowrap shrink-0">{{ formatDate(item.order_date) }}</span>
-                        <span class="text-sm font-semibold text-primary">#{{ item.order_number }}</span>
-                      </div>
-                      <UiStatusBadge :variant="channelVariant(item.channel)" size="sm" :value="channelLabel(item.channel)" />
+          <div class="flex flex-col gap-3">
+            <p class="text-sm font-semibold text-text-primary">Últimas 10 propinas</p>
+            <UiResponsiveDataView
+              :columns="columns"
+              :data="recentTips"
+              empty-message="Sin propinas registradas"
+              empty-sub-message="Las propinas atribuidas a este mesero aparecerán aquí."
+              item-key="id"
+              row-size="sm"
+            >
+              <template #card="{ item, index }">
+                <div :class="['flex flex-col gap-1.5 p-4 border-b border-border', index % 2 === 0 ? 'bg-surface' : 'bg-background']">
+                  <div class="flex items-center justify-between">
+                    <div class="flex items-baseline gap-2">
+                      <span class="text-xs text-text-secondary whitespace-nowrap shrink-0">{{ formatDate(item.order_date) }}</span>
+                      <span class="text-sm font-semibold text-primary">#{{ item.order_number }}</span>
                     </div>
-                    <div class="flex items-end justify-between">
-                      <p class="text-xs text-text-secondary">Subtotal: {{ formatCurrency(item.total_amount) }}</p>
-                      <div class="text-right">
-                        <p class="text-lg font-bold text-primary tabular-nums">{{ formatCurrency(item.tip_amount) }}</p>
-                        <p class="text-xs text-text-secondary tabular-nums">{{ formatPercent(item.tip_percent) }}</p>
-                      </div>
+                    <UiStatusBadge :variant="channelVariant(item.channel)" size="sm" :value="channelLabel(item.channel)" />
+                  </div>
+                  <div class="flex items-end justify-between">
+                    <p class="text-xs text-text-secondary">Subtotal: {{ formatCurrency(item.total_amount) }}</p>
+                    <div class="text-right">
+                      <p class="text-lg font-bold text-primary tabular-nums">{{ formatCurrency(item.tip_amount) }}</p>
+                      <p class="text-xs text-text-secondary tabular-nums">{{ formatPercent(item.tip_percent) }}</p>
                     </div>
                   </div>
-                </template>
+                </div>
+              </template>
 
-                <template #cell-order_date="{ value }">
-                  <span class="text-sm text-text-secondary whitespace-nowrap">{{ formatDate(value) }}</span>
-                </template>
-                <template #cell-order_number="{ value }">
-                  <span class="text-sm font-medium text-primary">#{{ value }}</span>
-                </template>
-                <template #cell-channel="{ row }">
-                  <UiStatusBadge :variant="channelVariant(row.channel)" size="sm" :value="channelLabel(row.channel)" />
-                </template>
-                <template #cell-total_amount="{ value }">
-                  <span class="text-sm tabular-nums">{{ formatCurrency(value) }}</span>
-                </template>
-                <template #cell-tip_amount="{ value }">
-                  <span class="text-sm font-bold text-primary tabular-nums">{{ formatCurrency(value) }}</span>
-                </template>
-                <template #cell-tip_percent="{ value }">
-                  <span class="text-sm tabular-nums text-text-secondary">{{ formatPercent(value) }}</span>
-                </template>
-              </UiResponsiveDataView>
-            </div>
+              <template #cell-order_date="{ value }">
+                <span class="text-sm text-text-secondary whitespace-nowrap">{{ formatDate(value) }}</span>
+              </template>
+              <template #cell-order_number="{ value }">
+                <span class="text-sm font-medium text-primary">#{{ value }}</span>
+              </template>
+              <template #cell-channel="{ row }">
+                <UiStatusBadge :variant="channelVariant(row.channel)" size="sm" :value="channelLabel(row.channel)" />
+              </template>
+              <template #cell-total_amount="{ value }">
+                <span class="text-sm tabular-nums">{{ formatCurrency(value) }}</span>
+              </template>
+              <template #cell-tip_amount="{ value }">
+                <span class="text-sm font-bold text-primary tabular-nums">{{ formatCurrency(value) }}</span>
+              </template>
+              <template #cell-tip_percent="{ value }">
+                <span class="text-sm tabular-nums text-text-secondary">{{ formatPercent(value) }}</span>
+              </template>
+            </UiResponsiveDataView>
           </div>
-        </HealthSemaphore>
+        </div>
       </template>
 
-      <HealthSemaphore v-else :is-unlocked="true" :title="member.name">
-        <template #header-actions>
+      <div v-else class="flex flex-col gap-3">
+        <div class="flex flex-wrap items-start justify-between gap-2">
+          <h2 class="text-base font-semibold text-text-primary">{{ member.name }}</h2>
           <div class="flex items-center gap-2 flex-shrink-0">
             <span
               v-if="member.email"
@@ -341,11 +339,11 @@ onUnmounted(() => clearRefreshHandler(handleRefresh))
               {{ roleLabel(member.role) }}
             </span>
           </div>
-        </template>
+        </div>
         <p class="text-sm text-text-secondary">
           Las propinas no están habilitadas en este restaurante.
         </p>
-      </HealthSemaphore>
+      </div>
     </div>
   </div>
 </template>

--- a/pages/equipo/miembros/index.vue
+++ b/pages/equipo/miembros/index.vue
@@ -10,48 +10,48 @@
 
     <!-- Content -->
     <div v-else class="flex flex-col gap-3 md:gap-4">
-    <UiAdvancedFiltersBar
-      v-model:search="localSearchTerm"
-      :search-fields="[]"
-      search-placeholder="Buscar por nombre o correo..."
-      :show-date-range="false"
-      :show-clear="hasActiveFilters"
-      @search="performSearch"
-      @clear="clearFilters"
-    >
-      <template #additional-filters>
-        <select
-          v-model="roleFilter"
-          :class="filterSelectClass"
-          aria-label="Filtrar por rol"
-        >
-          <option value="">Rol</option>
-          <option value="superuser">Superusuario</option>
-          <option value="admin">Administrador</option>
-          <option value="employee">Empleado</option>
-          <option value="member">Miembro</option>
-        </select>
-      </template>
-    </UiAdvancedFiltersBar>
+      <UiAdvancedFiltersBar
+        v-model:search="localSearchTerm"
+        :search-fields="[]"
+        search-placeholder="Buscar por nombre o correo..."
+        :show-date-range="false"
+        :show-clear="hasActiveFilters"
+        @search="performSearch"
+        @clear="clearFilters"
+      >
+        <template #additional-filters>
+          <select
+            v-model="roleFilter"
+            :class="filterSelectClass"
+            aria-label="Filtrar por rol"
+          >
+            <option value="">Rol</option>
+            <option value="superuser">Superusuario</option>
+            <option value="admin">Administrador</option>
+            <option value="employee">Empleado</option>
+            <option value="member">Miembro</option>
+          </select>
+        </template>
 
-    <!-- Responsive Data View -->
-    <HealthSemaphore :is-unlocked="true" title="Miembros del equipo">
-      <template #header-actions>
-        <button @click="openInviteModal" class="btn-primary px-4 py-2 rounded-lg flex items-center gap-2 text-sm font-medium whitespace-nowrap">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-          </svg>
-          Invitar miembro
-        </button>
-      </template>
-    <UiResponsiveDataView
-      :columns="teamMembersTableColumns"
-      :data="teamMembers"
-      empty-message="No hay miembros en este equipo"
-      empty-sub-message="Los miembros apareceran aqui cuando sean agregados"
-      variant="default"
-      row-size="sm"
-    >
+        <template #trailing>
+          <button @click="openInviteModal" class="btn-primary px-4 py-2 rounded-lg flex items-center gap-2 text-sm font-medium whitespace-nowrap">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+            </svg>
+            Invitar miembro
+          </button>
+        </template>
+      </UiAdvancedFiltersBar>
+
+      <!-- Responsive Data View -->
+      <UiResponsiveDataView
+        :columns="teamMembersTableColumns"
+        :data="teamMembers"
+        empty-message="No hay miembros en este equipo"
+        empty-sub-message="Los miembros apareceran aqui cuando sean agregados"
+        variant="default"
+        row-size="sm"
+      >
 
       <!-- Mobile Card -->
       <template #card="{ item, index }">
@@ -197,8 +197,7 @@
           </button>
         </div>
       </template>
-    </UiResponsiveDataView>
-    </HealthSemaphore>
+      </UiResponsiveDataView>
 
     <!-- Pending Invitations Section -->
     <div v-if="pendingInvitations.length > 0" class="bg-surface rounded-xl border border-border">
@@ -622,8 +621,6 @@
 </template>
 
 <script setup lang="ts">
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { useFormatters } from '~/composables/useFormatters'
 const { formatDate: _fmtDate } = useFormatters()
 useHead({ title: 'Miembros - Equipo' })

--- a/pages/equipo/nomina.vue
+++ b/pages/equipo/nomina.vue
@@ -4,8 +4,6 @@ import { useFormatters } from '~/composables/useFormatters'
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { usePaymentMethods } from '~/composables/usePaymentMethods'
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 
 useHead({ title: 'Nómina — Equipo' })
 
@@ -680,15 +678,14 @@ onUnmounted(() => { clearRefreshHandler(loadData) })
       </Transition>
 
       <!-- Data table -->
-      <HealthSemaphore :is-unlocked="true" title="Estado de Prestaciones Sociales">
-        <UiResponsiveDataView
-          :columns="tableColumns"
-          :data="tableData"
-          empty-message="No hay empleados registrados"
-          empty-sub-message="Los empleados y jornaleros aparecerán aquí"
-          variant="default"
-          row-size="xs"
-        >
+      <UiResponsiveDataView
+        :columns="tableColumns"
+        :data="tableData"
+        empty-message="No hay empleados registrados"
+        empty-sub-message="Los empleados y jornaleros aparecerán aquí"
+        variant="default"
+        row-size="xs"
+      >
 
           <!-- ── Mobile card ──────────────────────────────────────────── -->
           <template #card="{ item, index }">
@@ -853,8 +850,7 @@ onUnmounted(() => { clearRefreshHandler(loadData) })
             </button>
           </template>
 
-        </UiResponsiveDataView>
-      </HealthSemaphore>
+      </UiResponsiveDataView>
 
       <!-- ── PILA Section ──────────────────────────────────────────────── -->
       <div class="bg-surface border-2 border-border rounded-xl p-6 shadow-sm">

--- a/pages/equipo/salarios/index.vue
+++ b/pages/equipo/salarios/index.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
-// @ts-ignore
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 
 definePageMeta({
   layout: 'dashboard'
@@ -160,11 +158,8 @@ onUnmounted(() => {
         :show-clear="hasActiveFilters"
         @search="performSearch"
         @clear="clearFilters"
-      />
-
-      <!-- Responsive Data View -->
-      <HealthSemaphore :is-unlocked="true" title="Gestión de Salarios">
-        <template #header-actions>
+      >
+        <template #trailing>
           <NuxtLink
             to="/equipo/miembros"
             class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap"
@@ -173,6 +168,9 @@ onUnmounted(() => {
             <span class="sm:hidden">+ Nuevo</span>
           </NuxtLink>
         </template>
+      </UiAdvancedFiltersBar>
+
+      <!-- Responsive Data View -->
       <UiResponsiveDataView
         :columns="employeesTableColumns"
         :data="employees"
@@ -277,7 +275,6 @@ onUnmounted(() => {
           </div>
         </template>
       </UiResponsiveDataView>
-      </HealthSemaphore>
     </div>
   </div>
 </template>

--- a/pages/integraciones.vue
+++ b/pages/integraciones.vue
@@ -18,25 +18,25 @@
         <p class="text-xs text-status-info-text">Usa tu API Key con el header <code class="font-mono font-medium">Authorization: Bearer waro_sk_...</code></p>
       </div>
 
+      <div class="flex flex-wrap items-center justify-end gap-2">
+        <button @click="openCreateModal" class="btn-primary px-4 py-2 rounded-lg flex items-center gap-2 text-sm font-medium">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+          </svg>
+          <span class="hidden sm:inline">Crear API Key</span>
+          <span class="sm:hidden">+ Nueva</span>
+        </button>
+      </div>
+
       <!-- API Keys Table -->
-      <HealthSemaphore :is-unlocked="true" title="API Keys">
-        <template #header-actions>
-          <button @click="openCreateModal" class="btn-primary px-4 py-2 rounded-lg flex items-center gap-2 text-sm font-medium">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-            </svg>
-            <span class="hidden sm:inline">Crear API Key</span>
-            <span class="sm:hidden">+ Nueva</span>
-          </button>
-        </template>
-        <UiResponsiveDataView
-          :columns="tableColumns"
-          :data="activeTokens"
-          empty-message="No tienes API keys activas"
-          empty-sub-message="Crea una para comenzar a integrar"
-          variant="default"
-          row-size="sm"
-        >
+      <UiResponsiveDataView
+        :columns="tableColumns"
+        :data="activeTokens"
+        empty-message="No tienes API keys activas"
+        empty-sub-message="Crea una para comenzar a integrar"
+        variant="default"
+        row-size="sm"
+      >
         <!-- Mobile Card -->
         <template #card="{ item, index }">
           <div
@@ -120,8 +120,7 @@
             </button>
           </div>
         </template>
-        </UiResponsiveDataView>
-      </HealthSemaphore>
+      </UiResponsiveDataView>
     </div>
 
     <!-- Create Token Modal -->
@@ -287,8 +286,6 @@
 </template>
 
 <script setup lang="ts">
-// @ts-ignore — path alias resolved by Vite at runtime; TS language server false positive
-import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import { useFormatters } from '~/composables/useFormatters'
 
 definePageMeta({ layout: 'dashboard', module: 'integraciones' })


### PR DESCRIPTION
## Summary

- Remove remaining table/listing `HealthSemaphore` wrappers from equipo, integraciones, and clientes analytics pages.
- Move member/salary actions into the `UiAdvancedFiltersBar` trailing lane or a lightweight controls row.
- Preserve the profitability analytics `HealthSemaphore` because it still gates the unlock/MenuMatrix experience.

Closes #1208

## Validation

- `rg -n "HealthSemaphore|header-actions" pages/equipo pages/integraciones.vue pages/analitica/clientes pages/analitica/rentabilidad.vue` leaves only `pages/analitica/rentabilidad.vue`.
- `git diff --check`
- `npm run build`

## Manual smoke routes

- `/equipo/miembros`
- `/equipo/miembros/[id]` with tips on/off if possible
- `/equipo/nomina`
- `/equipo/salarios`
- `/integraciones`
- `/analitica/clientes`
- `/analitica/rentabilidad`
