### PR TITLE
Wire menu header filters to backend queries

### DIFF
--- a/pages/menu/modificadores/index.vue
+++ b/pages/menu/modificadores/index.vue
@@ -329,6 +329,11 @@ const requiredHeaderOptions = [
   { label: 'Obligatorio', value: 'required' },
   { label: 'Opcional', value: 'optional' },
 ]
+const isRequiredFilter = computed(() => {
+  if (requiredFilter.value === 'required') return true
+  if (requiredFilter.value === 'optional') return false
+  return null
+})
 const hasActiveModificadoresFilters = computed(() => hasActiveFilters.value || !!requiredFilter.value)
 
 watch(() => currentTenant.value?.id, () => { currentPage.value = 1 })
@@ -351,13 +356,15 @@ const { data: groupsData, asyncStatus: groupsAsyncStatus, refetch: refetchGroups
     page: currentPage.value,
     limit: itemsPerPage.value,
     search: appliedSearch.value || null,
+    is_required: isRequiredFilter.value,
   }],
   query: () => {
-    const params: Record<string, string | number> = {
+    const params: Record<string, string | number | boolean> = {
       page: currentPage.value,
       limit: itemsPerPage.value,
     }
     if (appliedSearch.value) params.search = appliedSearch.value
+    if (isRequiredFilter.value !== null) params.is_required = isRequiredFilter.value
     return $fetch('/api/menu/modifier-groups', { params })
   },
   enabled: () => !!currentTenant.value,
@@ -373,10 +380,7 @@ const { data: statsData, refetch: refetchStats } = useQuery({
 })
 
 const modifierGroups = computed(() => {
-  const list = groupsData.value?.data ?? []
-  if (requiredFilter.value === 'required') return list.filter((group: any) => group.is_required)
-  if (requiredFilter.value === 'optional') return list.filter((group: any) => !group.is_required)
-  return list
+  return groupsData.value?.data ?? []
 })
 
 const totalPages = computed(() =>

--- a/pages/menu/recetas/index.vue
+++ b/pages/menu/recetas/index.vue
@@ -306,6 +306,11 @@ const statusHeaderOptions = [
   { label: 'Activa', value: 'active' },
   { label: 'Inactiva', value: 'inactive' },
 ]
+const isActiveFilter = computed(() => {
+  if (statusFilter.value === 'active') return true
+  if (statusFilter.value === 'inactive') return false
+  return null
+})
 const hasActiveRecetasFilters = computed(() => hasActiveFilters.value || !!statusFilter.value)
 
 // Fetch recipe bases from backend with ingredients
@@ -314,15 +319,19 @@ const { data: productsData, status: queryStatus, asyncStatus: queryAsyncStatus, 
     page: currentPage.value,
     limit: itemsPerPage.value,
     search: apiSearchTerm.value || null,
+    is_active: isActiveFilter.value,
   }],
   query: () => {
-    const params: any = {
+    const params: Record<string, string | number | boolean> = {
       page: currentPage.value,
       limit: itemsPerPage.value,
       include_ingredients: true
     }
     if (apiSearchTerm.value) {
       params.search = apiSearchTerm.value
+    }
+    if (isActiveFilter.value !== null) {
+      params.is_active = isActiveFilter.value
     }
     return $fetch('/api/menu/recipe-bases', { params })
   },
@@ -353,7 +362,7 @@ const onClearRecetasFilters = () => {
 const recetas = computed(() => {
   if (!productsData.value?.data) return []
 
-  const list = productsData.value.data.map((recipeBase: any) => ({
+  return productsData.value.data.map((recipeBase: any) => ({
     id: recipeBase.id,
     producto_id: recipeBase.id,
     producto_name: recipeBase.name,
@@ -378,10 +387,6 @@ const recetas = computed(() => {
     }, 0) || 0,
     rendimiento: 1
   }))
-
-  if (statusFilter.value === 'active') return list.filter((recipe: any) => recipe.is_active)
-  if (statusFilter.value === 'inactive') return list.filter((recipe: any) => !recipe.is_active)
-  return list
 })
 
 // Pagination


### PR DESCRIPTION
## Summary
- Sends `/menu/modificadores` required/optional header filter state as `is_required=true/false` in the modifier-groups query.
- Sends `/menu/recetas` active/inactive header filter state as `is_active=true/false` in the recipe-bases query.
- Removes current-page-only filtering so table rows and pagination totals use backend-filtered result sets.

## Backend companion
- uno0uno/api-warolabs#393

## Validation
- `pytest tests/test_modifiers.py tests/test_recipe_bases.py` in `api_warocol.com`
- Frontend project has no lint/typecheck script; reviewed scoped Vue diffs and `git diff --check` passed.

## Manual validation routes
- `/menu/modificadores`
- `/menu/recetas`

Closes #1235