### PR TITLE
Configure online order limit from negocio

### DIFF
--- a/.wr/1292.yaml
+++ b/.wr/1292.yaml
@@ -1,0 +1,49 @@
+issue: 1292
+title: "Configurar limite maximo de compra online desde Negocio"
+repo: both
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-1292-online-order-limit
+
+paths:
+  - pages/negocio.vue
+  - stores/otp_auth.ts
+  - components/online/checkout/StepIdentity.vue
+  - ../api_warocol.com/app/models/tenant_public_profile.py
+  - ../api_warocol.com/app/services/tenant_config_service.py
+  - ../api_warocol.com/app/services/otp_service.py
+  - ../api_warocol.com/app/routers/online_verification.py
+  - ../api_warocol.com/app/routers/v1_ordering.py
+  - ../api_warocol.com/sql/20260609_tenant_online_order_limit.sql
+
+ac:
+  - "/negocio permite configurar el limite maximo de compra online/domicilios por tenant."
+  - "El API persiste y expone el limite con default compatible."
+  - "otp_service.py deja de usar 50000 hardcodeado y usa configuracion del tenant."
+  - "El checkout/OTP permite pedidos mayores a 50000 si el negocio sube o desactiva el limite."
+  - "El mensaje de bloqueo muestra el limite configurado."
+
+out_of_scope:
+  - "Redisenar reglas de riesgo/antifraude."
+  - "Cambiar tarifas de domicilio."
+  - "Modificar maximos por producto o inventario."
+
+hints:
+  entry: "pages/negocio.vue seccion Pedidos en linea; otp_service.validate_customer"
+  pattern: "tenant_public_profiles ya guarda accepts_online_orders, min_order_amount y estimated_preparation_time"
+  tests: "python -m compileall app/models/tenant_public_profile.py app/services/tenant_config_service.py app/services/otp_service.py app/routers/online_verification.py app/routers/v1_ordering.py; npm/bun targeted type check not required"
+
+risk:
+  sensitive: true
+  areas:
+    - "checkout publico"
+    - "validacion OTP"
+    - "tenant settings"
+
+skip:
+  audits:
+    - "No repo-wide audit after this contract."
+
+next:
+  after_pr: "/wr-review #PR porque toca validacion de checkout publico"

--- a/components/online/checkout/StepIdentity.vue
+++ b/components/online/checkout/StepIdentity.vue
@@ -249,7 +249,7 @@ const handleSendOTP = async () => {
       ? cartStore.subtotal + deliveryFee.value
       : 0
 
-    const validation = await otpAuthStore.validateCustomer(phone.value, safeTotal)
+    const validation = await otpAuthStore.validateCustomer(phone.value, safeTotal, cartStore.cartId)
 
     if (!validation.can_order) {
       customerValidationError.value = validation.reason || 'No puedes realizar este pedido.'

--- a/pages/negocio.vue
+++ b/pages/negocio.vue
@@ -262,10 +262,10 @@
 
       <!-- ══════ STATS STRIP ══════
            Hidden while editing (warocol.com#626): the "Pedidos en línea"
-           section below owns the editable inputs for these three fields,
+           section below owns the editable inputs for these fields,
            so showing the read-only summary at the same time duplicates
            labels and confuses the operator about where to edit. -->
-      <div v-if="businessProfile && !isEditMode" class="grid grid-cols-3 divide-x divide-border bg-surface border-2 border-border rounded-xl overflow-hidden">
+      <div v-if="businessProfile && !isEditMode" class="grid grid-cols-2 sm:grid-cols-4 divide-x divide-y sm:divide-y-0 divide-border bg-surface border-2 border-border rounded-xl overflow-hidden">
         <div class="px-3 sm:px-5 py-3 sm:py-4 flex flex-col justify-between text-left sm:text-center">
           <p class="text-[10px] sm:text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
             Tiempo prep.
@@ -280,6 +280,14 @@
           </p>
           <p class="text-base sm:text-lg font-bold text-text-primary">
             {{ formatCurrencyCompact(businessProfile.min_order_amount) }}
+          </p>
+        </div>
+        <div class="px-3 sm:px-5 py-3 sm:py-4 flex flex-col justify-between text-left sm:text-center">
+          <p class="text-[10px] sm:text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
+            Límite online
+          </p>
+          <p class="text-base sm:text-lg font-bold text-text-primary">
+            {{ formatOnlineOrderMaxAmountCompact(businessProfile.online_order_max_amount) }}
           </p>
         </div>
         <div class="px-3 sm:px-5 py-3 sm:py-4 flex flex-col justify-between items-start sm:items-center text-left sm:text-center">
@@ -505,6 +513,10 @@
               <span class="text-sm text-text-secondary">Pedido mínimo</span>
               <span class="text-sm font-semibold text-text-primary">{{ formatCurrency(businessProfile?.min_order_amount ?? 0) }}</span>
             </div>
+            <div class="flex items-center justify-between">
+              <span class="text-sm text-text-secondary">Límite máximo online</span>
+              <span class="text-sm font-semibold text-text-primary">{{ formatOnlineOrderMaxAmount(businessProfile?.online_order_max_amount) }}</span>
+            </div>
           </div>
         </template>
 
@@ -546,6 +558,17 @@
                   inputmode="numeric"
                   pattern="[0-9]*"
                   class="input-base w-full px-3 py-2 text-sm"
+                />
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-text-secondary mb-1">Límite máximo online (COP)</label>
+                <input
+                  v-model.number="editForm.online_order_max_amount"
+                  type="text"
+                  inputmode="numeric"
+                  pattern="[0-9]*"
+                  class="input-base w-full px-3 py-2 text-sm"
+                  placeholder="0"
                 />
               </div>
             </div>
@@ -671,6 +694,7 @@ const editForm = reactive({
   neighborhood: '',
   accepts_online_orders: false,
   min_order_amount: 0,
+  online_order_max_amount: '' as number | string,
   estimated_preparation_time: 30,
   business_hours: {} as Record<string, { open: string; close: string; closed: boolean }>,
   social_media: { instagram: '', whatsapp: '', facebook: '', twitter: '', tiktok: '' },
@@ -754,6 +778,29 @@ const formatCurrencyCompact = (value: number | string | null | undefined) => {
   return `$${n}`
 }
 
+const formatOnlineOrderMaxAmount = (value: number | string | null | undefined) => {
+  if (value === null || value === undefined || value === '') return 'Según cliente'
+  const n = Number(value)
+  if (!Number.isFinite(n)) return 'Según cliente'
+  if (n <= 0) return 'Sin límite'
+  return formatCurrency(n)
+}
+
+const formatOnlineOrderMaxAmountCompact = (value: number | string | null | undefined) => {
+  if (value === null || value === undefined || value === '') return 'Cliente'
+  const n = Number(value)
+  if (!Number.isFinite(n)) return 'Cliente'
+  if (n <= 0) return 'Sin límite'
+  return formatCurrencyCompact(n)
+}
+
+const normalizeOnlineOrderMaxAmount = (value: number | string | null | undefined) => {
+  if (value === null || value === undefined || value === '') return null
+  const n = Number(value)
+  if (!Number.isFinite(n)) return null
+  return Math.max(0, Math.round(n))
+}
+
 // ─── Edit actions ───
 const enterEditMode = () => {
   const bp = businessProfile.value  // may be null for first-time setup
@@ -771,6 +818,9 @@ const enterEditMode = () => {
   editForm.neighborhood = bp?.neighborhood || ''
   editForm.accepts_online_orders = bp?.accepts_online_orders ?? false
   editForm.min_order_amount = Number(bp?.min_order_amount) || 0
+  editForm.online_order_max_amount = bp?.online_order_max_amount === null || bp?.online_order_max_amount === undefined
+    ? ''
+    : Number(bp.online_order_max_amount)
   editForm.estimated_preparation_time = bp?.estimated_preparation_time ?? 30
 
   editForm.business_hours = {}
@@ -913,6 +963,7 @@ const saveChanges = async () => {
       neighborhood: editForm.neighborhood || null,
       accepts_online_orders: editForm.accepts_online_orders,
       min_order_amount: editForm.min_order_amount,
+      online_order_max_amount: normalizeOnlineOrderMaxAmount(editForm.online_order_max_amount),
       estimated_preparation_time: editForm.estimated_preparation_time,
       business_hours: cleanedHours,
       social_media: (() => {

--- a/stores/otp_auth.ts
+++ b/stores/otp_auth.ts
@@ -67,10 +67,10 @@ export const useOtpAuthStore = defineStore('otpAuth', () => {
   })
 
   const validateMutation = useMutation({
-    mutation: (vars: { phoneNumber: string; cartTotal: number }) =>
+    mutation: (vars: { phoneNumber: string; cartTotal: number; cartId?: string | null }) =>
       $fetch<CustomerValidation>('/api/online/customer/validate', {
         method: 'POST',
-        body: { phone_number: vars.phoneNumber, cart_total: vars.cartTotal },
+        body: { phone_number: vars.phoneNumber, cart_total: vars.cartTotal, cart_id: vars.cartId ?? null },
       }),
     onSuccess(_, vars) {
       phoneNumber.value = vars.phoneNumber
@@ -132,8 +132,8 @@ export const useOtpAuthStore = defineStore('otpAuth', () => {
   /**
    * Validate customer eligibility (blacklist, tier, spending limits)
    */
-  const validateCustomer = (phone: string, cartTotal: number): Promise<CustomerValidation> =>
-    validateMutation.mutateAsync({ phoneNumber: phone, cartTotal })
+  const validateCustomer = (phone: string, cartTotal: number, cartId?: string | null): Promise<CustomerValidation> =>
+    validateMutation.mutateAsync({ phoneNumber: phone, cartTotal, cartId })
       .catch((e: any) => { throw new Error(e.data?.detail || 'Error al validar cliente') })
 
   /**


### PR DESCRIPTION
## Summary\n\n- Add an online order max amount field to /negocio in the online orders section.\n- Show the configured limit in the business summary and profile view.\n- Send cart_id during public customer validation so the API can resolve tenant-specific limits.\n\n## Semantics\n\n- Empty value: keep current customer-tier defaults.\n- 0: no amount limit.\n- Positive value: tenant-configured max amount in COP.\n\n## Dependency\n\n- Requires API PR uno0uno/api-warolabs#418 before this frontend is deployed.\n\n## Validation\n\n- npm run postinstall\n- git diff --check on changed frontend files\n- curl -I --max-time 10 http://localhost:8080/negocio returned 200\n\nCloses #1292