### PR TITLE
Separar cache de metodos de pago y habilitar PUC en cartera

### DIFF
--- a/pages/analitica/clientes/[id].vue
+++ b/pages/analitica/clientes/[id].vue
@@ -4,6 +4,7 @@ import { es } from 'date-fns/locale';
 import { format as fnsFormat } from 'date-fns';
 import MetricCard from '~/components/shared/MetricCard.vue';
 import type { WaroTransaction } from '~/composables/useWarosCliente';
+import { resolvePaymentSelection } from '~/composables/usePaymentSelectValue';
 import {
   PAYMENT_DEFAULTS,
   WALLET_PAYMENT_SLUG,
@@ -21,7 +22,7 @@ const customerId = computed(() => route.params.id as string)
 
 // Payment groups for the payment form select
 const { data: paymentGroupsData } = useQuery({
-  key: () => ['payments', 'groups', currentTenant.value?.id],
+  key: () => ['payments', 'pos-methods', currentTenant.value?.id],
   query: () => $fetch<{ success: boolean; data: ApiPaymentGroup[] }>('/api/pos/payment-methods'),
   enabled: () => !!currentTenant.value,
   staleTime: 300_000,
@@ -30,6 +31,11 @@ const paymentGroups = computed(() =>
   mergePosPaymentGroupsFromApi(paymentGroupsData.value?.data ?? []),
 )
 const { resolveLabel } = usePaymentLabel(paymentGroups)
+const carteraPaymentGroups = computed(() =>
+  paymentGroups.value.filter(
+    group => group.slug !== 'credit' && group.slug !== WALLET_PAYMENT_SLUG,
+  ),
+)
 
 // ── Layout actions ────────────────────────────────────────────────────────
 const setShowBackButton = inject<(show: boolean) => void>('setShowBackButton')
@@ -302,15 +308,29 @@ const fetchCartera = async () => {
 const showPaymentPanel = ref(false)
 const selectedOrder = ref<any>(null)
 const isGlobalPayment = ref(false)
-const paymentForm = reactive({ amount: 0, payment_method: 'cash', notes: '' })
+const paymentForm = reactive({
+  amount: 0,
+  payment_method: 'cash',
+  payment_method_id: null as string | null,
+  notes: '',
+})
 const isSubmittingPayment = ref(false)
 const paymentError = ref<string | null>(null)
+const paymentSelectValue = computed({
+  get: () => `${paymentForm.payment_method}:${paymentForm.payment_method_id ?? ''}`,
+  set: (value: string) => {
+    const resolved = resolvePaymentSelection(value, carteraPaymentGroups.value)
+    paymentForm.payment_method = resolved.payment_method
+    paymentForm.payment_method_id = resolved.payment_method_id
+  },
+})
 
 const openPaymentPanel = (order: any) => {
   isGlobalPayment.value = false
   selectedOrder.value = order
   paymentForm.amount = order.remaining ?? order.total_amount
   paymentForm.payment_method = 'cash'
+  paymentForm.payment_method_id = null
   paymentForm.notes = ''
   paymentError.value = null
   showPaymentPanel.value = true
@@ -321,6 +341,7 @@ const openGlobalPaymentPanel = () => {
   selectedOrder.value = null
   paymentForm.amount = carteraData.value?.summary?.total_outstanding ?? 0
   paymentForm.payment_method = 'cash'
+  paymentForm.payment_method_id = null
   paymentForm.notes = ''
   paymentError.value = null
   showPaymentPanel.value = true
@@ -341,7 +362,12 @@ const submitPayment = async () => {
         const toPay = Math.min(remaining, order.remaining)
         await $fetch(`/api/credit/orders/${order.id}/payments`, {
           method: 'POST',
-          body: { amount: toPay, payment_method: paymentForm.payment_method, notes: paymentForm.notes || undefined }
+          body: {
+            amount: toPay,
+            payment_method: paymentForm.payment_method,
+            payment_method_id: paymentForm.payment_method_id || undefined,
+            notes: paymentForm.notes || undefined,
+          }
         })
         remaining -= toPay
       }
@@ -352,6 +378,7 @@ const submitPayment = async () => {
         body: {
           amount: paymentForm.amount,
           payment_method: paymentForm.payment_method,
+          payment_method_id: paymentForm.payment_method_id || undefined,
           notes: paymentForm.notes || undefined,
         }
       })
@@ -1100,10 +1127,22 @@ onUnmounted(() => {
               <label for="payment-method" class="text-sm font-medium text-text-primary">Forma de pago</label>
               <select
                 id="payment-method"
-                v-model="paymentForm.payment_method"
+                v-model="paymentSelectValue"
                 class="h-11 px-3 text-sm border-2 border-border rounded-lg bg-background text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-colors"
+                :disabled="isSubmittingPayment"
               >
-                <option v-for="group in paymentGroups" :key="group.slug" :value="group.slug">{{ group.name }}</option>
+                <template v-for="group in carteraPaymentGroups" :key="group.id">
+                  <option v-if="!(group.methods?.length)" :value="`${group.slug}:`">{{ group.name }}</option>
+                  <optgroup v-else :label="group.name">
+                    <option
+                      v-for="method in group.methods"
+                      :key="method.id"
+                      :value="`${group.slug}:${method.id}`"
+                    >
+                      {{ method.name }}
+                    </option>
+                  </optgroup>
+                </template>
               </select>
             </div>
 

--- a/pages/analitica/ventas.vue
+++ b/pages/analitica/ventas.vue
@@ -44,7 +44,7 @@ const hasDateFilter = computed(() =>
 
 // Payment groups for filter dropdown
 const { data: paymentGroupsData } = useQuery({
-  key: () => ['payments', 'groups', currentTenant.value?.id],
+  key: () => ['payments', 'admin-groups', currentTenant.value?.id],
   query: () => $fetch<{ success: boolean; data: { id: string; slug: string; name: string; sortOrder: number; isActive: boolean }[] }>('/api/finanzas/metodos-pago/grupos'),
   enabled: () => !!currentTenant.value,
   staleTime: 300_000,

--- a/pages/finanzas/contabilidad/cuentas/[id].vue
+++ b/pages/finanzas/contabilidad/cuentas/[id].vue
@@ -134,7 +134,7 @@ const { data: methodsData } = useQuery({
 })
 
 const { data: groupsData } = useQuery({
-  key: () => ['payments', 'groups', currentTenant.value?.id],
+  key: () => ['payments', 'admin-groups', currentTenant.value?.id],
   query: () => $fetch<{ success: boolean; data: PaymentGroup[] }>('/api/finanzas/metodos-pago/grupos'),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,

--- a/pages/finanzas/metodos-pago/[groupId].vue
+++ b/pages/finanzas/metodos-pago/[groupId].vue
@@ -412,7 +412,7 @@ const {
   error: groupsError,
   refetch: refetchGroups,
 } = useQuery({
-  key: () => ['payments', 'groups', currentTenant.value?.id],
+  key: () => ['payments', 'admin-groups', currentTenant.value?.id],
   query: () => $fetch<{ success: boolean; data: PaymentGroup[] }>('/api/finanzas/metodos-pago/grupos'),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,

--- a/pages/finanzas/metodos-pago/index.vue
+++ b/pages/finanzas/metodos-pago/index.vue
@@ -147,7 +147,7 @@ const {
   error: fetchError,
   refetch,
 } = useQuery({
-  key: () => ['payments', 'groups', currentTenant.value?.id],
+  key: () => ['payments', 'admin-groups', currentTenant.value?.id],
   query: () => $fetch<{ success: boolean; data: PaymentGroup[] }>('/api/finanzas/metodos-pago/grupos'),
   enabled: () => !!currentTenant.value,
   staleTime: 30_000,

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -255,7 +255,7 @@ const {
   data: paymentMethodsData,
   asyncStatus: paymentMethodsAsyncStatus,
 } = useQuery({
-  key: () => ['payments', 'groups', currentTenant.value?.id ?? null],
+  key: () => ['payments', 'pos-methods', currentTenant.value?.id ?? null],
   query: () => $fetch<{ success: boolean; data: PosPaymentGroup[] }>('/api/pos/payment-methods'),
   enabled: () => !!currentTenant.value,
   staleTime: 300_000,

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -15,7 +15,7 @@ const { singular: tableSingular } = useTableLabel()
 
 // Payment groups for label resolution and method buttons
 const { data: paymentGroupsData } = useQuery({
-  key: () => ['payments', 'groups', currentTenant.value?.id ?? null],
+  key: () => ['payments', 'pos-methods', currentTenant.value?.id ?? null],
   query: () => $fetch<{ success: boolean; data: { id: string; slug: string; name: string; methods: { id: string; name: string }[] }[] }>('/api/pos/payment-methods'),
   enabled: () => !!currentTenant.value,
   staleTime: 300_000,

--- a/pages/ventas/ordenes.vue
+++ b/pages/ventas/ordenes.vue
@@ -13,7 +13,7 @@ const { singular: tableSingular } = useTableLabel()
 
 // Payment groups for filter and bulk-update dropdowns
 const { data: paymentGroupsData } = useQuery({
-  key: () => ['payments', 'groups', currentTenant.value?.id],
+  key: () => ['payments', 'pos-methods', currentTenant.value?.id],
   query: () => $fetch<{ success: boolean; data: ApiPaymentGroup[] }>('/api/pos/payment-methods'),
   enabled: () => !!currentTenant.value,
   staleTime: 300_000,

--- a/pages/ventas/propinas/index.vue
+++ b/pages/ventas/propinas/index.vue
@@ -16,7 +16,7 @@ const toast = useToast()
 
 // Payment groups (same query as /ventas/ordenes — shared cache)
 const { data: paymentGroupsData } = useQuery({
-  key: () => ['payments', 'groups', currentTenant.value?.id],
+  key: () => ['payments', 'pos-methods', currentTenant.value?.id],
   query: () => $fetch<{ success: boolean; data: { id: string; slug: string; name: string; methods: { id: string; name: string }[] }[] }>('/api/pos/payment-methods'),
   enabled: () => !!currentTenant.value,
   staleTime: 300_000,


### PR DESCRIPTION
## Summary
- Separa las keys de cache entre metodos POS/wallet y grupos admin de Finanzas para evitar respuestas mezcladas.
- Actualiza Abonar a cartera en detalle de cliente para mostrar metodos personalizados anidados.
- Envia payment_method_id al registrar abonos individuales y globales FIFO.

## Validation
- SFC parse/compile de pages/analitica/clientes/[id].vue
- npx nuxi prepare
- GET /analitica/clientes/b4b97ddb-295d-4140-8be8-ca2fc8a7d7df => 200
- Verificado en DB: abonos recientes generan asientos cartera balanceados usando PUC 111020/111035 contra 1305.

Related: uno0uno/api-warolabs#412