### PR TITLE
Mostrar modificadores de venta manual en una columna

### DIFF
--- a/pages/ventas/crear.vue
+++ b/pages/ventas/crear.vue
@@ -733,7 +733,7 @@ async function submit() {
                           </span>
                         </button>
                       </div>
-                      <div v-else class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                      <div v-else class="grid grid-cols-1 gap-2">
                         <div
                           v-for="option in group.modifiers"
                           :key="option.id"


### PR DESCRIPTION
## Summary

- Shows multi-option manual sale modifiers in a single column inside the slideover.
- Keeps existing modifier quantity controls and behavior.

## Validation

```bash
node -e "const fs=require('fs'); const { parse }=require('@vue/compiler-sfc'); const r=parse(fs.readFileSync('pages/ventas/crear.vue','utf8'), { filename: 'pages/ventas/crear.vue' }); if (r.errors.length) { console.error(r.errors); process.exit(1) }"
curl -g -sS -o /tmp/ventas-crear-modifier-one-col.html -w '%{http_code}\n' 'http://[::1]:8080/ventas/crear'
```

Result: Vue SFC parse passed and `/ventas/crear` returned `200`.

Refs #1285
