### PR TITLE
Alinear grilla móvil de venta manual con POS

### DIFF
--- a/pages/ventas/crear.vue
+++ b/pages/ventas/crear.vue
@@ -606,7 +606,7 @@ async function submit() {
           </div>
 
           <!-- Product Grid -->
-          <div v-else class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3 min-w-0">
+          <div v-else class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-3 lg:grid-cols-2 xl:grid-cols-3 gap-2 md:gap-4 p-1 pb-4 min-w-0">
             <div
               v-for="product in filteredProducts"
               :key="product.id"


### PR DESCRIPTION
## Summary

- Aligns `/ventas/crear` product grid breakpoints with POS on mobile/tablet.
- Keeps desktop constrained with 2 columns at `lg` and 3 at `xl` so the cart does not overflow.

## Validation

```bash
npx nuxi prepare
curl -g -sS -o /tmp/ventas-crear-mobile-grid.html -w '%{http_code}\n' 'http://[::1]:8080/ventas/crear'
```

Result: types generated and `/ventas/crear` returned `200`.

Refs #1279
