### PR TITLE
Show online cart modifier quantities

### DIFF
--- a/components/online/CartItem.vue
+++ b/components/online/CartItem.vue
@@ -13,9 +13,14 @@
             :key="modifier.id"
             class="flex justify-between text-xs text-muted-foreground"
           >
-            <span>+ {{ modifier.name }}</span>
-            <span class="ml-4" :class="modifier.price === 0 ? 'text-success' : ''">
-              {{ modifier.price === 0 ? 'Gratis' : formatPrice(modifier.price) }}
+            <span>
+              + {{ modifier.name }}
+              <span v-if="modifier.quantity && modifier.quantity > 1" class="font-medium">
+                x{{ modifier.quantity }}
+              </span>
+            </span>
+            <span class="ml-4" :class="modifierLineAmount(modifier) === 0 ? 'text-success' : ''">
+              {{ modifierLineAmount(modifier) === 0 ? 'Gratis' : formatPrice(modifierLineAmount(modifier)) }}
             </span>
           </div>
         </div>
@@ -119,6 +124,7 @@
 
 <script setup lang="ts">
 import type { OnlineCartItem } from '~/stores/online_cart'
+import { modifierLineTotal } from '~/utils/saleModifierOption'
 
 const props = defineProps<{
   item: OnlineCartItem
@@ -139,6 +145,9 @@ const formatPrice = (price: number) => {
     minimumFractionDigits: 0,
   }).format(price)
 }
+
+const modifierLineAmount = (modifier: OnlineCartItem['modifiers'][number]) =>
+  modifierLineTotal(modifier)
 
 const increaseQuantity = () => {
   if (props.item.has_modifiers) {

--- a/components/online/checkout/StepConfirm.vue
+++ b/components/online/checkout/StepConfirm.vue
@@ -87,7 +87,8 @@
                 :key="mod.id"
                 class="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full"
               >
-                + {{ mod.name }}
+                + {{ mod.name }}<template v-if="mod.quantity && mod.quantity > 1"> x{{ mod.quantity }}</template>
+                <template v-if="modifierLineAmount(mod) !== 0"> · {{ formatPrice(modifierLineAmount(mod)) }}</template>
               </span>
             </div>
             <p v-if="item.notes" class="text-xs text-muted-foreground mt-1 italic">{{ item.notes }}</p>
@@ -258,6 +259,7 @@ import { useOrderNotification } from '~/composables/useOrderNotification'
 import CartSummary from '~/components/online/CartSummary.vue'
 import { Button } from '~/components/ui'
 import type { PosPaymentGroup } from '~/utils/paymentDefaults'
+import { modifierLineTotal } from '~/utils/saleModifierOption'
 
 const emit = defineEmits<{
   (e: 'success'): void
@@ -332,6 +334,9 @@ const formatPrice = (price: number) =>
     currency: 'COP',
     minimumFractionDigits: 0,
   }).format(price)
+
+const modifierLineAmount = (modifier: { price: number; quantity?: number }) =>
+  modifierLineTotal(modifier)
 
 const formatScheduledTime = (isoString: string) =>
   new Date(isoString).toLocaleString('es-CO', {


### PR DESCRIPTION
## Summary
- Show modifier quantity badges in the online cart when quantity is greater than 1
- Show modifier line totals instead of only unit prices
- Mirror modifier quantity/amount detail in checkout confirmation

## Validation
- Not run per request after stopping build
