### PR TITLE
Fix POS promo edit quantities

### DIFF
--- a/.wr/1305.yaml
+++ b/.wr/1305.yaml
@@ -1,0 +1,52 @@
+issue: 1305
+title: "Preserve POS BOGO quantities and block edits after kitchen fire"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1305-preserve-pos-bogo-edit
+
+paths:
+  - pages/pos/producto/[id].vue
+  - pages/pos/index.vue
+  - components/pos/CartPanel.vue
+  - components/pos/CartItem.vue
+  - stores/usePOSStore.ts
+
+ac:
+  - Non-fired POS cart/mesa line with BOGO quantity 2 opens edit mode showing/preserving 2 units.
+  - Saving edits for a non-fired BOGO line preserves quantity unless changed intentionally.
+  - POS/cart totals keep full quantity and promo discount after edit/save.
+  - Modifier selections and quantities are preserved for non-fired edits.
+  - Optional single-select/radio modifier groups can be cleared before fired.
+  - Multi-select modifier steppers can decrement to 0 before fired.
+  - Fired tab lines do not show edit actions.
+  - Direct tab edit navigation for fired items is blocked/redirected through edit-eligibility.
+  - Existing destructive/anular-with-reason flow remains unchanged.
+
+out_of_scope:
+  - backend promotion rules
+  - promotion persistence at mesa close
+  - promotion CRUD
+  - POS redesign
+  - kitchen/comanda status model changes
+
+hints:
+  entry: "pages/pos/producto/[id].vue edit/addToCart flow"
+  pattern: "cart edit currently saves quantity: 1; edit load maps modifiers/notes only; CartPanel emits edit-tab-item for fired tab lines"
+  tests: "bun run typecheck is broad; prefer targeted static review unless an existing focused command is available"
+
+risk:
+  sensitive: false
+  areas:
+    - POS cart line totals
+    - mesa tab edit eligibility
+    - modifier selection state
+
+skip:
+  audits:
+    - repo-wide search after contract
+    - full build/lint unless requested
+
+next:
+  after_pr: "none"

--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -113,6 +113,7 @@
           :promo-savings="tabLinePromoSavings(item)"
           :gross-total="item.subtotal"
           :hide-duplicate="true"
+          :hide-edit="isTabLineFired(item)"
           :lock-increment="isTabLineFired(item)"
           :hide-line-controls="isTabLineTerminal(item)"
           @edit="$emit('edit-tab-item', item.orderItemId, item.productId)"

--- a/pages/pos/producto/[id].vue
+++ b/pages/pos/producto/[id].vue
@@ -503,6 +503,12 @@ const isSingleSelectGroup = (group: ModifierGroup) => group.maxSelections === 1
 const selectRadioModifier = (modifier: ModifierOption, groupId: string) => {
   const group = modifierGroups.value.find(g => g.id === groupId)
   if (!group) return
+  const isSelected = isModifierSelected(modifier.id)
+
+  if (!group.required && isSelected) {
+    activeStepModifiers.value = activeStepModifiers.value.filter(m => m.id !== modifier.id)
+    return
+  }
 
   activeStepModifiers.value = activeStepModifiers.value.filter(m =>
     !group.options.some(opt => opt.id === m.id)
@@ -632,11 +638,12 @@ const addToCart = async () => {
         )
       }
     } else if (isEditMode.value && editCartIndex.value !== null) {
+      const existingItem = posStore.getCartItem(editCartIndex.value)
       await posStore.updateCartItem(editCartIndex.value, {
         product: productPayload,
         modifiers: [...selectedModifiers.value],
         notes: notes.value || undefined,
-        quantity: 1,
+        quantity: quantity.value || existingItem?.quantity || 1,
       })
     } else if (wizardMode.value) {
       await posStore.addCartItemsBatch(
@@ -682,6 +689,7 @@ watch(product, (newProduct) => {
   if (isEditMode.value && editCartIndex.value !== null) {
     const cartItem = posStore.getCartItem(editCartIndex.value)
     if (cartItem) {
+      quantity.value = cartItem.quantity || 1
       selectedModifiers.value = cartItem.modifiers.map(m => ({
         ...m,
         quantity: m.quantity ?? 1,
@@ -693,6 +701,11 @@ watch(product, (newProduct) => {
   if (isTabItemEditMode.value && editTabItemId.value) {
     const tabItem = posStore.tabItems.find(i => i.orderItemId === editTabItemId.value)
     if (tabItem) {
+      if ((tabItem.fulfillmentStatus ?? 'new') !== 'new') {
+        router.push('/pos')
+        return
+      }
+      quantity.value = tabItem.quantity || 1
       selectedModifiers.value = (tabItem.modifiers ?? []).map(m => ({
         id: m.id,
         name: m.name,
@@ -775,7 +788,7 @@ watch(product, (newProduct) => {
         </div>
 
         <!-- Quantity + per-unit wizard (online cart parity #1023) -->
-        <section v-if="!isLineEditMode" class="bg-surface rounded-2xl p-4 md:p-6 border border-border space-y-4">
+        <section v-if="!isTabItemEditMode" class="bg-surface rounded-2xl p-4 md:p-6 border border-border space-y-4">
           <div v-if="wizardMode" class="flex items-center justify-between">
             <h3 class="text-base md:text-lg font-bold text-text-primary">
               Ítem {{ wizardStep + 1 }} de {{ quantity }}
@@ -843,7 +856,7 @@ watch(product, (newProduct) => {
                 :name="'group-' + group.id"
                 class="sr-only"
                 :checked="isModifierSelected(option.id)"
-                @change="selectRadioModifier(option, group.id)"
+                @click.prevent="selectRadioModifier(option, group.id)"
               />
               <div
                 class="border-2 rounded-xl p-3 md:p-4 transition-all duration-200 bg-surface h-full flex flex-col justify-between"


### PR DESCRIPTION
## Summary
- preserve existing cart quantity when editing BOGO/promoted POS lines
- show local cart quantity during edit so 2-for-1 lines remain visible/editable before firing
- allow clearing optional single-select modifiers and hide edit actions for fired tab lines

## Validation
- git diff --check

Closes #1305