### PR TITLE
Show delivery modifier quantities

### DIFF
--- a/.wr/1294.yaml
+++ b/.wr/1294.yaml
@@ -1,0 +1,39 @@
+issue: 1294
+title: "Mostrar cantidades reales de modificadores en detalle de domicilio"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1294-delivery-modifier-quantities
+
+paths:
+  - pages/despacho/domicilios/[id].vue
+
+ac:
+  - "La vista /despacho/domicilios/:orderId muestra la cantidad real de cada modificador."
+  - "Para la orden #14832, TOMATE DE PRUEBA se ve como x2."
+  - "El subtotal visual del modificador usa cantidad real: 2 x $9.000 = $18.000."
+  - "Modificadores con cantidad 1 siguen mostrandose correctamente."
+
+out_of_scope:
+  - "Checkout online."
+  - "Persistencia de modificadores."
+  - "Calculo contable."
+  - "Cambios en POS/manual sales."
+
+hints:
+  entry: "pages/despacho/domicilios/[id].vue modifier rows"
+  pattern: "API already returns modifiers[].quantity from online_orders_service.py"
+  tests: "npm run postinstall; git diff --check -- pages/despacho/domicilios/[id].vue"
+
+risk:
+  sensitive: false
+  areas:
+    - "delivery order detail rendering"
+
+skip:
+  audits:
+    - "No repo-wide audit after this contract."
+
+next:
+  after_pr: "none"

--- a/pages/despacho/domicilios/[id].vue
+++ b/pages/despacho/domicilios/[id].vue
@@ -128,6 +128,17 @@ const { getStatusText, getStatusVariant } = useOnlineOrderStatus()
 
 const goBack = () => router.push('/despacho/domicilios')
 
+const modifierQuantity = (modifier: any) => {
+  const quantity = Number(modifier?.quantity)
+  return Number.isFinite(quantity) && quantity > 0 ? quantity : 1
+}
+
+const formatQuantity = (quantity: number) =>
+  quantity % 1 === 0 ? quantity.toFixed(0) : String(quantity)
+
+const modifierSubtotal = (modifier: any) =>
+  Number(modifier?.price || 0) * modifierQuantity(modifier)
+
 // Dashboard layout inject — dynamic back button
 const setShowBackButton = inject<(show: boolean) => void>('setShowBackButton')
 const setBackHandler    = inject<(handler: (() => void) | undefined) => void>('setBackHandler')
@@ -301,13 +312,13 @@ onUnmounted(() => {
                     </div>
                   </td>
                   <td class="px-6 py-2 text-center">
-                    <span class="text-xs text-text-tertiary">x{{ item.quantity }}</span>
+                    <span class="text-xs text-text-tertiary">x{{ formatQuantity(modifierQuantity(mod)) }}</span>
                   </td>
                   <td class="px-6 py-2 text-right">
                     <span class="text-xs text-text-secondary">{{ formatCurrency(mod.price) }}</span>
                   </td>
                   <td class="px-6 py-2 text-right">
-                    <span class="text-xs text-primary/70">{{ formatCurrency(mod.price * item.quantity) }}</span>
+                    <span class="text-xs text-primary/70">{{ formatCurrency(modifierSubtotal(mod)) }}</span>
                   </td>
                 </tr>
               </template>


### PR DESCRIPTION
## Summary\n\n- Use each modifier's own quantity in the delivery order detail table.\n- Calculate modifier row subtotal from modifier price x modifier quantity.\n- Keep a fallback of x1 for older rows without quantity.\n\n## Validation\n\n- npm run postinstall\n- git diff --check -- pages/despacho/domicilios/[id].vue .wr/1294.yaml\n- curl -I --max-time 10 http://localhost:8080/despacho/domicilios/db97c43e-da38-41b2-8ec7-4b3c496fcc7e returned 200\n\nCloses #1294