### PR TITLE
Move sales and payments filters into table headers

### DIFF
--- a/pages/pagos/index.vue
+++ b/pages/pagos/index.vue
@@ -22,7 +22,7 @@
         <template #additional-filters>
           <select
             v-model="selectedSupplierFilter"
-            :class="filterSelectClass"
+            :class="[filterSelectClass, 'md:hidden']"
             aria-label="Filtrar por proveedor"
           >
             <option value="">Proveedor</option>
@@ -80,6 +80,22 @@
             :sort-field="sortField"
             :sort-direction="sortDirection"
             @sort="handleSort">
+            <template #header-proveedor>
+              <UiTableHeaderFilter
+                v-model="selectedSupplierFilter"
+                title="Proveedor"
+                column-key="proveedor"
+                sortable
+                :sort-field="sortField"
+                :sort-direction="sortDirection"
+                filter-type="select"
+                :options="supplierHeaderOptions"
+                all-label="Proveedor"
+                align="left"
+                @sort="handleSort"
+              />
+            </template>
+
             <template #cell-seleccion="{ row }">
               <input type="checkbox" :checked="isSelected(row.purchaseData.id)"
                 @change="toggleSelection(row.purchaseData)"
@@ -139,6 +155,22 @@
             :sort-field="sortField"
             :sort-direction="sortDirection"
             @sort="handleSort">
+            <template #header-proveedor>
+              <UiTableHeaderFilter
+                v-model="selectedSupplierFilter"
+                title="Proveedor"
+                column-key="proveedor"
+                sortable
+                :sort-field="sortField"
+                :sort-direction="sortDirection"
+                filter-type="select"
+                :options="supplierHeaderOptions"
+                all-label="Proveedor"
+                align="left"
+                @sort="handleSort"
+              />
+            </template>
+
             <template #cell-orden="{ row }">
               <span :class="['text-sm font-bold text-text-primary', { 'animate-pulse': row.isHighlighted }]">{{ row.orden }}</span>
             </template>
@@ -254,6 +286,9 @@ const { data: suppliersData } = useQuery({
 })
 
 const suppliers = computed(() => (suppliersData.value as any)?.data || [])
+const supplierHeaderOptions = computed(() =>
+  suppliers.value.map((supplier: any) => ({ label: supplier.name, value: supplier.id })),
+)
 
 // Fetch all purchases with reactive filters
 const { data: purchasesData, status: queryStatus, asyncStatus: queryAsyncStatus, refetch } = useQuery({

--- a/pages/ventas/ordenes.vue
+++ b/pages/ventas/ordenes.vue
@@ -114,6 +114,10 @@ watch(dateRangeDates, (val) => {
   }
 })
 
+watch([paymentFilter, statusFilter, deliveryOnly], () => {
+  currentPage.value = 1
+})
+
 // Pagination computed (after ordersData is declared)
 const ordersTotalPages = computed(() => {
   const total = ordersData.value?.pagination?.total ?? 0
@@ -310,7 +314,16 @@ const exportOrders = async () => {
   }
 }
 
-const handleSort = ({ field, direction }: { field: string; direction: 'asc' | 'desc' }) => {
+const handleSort = (event: string | { field: string; direction?: 'asc' | 'desc' }) => {
+  const field = typeof event === 'string' ? event : event.field
+  if (!field) return
+  const direction =
+    typeof event === 'object' && event.direction
+      ? event.direction
+      : sortField.value === field && sortDirection.value === 'asc'
+        ? 'desc'
+        : 'asc'
+
   sortField.value = field
   sortDirection.value = direction
   currentPage.value = 1
@@ -351,6 +364,39 @@ const statusPills = [
   { label: 'Canceladas', value: 'cancelled' },
   { label: 'Pendientes', value: 'pending' },
 ]
+
+const statusHeaderOptions = [
+  { label: 'Completadas', value: 'completed' },
+  { label: 'Canceladas', value: 'cancelled' },
+  { label: 'Pendientes', value: 'pending' },
+]
+
+const paymentHeaderOptions = computed(() => {
+  const options: { label: string; value: string }[] = []
+  for (const group of paymentGroups.value) {
+    options.push({ label: group.name, value: `g:${group.slug}` })
+    for (const method of group.methods ?? []) {
+      options.push({ label: method.name, value: `m:${method.id}` })
+    }
+  }
+  return options
+})
+
+const statusHeaderFilter = computed({
+  get: () => statusFilter.value ?? '',
+  set: (value: string | boolean) => {
+    statusFilter.value = typeof value === 'string' && value ? value : null
+    currentPage.value = 1
+  },
+})
+
+const paymentHeaderFilter = computed({
+  get: () => paymentFilter.value ?? '',
+  set: (value: string | boolean) => {
+    paymentFilter.value = typeof value === 'string' && value ? value : null
+    currentPage.value = 1
+  },
+})
 
 const { formatDateTime: formatDateCompact } = useFormatters()
 
@@ -413,7 +459,7 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
         <select
           v-model="paymentFilter"
           @change="() => { currentPage.value = 1 }"
-          :class="filterSelectClass"
+          :class="[filterSelectClass, 'md:hidden']"
         >
           <option :value="null">Método pago</option>
           <template v-for="group in paymentGroups">
@@ -429,7 +475,7 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
         <select
           v-model="statusFilter"
           @change="() => { currentPage.value = 1 }"
-          :class="filterSelectClass"
+          :class="[filterSelectClass, 'md:hidden']"
         >
           <option :value="null">Estado</option>
           <option value="completed">Completadas</option>
@@ -439,7 +485,7 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
 
         <!-- Delivery-only filter chip -->
         <label
-          class="flex items-center gap-2 cursor-pointer min-h-[44px] px-3 py-2 rounded-lg border-2 transition-colors flex-shrink-0"
+          class="flex items-center gap-2 cursor-pointer min-h-[44px] px-3 py-2 rounded-lg border-2 transition-colors flex-shrink-0 md:hidden"
           :class="deliveryOnly
             ? 'border-emerald-500 bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400'
             : 'border-border bg-background text-text-secondary hover:text-text-primary hover:border-emerald-400'"
@@ -607,6 +653,43 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
           <div class="flex items-center justify-center">
             <UiBulkSelectCheckbox :checked="allPageSelected" @change="toggleSelectAll" />
           </div>
+        </template>
+
+        <template #header-source>
+          <UiTableHeaderFilter
+            v-model="deliveryOnly"
+            title="Origen"
+            filter-type="toggle"
+            toggle-label="Solo domicilios"
+            align="center"
+          />
+        </template>
+
+        <template #header-payment_method>
+          <UiTableHeaderFilter
+            v-model="paymentHeaderFilter"
+            title="Método Pago"
+            column-key="payment_method"
+            sortable
+            :sort-field="sortField"
+            :sort-direction="sortDirection"
+            filter-type="select"
+            :options="paymentHeaderOptions"
+            all-label="Método pago"
+            align="left"
+            @sort="handleSort"
+          />
+        </template>
+
+        <template #header-status>
+          <UiTableHeaderFilter
+            v-model="statusHeaderFilter"
+            title="Estado"
+            filter-type="select"
+            :options="statusHeaderOptions"
+            all-label="Estado"
+            align="center"
+          />
         </template>
 
         <template #cell-select="{ row }">

--- a/pages/ventas/productos.vue
+++ b/pages/ventas/productos.vue
@@ -105,12 +105,44 @@ watch(productsData, (data) => {
   }
 })
 
+const categoryHeaderOptions = computed(() =>
+  cachedCategories.value.map(category => ({ label: category.name, value: category.id })),
+)
+
+const categoryHeaderFilter = computed({
+  get: () => categoryFilter.value ?? '',
+  set: (value: string | boolean) => {
+    categoryFilter.value = typeof value === 'string' && value ? value : null
+  },
+})
+
+const TABLE_SORT_TO_API: Record<string, 'qty_desc' | 'revenue_desc' | 'name_asc'> = {
+  product_name: 'name_asc',
+  quantity_sold: 'qty_desc',
+  total_revenue: 'revenue_desc',
+}
+
+const API_SORT_TO_TABLE: Record<'qty_desc' | 'revenue_desc' | 'name_asc', { field: string; direction: 'asc' | 'desc' }> = {
+  qty_desc: { field: 'quantity_sold', direction: 'desc' },
+  revenue_desc: { field: 'total_revenue', direction: 'desc' },
+  name_asc: { field: 'product_name', direction: 'asc' },
+}
+
+const tableSortField = computed(() => API_SORT_TO_TABLE[sortFilter.value].field)
+const tableSortDirection = computed(() => API_SORT_TO_TABLE[sortFilter.value].direction)
+
+function handleTableSort(field: string) {
+  const nextSort = TABLE_SORT_TO_API[field]
+  if (!nextSort) return
+  sortFilter.value = nextSort
+}
+
 // ── Table columns ────────────────────────────────────────────────────────
 const tableColumns = [
-  { key: 'product_name', title: 'Producto', sortable: false },
+  { key: 'product_name', title: 'Producto', sortable: true },
   { key: 'category_name', title: 'Categoría', sortable: false },
-  { key: 'quantity_sold', title: 'Vendidos', sortable: false },
-  { key: 'total_revenue', title: 'Ingresos', sortable: false },
+  { key: 'quantity_sold', title: 'Vendidos', sortable: true },
+  { key: 'total_revenue', title: 'Ingresos', sortable: true },
 ]
 
 const formatCurrency = (value: number) =>
@@ -184,7 +216,7 @@ onUnmounted(() => {
             v-if="cachedCategories.length > 0"
             v-model="categoryFilter"
             aria-label="Filtrar por categoría"
-            :class="filterSelectClass"
+            :class="[filterSelectClass, 'md:hidden']"
           >
             <option :value="null">Categoría</option>
             <option v-for="cat in cachedCategories" :key="cat.id" :value="cat.id">{{ cat.name }}</option>
@@ -193,7 +225,7 @@ onUnmounted(() => {
           <select
             v-model="sortFilter"
             aria-label="Ordenar por"
-            :class="filterSelectClass"
+            :class="[filterSelectClass, 'md:hidden']"
           >
             <option value="qty_desc">Más vendidos</option>
             <option value="revenue_desc">Más ingresos</option>
@@ -226,8 +258,61 @@ onUnmounted(() => {
         :data="products"
         :empty-message="emptyMessage"
         :empty-sub-message="emptySubMessage"
+        :sort-field="tableSortField"
+        :sort-direction="tableSortDirection"
         variant="default"
+        @sort="handleTableSort"
       >
+        <template #header-product_name>
+          <UiTableHeaderFilter
+            title="Producto"
+            column-key="product_name"
+            sortable
+            :sort-field="tableSortField"
+            :sort-direction="tableSortDirection"
+            filter-type="none"
+            align="left"
+            @sort="handleTableSort"
+          />
+        </template>
+
+        <template #header-category_name>
+          <UiTableHeaderFilter
+            v-model="categoryHeaderFilter"
+            title="Categoría"
+            filter-type="select"
+            :options="categoryHeaderOptions"
+            all-label="Categoría"
+            align="left"
+          />
+        </template>
+
+        <template #header-quantity_sold>
+          <UiTableHeaderFilter
+            title="Vendidos"
+            column-key="quantity_sold"
+            sortable
+            :sort-field="tableSortField"
+            :sort-direction="tableSortDirection"
+            filter-type="none"
+            align="right"
+            @sort="handleTableSort"
+          />
+        </template>
+
+        <template #header-total_revenue>
+          <UiTableHeaderFilter
+            title="Ingresos"
+            column-key="total_revenue"
+            sortable
+            :sort-field="tableSortField"
+            :sort-direction="tableSortDirection"
+            filter-type="none"
+            align="right"
+            @sort="handleTableSort"
+          />
+        </template>
+
         <!-- Mobile card -->
         <template #card="{ item, index }">
           <div

--- a/pages/ventas/propinas/index.vue
+++ b/pages/ventas/propinas/index.vue
@@ -241,6 +241,41 @@ const channelVariant = (ch: string | null | undefined) => {
   return 'secondary'
 }
 
+const channelHeaderOptions = [
+  { label: 'POS', value: 'pos' },
+  { label: 'Mesa', value: 'mesa' },
+  { label: 'Online', value: 'online' },
+]
+
+const memberHeaderOptions = computed(() =>
+  memberOptions.value.map(member => ({ label: member.name, value: member.id })),
+)
+
+const paymentHeaderOptions = computed(() =>
+  paymentGroups.value.map(group => ({ label: group.name, value: group.slug })),
+)
+
+const memberHeaderFilter = computed({
+  get: () => memberFilter.value ?? '',
+  set: (value: string | boolean) => {
+    memberFilter.value = typeof value === 'string' && value ? value : null
+  },
+})
+
+const channelHeaderFilter = computed({
+  get: () => channelFilter.value ?? '',
+  set: (value: string | boolean) => {
+    channelFilter.value = typeof value === 'string' && value ? value as 'pos' | 'mesa' | 'online' : null
+  },
+})
+
+const paymentHeaderFilter = computed({
+  get: () => paymentFilter.value ?? '',
+  set: (value: string | boolean) => {
+    paymentFilter.value = typeof value === 'string' && value ? value : null
+  },
+})
+
 // ── Columns ─────────────────────────────────────────────────────────────────
 const columns: Column[] = [
   { key: 'order_date', title: 'Fecha', sortable: true, width: '180px' },
@@ -377,7 +412,7 @@ onUnmounted(() => clearRefreshHandler(refetch))
         <!-- Mesero -->
         <select
           v-model="memberFilter"
-          class="py-2 pl-3 pr-8 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer flex-shrink-0"
+          class="py-2 pl-3 pr-8 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer flex-shrink-0 md:hidden"
           aria-label="Filtrar por mesero"
         >
           <option :value="null">Mesero</option>
@@ -387,7 +422,7 @@ onUnmounted(() => clearRefreshHandler(refetch))
         <!-- Channel -->
         <select
           v-model="channelFilter"
-          class="py-2 pl-3 pr-8 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer flex-shrink-0"
+          class="py-2 pl-3 pr-8 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer flex-shrink-0 md:hidden"
           aria-label="Filtrar por canal"
         >
           <option :value="null">Canal</option>
@@ -399,7 +434,7 @@ onUnmounted(() => clearRefreshHandler(refetch))
         <!-- Payment method -->
         <select
           v-model="paymentFilter"
-          class="py-2 pl-3 pr-8 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer flex-shrink-0"
+          class="py-2 pl-3 pr-8 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer flex-shrink-0 md:hidden"
           aria-label="Filtrar por método de pago"
         >
           <option :value="null">Método pago</option>
@@ -454,6 +489,39 @@ onUnmounted(() => clearRefreshHandler(refetch))
         row-size="sm"
         @sort="handleSort"
       >
+        <template #header-channel>
+          <UiTableHeaderFilter
+            v-model="channelHeaderFilter"
+            title="Canal"
+            filter-type="select"
+            :options="channelHeaderOptions"
+            all-label="Canal"
+            align="center"
+          />
+        </template>
+
+        <template #header-member_name>
+          <UiTableHeaderFilter
+            v-model="memberHeaderFilter"
+            title="Mesero"
+            filter-type="select"
+            :options="memberHeaderOptions"
+            all-label="Mesero"
+            align="left"
+          />
+        </template>
+
+        <template #header-payment_method>
+          <UiTableHeaderFilter
+            v-model="paymentHeaderFilter"
+            title="Método de pago"
+            filter-type="select"
+            :options="paymentHeaderOptions"
+            all-label="Método pago"
+            align="left"
+          />
+        </template>
+
         <!-- Mobile card -->
         <template #card="{ item, index }">
           <div :class="['flex flex-col gap-2 p-4 border-b border-border', index % 2 === 0 ? 'bg-surface' : 'bg-background']">


### PR DESCRIPTION
## Summary
- Move column-owned filters into compact table header controls for sales/payments routes.
- Keep search, date ranges, exports, manual/payment actions, and non-column/global filters outside the table.
- Preserve mobile fallback by hiding moved external filters only on desktop.

## Moved to headers
- `/ventas/ordenes`: Método Pago, Estado, Solo domicilios/Origen.
- `/ventas/propinas`: Mesero, Canal, Método de pago.
- `/ventas/productos`: Categoría and API-backed sort controls for Producto, Vendidos, Ingresos.
- `/pagos`: Proveedor in both pending and paid desktop tables.

## Intentionally external
- Search/search-field controls.
- Date range or period presets.
- Export, Manual, Registrar Pago and bulk/action controls.
- `/ventas/productos` Canal because it has no visible table column in the current dataset.

## Validation
- `git diff --check`
- `bunx nuxi prepare`
- `curl` 200 checks for `/ventas/ordenes`, `/ventas/propinas`, `/ventas/productos`, `/pagos`

Note: Browser automation was attempted, but the in-app browser tab did not mount page content despite 200 responses and no browser console errors. Manual visual QA is recommended before merge.

Closes #1224
