### PR TITLE
Add product table header filters pilot

### DIFF
--- a/components/menu/MenuCatalogFiltersBar.vue
+++ b/components/menu/MenuCatalogFiltersBar.vue
@@ -14,6 +14,7 @@ const props = withDefaults(
     showNoRecipe?: boolean
     showCostDrift?: boolean
     showProductTypeFilter?: boolean
+    tableHeaderFilters?: boolean
   }>(),
   {
     searchPlaceholder: 'Buscar productos...',
@@ -23,6 +24,7 @@ const props = withDefaults(
     showNoRecipe: true,
     showCostDrift: false,
     showProductTypeFilter: false,
+    tableHeaderFilters: false,
   },
 )
 
@@ -80,6 +82,8 @@ const productTypeOptions: { label: string; value: ProductTypeFilter }[] = [
   { label: 'Menú', value: 'menu' },
   { label: 'Reventa', value: 'resale' },
 ]
+
+const columnFilterFallbackClass = computed(() => props.tableHeaderFilters ? 'md:hidden' : '')
 
 function productTypeChipClassFor(value: ProductTypeFilter): string {
   return productTypeChipClass(productTypeFilter.value === value)
@@ -146,7 +150,7 @@ watch(
         v-if="showProductTypeFilter"
         role="group"
         aria-label="Tipo de producto"
-        class="flex flex-wrap items-center gap-2"
+        :class="['flex flex-wrap items-center gap-2', columnFilterFallbackClass]"
       >
         <button
           v-for="opt in productTypeOptions"
@@ -165,6 +169,7 @@ watch(
         placeholder="Categoría"
         aria-label="Filtrar por categoría"
         :options="categories.map(c => ({ label: c.name, value: c.id }))"
+        :class="columnFilterFallbackClass"
       />
 
       <UiFilterSelect
@@ -172,6 +177,7 @@ watch(
         placeholder="Estado"
         aria-label="Filtrar por estado"
         :options="statusOptions"
+        :class="columnFilterFallbackClass"
       />
 
       <UiFilterSelect
@@ -189,14 +195,15 @@ watch(
         :options="sortOptions"
         always-active
         hide-placeholder
+        :class="columnFilterFallbackClass"
       />
 
-      <label v-if="showOnline" :class="filterChipClass(onlineOnly)">
+      <label v-if="showOnline" :class="[filterChipClass(onlineOnly), columnFilterFallbackClass]">
         <input v-model="onlineOnly" type="checkbox" class="sr-only" aria-label="Solo visibles en domicilios" />
         <span class="font-semibold">Domicilios</span>
       </label>
 
-      <label v-if="showQr" :class="filterChipClass(qrOnly)">
+      <label v-if="showQr" :class="[filterChipClass(qrOnly), columnFilterFallbackClass]">
         <input v-model="qrOnly" type="checkbox" class="sr-only" aria-label="Solo visibles en QR mesa" />
         <span class="font-semibold">QR mesa</span>
       </label>
@@ -206,7 +213,7 @@ watch(
         <span class="font-semibold">Sin receta</span>
       </label>
 
-      <label :class="filterChipClass(marginNegativeOnly)">
+      <label :class="[filterChipClass(marginNegativeOnly), columnFilterFallbackClass]">
         <input v-model="marginNegativeOnly" type="checkbox" class="sr-only" aria-label="Solo margen negativo" />
         <span class="font-semibold">Margen negativo</span>
       </label>

--- a/components/ui/TableHeaderFilter.vue
+++ b/components/ui/TableHeaderFilter.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+import {
+  CheckCircleIcon,
+  ChevronDownIcon,
+  ChevronUpDownIcon,
+  ChevronUpIcon,
+  FunnelIcon,
+} from '@heroicons/vue/24/outline'
+
+export interface TableHeaderFilterOption {
+  label: string
+  value: string
+}
+
+const props = withDefaults(
+  defineProps<{
+    title: string
+    columnKey?: string
+    sortable?: boolean
+    sortField?: string
+    sortDirection?: 'asc' | 'desc'
+    modelValue?: string | boolean
+    filterType?: 'none' | 'select' | 'toggle'
+    options?: TableHeaderFilterOption[]
+    allLabel?: string
+    toggleLabel?: string
+    align?: 'left' | 'center' | 'right'
+  }>(),
+  {
+    sortable: false,
+    sortDirection: 'asc',
+    modelValue: '',
+    filterType: 'select',
+    options: () => [],
+    allLabel: 'Todos',
+    toggleLabel: 'Solo activos',
+    align: 'left',
+  },
+)
+
+const emit = defineEmits<{
+  sort: [field: string]
+  'update:modelValue': [value: string | boolean]
+}>()
+
+const isSorted = computed(() => props.sortable && props.columnKey && props.sortField === props.columnKey)
+const sortIcon = computed(() => {
+  if (!props.sortable) return null
+  if (!isSorted.value) return ChevronUpDownIcon
+  return props.sortDirection === 'asc' ? ChevronUpIcon : ChevronDownIcon
+})
+const selectValue = computed(() => typeof props.modelValue === 'string' ? props.modelValue : '')
+const hasFilter = computed(() => props.filterType !== 'none')
+const isFilterActive = computed(() => {
+  if (props.filterType === 'toggle') return Boolean(props.modelValue)
+  if (props.filterType === 'select') return Boolean(selectValue.value)
+  return false
+})
+const activeFilterLabel = computed(() => {
+  if (props.filterType === 'toggle') return props.toggleLabel
+  return props.options.find(opt => opt.value === selectValue.value)?.label ?? props.allLabel
+})
+const filterIcon = computed(() => props.filterType === 'toggle' ? CheckCircleIcon : FunnelIcon)
+
+const textAlignClass = computed(() => {
+  if (props.align === 'center') return 'justify-center text-center'
+  if (props.align === 'right') return 'justify-end text-right'
+  return 'justify-start text-left'
+})
+
+function onSort() {
+  if (!props.sortable || !props.columnKey) return
+  emit('sort', props.columnKey)
+}
+</script>
+
+<template>
+  <div :class="['flex min-w-0 w-full items-center gap-1.5', textAlignClass]">
+    <button
+      v-if="sortable"
+      type="button"
+      class="inline-flex min-w-0 items-center gap-1 text-xs font-semibold uppercase tracking-wider text-data-table-header-text transition-colors hover:text-data-table-cell-text"
+      :aria-label="`Ordenar por ${title}`"
+      @click="onSort"
+    >
+      <span class="truncate">{{ title }}</span>
+      <component :is="sortIcon" v-if="sortIcon" class="h-3 w-3 shrink-0" />
+    </button>
+    <span
+      v-else
+      class="block min-w-0 truncate text-xs font-semibold uppercase tracking-wider text-data-table-header-text"
+    >
+      {{ title }}
+    </span>
+
+    <div v-if="hasFilter" class="relative inline-flex h-6 w-6 shrink-0 items-center justify-center">
+      <span
+        :class="[
+          'inline-flex h-6 w-6 items-center justify-center rounded-md border transition-colors',
+          isFilterActive
+            ? 'border-primary bg-primary/10 text-primary shadow-sm'
+            : 'border-transparent text-data-table-header-text/70 hover:border-data-table-border hover:bg-background hover:text-data-table-cell-text',
+        ]"
+        :title="`Filtrar ${title}: ${activeFilterLabel}`"
+      >
+        <component :is="filterIcon" class="h-3.5 w-3.5" />
+      </span>
+
+      <select
+        v-if="filterType === 'select'"
+        :value="selectValue"
+        class="absolute inset-0 h-6 w-6 cursor-pointer opacity-0"
+        :aria-label="`Filtrar ${title}`"
+        @change="emit('update:modelValue', ($event.target as HTMLSelectElement).value)"
+      >
+        <option value="">{{ allLabel }}</option>
+        <option v-for="opt in options" :key="opt.value" :value="opt.value">
+          {{ opt.label }}
+        </option>
+      </select>
+
+      <input
+        v-else-if="filterType === 'toggle'"
+        :checked="Boolean(modelValue)"
+        type="checkbox"
+        class="absolute inset-0 h-6 w-6 cursor-pointer opacity-0"
+        :aria-label="`Filtrar ${title}`"
+        @change="emit('update:modelValue', ($event.target as HTMLInputElement).checked)"
+      />
+    </div>
+  </div>
+</template>

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -41,6 +41,7 @@
 
         <MenuCatalogFiltersBar
           show-product-type-filter
+          table-header-filters
           :show-qr="showTableQrColumn"
           :show-online="showOnlineControls"
           @search="onCatalogSearch"
@@ -114,12 +115,109 @@
           :empty-sub-message="emptySubMessage"
           variant="default"
           row-size="sm"
+          :sort-field="tableSortField"
+          :sort-direction="tableSortDirection"
+          @sort="handleProductsTableSort"
         >
           <!-- Checkbox header: select all (same pattern as ventas/ordenes) -->
           <template #header-select>
             <div class="flex items-center justify-center">
               <UiBulkSelectCheckbox :checked="allPageSelected" @change="toggleSelectAll" />
             </div>
+          </template>
+
+          <template #header-name>
+            <UiTableHeaderFilter
+              title="Producto"
+              column-key="name"
+              sortable
+              :sort-field="tableSortField"
+              :sort-direction="tableSortDirection"
+              filter-type="none"
+              class="min-w-[11rem]"
+              @sort="handleProductsTableSort"
+            />
+          </template>
+
+          <template #header-tipo>
+            <UiTableHeaderFilter
+              v-model="productTypeFilter"
+              title="Tipo"
+              filter-type="select"
+              :options="productTypeHeaderOptions"
+              all-label="Todos"
+              align="left"
+            />
+          </template>
+
+          <template #header-category_name>
+            <UiTableHeaderFilter
+              v-model="categoryFilter"
+              title="Categoría"
+              filter-type="select"
+              :options="categoryHeaderOptions"
+              all-label="Todas"
+              align="left"
+            />
+          </template>
+
+          <template #header-price>
+            <UiTableHeaderFilter
+              title="Precio"
+              column-key="price"
+              sortable
+              :sort-field="tableSortField"
+              :sort-direction="tableSortDirection"
+              filter-type="none"
+              align="right"
+              @sort="handleProductsTableSort"
+            />
+          </template>
+
+          <template #header-margen_operativo>
+            <UiTableHeaderFilter
+              v-model="marginNegativeOnly"
+              title="Margen op."
+              column-key="margen_operativo"
+              sortable
+              :sort-field="tableSortField"
+              :sort-direction="tableSortDirection"
+              filter-type="toggle"
+              toggle-label="Negativo"
+              align="center"
+              @sort="handleProductsTableSort"
+            />
+          </template>
+
+          <template #header-is_available>
+            <UiTableHeaderFilter
+              v-model="statusFilter"
+              title="Estado"
+              filter-type="select"
+              :options="statusHeaderOptions"
+              all-label="Todos"
+              align="center"
+            />
+          </template>
+
+          <template v-if="showOnlineControls" #header-is_available_online>
+            <UiTableHeaderFilter
+              v-model="onlineOnly"
+              title="Domicilios"
+              filter-type="toggle"
+              toggle-label="Activos"
+              align="center"
+            />
+          </template>
+
+          <template v-if="showTableQrColumn" #header-is_available_table_qr>
+            <UiTableHeaderFilter
+              v-model="qrOnly"
+              title="QR mesa"
+              filter-type="toggle"
+              toggle-label="Activos"
+              align="center"
+            />
           </template>
 
           <template #cell-select="{ row }">
@@ -809,6 +907,31 @@ const QUERY_TO_PRODUCT_TYPE: Record<string, ProductTypeFilter> = {
   all: 'all',
 }
 
+const productTypeHeaderOptions: { label: string; value: ProductTypeFilter }[] = [
+  { label: 'Menú', value: 'menu' },
+  { label: 'Reventa', value: 'resale' },
+]
+
+const statusHeaderOptions = [
+  { label: 'Disponible', value: 'true' },
+  { label: 'No disponible', value: 'false' },
+]
+
+const TABLE_SORT_TO_API: Record<string, { asc: string; desc: string }> = {
+  name: { asc: 'name_asc', desc: 'name_desc' },
+  price: { asc: 'price_asc', desc: 'price_desc' },
+  margen_operativo: { asc: 'margin_asc', desc: 'margin_desc' },
+}
+
+const API_SORT_TO_TABLE: Record<string, { field: string; direction: 'asc' | 'desc' }> = {
+  name_asc: { field: 'name', direction: 'asc' },
+  name_desc: { field: 'name', direction: 'desc' },
+  price_asc: { field: 'price', direction: 'asc' },
+  price_desc: { field: 'price', direction: 'desc' },
+  margin_asc: { field: 'margen_operativo', direction: 'asc' },
+  margin_desc: { field: 'margen_operativo', direction: 'desc' },
+}
+
 function productTypeFromRouteQuery(tipo: unknown): ProductTypeFilter {
   if (typeof tipo !== 'string') return 'all'
   return QUERY_TO_PRODUCT_TYPE[tipo] ?? 'all'
@@ -1031,6 +1154,9 @@ const { data: categoriesData } = useQuery({
 })
 
 const categories = computed(() => (categoriesData.value as any)?.data || [])
+const categoryHeaderOptions = computed(() =>
+  categories.value.map((c: { id: string; name: string }) => ({ label: c.name, value: c.id })),
+)
 
 // Fetch products
 const { data: productsData, error: fetchError, asyncStatus: queryAsyncStatus, refetch } = useQuery({
@@ -1194,6 +1320,33 @@ function clearSelection() {
 }
 
 const onToggleEditMode = () => editToggleEditMode(clearSelection)
+
+const tableSortField = computed(() => API_SORT_TO_TABLE[sortFilter.value]?.field ?? '')
+const tableSortDirection = computed(() => API_SORT_TO_TABLE[sortFilter.value]?.direction ?? 'asc')
+
+function handleProductsTableSort(field: string) {
+  const sortConfig = TABLE_SORT_TO_API[field]
+  if (!sortConfig) return
+  const nextDirection = tableSortField.value === field && tableSortDirection.value === 'asc' ? 'desc' : 'asc'
+  sortFilter.value = sortConfig[nextDirection]
+  currentPage.value = 1
+}
+
+watch(
+  [
+    statusFilter,
+    categoryFilter,
+    stationFilter,
+    sortFilter,
+    onlineOnly,
+    qrOnly,
+    noRecipeOnly,
+    marginNegativeOnly,
+    productTypeFilter,
+    appliedSearch,
+  ],
+  () => { currentPage.value = 1 },
+)
 
 watch(
   [
@@ -1403,7 +1556,7 @@ const productosTableColumns = computed(() => {
     {
       key: 'name',
       title: 'Producto',
-      sortable: false,
+      sortable: true,
       format: 'text',
       align: 'left'
     },
@@ -1428,7 +1581,7 @@ const productosTableColumns = computed(() => {
     {
       key: 'price',
       title: 'Precio',
-      sortable: false,
+      sortable: true,
       format: 'currency',
       align: 'right'
     },
@@ -1442,7 +1595,7 @@ const productosTableColumns = computed(() => {
     {
       key: 'margen_operativo',
       title: 'Margen op.',
-      sortable: false,
+      sortable: true,
       format: 'text',
       align: 'center'
     },


### PR DESCRIPTION
## Summary
- Move product column filters into compact table header controls on desktop
- Keep external filters as mobile fallback and non-column filters in the toolbar
- Add reusable TableHeaderFilter component for future table migrations

## Validation
- bunx nuxi prepare
- git diff --check

Closes #1221