### PR TITLE
Show Table QR modifier quantities

### DIFF
--- a/pages/[tenant]/mesa/[token]/checkout.vue
+++ b/pages/[tenant]/mesa/[token]/checkout.vue
@@ -145,7 +145,9 @@ const handleSubmit = async () => {
               <div class="flex-1 min-w-0">
                 <p class="text-sm font-medium">{{ item.product_name }}</p>
                 <p v-if="item.modifiers.length" class="text-xs text-muted-foreground mt-1">
-                  <span v-for="mod in item.modifiers" :key="mod.id">+ {{ mod.name }} </span>
+                  <span v-for="mod in item.modifiers" :key="mod.id">
+                    + {{ mod.name }}<template v-if="(mod.quantity ?? 1) > 1"> x{{ mod.quantity }}</template>
+                  </span>
                 </p>
                 <p v-if="item.notes" class="text-xs italic text-muted-foreground mt-1">{{ item.notes }}</p>
               </div>


### PR DESCRIPTION
## Summary
- show Table QR checkout modifier quantities when a selected modifier has quantity > 1
- keep existing Table QR submit payload and total calculation paths unchanged

## Validation
- git diff --check
- targeted source checks for buildSubmitItems, modifiersCartTotal, and existing online modifier quantity display patterns

Closes #1300