### PR TITLE
Make stock header filters backend backed

### DIFF
--- a/pages/abastecimiento/stock.vue
+++ b/pages/abastecimiento/stock.vue
@@ -12,7 +12,7 @@
       :unit-filter="unitFilter"
       :status-filter="statusFilter"
       :stats="stats"
-      :inventory="displayInventory"
+      :inventory="inventory"
       :total="inventoryData?.total ?? 0"
       :items-per-page="itemsPerPage"
       :start-item="startItem"
@@ -124,6 +124,8 @@ const { data: inventoryData, asyncStatus: queryAsyncStatus, refetch } = useQuery
   key: () => ['inventory', 'stock', currentTenant.value?.id, {
     search: appliedSearch.value || null,
     status: statusFilter.value,
+    category: categoryFilter.value || null,
+    unit: unitFilter.value || null,
     sort_field: sortField.value,
     sort_direction: sortDirection.value,
     page: currentPage.value,
@@ -138,6 +140,8 @@ const { data: inventoryData, asyncStatus: queryAsyncStatus, refetch } = useQuery
       status_filter: statusFilter.value,
     }
     if (appliedSearch.value) params.search = appliedSearch.value
+    if (categoryFilter.value) params.category = categoryFilter.value
+    if (unitFilter.value) params.unit = unitFilter.value
     return $fetch('/api/inventory/stock', { params })
   },
   enabled: () => !!currentTenant.value,
@@ -156,36 +160,8 @@ const stats = computed(() => inventoryData.value?.stats || {
   total_inventory_value: 0
 })
 
-// Get unique categories from inventory
-const categories = computed(() => {
-  const cats = new Set<string>()
-  inventory.value.forEach(item => {
-    if (item.category) {
-      cats.add(item.category)
-    }
-  })
-  return Array.from(cats).sort()
-})
-
-// Get unique units from inventory
-const units = computed(() => {
-  const unitsSet = new Set<string>()
-  inventory.value.forEach(item => {
-    if (item.unit) {
-      unitsSet.add(item.unit)
-    }
-  })
-  return Array.from(unitsSet).sort()
-})
-
-/** Category/unit: no API params — filters current page only. */
-const displayInventory = computed(() =>
-  inventory.value.filter((item) => {
-    const matchesCategory = !categoryFilter.value || item.category === categoryFilter.value
-    const matchesUnit = !unitFilter.value || item.unit === unitFilter.value
-    return matchesCategory && matchesUnit
-  }),
-)
+const categories = computed(() => inventoryData.value?.filter_options?.categories || [])
+const units = computed(() => inventoryData.value?.filter_options?.units || [])
 
 const totalPages = computed(() =>
   Math.ceil((inventoryData.value?.total ?? 0) / itemsPerPage.value),


### PR DESCRIPTION
## Summary

- Sends stock category and unit filters through the inventory query key and API params.
- Removes current-page-only `displayInventory` filtering so table rows and totals come from backend-filtered results.
- Uses backend `filter_options` metadata for category/unit options so header filters and mobile selects are pagination-safe.

## Backend dependency

- API PR: uno0uno/api-warolabs#394

## Validation

- Front source review: no full build/typecheck run because this repo has no lightweight typecheck script and `/wr-ship` avoids full frontend builds unless requested.
- Backend validation in paired API PR: `pytest tests/test_inventory.py` — 22 passed; `python3 -m py_compile app/routers/inventory.py app/services/inventory_service.py tests/test_inventory.py`.

## Manual validation route

- `/abastecimiento/stock`

Closes #1236.
