### PR TITLE
Normalize POS receipt liquor tax label

### DIFF
--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -4401,7 +4401,7 @@ onUnmounted(() => {
       <span>{{ formatCurrency(taxPreview.standard_tax) }}</span>
     </div>
     <div v-if="taxPreview && taxPreview.liquor_tax > 0" class="receipt-item">
-      <span>Impuesto licores</span>
+      <span>IVA licores 5%</span>
       <span>{{ formatCurrency(taxPreview.liquor_tax) }}</span>
     </div>
     <!-- warocol.com#739 + #939 — pre-bill totals include tip and split settlement when applicable -->
@@ -4543,7 +4543,7 @@ onUnmounted(() => {
         <span>{{ formatCurrency(orderResult.standard_tax) }}</span>
       </div>
       <div v-if="orderResult?.liquor_tax && orderResult.liquor_tax > 0" class="receipt-item receipt-small">
-        <span>Impuesto licores</span>
+        <span>IVA licores 5%</span>
         <span>{{ formatCurrency(orderResult.liquor_tax) }}</span>
       </div>
     </template>


### PR DESCRIPTION
## Summary
- Normalize printed/POS receipt liquor tax labels to `IVA licores 5%`
- Keep order summary, printed receipt, and email tax labels aligned for #397

## Validation
- rg targeted receipt label checks

Closes #397