### PR TITLE
Validate persisted promo totals in checkout receipts

### DIFF
--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -601,6 +601,22 @@ function promoFieldsForReceipt(subtotal: number) {
     subtotal,
   }
 }
+
+function promoFieldsFromCloseResponse(
+  data: { promo_savings?: number; promo_breakdown?: PromoBreakdownLine[]; subtotal?: number | null } | null | undefined,
+  fallbackSubtotal: number,
+) {
+  const savings = Number(data?.promo_savings) || 0
+  if (savings <= 0) return {}
+  const breakdown = data?.promo_breakdown?.length
+    ? data.promo_breakdown
+    : [{ promotion_name: 'Promoción', promo_type: '', savings }]
+  return {
+    promo_savings: savings,
+    promo_breakdown: breakdown,
+    subtotal: Number(data?.subtotal) || fallbackSubtotal,
+  }
+}
 const discountAmount = computed(() => {
   if (!discountEnabled.value || !discountInput.value) return 0
   const val = Number(discountInput.value)
@@ -1608,15 +1624,7 @@ const processOrder = async () => {
         standard_tax: Number(closeResponse?.data?.standard_tax) || 0,
         liquor_tax: Number(closeResponse?.data?.liquor_tax) || 0,
         standard_tax_label: closeResponse?.data?.standard_tax_label || 'Impuesto',
-        ...(() => {
-          const fromApi = Number(closeResponse.data?.promo_savings) || 0
-          const savings = fromApi > 0 ? fromApi : promoSavings.value
-          if (savings <= 0) return {}
-          const breakdown = closeResponse.data?.promo_breakdown?.length
-            ? closeResponse.data.promo_breakdown
-            : displayPromoBreakdown.value.map(p => ({ ...p }))
-          return { promo_savings: savings, promo_breakdown: breakdown, subtotal: _subtotal }
-        })(),
+        ...promoFieldsFromCloseResponse(closeResponse.data, _subtotal),
         ...(discountEnabled.value && _discountAmt > 0
           ? { discount_amount: _discountAmt, subtotal: _subtotal }
           : {}),
@@ -1747,19 +1755,7 @@ const processOrder = async () => {
         standard_tax: response.data.standard_tax ?? 0,
         liquor_tax: response.data.liquor_tax ?? 0,
         standard_tax_label: response.data.standard_tax_label ?? 'Impuesto',
-        ...(() => {
-          const fromApi = Number(response.data.promo_savings) || 0
-          const savings = fromApi > 0 ? fromApi : promoSavings.value
-          if (savings <= 0) return {}
-          const breakdown = response.data.promo_breakdown?.length
-            ? response.data.promo_breakdown
-            : displayPromoBreakdown.value.map(p => ({ ...p }))
-          return {
-            promo_savings: savings,
-            promo_breakdown: breakdown,
-            subtotal: Number(response.data.subtotal) || _subtotalPos,
-          }
-        })(),
+        ...promoFieldsFromCloseResponse(response.data, _subtotalPos),
         ...(discountEnabled.value && _discountAmtPos > 0
           ? { discount_amount: _discountAmtPos, subtotal: _subtotalPos }
           : {}),


### PR DESCRIPTION
## Summary

- Adds a post-close promo helper that builds receipt/success-modal promo fields only from persisted API close/complete responses.
- Keeps pre-close checkout and prefactura display fallback intact, but stops final receipt data from silently falling back to stale client promotion evaluation.
- Applies the persisted/API-first behavior to both mesa close and standard POS cart complete paths.

## Validation

- `git diff --check`
- Static grep confirmed both final close paths use `promoFieldsFromCloseResponse` and no longer use `fromApi > 0 ? fromApi : promoSavings.value`.
- `pnpm exec nuxi typecheck --noEmit` could not run because pnpm attempted a non-interactive modules purge/install and aborted with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`; no dependency/filesystem changes were left behind.

## Manual route

1. Create a POS promotion ending within the next few minutes.
2. Add one eligible line before the promotion expires and confirm checkout/prefactura show the locked promo savings.
3. Wait until after expiry, add a new eligible line, and confirm only the pre-expiry line keeps the promo.
4. Complete checkout through both standard POS cart and mesa/bar close flows when available.
5. Confirm success modal, printed receipt/email payload, and `/ventas/{id}` order detail all show the same persisted `promo_savings` and `promo_breakdown` returned by the API.

Closes #1314
