### PR TITLE
Move admin table filters into headers

### DIFF
--- a/pages/equipo/miembros/index.vue
+++ b/pages/equipo/miembros/index.vue
@@ -22,8 +22,7 @@
         <template #additional-filters>
           <select
             v-model="roleFilter"
-            :class="filterSelectClass"
-            class="md:hidden"
+            :class="[filterSelectClass, 'md:hidden']"
             aria-label="Filtrar por rol"
           >
             <option value="">Rol</option>
@@ -631,6 +630,7 @@
 
 <script setup lang="ts">
 import { useFormatters } from '~/composables/useFormatters'
+import { filterSelectClass } from '~/composables/useFilterSelectClass'
 const { formatDate: _fmtDate } = useFormatters()
 useHead({ title: 'Miembros - Equipo' })
 

--- a/pages/equipo/miembros/index.vue
+++ b/pages/equipo/miembros/index.vue
@@ -23,13 +23,13 @@
           <select
             v-model="roleFilter"
             :class="filterSelectClass"
+            class="md:hidden"
             aria-label="Filtrar por rol"
           >
             <option value="">Rol</option>
-            <option value="superuser">Superusuario</option>
-            <option value="admin">Administrador</option>
-            <option value="employee">Empleado</option>
-            <option value="member">Miembro</option>
+            <option v-for="option in roleFilterOptions" :key="option.value" :value="option.value">
+              {{ option.label }}
+            </option>
           </select>
         </template>
 
@@ -52,6 +52,15 @@
         variant="default"
         row-size="sm"
       >
+      <template #header-role>
+        <UiTableHeaderFilter
+          v-model="roleFilter"
+          title="Rol"
+          filter-type="select"
+          :options="roleFilterOptions"
+          all-label="Todos"
+        />
+      </template>
 
       <!-- Mobile Card -->
       <template #card="{ item, index }">
@@ -632,6 +641,12 @@ const authStore = useAuthStore()
 
 const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
 const roleFilter = ref('')
+const roleFilterOptions = [
+  { label: 'Superusuario', value: 'superuser' },
+  { label: 'Administrador', value: 'admin' },
+  { label: 'Empleado', value: 'employee' },
+  { label: 'Miembro', value: 'member' },
+]
 
 const performSearch = () => applySearch()
 

--- a/pages/finanzas/cartera.vue
+++ b/pages/finanzas/cartera.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { filterSelectClass } from '~/composables/useFilterSelectClass'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
 const { setRefreshHandler, clearRefreshHandler, setLastUpdateText, registerProgressiveLoading } = useLayoutActions()
@@ -254,8 +255,7 @@ onUnmounted(() => {
         <template #additional-filters>
           <select
             v-model="statusFilter"
-            :class="filterSelectClass"
-            class="md:hidden"
+            :class="[filterSelectClass, 'md:hidden']"
             aria-label="Filtrar por estado"
           >
             <option value="all">Estado</option>

--- a/pages/finanzas/cartera.vue
+++ b/pages/finanzas/cartera.vue
@@ -40,6 +40,15 @@ const clearFilters = () => {
   agingFilter.value = null
 }
 
+const statusFilterOptions = [
+  { label: 'Vencidas', value: 'overdue' },
+  { label: 'Al día', value: 'current' },
+]
+
+const setStatusFilter = (value: string | boolean) => {
+  statusFilter.value = typeof value === 'string' && value ? value as 'overdue' | 'current' : 'all'
+}
+
 // ── Summary ───────────────────────────────────────────────────────────────
 const { data: summaryData, error: summaryError, refetch: refetchSummary } = useQuery({
   key: () => ['cartera', 'summary', currentTenant.value?.id],
@@ -246,11 +255,13 @@ onUnmounted(() => {
           <select
             v-model="statusFilter"
             :class="filterSelectClass"
+            class="md:hidden"
             aria-label="Filtrar por estado"
           >
             <option value="all">Estado</option>
-            <option value="overdue">Vencidas</option>
-            <option value="current">Al día</option>
+            <option v-for="option in statusFilterOptions" :key="option.value" :value="option.value">
+              {{ option.label }}
+            </option>
           </select>
         </template>
       </UiAdvancedFiltersBar>
@@ -264,6 +275,17 @@ onUnmounted(() => {
         empty-sub-message="No hay clientes con saldo pendiente en este momento"
         variant="default"
       >
+        <template #header-status>
+          <UiTableHeaderFilter
+            :model-value="statusFilter === 'all' ? '' : statusFilter"
+            title="Estado"
+            filter-type="select"
+            :options="statusFilterOptions"
+            all-label="Todos"
+            @update:model-value="setStatusFilter"
+          />
+        </template>
+
         <!-- Mobile card -->
         <template #card="{ item, index }">
           <div

--- a/pages/finanzas/contabilidad/asientos/index.vue
+++ b/pages/finanzas/contabilidad/asientos/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { filterSelectClass } from '~/composables/useFilterSelectClass'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
 definePageMeta({ layout: 'dashboard' })
@@ -281,8 +282,7 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
         <template #additional-filters>
           <select
             v-model="statusFilter"
-            :class="filterSelectClass"
-            class="md:hidden"
+            :class="[filterSelectClass, 'md:hidden']"
             aria-label="Filtrar por estado"
           >
             <option value="">Estado</option>
@@ -292,8 +292,7 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
           </select>
           <select
             v-model="sourceModuleFilter"
-            :class="filterSelectClass"
-            class="md:hidden"
+            :class="[filterSelectClass, 'md:hidden']"
             aria-label="Filtrar por módulo"
           >
             <option value="">Módulo</option>

--- a/pages/finanzas/contabilidad/asientos/index.vue
+++ b/pages/finanzas/contabilidad/asientos/index.vue
@@ -143,6 +143,22 @@ const STATUS_LABELS: Record<string, string> = {
   voided: 'Anulado',
 }
 
+const statusFilterOptions = [
+  { label: 'Borrador', value: 'draft' },
+  { label: 'Publicado', value: 'posted' },
+  { label: 'Anulado', value: 'voided' },
+]
+
+const sourceModuleFilterOptions = [
+  { label: 'Manual', value: 'manual' },
+  { label: 'Gastos', value: 'gastos' },
+  { label: 'Ventas', value: 'ventas' },
+  { label: 'Nómina', value: 'nomina' },
+  { label: 'Inventario', value: 'inventario' },
+  { label: 'Arqueo', value: 'arqueo' },
+  { label: 'Sistema', value: 'system' },
+]
+
 // ── Table columns ────────────────────────────────────────────────────────────
 const tableColumns = [
   { key: 'entryDate',     title: 'Fecha',       sortable: false },
@@ -266,26 +282,24 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
           <select
             v-model="statusFilter"
             :class="filterSelectClass"
+            class="md:hidden"
             aria-label="Filtrar por estado"
           >
             <option value="">Estado</option>
-            <option value="draft">Borrador</option>
-            <option value="posted">Publicado</option>
-            <option value="voided">Anulado</option>
+            <option v-for="option in statusFilterOptions" :key="option.value" :value="option.value">
+              {{ option.label }}
+            </option>
           </select>
           <select
             v-model="sourceModuleFilter"
             :class="filterSelectClass"
+            class="md:hidden"
             aria-label="Filtrar por módulo"
           >
             <option value="">Módulo</option>
-            <option value="manual">Manual</option>
-            <option value="gastos">Gastos</option>
-            <option value="ventas">Ventas</option>
-            <option value="nomina">Nómina</option>
-            <option value="inventario">Inventario</option>
-            <option value="arqueo">Arqueo</option>
-            <option value="system">Sistema</option>
+            <option v-for="option in sourceModuleFilterOptions" :key="option.value" :value="option.value">
+              {{ option.label }}
+            </option>
           </select>
         </template>
         <template #trailing>
@@ -318,6 +332,26 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
           variant="default"
           @row-click="openDetail"
         >
+        <template #header-sourceModule>
+          <UiTableHeaderFilter
+            v-model="sourceModuleFilter"
+            title="Módulo"
+            filter-type="select"
+            :options="sourceModuleFilterOptions"
+            all-label="Todos"
+          />
+        </template>
+
+        <template #header-status>
+          <UiTableHeaderFilter
+            v-model="statusFilter"
+            title="Estado"
+            filter-type="select"
+            :options="statusFilterOptions"
+            all-label="Todos"
+          />
+        </template>
+
         <!-- Mobile card -->
         <template #card="{ item, index }">
           <div

--- a/pages/finanzas/gastos/index.vue
+++ b/pages/finanzas/gastos/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
+import { filterSelectClass } from '~/composables/useFilterSelectClass'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
 definePageMeta({
@@ -176,14 +177,12 @@ onUnmounted(() => { clearRefreshHandler(refetch)
           <input
             v-model="currentMonth"
             type="month"
-            :class="filterSelectClass"
-            class="min-w-[9rem] cursor-pointer"
+            :class="[filterSelectClass, 'min-w-[9rem] cursor-pointer']"
             aria-label="Filtrar por mes"
           >
           <select
             v-model="categoryFilter"
-            :class="filterSelectClass"
-            class="md:hidden"
+            :class="[filterSelectClass, 'md:hidden']"
             aria-label="Filtrar por categoría"
           >
             <option value="">Categoría</option>
@@ -193,8 +192,7 @@ onUnmounted(() => { clearRefreshHandler(refetch)
           </select>
           <select
             v-model="expenseTypeFilter"
-            :class="filterSelectClass"
-            class="md:hidden"
+            :class="[filterSelectClass, 'md:hidden']"
             aria-label="Filtrar por tipo de gasto"
           >
             <option value="">Tipo</option>

--- a/pages/finanzas/gastos/index.vue
+++ b/pages/finanzas/gastos/index.vue
@@ -15,8 +15,8 @@ const { currentTenant } = useTenantReactive()
 const defaultMonth = () => new Date().toISOString().slice(0, 7)
 const currentMonth = ref(defaultMonth())
 const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
-const categoryFilter = ref<string | null>(null)
-const expenseTypeFilter = ref<string | null>(null)
+const categoryFilter = ref('')
+const expenseTypeFilter = ref('')
 
 const hasActiveFilters = computed(
   () =>
@@ -37,6 +37,8 @@ const EXPENSE_TYPE_LABELS: Record<string, string> = {
   other_expense: 'Otro gasto',
 }
 
+const expenseTypeFilterOptions = Object.entries(EXPENSE_TYPE_LABELS).map(([value, label]) => ({ value, label }))
+
 // Load categories from API
 const { data: categoriesData } = useQuery({
   key: () => ['finance', 'expense-categories', currentTenant.value?.id],
@@ -46,6 +48,12 @@ const { data: categoriesData } = useQuery({
 })
 
 const categories = computed(() => (categoriesData.value as any)?.data || [])
+const categoryFilterOptions = computed(() =>
+  categories.value.map((cat: any) => ({
+    label: cat.categoryName,
+    value: cat.id,
+  })),
+)
 
 // Load expenses from API
 const { data: expensesData, status: queryStatus, asyncStatus: queryAsyncStatus, error: fetchError, refetch } = useQuery({
@@ -76,8 +84,8 @@ const stats = computed(() => expensesData.value?.stats || null)
 
 const clearFilters = () => {
   clearSearch()
-  categoryFilter.value = null
-  expenseTypeFilter.value = null
+  categoryFilter.value = ''
+  expenseTypeFilter.value = ''
   currentMonth.value = defaultMonth()
 }
 
@@ -175,24 +183,24 @@ onUnmounted(() => { clearRefreshHandler(refetch)
           <select
             v-model="categoryFilter"
             :class="filterSelectClass"
+            class="md:hidden"
             aria-label="Filtrar por categoría"
           >
-            <option :value="null">Categoría</option>
-            <option v-for="cat in categories" :key="cat.id" :value="cat.id">
-              {{ cat.categoryName }}
+            <option value="">Categoría</option>
+            <option v-for="option in categoryFilterOptions" :key="option.value" :value="option.value">
+              {{ option.label }}
             </option>
           </select>
           <select
             v-model="expenseTypeFilter"
             :class="filterSelectClass"
+            class="md:hidden"
             aria-label="Filtrar por tipo de gasto"
           >
-            <option :value="null">Tipo</option>
-            <option value="cogs">Costo de ventas</option>
-            <option value="admin_expense">Gasto administrativo</option>
-            <option value="sales_expense">Gasto de ventas</option>
-            <option value="financial_expense">Gasto financiero</option>
-            <option value="other_expense">Otro gasto</option>
+            <option value="">Tipo</option>
+            <option v-for="option in expenseTypeFilterOptions" :key="option.value" :value="option.value">
+              {{ option.label }}
+            </option>
           </select>
         </template>
         <template #trailing>
@@ -215,6 +223,26 @@ onUnmounted(() => { clearRefreshHandler(refetch)
         empty-sub-message="Los gastos del mes aparecerán aquí"
         variant="default"
       >
+        <template #header-category>
+          <UiTableHeaderFilter
+            v-model="categoryFilter"
+            title="Categoría"
+            filter-type="select"
+            :options="categoryFilterOptions"
+            all-label="Todas"
+          />
+        </template>
+
+        <template #header-expenseType>
+          <UiTableHeaderFilter
+            v-model="expenseTypeFilter"
+            title="Tipo"
+            filter-type="select"
+            :options="expenseTypeFilterOptions"
+            all-label="Todos"
+          />
+        </template>
+
         <!-- Mobile Card -->
         <template #card="{ item, index }">
           <div

--- a/pages/proveedor/[token]/facturacion.vue
+++ b/pages/proveedor/[token]/facturacion.vue
@@ -23,15 +23,16 @@
       <div class="bg-filter-surface-bg rounded-lg shadow-sm border border-filter-surface-border p-6">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
           <!-- Document Type Filter -->
-          <div>
+          <div class="md:hidden">
             <label class="block text-sm font-medium text-text-primary mb-2">
               Tipo de Documento
             </label>
             <select v-model="filters.documentType" @change="applyFilters"
               class="w-full px-4 py-2 border border-form-control-border bg-form-control-bg text-form-control-text rounded-lg focus:ring-2 focus:ring-form-control-focus-ring focus:border-form-control-focus-border">
               <option value="">Todos</option>
-              <option value="factura">Factura</option>
-              <option value="remision">Remisión</option>
+              <option v-for="option in documentTypeFilterOptions" :key="option.value" :value="option.value">
+                {{ option.label }}
+              </option>
             </select>
           </div>
 
@@ -111,6 +112,18 @@
         empty-sub-message="Las facturas aparecerán aquí cuando sean creadas"
         variant="default"
       >
+        <template #header-tipo>
+          <UiTableHeaderFilter
+            :model-value="filters.documentType"
+            title="Tipo"
+            filter-type="select"
+            :options="documentTypeFilterOptions"
+            all-label="Todos"
+            align="center"
+            @update:model-value="setDocumentTypeFilter"
+          />
+        </template>
+
         <!-- Mobile Card -->
         <template #card="{ item }">
           <PurchasesInvoiceCard
@@ -278,6 +291,11 @@ const filters = ref({
   startDate: '',
   endDate: ''
 })
+
+const documentTypeFilterOptions = [
+  { label: 'Factura', value: 'factura' },
+  { label: 'Remisión', value: 'remision' },
+]
 
 // Selection state
 const selectedInvoices = ref<any[]>([])
@@ -529,6 +547,11 @@ async function submitLegalInvoice() {
 }
 
 function applyFilters() {
+  refresh()
+}
+
+function setDocumentTypeFilter(value: string | boolean) {
+  filters.value.documentType = typeof value === 'string' ? value : ''
   refresh()
 }
 


### PR DESCRIPTION
## Summary
- Moved column-owned filters into compact `UiTableHeaderFilter` controls for admin table headers.
- Kept mobile fallback selects in the existing filter bars while desktop uses header filters.
- Left dataset/global controls external: date ranges, search, actions, month selectors, supplier/date selectors, and cartera aging buckets.

## Moved filters
- `/finanzas/contabilidad/asientos`: `Módulo`, `Estado`
- `/finanzas/gastos`: `Categoría`, `Tipo`
- `/finanzas/cartera`: `Estado`
- `/equipo/miembros`: `Rol`
- `/proveedor/:token/facturacion`: `Tipo de Documento`

## Intentionally external
- Search/actions/month/date range controls.
- Cartera aging bucket summary filters.
- Supplier filter in the supplier portal because it is currently client-side over loaded invoices.
- Analytics/client detail date filters because they shape the dataset rather than one visible column.

## Validation
- `git diff --check`
- `npm exec nuxi -- prepare` (passes; existing duplicate-import warning remains)
- `npm exec nuxi -- typecheck` (fails on existing repo-wide type debt; no new targeted errors identified from the header-filter changes)
- Dev server smoke: representative changed routes returned `200 text/html` from `localhost:3000`.

Closes #1228
