### PR TITLE
Use backend internal access flag in frontend guards

### DIFF
--- a/utils/internalAccess.test.ts
+++ b/utils/internalAccess.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  canUseInternalSession,
+  hasExplicitInternalAccessAllow,
+  hasExplicitInternalAccessDenial,
+} from './internalAccess.ts'
+
+const sessionWithRole = (role: string, overrides: Record<string, unknown> = {}) => ({
+  user: { role },
+  ...overrides,
+})
+
+describe('canUseInternalSession', () => {
+  it('allows backend-approved future internal roles before local role fallback', () => {
+    assert.equal(
+      canUseInternalSession(sessionWithRole('future_backend_role', { has_internal_access: true })),
+      true,
+    )
+  })
+
+  it('denies explicit backend denial even for an internal-looking role', () => {
+    assert.equal(
+      canUseInternalSession(sessionWithRole('admin', { has_internal_access: false })),
+      false,
+    )
+  })
+
+  it('denies customer role sessions', () => {
+    assert.equal(canUseInternalSession(sessionWithRole('customer')), false)
+  })
+
+  it('allows known legacy team roles when explicit access is absent', () => {
+    assert.equal(canUseInternalSession(sessionWithRole('promotor')), true)
+  })
+
+  it('denies unknown legacy roles when explicit access is absent', () => {
+    assert.equal(canUseInternalSession(sessionWithRole('future_backend_role')), false)
+  })
+
+  it('keeps old no-role session fallback for older API responses', () => {
+    assert.equal(canUseInternalSession({ user: { email: 'team@example.com' } }), true)
+  })
+})
+
+describe('explicit internal access helpers', () => {
+  it('recognizes nested user allow aliases', () => {
+    assert.equal(
+      hasExplicitInternalAccessAllow({ user: { role: 'future_backend_role', has_internal_access: true } }),
+      true,
+    )
+  })
+
+  it('recognizes nested user denial aliases', () => {
+    assert.equal(
+      hasExplicitInternalAccessDenial({ user: { role: 'admin', has_internal_access: false } }),
+      true,
+    )
+  })
+})

--- a/utils/internalAccess.ts
+++ b/utils/internalAccess.ts
@@ -1,3 +1,4 @@
+// Legacy fallback for API responses that predate has_internal_access.
 const TEAM_ROLES = new Set([
   'owner',
   'superuser',
@@ -64,6 +65,14 @@ export const hasExplicitInternalAccessDenial = (session: any) =>
   || session?.customer_only === true
   || session?.is_customer_only === true
 
+export const hasExplicitInternalAccessAllow = (session: any) =>
+  session?.internal_access === true
+  || session?.can_access_internal === true
+  || session?.has_internal_access === true
+  || session?.user?.internal_access === true
+  || session?.user?.can_access_internal === true
+  || session?.user?.has_internal_access === true
+
 export const isCustomerOnlySession = (session: any) => {
   if (!session?.user) return false
   if (hasExplicitInternalAccessDenial(session)) return true
@@ -73,6 +82,7 @@ export const isCustomerOnlySession = (session: any) => {
 export const canUseInternalSession = (session: any) => {
   if (!session?.user) return false
   if (isCustomerOnlySession(session)) return false
+  if (hasExplicitInternalAccessAllow(session)) return true
 
   const role = getInternalSessionRole(session)
   if (role) return TEAM_ROLES.has(role)


### PR DESCRIPTION
## Summary

- Prefer explicit backend internal access allow flags before local role fallback in `canUseInternalSession()`.
- Keep the local team role allowlist only as compatibility fallback for older session responses.
- Add focused utility tests for explicit allow/deny, customer-only, legacy role fallback, and no-role legacy responses.

## Validation

- `node --test utils/internalAccess.test.ts`

## Manual validation routes

- Promotor magic-link login should verify through `/auth/verify` and land in the internal app, e.g. `/ventas`, instead of `/auth/customer-verify`.
- Customer-only login should still redirect to `/auth/customer-verify?redirect=/mis-pedidos`.

Closes uno0uno/api-warolabs#444
