### PR TITLE
Enforce required modifiers in POS and manual sales

### DIFF
--- a/pages/pos/producto/[id].vue
+++ b/pages/pos/producto/[id].vue
@@ -22,6 +22,7 @@ import {
   linePromoSavingsForProduct,
   promoBadgeForProduct,
 } from '~/utils/promoProductMatch'
+import { firstMissingRequiredModifierGroup } from '~/utils/modifierSelection'
 
 definePageMeta({
   layout: 'dashboard',
@@ -167,6 +168,11 @@ const enableWizard = () => {
 }
 
 const goToNextStep = () => {
+  const missingGroup = missingRequiredModifierGroupFor(activeStepModifiers.value)
+  if (missingGroup) {
+    notifyMissingRequiredGroup(missingGroup, wizardStep.value + 1)
+    return
+  }
   wizardStep.value++
 }
 
@@ -194,6 +200,7 @@ interface ModifierGroup {
   id: string
   name: string
   required: boolean
+  minQty: number
   maxSelections: number
   options: ModifierOption[]
 }
@@ -438,6 +445,7 @@ const modifierGroups = computed<ModifierGroup[]>(() => {
         id: group.id,
         name: group.name,
         required: group.is_required || false,
+        minQty: Math.max(0, Number(group.min_qty) || 0),
         maxSelections: group.max_qty || 1,
         options: (group.modifiers || [])
           .filter((mod: any) => mod && mod.is_available !== false)
@@ -524,12 +532,31 @@ const getModifierQty = (modifierId: string) =>
 
 const isSingleSelectGroup = (group: ModifierGroup) => group.maxSelections === 1
 
+const missingRequiredModifierGroupFor = (modifiers: CartModifier[]) =>
+  firstMissingRequiredModifierGroup(
+    modifiers,
+    modifierGroups.value.map(group => ({
+      id: group.id,
+      name: group.name,
+      required: group.required,
+      minQty: group.minQty,
+      optionIds: group.options.map(option => option.id),
+    })),
+  )
+
+const notifyMissingRequiredGroup = (group: { name: string }, unitNumber?: number) => {
+  const prefix = unitNumber ? `Ítem ${unitNumber}: ` : ''
+  useToast().warning(`${prefix}selecciona ${group.name} antes de continuar`, {
+    title: 'Modificador obligatorio',
+  })
+}
+
 const selectRadioModifier = (modifier: ModifierOption, groupId: string) => {
   const group = modifierGroups.value.find(g => g.id === groupId)
   if (!group) return
   const isSelected = isModifierSelected(modifier.id)
 
-  if (!group.required && isSelected) {
+  if (!group.required && group.minQty <= 0 && isSelected) {
     activeStepModifiers.value = activeStepModifiers.value.filter(m => m.id !== modifier.id)
     return
   }
@@ -608,6 +635,24 @@ const isModifierSelected = (modifierId: string) => getModifierQty(modifierId) > 
 
 const addToCart = async () => {
   if (!product.value || isAdding.value) return
+
+  if (wizardMode.value) {
+    const invalidUnitIndex = wizardUnits.value.findIndex(unit =>
+      missingRequiredModifierGroupFor(unit.modifiers)
+    )
+    if (invalidUnitIndex !== -1) {
+      wizardStep.value = invalidUnitIndex
+      const missingGroup = missingRequiredModifierGroupFor(wizardUnits.value[invalidUnitIndex].modifiers)
+      if (missingGroup) notifyMissingRequiredGroup(missingGroup, invalidUnitIndex + 1)
+      return
+    }
+  } else {
+    const missingGroup = missingRequiredModifierGroupFor(selectedModifiers.value)
+    if (missingGroup) {
+      notifyMissingRequiredGroup(missingGroup)
+      return
+    }
+  }
 
   isAdding.value = true
 
@@ -864,7 +909,9 @@ watch(product, (newProduct) => {
           <div class="flex items-center justify-between mb-3 md:mb-4">
             <h3 class="text-base md:text-lg font-bold text-text-primary">{{ group.name }}</h3>
             <span class="text-xs font-medium bg-surface-secondary text-text-secondary px-2 py-1 rounded">
-              {{ group.required ? 'Obligatorio' : 'Opcional' }} • Máx {{ group.maxSelections }}
+              {{ group.required || group.minQty > 0 ? 'Obligatorio' : 'Opcional' }}
+              <template v-if="group.minQty > 1"> • Mín {{ group.minQty }}</template>
+              • Máx {{ group.maxSelections }}
             </span>
           </div>
 

--- a/pages/ventas/crear.vue
+++ b/pages/ventas/crear.vue
@@ -7,6 +7,7 @@ useHead({ title: 'Nueva Venta' })
 
 import { modifiersCartTotal, formatSaleModifierPriceLabel, mapApiModifierToSaleOption, normalizeModifierOptionType } from '~/utils/saleModifierOption'
 import { formatModifierOptionTypeLabel } from '~/composables/useModifierOptionForm'
+import { firstMissingRequiredModifierGroup } from '~/utils/modifierSelection'
 import {
   WALLET_PAYMENT_SLUG,
   mergePosPaymentGroupsFromApi,
@@ -30,6 +31,7 @@ interface ModifierGroup {
   id: string
   name: string
   is_required: boolean
+  min_qty: number
   max_qty: number
   modifiers: ModifierOption[]
 }
@@ -192,6 +194,7 @@ function normalizeModifierGroups(groups: any[] = []): ModifierGroup[] {
     id: String(group.id),
     name: String(group.name || ''),
     is_required: Boolean(group.is_required),
+    min_qty: Math.max(0, Number(group.min_qty) || 0),
     max_qty: Math.max(1, Number(group.max_qty) || 1),
     modifiers: (group.modifiers || [])
       .filter((mod: any) => mod && mod.is_available !== false)
@@ -249,6 +252,11 @@ function closeCustomizationPanel() {
 
 function confirmProductDetail() {
   if (!pendingProduct.value || !pendingItem.value) return
+  const missingGroup = missingRequiredModifierGroupForItem(pendingItem.value)
+  if (missingGroup) {
+    notifyMissingRequiredGroup(missingGroup)
+    return
+  }
   addProductToCart(pendingProduct.value, pendingItem.value.selected_modifiers)
   closeProductDetail()
 }
@@ -295,6 +303,12 @@ function isSingleSelectGroup(group: ModifierGroup): boolean {
 }
 
 function selectRadioModifier(item: LineItem, option: ModifierOption, group: ModifierGroup) {
+  const isSelected = isModifierSelected(item, option.id)
+  if (!group.is_required && group.min_qty <= 0 && isSelected) {
+    item.selected_modifiers = item.selected_modifiers.filter(m => m.id !== option.id)
+    return
+  }
+
   item.selected_modifiers = item.selected_modifiers.filter(m =>
     !group.modifiers.some(o => o.id === m.id)
   )
@@ -352,6 +366,25 @@ function decrementModifier(item: LineItem, option: ModifierOption) {
 
 function isModifierSelected(item: LineItem, modifierId: string) {
   return getModifierQty(item, modifierId) > 0
+}
+
+function missingRequiredModifierGroupForItem(item: LineItem) {
+  return firstMissingRequiredModifierGroup(
+    item.selected_modifiers,
+    item.modifier_groups.map(group => ({
+      id: group.id,
+      name: group.name,
+      isRequired: group.is_required,
+      min_qty: group.min_qty,
+      optionIds: group.modifiers.map(option => option.id),
+    })),
+  )
+}
+
+function notifyMissingRequiredGroup(group: { name: string }) {
+  useToast().warning(`Selecciona ${group.name} antes de continuar`, {
+    title: 'Modificador obligatorio',
+  })
 }
 
 // ─── Totals ───────────────────────────────────────────────────────────────────
@@ -425,6 +458,13 @@ function clearCustomer() {
 
 async function submit() {
   if (!canSubmit.value) return
+  const invalidItem = form.value.items.find(item => missingRequiredModifierGroupForItem(item))
+  if (invalidItem) {
+    const missingGroup = missingRequiredModifierGroupForItem(invalidItem)
+    if (missingGroup) notifyMissingRequiredGroup(missingGroup)
+    activeItemIndex.value = form.value.items.indexOf(invalidItem)
+    return
+  }
   loading.value = true
   try {
     // Convert the local-time input value (e.g. "2026-05-07T14:30") to a UTC
@@ -712,8 +752,10 @@ async function submit() {
                     >
                       <p class="text-sm font-medium text-text-secondary">
                         {{ group.name }}
-                        <span v-if="group.is_required" class="text-destructive" aria-hidden="true">*</span>
-                        <span class="normal-case font-normal ml-1 text-xs">(máx. {{ group.max_qty }})</span>
+                        <span v-if="group.is_required || group.min_qty > 0" class="text-destructive" aria-hidden="true">*</span>
+                        <span class="normal-case font-normal ml-1 text-xs">
+                          (<template v-if="group.min_qty > 1">mín. {{ group.min_qty }} · </template>máx. {{ group.max_qty }})
+                        </span>
                       </p>
                       <div v-if="isSingleSelectGroup(group)" class="flex flex-wrap gap-2">
                         <button

--- a/utils/modifierSelection.test.ts
+++ b/utils/modifierSelection.test.ts
@@ -2,8 +2,10 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   canIncrementModifierSelection,
+  firstMissingRequiredModifierGroup,
   modifierGroupSelectionCount,
   modifierSelectionQty,
+  requiredModifierGroupMinQty,
 } from './modifierSelection.ts'
 
 describe('modifierSelectionQty', () => {
@@ -66,5 +68,104 @@ describe('canIncrementModifierSelection', () => {
       }),
       false,
     )
+  })
+})
+
+describe('requiredModifierGroupMinQty', () => {
+  it('requires one selection when a group is marked required without min quantity', () => {
+    assert.equal(
+      requiredModifierGroupMinQty({
+        id: 'sauces',
+        name: 'Salsas',
+        isRequired: true,
+        optionIds: ['bbq'],
+      }),
+      1,
+    )
+  })
+
+  it('uses explicit min_qty when present', () => {
+    assert.equal(
+      requiredModifierGroupMinQty({
+        id: 'toppings',
+        name: 'Adiciones',
+        min_qty: 2,
+        optionIds: ['cheese', 'bacon'],
+      }),
+      2,
+    )
+  })
+
+  it('does not require optional groups with zero min quantity', () => {
+    assert.equal(
+      requiredModifierGroupMinQty({
+        id: 'extras',
+        name: 'Extras',
+        isRequired: false,
+        min_qty: 0,
+        optionIds: ['cheese'],
+      }),
+      0,
+    )
+  })
+})
+
+describe('firstMissingRequiredModifierGroup', () => {
+  it('returns the first required group with too few selected options', () => {
+    const missing = firstMissingRequiredModifierGroup(
+      [{ id: 'cheese', quantity: 1 }],
+      [
+        {
+          id: 'sauce',
+          name: 'Salsa',
+          isRequired: true,
+          optionIds: ['bbq', 'garlic'],
+        },
+        {
+          id: 'extras',
+          name: 'Extras',
+          min_qty: 2,
+          optionIds: ['cheese', 'bacon'],
+        },
+      ],
+    )
+
+    assert.equal(missing?.id, 'sauce')
+  })
+
+  it('counts distinct quantity selections toward min_qty', () => {
+    const missing = firstMissingRequiredModifierGroup(
+      [
+        { id: 'cheese', quantity: 2 },
+        { id: 'bacon', quantity: 1 },
+      ],
+      [
+        {
+          id: 'extras',
+          name: 'Extras',
+          minQty: 2,
+          optionIds: ['cheese', 'bacon', 'avocado'],
+        },
+      ],
+    )
+
+    assert.equal(missing, null)
+  })
+
+  it('allows optional groups to be cleared', () => {
+    const missing = firstMissingRequiredModifierGroup(
+      [],
+      [
+        {
+          id: 'extras',
+          name: 'Extras',
+          required: false,
+          min_qty: 0,
+          optionIds: ['cheese'],
+        },
+      ],
+    )
+
+    assert.equal(missing, null)
   })
 })

--- a/utils/modifierSelection.ts
+++ b/utils/modifierSelection.ts
@@ -11,6 +11,16 @@ interface CanIncrementModifierSelectionInput {
   groupMaxSelections?: number | null
 }
 
+export interface RequiredModifierGroupInput {
+  id: string
+  name: string
+  isRequired?: boolean | null
+  required?: boolean | null
+  minQty?: number | string | null
+  min_qty?: number | string | null
+  optionIds: string[]
+}
+
 export function modifierSelectionQty(
   selections: ModifierSelection[],
   modifierId: string,
@@ -49,4 +59,21 @@ export function canIncrementModifierSelection({
   }
 
   return true
+}
+
+export function requiredModifierGroupMinQty(group: RequiredModifierGroupInput): number {
+  const minQty = Number(group.min_qty ?? group.minQty) || 0
+  if (minQty > 0) return minQty
+  return group.isRequired || group.required ? 1 : 0
+}
+
+export function firstMissingRequiredModifierGroup(
+  selections: ModifierSelection[],
+  groups: RequiredModifierGroupInput[],
+): RequiredModifierGroupInput | null {
+  return groups.find((group) => {
+    const minQty = requiredModifierGroupMinQty(group)
+    if (minQty <= 0) return false
+    return modifierGroupSelectionCount(selections, group.optionIds) < minQty
+  }) ?? null
 }


### PR DESCRIPTION
## Summary

- Adds shared required modifier group validation using `is_required` and `min_qty`.
- Blocks POS normal add/edit, mesa tab item edit, and per-unit wizard add/step navigation when required groups are incomplete.
- Blocks manual sale customization confirmation and final submit when line modifiers are incomplete.
- Keeps venta libre/open-priced flows modifier-free and preserves optional group clearing.

## Validation

- `node --test utils/modifierSelection.test.ts`
- `git diff --check -- pages/pos/producto/'[id].vue' pages/ventas/crear.vue utils/modifierSelection.ts utils/modifierSelection.test.ts`

## Manual validation route

- POS product with required modifiers: try normal add without selecting required group, then select and add.
- POS quantity wizard: try next/final add with one unit missing the required group, then complete all units.
- Manual sales: try confirming a customizable product and submitting an edited line with required modifiers missing.
- Venta libre/open-priced: confirm it still uses `modifiers: []` and does not open modifier validation.

Closes #1309
