### PR TITLE
Mostrar saldo wallet en venta manual

### DIFF
--- a/.wr/1268.yaml
+++ b/.wr/1268.yaml
@@ -1,0 +1,38 @@
+issue: 1268
+title: "Mostrar saldo wallet en cliente seleccionado de venta manual"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1268-manual-sale-wallet-balance
+
+paths:
+  - pages/ventas/crear.vue
+
+ac:
+  - En /ventas/crear, al seleccionar cliente identificado, se ve el saldo wallet en la tarjeta del cliente.
+  - El formato visual/currency coincide con POS.
+  - Si el saldo está cargando o no hay wallet, la UI no se rompe ni muestra datos engañosos.
+  - No cambia la lógica de pago ni descuento wallet.
+
+out_of_scope:
+  - Cambiar reglas de visibilidad del método Saldo wallet.
+  - Cambiar backend, contabilidad o saldo wallet.
+  - Rediseñar POS.
+
+hints:
+  entry: "pages/ventas/crear.vue customer selected card"
+  pattern: "pages/pos/checkout.vue:2683 wallet badge/pending skeleton"
+  tests: "targeted Vue SFC parse/compile for pages/ventas/crear.vue"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits:
+    - repo-wide search
+    - full Nuxt build/typecheck
+
+next:
+  after_pr: "none"

--- a/pages/ventas/crear.vue
+++ b/pages/ventas/crear.vue
@@ -89,8 +89,10 @@ const { data: paymentGroupsData } = useFetch<{ success: boolean; data: ApiPaymen
 )
 const paymentGroups = computed(() => mergePosPaymentGroupsFromApi(paymentGroupsData.value?.data ?? []))
 const customerIdRef = computed(() => selectedCustomer.value?.id ?? '')
-const { wallet: customerWallet } = useCustomerWallet(customerIdRef)
+const { wallet: customerWallet, isLoading: isLoadingWallet, isRefreshing: isRefreshingWallet } =
+  useCustomerWallet(customerIdRef)
 const walletBalanceCop = computed(() => customerWallet.value?.balance_cop ?? 0)
+const isWalletPending = computed(() => isLoadingWallet.value || isRefreshingWallet.value)
 const isAnonymousCustomer = computed(() => selectedCustomer.value?.phone_number === '0000000000')
 
 function isPaymentGroupVisible(group: PosPaymentGroup) {
@@ -368,6 +370,23 @@ async function submit() {
               <p class="text-xs text-text-secondary truncate">
                 {{ selectedCustomer.phone_number || 'Sin teléfono' }}
               </p>
+              <div
+                v-if="!isAnonymousCustomer"
+                class="flex flex-wrap gap-2 mt-1"
+                aria-live="polite"
+              >
+                <div
+                  v-if="isWalletPending"
+                  class="h-5 w-[6.5rem] rounded-full bg-surface-secondary animate-pulse"
+                  aria-label="Cargando saldo wallet"
+                />
+                <span
+                  v-else
+                  class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase px-2 py-0.5 rounded-full bg-state-success-bg text-state-success-text border border-state-success-border"
+                >
+                  Wallet: {{ formatCurrency(walletBalanceCop) }}
+                </span>
+              </div>
             </div>
             <button
               type="button"


### PR DESCRIPTION
## Summary

- Shows the selected customer wallet balance in `/ventas/crear`, below the customer phone.
- Mirrors the POS wallet badge/pending skeleton pattern.
- Keeps wallet payment visibility and settlement logic unchanged.

## Validation

- Targeted Vue SFC parse/compile for `pages/ventas/crear.vue`.
- `git diff --check`.

Closes #1268