### PR TITLE
Align POS promo previews with eligible subtotal

### DIFF
--- a/.wr/1305.yaml
+++ b/.wr/1305.yaml
@@ -1,0 +1,52 @@
+issue: 1305
+title: "Preserve POS BOGO quantities and block edits after kitchen fire"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1305-preserve-pos-bogo-edit
+
+paths:
+  - pages/pos/producto/[id].vue
+  - pages/pos/index.vue
+  - components/pos/CartPanel.vue
+  - components/pos/CartItem.vue
+  - stores/usePOSStore.ts
+
+ac:
+  - Non-fired POS cart/mesa line with BOGO quantity 2 opens edit mode showing/preserving 2 units.
+  - Saving edits for a non-fired BOGO line preserves quantity unless changed intentionally.
+  - POS/cart totals keep full quantity and promo discount after edit/save.
+  - Modifier selections and quantities are preserved for non-fired edits.
+  - Optional single-select/radio modifier groups can be cleared before fired.
+  - Multi-select modifier steppers can decrement to 0 before fired.
+  - Fired tab lines do not show edit actions.
+  - Direct tab edit navigation for fired items is blocked/redirected through edit-eligibility.
+  - Existing destructive/anular-with-reason flow remains unchanged.
+
+out_of_scope:
+  - backend promotion rules
+  - promotion persistence at mesa close
+  - promotion CRUD
+  - POS redesign
+  - kitchen/comanda status model changes
+
+hints:
+  entry: "pages/pos/producto/[id].vue edit/addToCart flow"
+  pattern: "cart edit currently saves quantity: 1; edit load maps modifiers/notes only; CartPanel emits edit-tab-item for fired tab lines"
+  tests: "bun run typecheck is broad; prefer targeted static review unless an existing focused command is available"
+
+risk:
+  sensitive: false
+  areas:
+    - POS cart line totals
+    - mesa tab edit eligibility
+    - modifier selection state
+
+skip:
+  audits:
+    - repo-wide search after contract
+    - full build/lint unless requested
+
+next:
+  after_pr: "none"

--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -113,6 +113,7 @@
           :promo-savings="tabLinePromoSavings(item)"
           :gross-total="item.subtotal"
           :hide-duplicate="true"
+          :hide-edit="isTabLineFired(item)"
           :lock-increment="isTabLineFired(item)"
           :hide-line-controls="isTabLineTerminal(item)"
           @edit="$emit('edit-tab-item', item.orderItemId, item.productId)"

--- a/composables/usePosOrderPromoTotals.ts
+++ b/composables/usePosOrderPromoTotals.ts
@@ -1,4 +1,5 @@
 import {
+  computePromoEligibleSubtotal,
   linePromoSavingsForProduct,
   promoBadgeForProduct,
   type PromoBadgeDisplay,
@@ -9,7 +10,7 @@ export type PosPromoCartItem = {
     id: string
     price: number
   }
-  modifiers: Array<{ price: number; quantity?: number }>
+  modifiers: Array<{ id: string; price: number; quantity?: number }>
   quantity: number
   promo_opt_out?: boolean
 }
@@ -37,6 +38,10 @@ export function usePosOrderPromoTotals(
     return posStore.getProduct(productId)?.category_id ?? null
   }
 
+  function modifierGroupsForProduct(productId: string) {
+    return posStore.getProduct(productId)?.modifier_groups ?? []
+  }
+
   function cartLineGross(item: PosPromoCartItem): number {
     const basePrice = Number(item.product.price) || 0
     const modifiersPrice = (item.modifiers ?? []).reduce(
@@ -51,7 +56,16 @@ export function usePosOrderPromoTotals(
     return linePromoSavingsForProduct(
       activePromos.value,
       item.product.id,
-      { subtotal: cartLineGross(item), quantity: item.quantity },
+      {
+        subtotal: cartLineGross(item),
+        eligibleSubtotal: computePromoEligibleSubtotal(
+          item.product.price,
+          item.modifiers ?? [],
+          modifierGroupsForProduct(item.product.id),
+          item.quantity,
+        ),
+        quantity: item.quantity,
+      },
       categoryForProduct(item.product.id),
       promoPickOptions.value,
     )

--- a/composables/useWaroRedemptionPreview.ts
+++ b/composables/useWaroRedemptionPreview.ts
@@ -9,6 +9,7 @@ export interface PromoLineForRedemption {
   category_id?: string | null
   quantity: number
   subtotal: number
+  promo_eligible_subtotal?: number
   promo_opt_out?: boolean
 }
 

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -14,7 +14,7 @@ import DeliveryAddressPicker from '~/components/pos/checkout/DeliveryAddressPick
 import DeliveryAddressForm from '~/components/pos/checkout/DeliveryAddressForm.vue'
 import { displayTableCode } from '~/composables/useTableDisplayCode'
 import { formatPromoTypeLabel } from '~/utils/promotionPreview'
-import { linePromoSavingsForProduct } from '~/utils/promoProductMatch'
+import { computePromoEligibleSubtotal, linePromoSavingsForProduct } from '~/utils/promoProductMatch'
 import { posDebugLog, posDebugSerializeError } from '~/utils/posDebugLog'
 
 interface TopProduct {
@@ -479,7 +479,14 @@ const promoLineById = computed(() => {
   return map
 })
 
-function checkoutLineGross(item: { product: { price: number }; modifiers?: Array<{ price: number; quantity?: number }>; quantity: number; orderItemId?: string }): number {
+type CheckoutPromoLineItem = {
+  product: { id: string; price: number }
+  modifiers?: Array<{ id: string; price: number; quantity?: number }>
+  quantity: number
+  orderItemId?: string
+}
+
+function checkoutLineGross(item: CheckoutPromoLineItem): number {
   if (isKitchenServiceMode.value) {
     const tab = storeTabItems.value.find(t => t.orderItemId === item.orderItemId)
     if (tab) return tab.subtotal
@@ -490,6 +497,15 @@ function checkoutLineGross(item: { product: { price: number }; modifiers?: Array
     0,
   )
   return (base + mods) * (Number(item.quantity) || 1)
+}
+
+function checkoutLineEligibleSubtotal(item: CheckoutPromoLineItem): number {
+  return computePromoEligibleSubtotal(
+    Number(item.product.price) || 0,
+    item.modifiers ?? [],
+    posStore.getProduct(item.product.id)?.modifier_groups ?? [],
+    Number(item.quantity) || 1,
+  )
 }
 
 function checkoutLineCategoryId(item: { product: { id: string }; orderItemId?: string }): string | null {
@@ -523,7 +539,11 @@ const clientPromoSavings = computed(() => {
     total += linePromoSavingsForProduct(
       activePromos.value,
       productId,
-      { subtotal: checkoutLineGross(item), quantity: item.quantity },
+      {
+        subtotal: checkoutLineGross(item),
+        eligibleSubtotal: checkoutLineEligibleSubtotal(item),
+        quantity: item.quantity,
+      },
       checkoutLineCategoryId(item),
       promoPickOptions.value,
     )
@@ -1153,6 +1173,7 @@ function buildRedemptionPromoLines(): PromoLineForRedemption[] {
       category_id: checkoutLineCategoryId(item),
       quantity: Number(item.quantity) || 1,
       subtotal: checkoutLineGross(item),
+      promo_eligible_subtotal: checkoutLineEligibleSubtotal(item),
       promo_opt_out: Boolean(item.promo_opt_out ?? item.promoOptOut),
     }))
     .filter(line => line.id && line.product_id)
@@ -1413,7 +1434,11 @@ const getLinePromoSavings = (item: any): number => {
   return linePromoSavingsForProduct(
     activePromos.value,
     productId,
-    { subtotal: checkoutLineGross(item), quantity: item.quantity },
+    {
+      subtotal: checkoutLineGross(item),
+      eligibleSubtotal: checkoutLineEligibleSubtotal(item),
+      quantity: item.quantity,
+    },
     checkoutLineCategoryId(item),
     promoPickOptions.value,
   )

--- a/pages/pos/producto/[id].vue
+++ b/pages/pos/producto/[id].vue
@@ -503,6 +503,12 @@ const isSingleSelectGroup = (group: ModifierGroup) => group.maxSelections === 1
 const selectRadioModifier = (modifier: ModifierOption, groupId: string) => {
   const group = modifierGroups.value.find(g => g.id === groupId)
   if (!group) return
+  const isSelected = isModifierSelected(modifier.id)
+
+  if (!group.required && isSelected) {
+    activeStepModifiers.value = activeStepModifiers.value.filter(m => m.id !== modifier.id)
+    return
+  }
 
   activeStepModifiers.value = activeStepModifiers.value.filter(m =>
     !group.options.some(opt => opt.id === m.id)
@@ -632,11 +638,12 @@ const addToCart = async () => {
         )
       }
     } else if (isEditMode.value && editCartIndex.value !== null) {
+      const existingItem = posStore.getCartItem(editCartIndex.value)
       await posStore.updateCartItem(editCartIndex.value, {
         product: productPayload,
         modifiers: [...selectedModifiers.value],
         notes: notes.value || undefined,
-        quantity: 1,
+        quantity: quantity.value || existingItem?.quantity || 1,
       })
     } else if (wizardMode.value) {
       await posStore.addCartItemsBatch(
@@ -682,6 +689,7 @@ watch(product, (newProduct) => {
   if (isEditMode.value && editCartIndex.value !== null) {
     const cartItem = posStore.getCartItem(editCartIndex.value)
     if (cartItem) {
+      quantity.value = cartItem.quantity || 1
       selectedModifiers.value = cartItem.modifiers.map(m => ({
         ...m,
         quantity: m.quantity ?? 1,
@@ -693,6 +701,11 @@ watch(product, (newProduct) => {
   if (isTabItemEditMode.value && editTabItemId.value) {
     const tabItem = posStore.tabItems.find(i => i.orderItemId === editTabItemId.value)
     if (tabItem) {
+      if ((tabItem.fulfillmentStatus ?? 'new') !== 'new') {
+        router.push('/pos')
+        return
+      }
+      quantity.value = tabItem.quantity || 1
       selectedModifiers.value = (tabItem.modifiers ?? []).map(m => ({
         id: m.id,
         name: m.name,
@@ -775,7 +788,7 @@ watch(product, (newProduct) => {
         </div>
 
         <!-- Quantity + per-unit wizard (online cart parity #1023) -->
-        <section v-if="!isLineEditMode" class="bg-surface rounded-2xl p-4 md:p-6 border border-border space-y-4">
+        <section v-if="!isTabItemEditMode" class="bg-surface rounded-2xl p-4 md:p-6 border border-border space-y-4">
           <div v-if="wizardMode" class="flex items-center justify-between">
             <h3 class="text-base md:text-lg font-bold text-text-primary">
               Ítem {{ wizardStep + 1 }} de {{ quantity }}
@@ -843,7 +856,7 @@ watch(product, (newProduct) => {
                 :name="'group-' + group.id"
                 class="sr-only"
                 :checked="isModifierSelected(option.id)"
-                @change="selectRadioModifier(option, group.id)"
+                @click.prevent="selectRadioModifier(option, group.id)"
               />
               <div
                 class="border-2 rounded-xl p-3 md:p-4 transition-all duration-200 bg-surface h-full flex flex-col justify-between"

--- a/pages/pos/producto/[id].vue
+++ b/pages/pos/producto/[id].vue
@@ -17,7 +17,11 @@ import {
 } from '@heroicons/vue/24/outline'
 
 import { formatPromoTypeLabel } from '~/utils/promotionPreview'
-import { linePromoSavingsForProduct, promoBadgeForProduct } from '~/utils/promoProductMatch'
+import {
+  computePromoEligibleSubtotal,
+  linePromoSavingsForProduct,
+  promoBadgeForProduct,
+} from '~/utils/promoProductMatch'
 
 definePageMeta({
   layout: 'dashboard',
@@ -472,20 +476,40 @@ const promoSavings = computed(() => {
     const basePrice = Number(product.value.price) || 0
     return wizardUnits.value.reduce((sum, unit) => {
       const modifiersPrice = unit.modifiers.reduce((modSum, mod) => modSum + modifierLineTotal(mod), 0)
+      const subtotal = basePrice + modifiersPrice
       return sum + linePromoSavingsForProduct(
         activePromos.value,
         product.value!.id,
-        { subtotal: basePrice + modifiersPrice, quantity: 1 },
+        {
+          subtotal,
+          eligibleSubtotal: computePromoEligibleSubtotal(
+            basePrice,
+            unit.modifiers,
+            product.value!.modifier_groups,
+            1,
+          ),
+          quantity: 1,
+        },
         product.value!.category_id,
       )
     }, 0)
   }
   const modifiersPrice = selectedModifiers.value.reduce((sum, mod) => sum + modifierLineTotal(mod), 0)
   const unitSubtotal = basePriceFromProduct() + modifiersPrice
+  const subtotal = unitSubtotal * quantity.value
   return linePromoSavingsForProduct(
     activePromos.value,
     product.value.id,
-    { subtotal: unitSubtotal * quantity.value, quantity: quantity.value },
+    {
+      subtotal,
+      eligibleSubtotal: computePromoEligibleSubtotal(
+        basePriceFromProduct(),
+        selectedModifiers.value,
+        product.value.modifier_groups,
+        quantity.value,
+      ),
+      quantity: quantity.value,
+    },
     product.value.category_id,
   )
 })

--- a/utils/promoProductMatch.test.ts
+++ b/utils/promoProductMatch.test.ts
@@ -4,6 +4,7 @@ import type { ActivePromotionRow } from './promoProductMatch.ts'
 import {
   bogoMinQuantity,
   computeLinePromoSavings,
+  computePromoEligibleSubtotal,
   linePromoSavingsForProduct,
   pickBestPromotionForProduct,
   promoBadgeForProduct,
@@ -126,6 +127,129 @@ describe('linePromoSavingsForProduct', () => {
       10000,
     )
     assert.equal(pickBestPromotionForProduct([bogo, percent], productId)?.name, 'BOGO')
+  })
+})
+
+describe('computeLinePromoSavings', () => {
+  it('uses eligible subtotal for percent savings while preserving gross subtotal cap', () => {
+    const percent = promo({
+      promo_type: 'percent_off',
+      value_json: { percent: 10 },
+    })
+
+    assert.equal(
+      computeLinePromoSavings(
+        { subtotal: 12000, eligibleSubtotal: 10000, quantity: 1 },
+        percent,
+      ),
+      1000,
+    )
+  })
+
+  it('caps fixed savings against eligible subtotal', () => {
+    const fixed = promo({
+      promo_type: 'fixed_off',
+      value_json: { amount_cop: 15000 },
+    })
+
+    assert.equal(
+      computeLinePromoSavings(
+        { subtotal: 12000, eligibleSubtotal: 10000, quantity: 1 },
+        fixed,
+      ),
+      10000,
+    )
+  })
+
+  it('uses eligible unit price for same-line BOGO savings', () => {
+    const bogo = promo({
+      promo_type: 'bogo',
+      value_json: { buy_qty: 1, get_qty: 1 },
+    })
+
+    assert.equal(
+      computeLinePromoSavings(
+        { subtotal: 24000, eligibleSubtotal: 20000, quantity: 2 },
+        bogo,
+      ),
+      10000,
+    )
+  })
+})
+
+describe('computePromoEligibleSubtotal', () => {
+  const groups = [
+    {
+      id: 'required-group',
+      is_required: true,
+      modifiers: [
+        { id: 'required-cheese', is_default: false },
+      ],
+    },
+    {
+      id: 'min-group',
+      minQty: 1,
+      modifiers: [
+        { id: 'min-sauce', isDefault: false },
+      ],
+    },
+    {
+      id: 'optional-group',
+      isRequired: false,
+      min_qty: 0,
+      modifiers: [
+        { id: 'default-bread', is_default: true },
+        { id: 'optional-bacon', is_default: false },
+        { id: 'optional-discount', is_default: false },
+      ],
+    },
+  ]
+
+  it('includes required, min-qty, and default modifiers', () => {
+    assert.equal(
+      computePromoEligibleSubtotal(
+        10000,
+        [
+          { id: 'required-cheese', price: 1000, quantity: 2 },
+          { id: 'min-sauce', price: 500, quantity: 1 },
+          { id: 'default-bread', price: 700, quantity: 1 },
+          { id: 'optional-bacon', price: 2000, quantity: 1 },
+        ],
+        groups,
+        1,
+      ),
+      13200,
+    )
+  })
+
+  it('excludes optional positive and negative modifiers from eligibility', () => {
+    assert.equal(
+      computePromoEligibleSubtotal(
+        10000,
+        [
+          { id: 'optional-bacon', price: 2000, quantity: 1 },
+          { id: 'optional-discount', price: -500, quantity: 1 },
+        ],
+        groups,
+        1,
+      ),
+      10000,
+    )
+  })
+
+  it('multiplies the eligible unit subtotal by quantity', () => {
+    assert.equal(
+      computePromoEligibleSubtotal(
+        10000,
+        [
+          { id: 'required-cheese', price: 1000, quantity: 1 },
+          { id: 'optional-bacon', price: 2000, quantity: 1 },
+        ],
+        groups,
+        3,
+      ),
+      33000,
+    )
   })
 })
 

--- a/utils/promoProductMatch.ts
+++ b/utils/promoProductMatch.ts
@@ -204,6 +204,84 @@ export function promoBadgeForProduct(
 export type LinePromoInput = {
   subtotal: number
   quantity?: number
+  eligibleSubtotal?: number
+  promoEligibleSubtotal?: number
+}
+
+export type PromoModifierInput = {
+  id: string
+  price: number
+  quantity?: number
+}
+
+export type PromoModifierOptionInput = {
+  id?: unknown
+  is_default?: unknown
+  isDefault?: unknown
+}
+
+export type PromoModifierGroupInput = {
+  is_required?: unknown
+  isRequired?: unknown
+  min_qty?: unknown
+  minQty?: unknown
+  modifiers?: PromoModifierOptionInput[]
+}
+
+function truthyFlag(value: unknown): boolean {
+  return value === true || value === 'true' || value === 1 || value === '1'
+}
+
+function numericField(...values: unknown[]): number {
+  for (const value of values) {
+    if (value == null || value === '') continue
+    const numberValue = Number(value)
+    if (Number.isFinite(numberValue)) return numberValue
+  }
+  return 0
+}
+
+function promoBasisForLine(line: LinePromoInput): number {
+  const subtotal = Number(line.subtotal) || 0
+  const eligibleSubtotal = Number(
+    line.promoEligibleSubtotal ?? line.eligibleSubtotal ?? subtotal,
+  ) || 0
+  if (subtotal <= 0 || eligibleSubtotal <= 0) return 0
+  return Math.min(subtotal, eligibleSubtotal)
+}
+
+export function computePromoEligibleSubtotal(
+  basePrice: number,
+  modifiers: PromoModifierInput[],
+  modifierGroups: PromoModifierGroupInput[] | null | undefined,
+  quantity = 1,
+): number {
+  const qty = Math.max(1, Number(quantity) || 1)
+  const base = Number(basePrice) || 0
+  const groups = Array.isArray(modifierGroups) ? modifierGroups : []
+  if (groups.length === 0) return base * qty
+
+  const eligibleModifierIds = new Set<string>()
+  for (const group of groups) {
+    const groupIsEligible =
+      truthyFlag(group.is_required ?? group.isRequired)
+      || numericField(group.min_qty, group.minQty) > 0
+
+    for (const option of group.modifiers ?? []) {
+      const id = option.id == null ? '' : String(option.id)
+      if (!id) continue
+      if (groupIsEligible || truthyFlag(option.is_default ?? option.isDefault)) {
+        eligibleModifierIds.add(id)
+      }
+    }
+  }
+
+  const eligibleModifiers = modifiers.reduce((sum, modifier) => {
+    if (!eligibleModifierIds.has(String(modifier.id))) return sum
+    return sum + (Number(modifier.price) || 0) * (modifier.quantity ?? 1)
+  }, 0)
+
+  return (base + eligibleModifiers) * qty
 }
 
 /** Client mirror of api promotions_service._compute_line_promo_savings. */
@@ -212,21 +290,22 @@ export function computeLinePromoSavings(
   promo: Pick<ActivePromotionRow, 'promo_type' | 'value_json'>,
 ): number {
   const subtotal = Number(line.subtotal) || 0
+  const promoBasis = promoBasisForLine(line)
   const quantity = Math.max(1, Number(line.quantity) || 1)
-  if (subtotal <= 0) return 0
+  if (subtotal <= 0 || promoBasis <= 0) return 0
 
   const valueJson = (promo.value_json ?? {}) as Record<string, unknown>
 
   if (promo.promo_type === 'percent_off') {
     const pct = Number(valueJson.percent) || 0
     if (pct <= 0) return 0
-    return Math.min(Math.round(subtotal * pct / 100), Math.round(subtotal))
+    return Math.min(Math.round(promoBasis * pct / 100), Math.round(promoBasis))
   }
 
   if (promo.promo_type === 'fixed_off') {
     const amount = Number(valueJson.amount_cop) || 0
     if (amount <= 0) return 0
-    return Math.min(Math.round(amount), Math.round(subtotal))
+    return Math.min(Math.round(amount), Math.round(promoBasis))
   }
 
   if (promo.promo_type === 'bogo') {
@@ -236,9 +315,9 @@ export function computeLinePromoSavings(
     const bundle = buyQty + getQty
     const sets = Math.floor(quantity / bundle)
     if (sets <= 0) return 0
-    const unitPrice = subtotal / quantity
+    const unitPrice = promoBasis / quantity
     const freeUnits = sets * getQty
-    return Math.min(Math.round(freeUnits * unitPrice), Math.round(subtotal))
+    return Math.min(Math.round(freeUnits * unitPrice), Math.round(promoBasis))
   }
 
   return 0


### PR DESCRIPTION
## Summary
- add eligible subtotal support to client promo savings for percent, fixed, and BOGO previews
- derive eligible modifier subtotal from cached product modifier groups for POS product, cart, checkout, and WaRo preview fallbacks
- keep API promo preview values authoritative while preserving gross totals for optional extras

## Validation
- node --test utils/promoProductMatch.test.ts

Closes #1308