### PR TITLE
Clean up dashboard title subtitle state

### DIFF
--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -107,8 +107,6 @@ const goBack = () => {
 }
 
 const {
-  pageTitle,
-  pageSubtitle,
   activePage,
   showBreadcrumb,
   breadcrumbPage,
@@ -140,22 +138,7 @@ const {
 } = useLayoutActions()
 const handleRefresh = triggerRefresh
 
-// Dynamic title - can be set by child pages
-const dynamicTitle = ref<string | undefined>(undefined)
 const isSidebarExpanded = ref(false)
-
-// Provide title setter for child pages
-provide('setPageTitle', (title: string | undefined) => {
-  dynamicTitle.value = title
-})
-
-// Dynamic subtitle - can be set by child pages
-const dynamicSubtitle = ref<string | undefined>(undefined)
-
-// Provide subtitle setter for child pages
-provide('setPageSubtitle', (subtitle: string | undefined) => {
-  dynamicSubtitle.value = subtitle
-})
 
 // Last update text - shared via composable
 const dynamicLastUpdateText = composableLastUpdateText
@@ -189,62 +172,8 @@ provide('setHeaderAction', (action: { label: string; icon?: boolean; handler: ()
   dynamicHeaderAction.value = action
 })
 
-// Combined values (dynamic takes precedence)
-const displayTitle = computed(() => dynamicTitle.value || pageTitle.value)
-const displaySubtitle = computed(() => dynamicSubtitle.value || pageSubtitle.value)
 const showBackBtn = computed(() => dynamicBackButton.value || !!backButton.value)
 const backBtnHandler = computed(() => dynamicBackHandler.value || (backButton.value ? goBack : undefined))
-
-const animatedDisplayTitle = ref(displayTitle.value)
-const isTypingTitle = ref(false)
-let titleTypingTimeout: ReturnType<typeof setTimeout> | null = null
-
-const clearTitleTypingTimeout = () => {
-  if (titleTypingTimeout) {
-    clearTimeout(titleTypingTimeout)
-    titleTypingTimeout = null
-  }
-}
-
-const typeTitle = (nextTitle: string) => {
-  clearTitleTypingTimeout()
-
-  if (!nextTitle) {
-    animatedDisplayTitle.value = ''
-    isTypingTitle.value = false
-    return
-  }
-
-  animatedDisplayTitle.value = ''
-  isTypingTitle.value = true
-  let index = 0
-
-  const step = () => {
-    index += 1
-    animatedDisplayTitle.value = nextTitle.slice(0, index)
-
-    if (index >= nextTitle.length) {
-      isTypingTitle.value = false
-      titleTypingTimeout = null
-      return
-    }
-
-    titleTypingTimeout = setTimeout(step, 22)
-  }
-
-  titleTypingTimeout = setTimeout(step, 22)
-}
-
-watch(displayTitle, (nextTitle, previousTitle) => {
-  if (!previousTitle || nextTitle === previousTitle) {
-    animatedDisplayTitle.value = nextTitle
-    isTypingTitle.value = false
-    clearTitleTypingTimeout()
-    return
-  }
-
-  typeTitle(nextTitle)
-}, { immediate: true })
 
 // Inject cart data from POS page
 const { itemCount: posMobileCartItemCount, formattedTotal: posMobileCartFormattedTotal, openCart: openPosMobileCart, sheetOpen: posMobileCartSheetOpen } = usePosMobileCart()
@@ -268,10 +197,6 @@ useHead({
   meta: [
     { name: 'robots', content: 'noindex, nofollow' }, // Dashboard pages shouldn't be indexed
   ]
-})
-
-onUnmounted(() => {
-  clearTitleTypingTimeout()
 })
 </script>
 

--- a/pages/analitica/clientes/[id].vue
+++ b/pages/analitica/clientes/[id].vue
@@ -25,8 +25,6 @@ const paymentGroups = computed(() => paymentGroupsData.value?.data ?? [])
 const { resolveLabel } = usePaymentLabel(paymentGroups)
 
 // ── Layout actions ────────────────────────────────────────────────────────
-const setPageTitle = inject<(title: string | undefined) => void>('setPageTitle')
-const setPageSubtitle = inject<(subtitle: string | undefined) => void>('setPageSubtitle')
 const setShowBackButton = inject<(show: boolean) => void>('setShowBackButton')
 const setBackHandler = inject<(handler: (() => void) | undefined) => void>('setBackHandler')
 
@@ -360,11 +358,6 @@ const submitPayment = async () => {
   }
 }
 
-// ── Layout wiring ─────────────────────────────────────────────────────────
-watch(customer, (c) => {
-  if (c) setPageTitle?.(c.name)
-}, { immediate: true })
-
 onMounted(() => {
   setShowBackButton?.(true)
   setBackHandler?.(goBack)
@@ -372,7 +365,6 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
-  setPageTitle?.(undefined)
   setShowBackButton?.(false)
   setBackHandler?.(undefined)
 })

--- a/pages/despacho/domicilios/[id].vue
+++ b/pages/despacho/domicilios/[id].vue
@@ -128,18 +128,9 @@ const { getStatusText, getStatusVariant } = useOnlineOrderStatus()
 
 const goBack = () => router.push('/despacho/domicilios')
 
-// Dashboard layout inject — dynamic title / subtitle / back button
-const setPageTitle      = inject<(title: string | undefined) => void>('setPageTitle')
-const setPageSubtitle   = inject<(subtitle: string | undefined) => void>('setPageSubtitle')
+// Dashboard layout inject — dynamic back button
 const setShowBackButton = inject<(show: boolean) => void>('setShowBackButton')
 const setBackHandler    = inject<(handler: (() => void) | undefined) => void>('setBackHandler')
-
-watch(order, (newOrder) => {
-  if (newOrder) {
-    setPageTitle?.(`Pedido #${newOrder.order_number}`)
-    setPageSubtitle?.(formatDate(newOrder.order_date))
-  }
-}, { immediate: true })
 
 // Header refresh button + progressive loader (parity with /ventas/ordenes)
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
@@ -154,8 +145,6 @@ onMounted(() => {
 registerProgressiveLoading(isRefreshing)
 
 onUnmounted(() => {
-  setPageTitle?.(undefined)
-  setPageSubtitle?.(undefined)
   setShowBackButton?.(false)
   setBackHandler?.(undefined)
   clearRefreshHandler(refreshAll)

--- a/pages/despacho/en-mesa/[id].vue
+++ b/pages/despacho/en-mesa/[id].vue
@@ -133,17 +133,8 @@ async function rejectRequest() {
 
 const goBack = () => router.push('/despacho/en-mesa')
 
-const setPageTitle = inject<(title: string | undefined) => void>('setPageTitle')
-const setPageSubtitle = inject<(subtitle: string | undefined) => void>('setPageSubtitle')
 const setShowBackButton = inject<(show: boolean) => void>('setShowBackButton')
 const setBackHandler = inject<(handler: (() => void) | undefined) => void>('setBackHandler')
-
-watch(request, (req) => {
-  if (req) {
-    setPageTitle?.(req.table_name)
-    setPageSubtitle?.(formatDateTime(req.created_at))
-  }
-}, { immediate: true })
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 onMounted(() => {
@@ -154,8 +145,6 @@ onMounted(() => {
 registerProgressiveLoading(isRefreshing)
 
 onUnmounted(() => {
-  setPageTitle?.(undefined)
-  setPageSubtitle?.(undefined)
   setShowBackButton?.(false)
   setBackHandler?.(undefined)
   clearRefreshHandler(refetch)

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -56,9 +56,6 @@ const { activePromos, hasActivePromos, activePromoHint, promoPickOptions } = use
   onActivePromosChanged: invalidateCheckoutPromoPreview,
 })
 
-// Inject subtitle setter from layout
-const setPageSubtitle = inject<(subtitle: string | undefined) => void>('setPageSubtitle', () => {})
-
 // State
 const selectedPaymentMethod = ref<string>('cash')
 const selectedPaymentMethodId = ref<string | null>(null)
@@ -2406,11 +2403,9 @@ watch(() => selectedCustomer.value?.id, () => {
   resetSplitPayments()
 })
 
-// Set page subtitle and sync cart on mount. payment-methods, mesa /current
-// and pos cart queries are already in flight (declared above as useQuery —
-// they fire from setup, in parallel with the mount).
+// Sync cart on mount. payment-methods, mesa /current and pos cart queries are
+// already in flight (declared above as useQuery, in parallel with the mount).
 onMounted(async () => {
-  setPageSubtitle('Checkout')
   posDebugLog('checkout', 'mount', {
     route: useRoute().path,
     debugEnabled: true,
@@ -2511,9 +2506,8 @@ watch(
   { immediate: true },
 )
 
-// Clear subtitle and pending timers on unmount
+// Clear pending timers on unmount
 onUnmounted(() => {
-  setPageSubtitle(undefined)
   if (estimateTimer) clearTimeout(estimateTimer)
 })
 </script>

--- a/pages/pos/producto/[id].vue
+++ b/pages/pos/producto/[id].vue
@@ -34,9 +34,6 @@ const router = useRouter()
 const posStore = usePOSStore()
 const { activePromos } = useActivePromotions()
 
-// Inject subtitle setter from layout
-const setPageSubtitle = inject<(subtitle: string | undefined) => void>('setPageSubtitle', () => {})
-
 // Product ID from route
 const productId = computed(() => route.params.id as string)
 
@@ -672,13 +669,6 @@ const formatCurrency = (value: number) => {
   }).format(value)
 }
 
-// Update page subtitle when product changes
-watch(product, (newProduct) => {
-  if (newProduct) {
-    setPageSubtitle(newProduct.name)
-  }
-}, { immediate: true })
-
 // Watch for product availability - redirect if not in cache
 watch(cachedProduct, (p) => {
   if (!p) {
@@ -714,10 +704,6 @@ watch(product, (newProduct) => {
   }
 }, { immediate: true })
 
-// Clear subtitle on unmount
-onUnmounted(() => {
-  setPageSubtitle(undefined)
-})
 </script>
 
 <template>

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -413,8 +413,6 @@ const saveChanges = async () => {
 }
 
 // Get layout setters
-const setPageTitle = inject<(title: string | undefined) => void>('setPageTitle')
-const setPageSubtitle = inject<(subtitle: string | undefined) => void>('setPageSubtitle')
 const setPageStatus = inject<(status: { label: string; color: string } | undefined) => void>('setPageStatus')
 const setShowBackButton = inject<(show: boolean) => void>('setShowBackButton')
 const setBackHandler = inject<(handler: (() => void) | undefined) => void>('setBackHandler')
@@ -423,8 +421,6 @@ const setHeaderAction = inject<(action: { label: string; icon?: boolean; handler
 // Watch order data and update layout header
 watch(order, (newOrder) => {
   if (newOrder) {
-    setPageTitle?.(`Orden #${newOrder.order_number}`)
-    setPageSubtitle?.(formatDate(newOrder.order_date))
     setPageStatus?.({
       label: getStatusLabel(newOrder.status),
       color: getStatusColor(newOrder.status)
@@ -447,8 +443,6 @@ onMounted(() => {
 // Clean up on unmount
 onUnmounted(() => {
   clearRefreshHandler(handleRefresh)
-  setPageTitle?.(undefined)
-  setPageSubtitle?.(undefined)
   setPageStatus?.(undefined)
   setShowBackButton?.(false)
   setBackHandler?.(undefined)


### PR DESCRIPTION
## Summary

- Remove unused dashboard layout title/subtitle state, providers, computed display values, and typing animation after the visible header block was removed.
- Remove dashboard-page `setPageTitle` / `setPageSubtitle` injections and cleanup calls that only fed that removed visual header state.
- Preserve `useDashboardPageConfig` and page-level `useHead` document title behavior.

## Validation

- `git diff --check` passes.
- `rg "setPageTitle|setPageSubtitle|displayTitle|displaySubtitle|animatedDisplayTitle|isTypingTitle|typeTitle|titleTypingTimeout|clearTitleTypingTimeout" layouts/dashboard.vue 'pages/ventas/[id].vue' 'pages/analitica/clientes/[id].vue' 'pages/despacho/en-mesa/[id].vue' 'pages/despacho/domicilios/[id].vue' 'pages/pos/checkout.vue' 'pages/pos/producto/[id].vue'` returns no matches.
- `npx tsc --noEmit` fails before project code because local TypeScript 4.7 does not support the Nuxt-generated options (`verbatimModuleSyntax`, modern `moduleResolution`).
- `npx nuxi typecheck` was run instead of build, per request. It fails with pre-existing project-wide type errors in unrelated modules and also existing errors in some touched files around query keys, refresh handlers, and POS item typing; no build was run.

Closes #1246
