### PR TITLE
Allow setting inventory stock to zero

### DIFF
--- a/components/abastecimiento/AbastecimientoStockAdjustmentFullForm.vue
+++ b/components/abastecimiento/AbastecimientoStockAdjustmentFullForm.vue
@@ -237,7 +237,7 @@
               </div>
 
               <!-- Preview of new stock -->
-              <div v-if="form.quantity && form.quantity > 0" class="mt-2 p-3 bg-state-info-bg border border-state-info-border rounded-lg">
+              <div v-if="hasValidQuantity" class="mt-2 p-3 bg-state-info-bg border border-state-info-border rounded-lg">
                 <p class="text-sm text-state-info-text">
                   <span class="font-semibold">Resultado:</span>
                   Stock {{ form.adjustmentType === 'increment' ? 'aumentará' : form.adjustmentType === 'decrement' ? 'disminuirá' : 'se establecerá' }} a
@@ -334,7 +334,7 @@
                   {{ form.adjustmentType === 'increment' ? 'Incremento' : form.adjustmentType === 'decrement' ? 'Decremento' : 'Ajustar a' }}
                 </span>
               </div>
-              <div v-if="form.quantity && form.quantity > 0">
+              <div v-if="hasValidQuantity">
                 <p class="text-sm text-text-secondary mb-1">Nuevo Stock</p>
                 <p class="text-lg font-bold text-text-primary">
                   {{ formatNumber(newStockInBase) }} {{ selectedIngredient?.unit || '' }}
@@ -405,6 +405,7 @@ const {
   isSubmitting,
   errorMessage,
   isFormValid,
+  hasValidQuantity,
   calculateNewStockInBase,
   largeAdjustmentWarning,
   loadCurrentStock,

--- a/components/abastecimiento/StockAdjustmentPanel.vue
+++ b/components/abastecimiento/StockAdjustmentPanel.vue
@@ -225,7 +225,7 @@
                 </span>
               </div>
               <p
-                v-if="form.quantity && form.quantity > 0 && form.unit !== selectedIngredient.unit"
+                v-if="hasValidQuantity && form.unit !== selectedIngredient.unit"
                 class="text-[11px] text-text-secondary leading-snug"
               >
                 = {{ formatNumber(convertedQuantity) }} {{ selectedIngredient.unit }}
@@ -269,7 +269,7 @@
 
           <!-- 6. Result preview -->
           <div
-            v-if="selectedIngredient && form.adjustmentType && form.quantity && form.quantity > 0"
+            v-if="selectedIngredient && form.adjustmentType && hasValidQuantity"
             class="rounded-xl border border-primary/20 bg-primary/5 p-3"
           >
             <p class="text-xs text-text-secondary leading-snug">Resultado</p>
@@ -431,6 +431,7 @@ const {
   isSubmitting,
   errorMessage,
   isFormValid,
+  hasValidQuantity,
   calculateNewStockInBase,
   largeAdjustmentWarning,
   loadCurrentStock,
@@ -455,8 +456,8 @@ const purchaseUnitOptions = computed(() =>
 )
 
 const convertedQuantity = computed(() => {
-  if (!form.quantity || form.quantity <= 0 || !form.unit) return 0
-  return purchaseUnitsApi.convertToBase(form.ingredientId, form.quantity, form.unit)
+  if (!hasValidQuantity.value || !form.unit) return 0
+  return purchaseUnitsApi.convertToBase(form.ingredientId, form.quantity as number, form.unit)
 })
 
 // Stock Actual rendered in the operator-selected unit, when it differs from

--- a/composables/useInventoryAdjustment.ts
+++ b/composables/useInventoryAdjustment.ts
@@ -72,13 +72,21 @@ export function useInventoryAdjustment() {
   const isSubmitting = ref(false)
   const errorMessage = ref('')
 
+  const hasValidQuantity = computed(() => {
+    const qty = form.quantity
+    if (qty === null || qty === undefined || Number.isNaN(qty)) return false
+    // "Ajustar a" allows 0 (physical count with no stock). Increment/decrement stay > 0.
+    if (form.adjustmentType === 'set') return qty >= 0
+    return qty > 0
+  })
+
   const isFormValid = computed(() => {
     // Block submit until the current stock has been confirmed by the
     // backend — otherwise an operator could increment against a stale 0
     // and silently distort inventory (caught in #608 follow-up).
     if (!stockLoaded.value || isLoadingStock.value) return false
     if (!form.ingredientId || !form.adjustmentType || !form.unit) return false
-    if (!form.quantity || form.quantity <= 0) return false
+    if (!hasValidQuantity.value) return false
     if (!form.reason) return false
     if (form.reason === 'other' && !form.notes.trim()) return false
     return true
@@ -92,12 +100,13 @@ export function useInventoryAdjustment() {
    */
   const calculateNewStockInBase = (convertToBase: (qty: number, unit: string) => number): number => {
     const qty = form.quantity ?? 0
-    if (qty <= 0) return currentStock.value
+    if (form.adjustmentType !== 'set' && qty <= 0) return currentStock.value
+    if (form.adjustmentType === 'set' && qty < 0) return currentStock.value
     const qtyInBase = convertToBase(qty, form.unit)
     switch (form.adjustmentType) {
       case 'increment': return currentStock.value + qtyInBase
       case 'decrement': return Math.max(0, currentStock.value - qtyInBase)
-      case 'set':       return qtyInBase
+      case 'set':       return Math.max(0, qtyInBase)
       default:          return currentStock.value
     }
   }
@@ -248,6 +257,7 @@ export function useInventoryAdjustment() {
     isSubmitting,
     errorMessage,
     isFormValid,
+    hasValidQuantity,
     calculateNewStockInBase,
     largeAdjustmentWarning,
     loadCurrentStock,


### PR DESCRIPTION
## Summary
- Allow "Ajustar a" adjustments with quantity `0` in stock panel and full adjustment form
- Keep increment/decrement validation requiring quantities above zero
- Show stock preview when setting target stock to zero

## Test plan
- [ ] Open `/abastecimiento/stock`, pick an ingredient with stock > 0, choose "Ajustar a", enter `0`, submit
- [ ] Confirm stock becomes `0` and movement is recorded
- [ ] Repeat on `/abastecimiento/ajustes/crear?ingredientId=...`
- [ ] Confirm increment/decrement with `0` still cannot be submitted
- [ ] Confirm ingredient already at `0` can be submitted with "Ajustar a" = `0` after API deploy


Made with [Cursor](https://cursor.com)