### PR TITLE
Move category type filter to table header

### DIFF
--- a/pages/menu/categorias/index.vue
+++ b/pages/menu/categorias/index.vue
@@ -38,7 +38,7 @@
           <template #additional-filters>
             <select
               v-model="tipoFilter"
-              :class="filterSelectClass"
+              :class="[filterSelectClass, 'md:hidden']"
               aria-label="Filtrar por tipo"
             >
               <option value="">Tipo</option>
@@ -57,6 +57,17 @@
           variant="default"
           row-size="sm"
         >
+          <template #header-tipo>
+            <UiTableHeaderFilter
+              v-model="tipoFilter"
+              title="Tipo"
+              filter-type="select"
+              :options="tipoHeaderOptions"
+              all-label="Todos"
+              align="left"
+            />
+          </template>
+
       <!-- Mobile row (matches /menu/modificadores pattern) -->
       <template #card="{ item, index }">
         <div
@@ -198,6 +209,10 @@ const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch 
 const tipoFilter = ref<'global' | 'own' | ''>('')
 
 const performSearch = () => applySearch()
+const tipoHeaderOptions = [
+  { label: 'Global', value: 'global' },
+  { label: 'Propia', value: 'own' },
+]
 
 const hasActiveFilters = computed(
   () => !!localSearchTerm.value || !!appliedSearch.value || !!tipoFilter.value,


### PR DESCRIPTION
## Summary
- Moved `/menu/categorias` `Tipo` filter into the table header using `UiTableHeaderFilter`.
- Kept the external `Tipo` selector as a mobile fallback only.
- Left search and create actions external for `/menu/categorias`; `/menu/recetas` and `/menu/modificadores` have no external column-owned filters to migrate in this batch.

## Validation
- `npm exec nuxi -- prepare`
- SFC compile check for `pages/menu/categorias/index.vue` with `@vue/compiler-sfc`
- `git diff --check`

## Notes
- Local browser smoke test was blocked by the dev server emitting an absolute `_nuxt/.../entry.js` URL containing the workspace path with spaces, which 404s before the app renders. This is unrelated to the page change and reproduced before route-level interaction.

Closes #1225
