### PR TITLE
Move abastecimiento filters into table headers

### DIFF
--- a/components/inventario/StockInventoryView.vue
+++ b/components/inventario/StockInventoryView.vue
@@ -36,7 +36,7 @@
       <template #additional-filters>
         <select
           :value="categoryFilter"
-          :class="filterSelectClass"
+          :class="[filterSelectClass, 'md:hidden']"
           aria-label="Filtrar por categoría"
           @change="$emit('update:categoryFilter', ($event.target as HTMLSelectElement).value)"
         >
@@ -48,7 +48,7 @@
 
         <select
           :value="statusFilter"
-          :class="filterSelectClass"
+          :class="[filterSelectClass, 'md:hidden']"
           aria-label="Filtrar por estado"
           @change="$emit('update:statusFilter', ($event.target as HTMLSelectElement).value)"
         >
@@ -60,7 +60,7 @@
 
         <select
           :value="unitFilter"
-          :class="filterSelectClass"
+          :class="[filterSelectClass, 'md:hidden']"
           aria-label="Filtrar por unidad"
           @change="$emit('update:unitFilter', ($event.target as HTMLSelectElement).value)"
         >
@@ -85,6 +85,45 @@
       variant="default"
       @sort="$emit('sort', $event)"
     >
+        <template #header-unit>
+          <UiTableHeaderFilter
+            title="Unidad"
+            filter-type="select"
+            :model-value="unitFilter"
+            :options="unitHeaderOptions"
+            all-label="Todas"
+            @update:model-value="$emit('update:unitFilter', typeof $event === 'string' ? $event : '')"
+          />
+        </template>
+
+        <template #header-category>
+          <UiTableHeaderFilter
+            title="Categoría"
+            filter-type="select"
+            :model-value="categoryFilter"
+            :options="categoryHeaderOptions"
+            all-label="Todas"
+            @update:model-value="$emit('update:categoryFilter', typeof $event === 'string' ? $event : '')"
+          />
+        </template>
+
+        <template #header-status>
+          <UiTableHeaderFilter
+            title="Estado"
+            column-key="status"
+            sortable
+            :sort-field="sortField"
+            :sort-direction="sortDirection"
+            filter-type="select"
+            :model-value="headerStatusFilter"
+            :options="stockStatusHeaderOptions"
+            all-label="Todos"
+            align="center"
+            @sort="$emit('sort', $event)"
+            @update:model-value="updateHeaderStatusFilter"
+          />
+        </template>
+
         <template #card="{ item, index }">
           <div
             class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-surface-secondary"
@@ -131,6 +170,10 @@
 
         <template #cell-unit="{ value }">
           <span class="text-sm text-text-secondary">{{ value }}</span>
+        </template>
+
+        <template #cell-category="{ value }">
+          <span class="text-sm text-text-secondary">{{ value || '-' }}</span>
         </template>
 
         <template #cell-current_stock="{ value }">
@@ -304,7 +347,7 @@ const props = withDefaults(defineProps<{
   highlightNegativeStock: false,
 })
 
-defineEmits<{
+const emit = defineEmits<{
   'update:search': [value: string]
   'update:categoryFilter': [value: string]
   'update:statusFilter': [value: string]
@@ -318,6 +361,33 @@ defineEmits<{
 
 const filterSelectClass = 'h-10 min-h-[44px] px-3 rounded-lg border border-border bg-surface text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 flex-shrink-0'
 
+const categoryHeaderOptions = computed(() =>
+  props.categories.map(category => ({
+    label: category,
+    value: category,
+  })),
+)
+
+const unitHeaderOptions = computed(() =>
+  props.units.map(unit => ({
+    label: unit,
+    value: unit,
+  })),
+)
+
+const stockStatusHeaderOptions = computed(() =>
+  props.statusOptions.map(option => ({
+    label: option.label,
+    value: option.value,
+  })),
+)
+
+const headerStatusFilter = computed(() => props.statusFilter === 'all' ? '' : props.statusFilter)
+
+const updateHeaderStatusFilter = (value: string | boolean) => {
+  emit('update:statusFilter', typeof value === 'string' && value ? value : 'all')
+}
+
 const stockTableColumns = computed(() => [
   {
     key: 'ingredient_name',
@@ -329,6 +399,13 @@ const stockTableColumns = computed(() => [
   {
     key: 'unit',
     title: 'Unidad',
+    sortable: false,
+    format: 'text',
+    align: 'left',
+  },
+  {
+    key: 'category',
+    title: 'Categoría',
     sortable: false,
     format: 'text',
     align: 'left',

--- a/pages/abastecimiento/ajustes/index.vue
+++ b/pages/abastecimiento/ajustes/index.vue
@@ -47,7 +47,7 @@
 
           <select
             v-model="adjustmentTypeFilter"
-            :class="filterSelectClass"
+            :class="[filterSelectClass, 'md:hidden']"
             aria-label="Filtrar por tipo de ajuste"
           >
             <option value="">Tipo ajuste</option>
@@ -69,6 +69,18 @@
         variant="default"
         row-size="sm"
       >
+        <template #header-adjustment_type>
+          <UiTableHeaderFilter
+            title="Tipo"
+            filter-type="select"
+            :model-value="adjustmentTypeFilter"
+            :options="adjustmentTypeOptions"
+            all-label="Todos"
+            align="center"
+            @update:model-value="adjustmentTypeFilter = typeof $event === 'string' ? $event : ''"
+          />
+        </template>
+
         <!-- Mobile Card -->
         <template #card="{ item, index }">
           <div
@@ -158,6 +170,11 @@ const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch 
 const { dateRangeDates, presetDates, formatDateRange, dateRange, clearDateRange } = useDateRangePresets()
 const ingredientFilter = ref('')
 const adjustmentTypeFilter = ref('')
+
+const adjustmentTypeOptions = [
+  { value: 'positive', label: 'Incrementos' },
+  { value: 'negative', label: 'Decrementos' },
+]
 
 const hasActiveFilters = computed(
   () =>

--- a/pages/abastecimiento/compras-directas/index.vue
+++ b/pages/abastecimiento/compras-directas/index.vue
@@ -24,7 +24,7 @@
         <template #additional-filters>
           <select
             v-model="proveedorFilter"
-            :class="filterSelectClass"
+            :class="[filterSelectClass, 'md:hidden']"
             aria-label="Filtrar por proveedor"
             @change="currentPage = 1"
           >
@@ -34,7 +34,7 @@
 
           <select
             v-model="statusFilter"
-            :class="filterSelectClass"
+            :class="[filterSelectClass, 'md:hidden']"
             aria-label="Filtrar por estado"
             @change="currentPage = 1"
           >
@@ -83,6 +83,39 @@
         variant="default"
         row-size="sm"
       >
+        <template #header-supplier_name>
+          <UiTableHeaderFilter
+            title="Proveedor"
+            column-key="supplier_name"
+            sortable
+            :sort-field="sortField"
+            :sort-direction="sortDirection"
+            filter-type="select"
+            :model-value="proveedorFilter"
+            :options="supplierHeaderOptions"
+            all-label="Todos"
+            @sort="handleSort"
+            @update:model-value="updateProveedorFilter"
+          />
+        </template>
+
+        <template #header-status>
+          <UiTableHeaderFilter
+            title="Estado"
+            column-key="status"
+            sortable
+            :sort-field="sortField"
+            :sort-direction="sortDirection"
+            filter-type="select"
+            :model-value="statusFilter"
+            :options="statusOptions"
+            all-label="Todos"
+            align="center"
+            @sort="handleSort"
+            @update:model-value="updateStatusFilter"
+          />
+        </template>
+
         <!-- Mobile Card Slot -->
         <template #card="{ item, index }">
           <div
@@ -295,6 +328,13 @@ const { data: suppliersResponse } = useQuery({
 })
 const suppliers = computed(() => suppliersResponse.value?.data || [])
 
+const supplierHeaderOptions = computed(() =>
+  suppliers.value.map((supplier: any) => ({
+    label: supplier.name,
+    value: supplier.id,
+  })),
+)
+
 // Status options
 const statusOptions = [
   { value: 'received', label: 'Recibida' },
@@ -374,6 +414,16 @@ const handleSort = (field: string) => {
     sortField.value = field
     sortDirection.value = 'desc'
   }
+}
+
+const updateProveedorFilter = (value: string | boolean) => {
+  proveedorFilter.value = typeof value === 'string' ? value : ''
+  currentPage.value = 1
+}
+
+const updateStatusFilter = (value: string | boolean) => {
+  statusFilter.value = typeof value === 'string' ? value : ''
+  currentPage.value = 1
 }
 
 const hasActiveFilters = computed(

--- a/pages/abastecimiento/compras.vue
+++ b/pages/abastecimiento/compras.vue
@@ -24,7 +24,7 @@
         <template #additional-filters>
           <select
             v-model="proveedorFilter"
-            :class="filterSelectClass"
+            :class="[filterSelectClass, 'md:hidden']"
             aria-label="Filtrar por proveedor"
             @change="currentPage = 1"
           >
@@ -34,7 +34,7 @@
 
           <select
             v-model="statusFilter"
-            :class="filterSelectClass"
+            :class="[filterSelectClass, 'md:hidden']"
             aria-label="Filtrar por estado"
             @change="currentPage = 1"
           >
@@ -73,6 +73,39 @@
         empty-sub-message="Crea una nueva orden para comenzar"
         variant="default"
       >
+        <template #header-proveedor>
+          <UiTableHeaderFilter
+            title="Proveedor"
+            column-key="proveedor"
+            sortable
+            :sort-field="sortField"
+            :sort-direction="sortDirection"
+            filter-type="select"
+            :model-value="proveedorFilter"
+            :options="supplierHeaderOptions"
+            all-label="Todos"
+            @sort="handleSort"
+            @update:model-value="updateProveedorFilter"
+          />
+        </template>
+
+        <template #header-estado>
+          <UiTableHeaderFilter
+            title="Estado"
+            column-key="estado"
+            sortable
+            :sort-field="sortField"
+            :sort-direction="sortDirection"
+            filter-type="select"
+            :model-value="statusFilter"
+            :options="purchaseStatusOptions"
+            all-label="Todos"
+            align="center"
+            @sort="handleSort"
+            @update:model-value="updateStatusFilter"
+          />
+        </template>
+
         <!-- Mobile Card Slot -->
         <template #card="{ item, index }">
           <div
@@ -271,7 +304,24 @@ const purchaseStatusOptions = [
   { label: 'Cancelada', value: 'cancelled' }
 ]
 
+const supplierHeaderOptions = computed(() =>
+  suppliers.value.map((supplier: any) => ({
+    label: supplier.name,
+    value: supplier.id,
+  })),
+)
+
 const performSearch = () => applySearch(() => { currentPage.value = 1 })
+
+const updateProveedorFilter = (value: string | boolean) => {
+  proveedorFilter.value = typeof value === 'string' ? value : ''
+  currentPage.value = 1
+}
+
+const updateStatusFilter = (value: string | boolean) => {
+  statusFilter.value = typeof value === 'string' ? value : ''
+  currentPage.value = 1
+}
 
 const hasActiveFilters = computed(
   () =>
@@ -284,7 +334,7 @@ const hasActiveFilters = computed(
 
 // Sorting state
 const sortField = ref('')
-const sortDirection = ref('asc')
+const sortDirection = ref<'asc' | 'desc'>('asc')
 
 const clearFilters = () => {
   clearSearch()

--- a/pages/abastecimiento/ingredientes-propios.vue
+++ b/pages/abastecimiento/ingredientes-propios.vue
@@ -25,7 +25,7 @@
         <template #additional-filters>
           <select
             v-model="typeFilter"
-            :class="filterSelectClass"
+            :class="[filterSelectClass, 'md:hidden']"
             aria-label="Filtrar por tipo"
             @change="currentPage = 1"
           >
@@ -73,6 +73,17 @@
         variant="default"
         row-size="xs"
       >
+        <template #header-type>
+          <UiTableHeaderFilter
+            title="Tipo"
+            filter-type="select"
+            :model-value="typeFilter"
+            :options="typeHeaderOptions"
+            all-label="Todos"
+            @update:model-value="updateTypeFilter"
+          />
+        </template>
+
         <!-- Mobile Card -->
         <template #card="{ item, index }">
           <div
@@ -249,6 +260,12 @@ const TYPE_LABELS: Record<string, string> = {
   service: WAREHOUSE_COPY.typeService,
 }
 
+const typeHeaderOptions = [
+  { value: 'food', label: WAREHOUSE_COPY.typeFood },
+  { value: 'supply', label: WAREHOUSE_COPY.typeSupply },
+  { value: 'service', label: WAREHOUSE_COPY.typeService },
+]
+
 const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
 const typeFilter = ref('')
 
@@ -287,6 +304,11 @@ const performSearch = () => applySearch(() => { currentPage.value = 1 })
 
 const toggleArchived = () => {
   showArchived.value = !showArchived.value
+  currentPage.value = 1
+}
+
+const updateTypeFilter = (value: string | boolean) => {
+  typeFilter.value = typeof value === 'string' ? value : ''
   currentPage.value = 1
 }
 

--- a/pages/abastecimiento/movimientos.vue
+++ b/pages/abastecimiento/movimientos.vue
@@ -21,7 +21,7 @@
 
           <select
             v-model="movementTypeFilter"
-            :class="filterSelectClass"
+            :class="[filterSelectClass, 'md:hidden']"
             aria-label="Filtrar por tipo de movimiento"
           >
             <option value="">Tipo</option>
@@ -45,6 +45,23 @@
         empty-sub-message="Los movimientos aparecerán cuando se registren compras o ventas"
         variant="default"
       >
+        <template #header-movement_type>
+          <UiTableHeaderFilter
+            title="Tipo"
+            column-key="movement_type"
+            sortable
+            :sort-field="sortField"
+            :sort-direction="sortDirection"
+            filter-type="select"
+            :model-value="movementTypeFilter"
+            :options="movementTypeOptions"
+            all-label="Todos"
+            align="center"
+            @sort="handleSort"
+            @update:model-value="movementTypeFilter = typeof $event === 'string' ? $event : ''"
+          />
+        </template>
+
         <template #card="{ item, index }">
           <div
             class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-surface-secondary"
@@ -143,6 +160,14 @@ const { dateRangeDates, presetDates, formatDateRange, dateRange, clearDateRange 
 const ingredientFilter = ref('')
 const movementTypeFilter = ref('')
 
+const movementTypeOptions = [
+  { value: 'purchase', label: 'Compras' },
+  { value: 'consumption', label: 'Consumo' },
+  { value: 'adjustment', label: 'Ajustes' },
+  { value: 'return', label: 'Devoluciones' },
+  { value: 'loss', label: 'Pérdidas' },
+]
+
 const hasActiveFilters = computed(
   () =>
     !!localSearchTerm.value
@@ -155,7 +180,7 @@ const hasActiveFilters = computed(
 const performSearch = () => applySearch()
 
 const sortField = ref('')
-const sortDirection = ref('desc')
+const sortDirection = ref<'asc' | 'desc'>('desc')
 
 const dateParts = computed(() => {
   if (!dateRange.value.from || !dateRange.value.to) return {}

--- a/pages/abastecimiento/proveedores.vue
+++ b/pages/abastecimiento/proveedores.vue
@@ -23,7 +23,7 @@
         <template #additional-filters>
           <select
             v-model="statusFilter"
-            :class="filterSelectClass"
+            :class="[filterSelectClass, 'md:hidden']"
             aria-label="Filtrar por estado"
             @change="onStatusFilterChange"
           >
@@ -64,6 +64,23 @@
         variant="default"
         row-size="sm"
       >
+        <template #header-is_active>
+          <UiTableHeaderFilter
+            title="Estado"
+            column-key="is_active"
+            sortable
+            :sort-field="sortField"
+            :sort-direction="sortDirection"
+            filter-type="select"
+            :model-value="statusFilter"
+            :options="supplierStatusOptions"
+            all-label="Todos"
+            align="center"
+            @sort="handleSort"
+            @update:model-value="updateStatusHeaderFilter"
+          />
+        </template>
+
         <!-- Mobile Card -->
         <template #card="{ item, index }">
           <div
@@ -228,7 +245,7 @@ const itemsPerPage = ref(20);
 
 // Sorting state
 const sortField = ref('')
-const sortDirection = ref('asc')
+const sortDirection = ref<'asc' | 'desc'>('asc')
 
 const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
 const apiSearchField = ref('name')
@@ -242,6 +259,11 @@ const searchFields = [
   { label: 'Teléfono', value: 'phone' },
 ]
 
+const supplierStatusOptions = [
+  { value: 'active', label: 'Activo' },
+  { value: 'inactive', label: 'Inactivo' },
+]
+
 const apiIsActive = ref<boolean | null>(null)
 const apiPaymentTerms = ref<string | null>(null)
 
@@ -250,6 +272,11 @@ const onStatusFilterChange = () => {
   else if (statusFilter.value === 'inactive') apiIsActive.value = false
   else apiIsActive.value = null
   currentPage.value = 1
+}
+
+const updateStatusHeaderFilter = (value: string | boolean) => {
+  statusFilter.value = typeof value === 'string' ? value : ''
+  onStatusFilterChange()
 }
 
 const onPaymentTermsChange = () => {

--- a/pages/abastecimiento/stock.vue
+++ b/pages/abastecimiento/stock.vue
@@ -8,8 +8,8 @@
     <InventarioStockInventoryView
       v-else
       v-model:search="localSearchTerm"
-      v-model:category-filter="categoryFilter"
-      v-model:unit-filter="unitFilter"
+      :category-filter="categoryFilter"
+      :unit-filter="unitFilter"
       :status-filter="statusFilter"
       :stats="stats"
       :inventory="displayInventory"
@@ -29,7 +29,9 @@
       :copy="stockCopy"
       :status-options="stockStatusOptions"
       highlight-negative-stock
+      @update:category-filter="updateCategoryFilter"
       @update:status-filter="updateStatusFilter"
+      @update:unit-filter="updateUnitFilter"
       @search="performSearch"
       @clear="clearFilters"
       @sort="handleSort"
@@ -206,6 +208,16 @@ const nextPage = () => {
 
 const updateStatusFilter = (value: string) => {
   statusFilter.value = value
+  currentPage.value = 1
+}
+
+const updateCategoryFilter = (value: string) => {
+  categoryFilter.value = value
+  currentPage.value = 1
+}
+
+const updateUnitFilter = (value: string) => {
+  unitFilter.value = value
   currentPage.value = 1
 }
 


### PR DESCRIPTION
## Summary
- Move column-owned filters into compact table header controls across abastecimiento and stock inventory tables.
- Keep global/non-column filters external: search, date ranges, ingredient search, stock action button, archived toggle, and payment terms.
- Add a visible stock category column so the category filter is owned by an actual table column.

## Moved to headers
- Stock: category, unit, status.
- Purchases and direct purchases: supplier, status.
- Movements: movement type.
- Adjustments: adjustment type.
- Custom ingredients: type.
- Suppliers: active/inactive status.

## Intentionally external
- Search fields and search bars.
- Purchase period/date filters and movement/adjustment date ranges.
- Ingredient search/typeahead controls.
- Stock adjustment actions.
- Custom ingredient archived toggle.
- Supplier payment terms, since it is not a visible table column.

## Validation
- `npm exec nuxi -- prepare`
- Targeted Vue SFC parse for all edited files.
- Dev server route checks returned 200 for `/abastecimiento/stock`, `/abastecimiento/compras`, `/abastecimiento/compras-directas`, `/abastecimiento/movimientos`, `/abastecimiento/ajustes`, `/abastecimiento/ingredientes-propios`, and `/abastecimiento/proveedores`.

Closes #1226
