### PR TITLE
Guard dashboard access when no team tenants exist

### DIFF
--- a/middleware/tenants.global.js
+++ b/middleware/tenants.global.js
@@ -1,3 +1,5 @@
+import { CUSTOMER_PORTAL_LOGIN } from '~/utils/internalAccess'
+
 export default defineNuxtRouteMiddleware(async (to, from) => {
   // Skip on server-side rendering
   if (process.server) return
@@ -20,16 +22,28 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   ) return
 
   const authStore = useAuthStore()
+  const accessStore = useAccessStore()
   const tenantsStore = useTenantsStore()
+
+  const clearInternalState = () => {
+    authStore.expireSession()
+    accessStore.clear()
+    tenantsStore.clearTenants()
+  }
 
   // Only fetch tenants if user is authenticated and tenants are not loaded
   if (authStore.session?.success && !tenantsStore.hasTenants && !tenantsStore.isLoading) {
     try {
       await tenantsStore.fetchUserTenants()
+
+      if (tenantsStore.noInternalAccess || (!tenantsStore.hasTenants && !tenantsStore.isLoading)) {
+        clearInternalState()
+        return navigateTo(CUSTOMER_PORTAL_LOGIN)
+      }
       
       // Set selected tenant from URL parameter if available
       const tenantParam = to.query.tenant
-      if (tenantParam && !tenantsStore.selectTenantBySlug(tenantParam)) {
+      if (tenantParam && !(await tenantsStore.selectTenantBySlug(tenantParam))) {
         // If tenant param in URL is invalid, redirect to first available tenant
         if (tenantsStore.hasTenants) {
           await navigateTo({

--- a/stores/tenants.ts
+++ b/stores/tenants.ts
@@ -6,6 +6,7 @@
  */
 import { defineStore } from 'pinia'
 import { usePOSStore } from '~/stores/usePOSStore'
+import { canUseInternalSession, isInternalAccessDeniedError } from '~/utils/internalAccess'
 
 export interface BusinessHours {
   open?: string    // "HH:MM" — may be absent when closed: true
@@ -53,18 +54,30 @@ export const useTenantsStore = defineStore('tenants', () => {
   // ── UI state ──────────────────────────────────────────────────────────────────
   const selectedTenant = ref<Tenant | null>(null)
   const error = ref<string | null>(null)
+  const noInternalAccess = ref(false)
 
   // ── User tenants query ────────────────────────────────────────────────────────
   // Client-only: SSR has no session cookie → /api/tenants/user-tenants 401 (#977).
-  const { data: tenantData, status } = useQuery({
+  const { data: tenantData, status, asyncStatus, refetch } = useQuery({
     key: ['tenants', 'user'],
     enabled: () => import.meta.client,
     query: async () => {
-      const [tenantsRes, sessionRes] = await Promise.all([
-        $fetch<{ success: boolean; data: Tenant[] }>('/api/tenants/user-tenants'),
-        $fetch<{ success: boolean; currentTenant?: { id: string } }>('/api/auth/session'),
-      ])
-      return { tenants: tenantsRes.data ?? [], session: sessionRes }
+      try {
+        const [tenantsRes, sessionRes] = await Promise.all([
+          $fetch<{ success: boolean; data: Tenant[] }>('/api/tenants/user-tenants'),
+          $fetch<{ success: boolean; currentTenant?: { id: string } }>('/api/auth/session'),
+        ])
+        const tenants = tenantsRes.data ?? []
+        noInternalAccess.value = !!sessionRes?.success && (!canUseInternalSession(sessionRes) || tenants.length === 0)
+        return { tenants, session: sessionRes }
+      } catch (err) {
+        if (isInternalAccessDeniedError(err)) {
+          noInternalAccess.value = true
+          return { tenants: [], session: null }
+        }
+        noInternalAccess.value = false
+        throw err
+      }
     },
   })
 
@@ -87,8 +100,8 @@ export const useTenantsStore = defineStore('tenants', () => {
   const tenants = computed<Tenant[]>(() => tenantData.value?.tenants ?? [])
 
   // ── Business profile query (reactive on selectedTenant) ───────────────────────
-  const { data: businessProfile, status: profileStatus } = useQuery({
-    key: () => ['tenant', 'business-profile', selectedTenant.value?.slug],
+  const { data: businessProfile, status: profileStatus, asyncStatus: profileAsyncStatus } = useQuery({
+    key: () => ['tenant', 'business-profile', selectedTenant.value?.slug ?? null],
     query: () => $fetch<{ success: boolean; data: TenantBusinessProfile }>(
       '/api/api/tenant/public-profile'
     ).then(r => r?.data ?? null),
@@ -135,18 +148,24 @@ export const useTenantsStore = defineStore('tenants', () => {
   // ── Derived state ─────────────────────────────────────────────────────────────
   const hasTenants = computed(() => tenants.value.length > 0)
   const selectedTenantSlug = computed(() => selectedTenant.value?.slug ?? null)
-  const isLoading = computed(() => status.value === 'loading' || switchMutation.isLoading.value)
-  const isBusinessProfileLoading = computed(() => profileStatus.value === 'loading')
+  const isLoading = computed(() =>
+    status.value === 'pending'
+    || asyncStatus.value === 'loading'
+    || switchMutation.isLoading.value
+  )
+  const isBusinessProfileLoading = computed(() =>
+    profileStatus.value === 'pending'
+    || profileAsyncStatus.value === 'loading'
+  )
 
   // ── Public action wrappers ────────────────────────────────────────────────────
 
   /** Trigger a fresh fetch of user tenants (awaitable — resolves when data is loaded) */
-  const fetchUserTenants = () =>
-    cache.invalidateQueries({ key: ['tenants', 'user'] })
+  const fetchUserTenants = () => refetch()
 
   /** Force-refresh the business profile (e.g. after PATCH to public-profile) */
   const fetchBusinessProfile = () =>
-    cache.invalidateQueries({ key: ['tenant', 'business-profile', selectedTenant.value?.slug] })
+    cache.invalidateQueries({ key: ['tenant', 'business-profile', selectedTenant.value?.slug ?? null] })
 
   const selectTenant = async (tenant: Tenant): Promise<boolean> => {
     if (selectedTenant.value?.slug === tenant.slug) return true
@@ -168,6 +187,7 @@ export const useTenantsStore = defineStore('tenants', () => {
   const clearTenants = () => {
     selectedTenant.value = null
     error.value = null
+    noInternalAccess.value = false
     cache.invalidateQueries({ key: ['tenants'] })
     cache.invalidateQueries({ key: ['tenant'] })
   }
@@ -178,6 +198,7 @@ export const useTenantsStore = defineStore('tenants', () => {
     selectedTenant,
     isLoading,
     error,
+    noInternalAccess,
     businessProfile,
     isBusinessProfileLoading,
 


### PR DESCRIPTION
## Summary

- treat an authenticated session with zero internal tenants as a no-internal-access state
- redirect customer-only/no-team users out of the dashboard shell to the customer portal entry point
- clear auth, access, and tenant state before redirecting so stale dashboard state cannot flash
- make the tenant refresh path await the actual Pinia Colada refetch and fix the async tenant query-param selection branch

## Validation

```bash
NODE_OPTIONS=--max-old-space-size=4096 npx nuxi typecheck
```

Result: fails on existing broad frontend type debt. Re-ran filtered validation for touched files:

```bash
NODE_OPTIONS=--max-old-space-size=4096 npx nuxi typecheck 2>&1 | rg 'stores/tenants|middleware/tenants' || true
```

Result: no errors for `stores/tenants.ts` or `middleware/tenants.global.js`.

## Manual smoke checklist

- customer-only direct `/ventas` -> redirected to `/auth/customer-verify?redirect=/mis-pedidos`, no dashboard shell
- customer-only magic link/code denial -> customer portal message/link remains available
- customer+team internal session -> tenants load and allowed internal routes continue normally
- customer portal OTP `/mis-pedidos` -> unaffected because customer-portal layout is skipped by internal middleware

Closes uno0uno/api-warolabs#432
