### PR TITLE
Move operations and dispatch filters into table headers

### DIFF
--- a/pages/despacho/comandas.vue
+++ b/pages/despacho/comandas.vue
@@ -16,6 +16,12 @@ const selectedSourceType = ref('')
 const selectedStationId = ref('')
 const selectedStatus = ref('pending,preparing,ready')
 const selectedDate = ref('')
+const selectedStatusHeaderFilter = computed({
+  get: () => selectedStatus.value === 'pending,preparing,ready' ? '' : selectedStatus.value,
+  set: (value: string | boolean) => {
+    selectedStatus.value = typeof value === 'string' && value ? value : 'pending,preparing,ready'
+  },
+})
 
 const filters = computed(() => ({
   source_type: selectedSourceType.value || undefined,
@@ -46,6 +52,9 @@ const SOURCE_LABELS = computed<Record<string, string>>(() => ({
   delivery: 'Domicilio',
   pickup:   'Recogida',
 }))
+const sourceHeaderOptions = computed(() =>
+  Object.entries(SOURCE_LABELS.value).map(([value, label]) => ({ value, label })),
+)
 
 const COMANDA_STATUS_LABELS: Record<string, string> = {
   pending:   'Pendiente',
@@ -54,6 +63,14 @@ const COMANDA_STATUS_LABELS: Record<string, string> = {
   delivered: 'Entregada',
   cancelled: 'Cancelada',
 }
+const comandaStatusHeaderOptions = [
+  { value: 'ready', label: 'Listas' },
+  { value: 'pending', label: 'Pendientes' },
+  { value: 'preparing', label: 'En preparación' },
+  { value: 'delivered', label: 'Entregadas' },
+  { value: 'cancelled', label: 'Canceladas' },
+  { value: 'pending,preparing,ready,delivered,cancelled', label: 'Todas' },
+]
 
 const columns: Column[] = [
   { key: '_select',            title: '',          sortable: false, align: 'center' as const, width: '44px', class: '!px-0' },
@@ -221,6 +238,7 @@ const getComandaStatusVariant = (status: string): string => {
           <select
             v-model="selectedSourceType"
             :class="filterSelectClass"
+            class="md:hidden"
             aria-label="Filtrar por origen"
           >
             <option value="">Origen</option>
@@ -242,6 +260,7 @@ const getComandaStatusVariant = (status: string): string => {
           <select
             v-model="selectedStatus"
             :class="filterSelectClass"
+            class="md:hidden"
             aria-label="Filtrar por estado"
           >
             <option value="pending,preparing,ready">Activas</option>
@@ -330,6 +349,28 @@ const getComandaStatusVariant = (status: string): string => {
             </span>
           </label>
       </div>
+      </template>
+
+      <template #header-source_type>
+        <UiTableHeaderFilter
+          v-model="selectedSourceType"
+          title="Origen"
+          filter-type="select"
+          :options="sourceHeaderOptions"
+          all-label="Todos"
+          align="left"
+        />
+      </template>
+
+      <template #header-status>
+        <UiTableHeaderFilter
+          v-model="selectedStatusHeaderFilter"
+          title="Estado"
+          filter-type="select"
+          :options="comandaStatusHeaderOptions"
+          all-label="Activas"
+          align="left"
+        />
       </template>
 
       <!-- Checkbox cell -->

--- a/pages/despacho/domicilios/index.vue
+++ b/pages/despacho/domicilios/index.vue
@@ -14,6 +14,20 @@ const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch 
 const { dateRangeDates, presetDates, formatDateRange, dateRange, clearDateRange } = useDateRangePresets()
 const statusFilter = ref<string | null>(null)
 const orderTypeFilter = ref<string | null>(null)
+const statusHeaderFilter = computed({
+  get: () => statusFilter.value ?? '',
+  set: (value: string | boolean) => {
+    statusFilter.value = typeof value === 'string' && value ? value : null
+  },
+})
+const statusHeaderOptions = [
+  { value: 'pending', label: 'Pendiente' },
+  { value: 'confirmed', label: 'Confirmado' },
+  { value: 'preparing', label: 'En preparación' },
+  { value: 'delivered', label: 'Entregado' },
+  { value: 'completed', label: 'Completado' },
+  { value: 'cancelled', label: 'Cancelado' },
+]
 
 const sortField = ref('order_date')
 const sortDirection = ref<'asc' | 'desc'>('desc')
@@ -106,7 +120,11 @@ const ORDER_TYPE_LABELS: Record<string, string> = {
 
 const { getStatusText, getStatusVariant } = useOnlineOrderStatus()
 
-const handleSort = ({ field, direction }: { field: string; direction: 'asc' | 'desc' }) => {
+const handleSort = (event: string | { field: string; direction?: 'asc' | 'desc' }) => {
+  const field = typeof event === 'string' ? event : event.field
+  const direction = typeof event === 'string'
+    ? (sortField.value === event && sortDirection.value === 'asc' ? 'desc' : 'asc')
+    : event.direction ?? 'asc'
   sortField.value = field
   sortDirection.value = direction
 }
@@ -141,6 +159,7 @@ const viewOrder = (order: any) => {
           <select
             v-model="statusFilter"
             :class="filterSelectClass"
+            class="md:hidden"
             aria-label="Filtrar por estado"
           >
             <option :value="null">Estado</option>
@@ -176,6 +195,17 @@ const viewOrder = (order: any) => {
           @sort="handleSort"
           @row-click="viewOrder"
         >
+          <template #header-status>
+            <UiTableHeaderFilter
+              v-model="statusHeaderFilter"
+              title="Estado"
+              filter-type="select"
+              :options="statusHeaderOptions"
+              all-label="Todos"
+              align="center"
+            />
+          </template>
+
           <template #card="{ item, index }">
             <div
               class="flex items-center gap-3 py-3 px-3 border-b border-border cursor-pointer transition-colors hover:bg-surface-secondary"

--- a/pages/despacho/en-mesa/index.vue
+++ b/pages/despacho/en-mesa/index.vue
@@ -79,6 +79,12 @@ const tableOptions = computed(() =>
     name: t.table_name,
   })),
 )
+const tableHeaderOptions = computed(() =>
+  tableOptions.value.map(t => ({
+    value: t.id,
+    label: t.name,
+  })),
+)
 
 const requests = computed<TableQrRequestRow[]>(() =>
   (pendingData.value?.data?.tables ?? []).flatMap(t =>
@@ -150,7 +156,11 @@ onMounted(() => {
 onUnmounted(() => { clearRefreshHandler(refetchPending) })
 registerProgressiveLoading(isRefreshing)
 
-const handleSort = ({ field, direction }: { field: string; direction: 'asc' | 'desc' }) => {
+const handleSort = (event: string | { field: string; direction?: 'asc' | 'desc' }) => {
+  const field = typeof event === 'string' ? event : event.field
+  const direction = typeof event === 'string'
+    ? (sortField.value === event && sortDirection.value === 'asc' ? 'desc' : 'asc')
+    : event.direction ?? 'asc'
   sortField.value = field
   sortDirection.value = direction
 }
@@ -182,6 +192,7 @@ const viewRequest = (request: TableQrRequestRow) => {
           <select
             v-model="tableFilterId"
             :class="filterSelectClass"
+            class="md:hidden"
             aria-label="Filtrar por mesa"
           >
             <option value="">Mesa</option>
@@ -204,6 +215,21 @@ const viewRequest = (request: TableQrRequestRow) => {
           @sort="handleSort"
           @row-click="viewRequest"
         >
+          <template #header-table_name>
+            <UiTableHeaderFilter
+              v-model="tableFilterId"
+              title="Mesa"
+              column-key="table_name"
+              sortable
+              :sort-field="sortField"
+              :sort-direction="sortDirection"
+              filter-type="select"
+              :options="tableHeaderOptions"
+              all-label="Todas"
+              @sort="handleSort"
+            />
+          </template>
+
           <template #card="{ item, index }">
             <div
               class="flex items-center gap-3 py-3 px-3 border-b border-data-table-border cursor-pointer transition-colors hover:bg-data-table-row-hover-bg"

--- a/pages/operaciones/bitacora.vue
+++ b/pages/operaciones/bitacora.vue
@@ -26,6 +26,27 @@ const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = u
 
 const channelFilter = ref<string | null>(null)
 const actionFilter = ref<string | null>(null)
+const channelHeaderFilter = computed({
+  get: () => channelFilter.value ?? '',
+  set: (value: string | boolean) => {
+    channelFilter.value = typeof value === 'string' && value ? value : null
+  },
+})
+const actionHeaderFilter = computed({
+  get: () => actionFilter.value ?? '',
+  set: (value: string | boolean) => {
+    actionFilter.value = typeof value === 'string' && value ? value : null
+  },
+})
+const channelHeaderOptions = [
+  { value: 'mesa', label: CHANNEL_LABELS.mesa },
+  { value: 'barra', label: CHANNEL_LABELS.barra },
+  { value: 'mostrador', label: CHANNEL_LABELS.mostrador },
+]
+const actionHeaderOptions = OPERATION_EVENT_ACTIONS.map(action => ({
+  value: action,
+  label: ACTION_LABELS[action],
+}))
 const currentPage = ref(1)
 const detailOpen = ref(false)
 const selectedEvent = ref<OperationEventRow | null>(null)
@@ -150,6 +171,7 @@ const tableNameFor = (row: OperationEventRow) =>
           <select
             v-model="channelFilter"
             :class="filterSelectClass"
+            class="md:hidden"
             aria-label="Filtrar por canal"
           >
             <option :value="null">Todos los canales</option>
@@ -161,6 +183,7 @@ const tableNameFor = (row: OperationEventRow) =>
           <select
             v-model="actionFilter"
             :class="filterSelectClass"
+            class="md:hidden"
             aria-label="Filtrar por acción"
           >
             <option :value="null">Todas las acciones</option>
@@ -193,6 +216,28 @@ const tableNameFor = (row: OperationEventRow) =>
         row-size="sm"
         @row-click="openDetail"
       >
+        <template #header-channel>
+          <UiTableHeaderFilter
+            v-model="channelHeaderFilter"
+            title="Canal"
+            filter-type="select"
+            :options="channelHeaderOptions"
+            all-label="Todos"
+            align="center"
+          />
+        </template>
+
+        <template #header-action>
+          <UiTableHeaderFilter
+            v-model="actionHeaderFilter"
+            title="Acción"
+            filter-type="select"
+            :options="actionHeaderOptions"
+            all-label="Todas"
+            align="left"
+          />
+        </template>
+
         <template #cell-created_at="{ value }">
           <span class="text-sm text-text-secondary whitespace-nowrap">{{ formatDateTime(value) }}</span>
         </template>

--- a/pages/operaciones/mesas.vue
+++ b/pages/operaciones/mesas.vue
@@ -431,6 +431,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
         <template #additional-filters>
           <UiFilterSelect
             v-model="statusFilter"
+            class="md:hidden"
             placeholder="Todos los estados"
             :options="statusOptions"
             aria-label="Estado"
@@ -456,6 +457,17 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
         variant="default"
         row-size="sm"
       >
+          <template #header-status>
+            <UiTableHeaderFilter
+              v-model="statusFilter"
+              title="Estado"
+              filter-type="select"
+              :options="statusOptions"
+              all-label="Todos"
+              align="center"
+            />
+          </template>
+
           <!-- Mobile card -->
           <template #card="{ item }">
             <div class="flex items-center gap-3 py-2 px-3 border-b border-border transition-colors hover:bg-surface-secondary">

--- a/pages/operaciones/promociones/index.vue
+++ b/pages/operaciones/promociones/index.vue
@@ -51,6 +51,7 @@
           <select
             v-model="statusFilter"
             :class="filterSelectClassFor(statusFilter)"
+            class="md:hidden"
             aria-label="Filtrar por estado"
           >
             <option value="">Estado</option>
@@ -61,6 +62,7 @@
           <select
             v-model="promoTypeFilter"
             :class="filterSelectClassFor(promoTypeFilter)"
+            class="md:hidden"
             aria-label="Filtrar por tipo"
           >
             <option value="">Tipo</option>
@@ -89,6 +91,28 @@
         variant="default"
         row-size="sm"
       >
+          <template #header-promo_type>
+            <UiTableHeaderFilter
+              v-model="promoTypeFilter"
+              title="Tipo"
+              filter-type="select"
+              :options="promoTypeHeaderOptions"
+              all-label="Todos"
+              align="center"
+            />
+          </template>
+
+          <template #header-status>
+            <UiTableHeaderFilter
+              v-model="statusFilter"
+              title="Estado"
+              filter-type="select"
+              :options="statusHeaderOptions"
+              all-label="Todos"
+              align="center"
+            />
+          </template>
+
           <template #card="{ item, index }">
             <div
               v-if="item"
@@ -319,6 +343,15 @@ const scopePopoverPromo = ref<PromotionRow | null>(null)
 const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
 const statusFilter = ref<'' | 'active' | 'inactive'>('')
 const promoTypeFilter = ref<'' | 'percent_off' | 'fixed_off' | 'bogo'>('')
+const statusHeaderOptions = [
+  { value: 'active', label: 'Activas' },
+  { value: 'inactive', label: 'Inactivas' },
+]
+const promoTypeHeaderOptions = [
+  { value: 'percent_off', label: '% descuento' },
+  { value: 'fixed_off', label: 'Descuento fijo' },
+  { value: 'bogo', label: '2x1 / BOGO' },
+]
 
 const hasActiveFilters = computed(
   () =>


### PR DESCRIPTION
## Summary
- Move column-owned filters into compact table header controls for operaciones and despacho tables when the filter is local over a complete loaded set or already backed by backend/query params.
- Keep mobile fallback selects in the external filter bars while hiding moved desktop filters.
- Preserve existing backend/query-param wiring for server-backed filters instead of converting them to client-only filters.

## Moved to headers
- `/operaciones/mesas`: Estado.
- `/operaciones/promociones`: Tipo, Estado.
- `/operaciones/bitacora`: Canal, Acción.
- `/despacho/en-mesa`: Mesa, over the complete pending QR grouped payload.
- `/despacho/domicilios`: Estado only, because it is already sent to `/api/online/orders`.
- `/despacho/comandas`: Origen, Estado, both sent through `/api/api/comandas` params.

## Intentionally external
- Search fields and create/action controls.
- Date ranges on bitácora and domicilios.
- `/despacho/domicilios` Tipo, because `/api/online/orders` does not currently accept `order_type`; keeping it out of the header avoids presenting a column header filter that does not call backend.
- Comandas Estación and Fecha, because Estación is not a visible table column and Fecha shapes the monitor dataset.

## Validation
- `npm exec nuxi -- prepare`
- Route/browser validation intentionally skipped; Saifer will validate manually.

Closes #1227
