### PR TITLE
Show comanda modifier quantities

### DIFF
--- a/components/cocina/ItemRow.vue
+++ b/components/cocina/ItemRow.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { inject, type Ref } from 'vue'
 import { ExclamationTriangleIcon } from '@heroicons/vue/24/outline'
+import { formatComandaModifierLabel } from '~/composables/useComandaPrint'
 
 const props = defineProps<{
   item: any
@@ -61,7 +62,7 @@ const toggleStatus = async () => {
           :key="idx"
           class="text-[10px] font-bold bg-surface-secondary text-text-secondary px-1.5 py-0.5 rounded uppercase"
         >
-          + {{ mod.name }}
+          + {{ formatComandaModifierLabel(mod) }}
         </span>
       </div>
 

--- a/components/despacho/ComandaDetailPanel.vue
+++ b/components/despacho/ComandaDetailPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch, onUnmounted } from 'vue'
 import { ClipboardList, X, MessageSquare } from 'lucide-vue-next'
+import { formatComandaModifierLabel } from '~/composables/useComandaPrint'
 
 const props = defineProps<{
   modelValue: boolean
@@ -253,7 +254,7 @@ const activeItems = computed(() => props.comanda?.items ?? [])
                   class="flex items-center gap-2 rounded-xl border-2 border-primary/20 bg-primary/5 px-3 py-2"
                 >
                   <span class="text-primary font-black text-sm leading-none flex-shrink-0">+</span>
-                  <span class="text-xs font-semibold text-primary leading-tight">{{ mod.name }}</span>
+                  <span class="text-xs font-semibold text-primary leading-tight">{{ formatComandaModifierLabel(mod) }}</span>
                 </div>
               </div>
 

--- a/components/pos/ComandasEstadoPanel.vue
+++ b/components/pos/ComandasEstadoPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onUnmounted } from 'vue'
+import { formatComandaModifierLabel } from '~/composables/useComandaPrint'
 
 const { singular: tableSingular } = useTableLabel()
 import {
@@ -17,6 +18,7 @@ interface ComandaItem {
   kitchen_name: string
   quantity: number
   notes?: string | null
+  modifiers_snapshot?: Array<{ name: string; price?: number; quantity?: number }> | null
 }
 
 interface Comanda {
@@ -369,10 +371,21 @@ const submit = async () => {
                   </div>
 
                   <!-- Row 3 — Items -->
-                  <ul v-if="c.items?.length" class="text-xs text-text-secondary leading-snug space-y-0.5">
-                    <li v-for="i in c.items" :key="i.id" class="flex gap-1.5">
-                      <span class="font-semibold text-text-primary tabular-nums flex-shrink-0">{{ i.quantity }}×</span>
-                      <span class="truncate">{{ i.kitchen_name }}</span>
+                  <ul v-if="c.items?.length" class="text-xs text-text-secondary leading-snug space-y-1">
+                    <li v-for="i in c.items" :key="i.id" class="min-w-0">
+                      <div class="flex gap-1.5">
+                        <span class="font-semibold text-text-primary tabular-nums flex-shrink-0">{{ i.quantity }}×</span>
+                        <span class="truncate">{{ i.kitchen_name }}</span>
+                      </div>
+                      <div v-if="i.modifiers_snapshot?.length" class="mt-0.5 ml-5 flex flex-wrap gap-1">
+                        <span
+                          v-for="(mod, idx) in i.modifiers_snapshot"
+                          :key="idx"
+                          class="min-w-0 max-w-full truncate rounded bg-surface-secondary px-1.5 py-0.5 text-[10px] font-semibold text-text-tertiary"
+                        >
+                          + {{ formatComandaModifierLabel(mod) }}
+                        </span>
+                      </div>
                     </li>
                   </ul>
                 </div>


### PR DESCRIPTION
## Summary
- show modifier quantities in comanda detail and KDS item rows using the existing comanda modifier formatter
- include modifier chips in the POS comanda status panel from `modifiers_snapshot`
- preserve fallback-to-1 behavior for missing old modifier quantities

## Validation
- `npx nuxi prepare`
- `git diff --check -- components/despacho/ComandaDetailPanel.vue components/cocina/ItemRow.vue components/pos/ComandasEstadoPanel.vue`

Closes #1299
