### PR TITLE
Guard internal auth from customer-only sessions

### DIFF
--- a/components/Auth/LoginForm.vue
+++ b/components/Auth/LoginForm.vue
@@ -139,6 +139,14 @@
               <div class="ml-3">
                 <p class="text-sm font-medium" style="color: hsl(var(--destructive));">Error de autenticación</p>
                 <p class="text-sm mt-1" style="color: hsl(var(--destructive));">{{ error }}</p>
+                <NuxtLink
+                  v-if="showCustomerPortalLink"
+                  :to="CUSTOMER_PORTAL_LOGIN"
+                  class="inline-flex mt-3 text-sm font-semibold underline"
+                  style="color: hsl(var(--destructive));"
+                >
+                  Ir al portal de clientes
+                </NuxtLink>
               </div>
             </div>
           </div>
@@ -149,6 +157,14 @@
 </template>
 
 <script setup lang="ts">
+import {
+  CUSTOMER_PORTAL_LOGIN,
+  canUseInternalSession,
+  getInternalAccessDeniedMessage,
+  getSafeInternalRedirect,
+  isInternalAccessDeniedError,
+} from '~/utils/internalAccess'
+
 const email = ref('')
 const loading = ref(false)
 const error = ref('')
@@ -156,6 +172,7 @@ const checkingSession = ref(true)
 const emailSent = ref(false)
 const verificationCode = ref('')
 const verifyingCode = ref(false)
+const showCustomerPortalLink = ref(false)
 const toast = useToast()
 
 
@@ -253,7 +270,7 @@ onMounted(async () => {
     const session = await $fetch('/api/auth/session', {
       credentials: 'include'
     })
-    if (session?.success && session?.user) {
+    if (session?.success && canUseInternalSession(session)) {
 
       // Verificar que la sesión sea válida para warocol.com
       const { public: config } = useRuntimeConfig()
@@ -262,13 +279,20 @@ onMounted(async () => {
 
         // Redirigir al perfil de warocol
         const route = useRoute()
-        const redirectUrl = route.query.redirect || '/ventas'
+        const redirectUrl = getSafeInternalRedirect(route.query.redirect)
         await navigateTo(redirectUrl)
         return
       } else {
       }
+    } else if (session?.user) {
+      await navigateTo(CUSTOMER_PORTAL_LOGIN)
+      return
     }
   } catch (error) {
+    if (isInternalAccessDeniedError(error)) {
+      await navigateTo(CUSTOMER_PORTAL_LOGIN)
+      return
+    }
     // No hay sesión válida o es para otro tenant, mostrar formulario
   } finally {
     checkingSession.value = false
@@ -305,6 +329,9 @@ async function handleSubmit() {
       err?.data?.message?.toLowerCase().includes('user not found')
     if (isUserNotFound) {
       useAccessRequestModal().open(email.value)
+    } else if (isInternalAccessDeniedError(err)) {
+      showCustomerPortalLink.value = true
+      error.value = getInternalAccessDeniedMessage()
     } else {
       error.value = err?.data?.message || err?.message || 'Error al enviar el magic link. Intenta nuevamente.'
     }
@@ -336,7 +363,7 @@ async function verifyCode() {
 
     // Redirigir con recarga completa para asegurar que la cookie se incluya
     const route = useRoute()
-    const redirectUrl = route.query.redirect || '/ventas'
+    const redirectUrl = getSafeInternalRedirect(route.query.redirect)
 
     // Agregar delay antes de redirección
     setTimeout(() => {
@@ -346,6 +373,11 @@ async function verifyCode() {
 
   } catch (err) {
     console.error('❌ Error al verificar código:', err)
+    if (isInternalAccessDeniedError(err)) {
+      showCustomerPortalLink.value = true
+      error.value = getInternalAccessDeniedMessage()
+      return
+    }
     error.value = err.message || 'Código inválido o expirado'
   } finally {
     verifyingCode.value = false
@@ -357,6 +389,7 @@ watch([email, verificationCode], () => {
   if (error.value) {
     error.value = ''
   }
+  showCustomerPortalLink.value = false
 })
 
 // Cleanup observer cuando el componente se desmonte

--- a/middleware/auth.global.js
+++ b/middleware/auth.global.js
@@ -1,3 +1,11 @@
+import {
+  CUSTOMER_PORTAL_LOGIN,
+  INTERNAL_APP_HOME,
+  canUseInternalSession,
+  getSafeInternalRedirect,
+  isInternalAccessDeniedError,
+} from '~/utils/internalAccess'
+
 export default defineNuxtRouteMiddleware(async (to, from) => {
   // Skip on server-side rendering
   if (process.server) return
@@ -13,17 +21,33 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 
   const authStore = useAuthStore()
   const accessStore = useAccessStore()
+  const tenantsStore = useTenantsStore()
 
-  // If user already has a valid session and tries to access login, redirect to ventas
+  const clearInternalState = () => {
+    authStore.expireSession()
+    accessStore.clear()
+    tenantsStore.clearTenants()
+  }
+
+  // If user already has a valid internal session and tries login, redirect home.
   if (authStore.isSessionValid && to.path === '/auth/login') {
     try {
       const sessionResponse = await $fetch('/api/auth/session', {
         credentials: 'include',
       })
-      if (sessionResponse?.user) return navigateTo('/ventas')
-    } catch {
-      authStore.expireSession()
-      accessStore.clear()
+      if (canUseInternalSession(sessionResponse)) {
+        return navigateTo(getSafeInternalRedirect(to.query.redirect) || INTERNAL_APP_HOME)
+      }
+      if (sessionResponse?.user) {
+        clearInternalState()
+        return navigateTo(CUSTOMER_PORTAL_LOGIN)
+      }
+    } catch (err) {
+      if (isInternalAccessDeniedError(err)) {
+        clearInternalState()
+        return navigateTo(CUSTOMER_PORTAL_LOGIN)
+      }
+      clearInternalState()
     }
   }
 
@@ -49,9 +73,11 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
       credentials: 'include',
     })
 
-    if (!sessionResponse?.user) {
-      authStore.expireSession()
-      accessStore.clear()
+    if (!canUseInternalSession(sessionResponse)) {
+      clearInternalState()
+      if (sessionResponse?.user || isInternalAccessDeniedError(sessionResponse)) {
+        return navigateTo(CUSTOMER_PORTAL_LOGIN)
+      }
       return navigateTo('/auth/login')
     }
 
@@ -64,11 +90,21 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
       }
     })
 
-    await accessStore.load()
+    try {
+      await accessStore.load()
+    } catch (err) {
+      if (isInternalAccessDeniedError(err)) {
+        clearInternalState()
+        return navigateTo(CUSTOMER_PORTAL_LOGIN)
+      }
+      throw err
+    }
   } catch (err) {
     console.error('Auth middleware error:', err)
-    authStore.expireSession()
-    accessStore.clear()
+    clearInternalState()
+    if (isInternalAccessDeniedError(err)) {
+      return navigateTo(CUSTOMER_PORTAL_LOGIN)
+    }
     return navigateTo('/auth/login')
   } finally {
     authStore.setLoading(false)

--- a/pages/auth/accept-invitation.vue
+++ b/pages/auth/accept-invitation.vue
@@ -64,13 +64,13 @@
 
           <div class="space-y-3">
             <NuxtLink
-              to="/auth/login"
+              :to="errorActionTo"
               class="w-full py-3 px-6 rounded-md text-base font-medium transition-all inline-block text-center"
               style="background-color: hsl(250, 30%, 16%); color: white;"
               @mouseenter="$event.target.style.backgroundColor = 'hsl(243, 26%, 23%)'"
               @mouseleave="$event.target.style.backgroundColor = 'hsl(250, 30%, 16%)'"
             >
-              Ir al inicio de sesión
+              {{ errorActionLabel }}
             </NuxtLink>
 
             <p class="text-xs" style="color: hsl(220, 13%, 28%);">
@@ -84,6 +84,12 @@
 </template>
 
 <script setup lang="ts">
+import {
+  CUSTOMER_PORTAL_LOGIN,
+  getInternalAccessDeniedMessage,
+  isInternalAccessDeniedError,
+} from '~/utils/internalAccess'
+
 definePageMeta({
   layout: false,
   robots: 'noindex, nofollow'
@@ -98,6 +104,8 @@ const verifying = ref(true)
 const success = ref(false)
 const error = ref(false)
 const errorMessage = ref('')
+const errorActionTo = ref('/auth/login')
+const errorActionLabel = ref('Ir al inicio de sesión')
 const redirectProgress = ref(0)
 const userName = ref('')
 
@@ -208,9 +216,15 @@ const acceptInvitation = async () => {
 
     verifying.value = false
     error.value = true
+    errorActionTo.value = '/auth/login'
+    errorActionLabel.value = 'Ir al inicio de sesión'
 
     // Determinar mensaje de error específico
-    if (err.message?.includes('expirada') || err.message?.includes('expired')) {
+    if (isInternalAccessDeniedError(err)) {
+      errorMessage.value = getInternalAccessDeniedMessage()
+      errorActionTo.value = CUSTOMER_PORTAL_LOGIN
+      errorActionLabel.value = 'Ir al portal de clientes'
+    } else if (err.message?.includes('expirada') || err.message?.includes('expired')) {
       errorMessage.value = 'La invitación ha expirado. Solicita una nueva invitación al administrador.'
     } else if (err.message?.includes('inválida') || err.message?.includes('invalid')) {
       errorMessage.value = 'La invitación es inválida o ya fue utilizada.'

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -9,6 +9,13 @@
 </template>
 
 <script setup lang="ts">
+import {
+  CUSTOMER_PORTAL_LOGIN,
+  canUseInternalSession,
+  getSafeInternalRedirect,
+  isInternalAccessDeniedError,
+} from '~/utils/internalAccess'
+
 definePageMeta({
   layout: false,
   robots: 'noindex, nofollow'
@@ -21,7 +28,7 @@ const checking = ref(true)
 onMounted(async () => {
   try {
     const sessionData = await $fetch('/api/auth/session')
-    if (sessionData?.user) {
+    if (canUseInternalSession(sessionData)) {
       const authStore = useAuthStore()
       authStore.initializeFromMiddleware({
         session: sessionData,
@@ -31,9 +38,15 @@ onMounted(async () => {
           email: sessionData.user.email,
         }
       })
-      return navigateTo('/ventas')
+      return navigateTo(getSafeInternalRedirect(useRoute().query.redirect))
     }
-  } catch (e) {
+    if (sessionData?.user) {
+      return navigateTo(CUSTOMER_PORTAL_LOGIN)
+    }
+  } catch (e: any) {
+    if (isInternalAccessDeniedError(e)) {
+      return navigateTo(CUSTOMER_PORTAL_LOGIN)
+    }
     // No valid session
   }
   checking.value = false

--- a/pages/auth/verify.vue
+++ b/pages/auth/verify.vue
@@ -59,13 +59,13 @@
 
           <div class="space-y-3">
             <NuxtLink
-              to="/auth/login"
+              :to="errorActionTo"
               class="w-full py-3 px-6 rounded-md text-base font-medium transition-all inline-block text-center"
               style="background-color: hsl(250, 30%, 16%); color: white;"
               @mouseenter="$event.target.style.backgroundColor = 'hsl(243, 26%, 23%)'"
               @mouseleave="$event.target.style.backgroundColor = 'hsl(250, 30%, 16%)'"
             >
-              Intentar nuevamente
+              {{ errorActionLabel }}
             </NuxtLink>
 
             <p class="text-xs" style="color: hsl(220, 13%, 28%);">
@@ -79,6 +79,14 @@
 </template>
 
 <script setup lang="ts">
+import {
+  CUSTOMER_PORTAL_LOGIN,
+  canUseInternalSession,
+  getInternalAccessDeniedMessage,
+  getSafeInternalRedirect,
+  isInternalAccessDeniedError,
+} from '~/utils/internalAccess'
+
 definePageMeta({
   layout: false,
   robots: 'noindex, nofollow'
@@ -95,12 +103,14 @@ const verifying = ref(true)
 const success = ref(false)
 const error = ref(false)
 const errorMessage = ref('')
+const errorActionTo = ref('/auth/login')
+const errorActionLabel = ref('Intentar nuevamente')
 const redirectProgress = ref(0)
 
 // Obtener parámetros de la URL
 const token = route.query.token
 const email = route.query.email
-const redirectUrl = route.query.redirect || '/ventas'
+const redirectUrl = getSafeInternalRedirect(route.query.redirect)
 
 // ========================================
 // LÓGICA PARA EMOJIS DE COMIDA
@@ -178,6 +188,10 @@ const verifyToken = async () => {
       credentials: 'include'
     })
 
+    if (response?.success === false || (response?.user && !canUseInternalSession(response))) {
+      throw response
+    }
+
     // Marcar como exitoso
     verifying.value = false
     success.value = true
@@ -200,9 +214,15 @@ const verifyToken = async () => {
 
     verifying.value = false
     error.value = true
+    errorActionTo.value = '/auth/login'
+    errorActionLabel.value = 'Intentar nuevamente'
 
     // Determinar mensaje de error específico
-    if (err.message?.includes('Token inválido') || err.message?.includes('expirado')) {
+    if (isInternalAccessDeniedError(err)) {
+      errorMessage.value = getInternalAccessDeniedMessage()
+      errorActionTo.value = CUSTOMER_PORTAL_LOGIN
+      errorActionLabel.value = 'Ir al portal de clientes'
+    } else if (err.message?.includes('Token inválido') || err.message?.includes('expirado')) {
       errorMessage.value = 'El magic link ha expirado o es inválido. Solicita uno nuevo.'
     } else if (err.message?.includes('faltante')) {
       errorMessage.value = 'El enlace de verificación está incompleto.'

--- a/stores/access.ts
+++ b/stores/access.ts
@@ -13,6 +13,7 @@
  * there, mirror it here.
  */
 import { defineStore } from 'pinia'
+import { isInternalAccessDeniedError } from '~/utils/internalAccess'
 
 export type Module =
   | 'pos'
@@ -66,6 +67,10 @@ export const useAccessStore = defineStore('access', () => {
       isLoaded.value = true
       armPolling()
     } catch (err) {
+      if (isInternalAccessDeniedError(err)) {
+        clear()
+        throw err
+      }
       // Fail-open: keep current state. enforcementMode stays at its current
       // value (initially 'disabled' which makes can() always return true).
       // Matches the safety guarantee in Epic 4's body. Polling stays unarmed

--- a/stores/tenants.ts
+++ b/stores/tenants.ts
@@ -71,13 +71,17 @@ export const useTenantsStore = defineStore('tenants', () => {
   // Auto-select tenant from session (or first) when query loads
   watch(tenantData, (result) => {
     if (!result) return
-    if (selectedTenant.value) return  // already selected — don't override on background refetch
     const { tenants, session } = result
+    if (tenants.length === 0) {
+      selectedTenant.value = null
+      return
+    }
+    if (selectedTenant.value && tenants.some(t => t.id === selectedTenant.value!.id)) return
     if (session?.success && session.currentTenant) {
       const fromSession = tenants.find(t => t.id === session.currentTenant!.id)
       if (fromSession) { selectedTenant.value = fromSession; return }
     }
-    if (tenants.length > 0) selectedTenant.value = tenants[0]
+    selectedTenant.value = tenants[0]
   })
 
   const tenants = computed<Tenant[]>(() => tenantData.value?.tenants ?? [])

--- a/utils/internalAccess.ts
+++ b/utils/internalAccess.ts
@@ -1,0 +1,126 @@
+const TEAM_ROLES = new Set([
+  'owner',
+  'superuser',
+  'admin',
+  'supervisor',
+  'cashier',
+  'employee',
+  'member',
+  'kitchen',
+])
+
+const CUSTOMER_ONLY_CODES = new Set([
+  'customer_only',
+  'customer-only',
+  'no_team_access',
+  'no-team-access',
+  'no_internal_access',
+  'no-internal-access',
+  'internal_access_denied',
+  'internal-access-denied',
+  'team_access_required',
+  'team-access-required',
+])
+
+const CUSTOMER_ONLY_TEXT = [
+  'customer only',
+  'customer-only',
+  'solo cliente',
+  'solo para clientes',
+  'no team access',
+  'no internal access',
+  'internal platform access',
+  'team access required',
+  'requiere acceso interno',
+  'requiere pertenecer al equipo',
+]
+
+export const INTERNAL_APP_HOME = '/ventas'
+export const CUSTOMER_PORTAL_LOGIN = '/auth/customer-verify?redirect=/mis-pedidos'
+
+const normalizeRole = (role: unknown) =>
+  typeof role === 'string' ? role.trim().toLowerCase() : null
+
+export const getInternalSessionRole = (session: any) =>
+  normalizeRole(
+    session?.user?.team_role
+    ?? session?.user?.internal_role
+    ?? session?.user?.role
+    ?? session?.currentTenant?.team_role
+    ?? session?.currentTenant?.role
+    ?? session?.team_role
+    ?? session?.role,
+  )
+
+export const hasExplicitInternalAccessDenial = (session: any) =>
+  session?.internal_access === false
+  || session?.can_access_internal === false
+  || session?.has_internal_access === false
+  || session?.user?.internal_access === false
+  || session?.user?.can_access_internal === false
+  || session?.user?.has_internal_access === false
+  || session?.user?.is_customer_only === true
+  || session?.customer_only === true
+  || session?.is_customer_only === true
+
+export const isCustomerOnlySession = (session: any) => {
+  if (!session?.user) return false
+  if (hasExplicitInternalAccessDenial(session)) return true
+  return getInternalSessionRole(session) === 'customer'
+}
+
+export const canUseInternalSession = (session: any) => {
+  if (!session?.user) return false
+  if (isCustomerOnlySession(session)) return false
+
+  const role = getInternalSessionRole(session)
+  if (role) return TEAM_ROLES.has(role)
+
+  // Backwards-compatible: older API responses did not expose role/access fields.
+  return true
+}
+
+const collectErrorValues = (input: any): string[] => {
+  const data = input?.data ?? input?.response?._data ?? input
+  return [
+    input?.statusCode,
+    input?.status,
+    data?.code,
+    data?.error,
+    data?.reason,
+    data?.message,
+    data?.detail,
+    input?.message,
+  ]
+    .filter((value) => value !== null && value !== undefined)
+    .map((value) => String(value).trim().toLowerCase())
+}
+
+export const isInternalAccessDeniedError = (input: any) => {
+  const values = collectErrorValues(input)
+  if (values.some((value) => CUSTOMER_ONLY_CODES.has(value))) return true
+  if (values.some((value) => CUSTOMER_ONLY_TEXT.some((needle) => value.includes(needle)))) return true
+
+  const status = Number(input?.statusCode ?? input?.status ?? input?.response?.status)
+  if (status !== 403) return false
+
+  return values.some((value) =>
+    value.includes('customer')
+    || value.includes('cliente')
+    || value.includes('team')
+    || value.includes('equipo')
+    || value.includes('internal')
+    || value.includes('interno')
+  )
+}
+
+export const getInternalAccessDeniedMessage = () =>
+  'Tu cuenta esta registrada como cliente de este negocio. Para entrar a tus pedidos usa el portal de clientes; para acceder al panel interno pide una invitacion del equipo.'
+
+export const getSafeInternalRedirect = (redirect: unknown) => {
+  const target = Array.isArray(redirect) ? redirect[0] : redirect
+  if (typeof target !== 'string') return INTERNAL_APP_HOME
+  if (!target.startsWith('/') || target.startsWith('//')) return INTERNAL_APP_HOME
+  if (target.startsWith('/auth/customer-verify')) return INTERNAL_APP_HOME
+  return target
+}


### PR DESCRIPTION
## Summary
- add a shared internal-access helper for customer-only/no-team-access session and error payloads
- prevent customer-only internal sessions from reaching the dashboard shell and clear stale auth/access/tenant state
- align login, magic-link, code verification, invitation errors, and tenant selection fallback with separate customer portal vs internal team access

## Validation
- `npx nuxi prepare`
- `git diff --cached --check`
- focused grep confirmed the only remaining raw `/ventas` redirect is successful team invitation

## Manual smoke to run after deploy
- customer-only magic link/code shows customer portal guidance instead of internal dashboard
- customer-only direct `/ventas` does not render dashboard shell
- customer+team user reaches allowed internal routes according to team role
- customer portal OTP `/mis-pedidos` remains unaffected

Refs uno0uno/api-warolabs#432