### PR TITLE
Notify paid tenants about pending TyC acceptance

### DIFF
--- a/components/DashboardBottomNav.vue
+++ b/components/DashboardBottomNav.vue
@@ -144,12 +144,17 @@
         <li v-for="notification in notifications" :key="notification.id">
           <NuxtLink
             :to="notificationDespachoPath(notification)"
-            @click="handleMarkAsRead(notification.id); showNotificationsModal = false"
+            @click="handleNotificationClick(notification)"
             class="flex items-start gap-3 px-4 py-3 hover:bg-icon-button-neutral-hover-bg transition-colors"
             :class="!notification.read_at ? 'bg-icon-button-primary-bg/40' : ''"
           >
             <div class="flex-shrink-0 w-8 h-8 rounded-full bg-icon-button-primary-bg flex items-center justify-center mt-0.5">
-              <ShoppingBagIcon class="w-4 h-4 text-icon-button-primary-text" aria-hidden="true" />
+              <DocumentTextIcon
+                v-if="notificationIsTermsAcceptanceRequired(notification)"
+                class="w-4 h-4 text-icon-button-primary-text"
+                aria-hidden="true"
+              />
+              <ShoppingBagIcon v-else class="w-4 h-4 text-icon-button-primary-text" aria-hidden="true" />
             </div>
             <div class="flex-1 min-w-0">
               <p class="text-sm font-semibold text-text-primary leading-snug">
@@ -228,15 +233,17 @@ import {
   SpeakerXMarkIcon,
   CheckCircleIcon,
   Cog6ToothIcon,
+  DocumentTextIcon,
   HomeIcon,
   ShoppingBagIcon,
 } from '@heroicons/vue/24/outline'
 import { computed, ref } from 'vue'
 import { useLayoutActions } from '../composables/useLayoutActions'
-import { notificationDespachoPath, notificationDespachoTitle } from '~/composables/useNotificationDespachoLink'
+import { notificationDespachoPath, notificationDespachoTitle, notificationIsTermsAcceptanceRequired } from '~/composables/useNotificationDespachoLink'
 import { useDespachoNotificationAudio } from '~/composables/useDespachoNotificationAudio'
 import { dashboardMobileGridItems, type ActivePage } from '~/constants/dashboardNavigation'
 import type { Tenant } from '~/stores/tenants'
+import type { Notification } from '~/composables/useNotifications'
 
 interface Props {
   activePage?: ActivePage
@@ -274,6 +281,13 @@ const {
 
 const handleMarkAsRead = async (id: string) => {
   await markAsRead(id)
+}
+
+const handleNotificationClick = async (notification: Notification) => {
+  if (!notificationIsTermsAcceptanceRequired(notification)) {
+    await handleMarkAsRead(notification.id)
+  }
+  showNotificationsModal.value = false
 }
 
 const openNotificationsModal = () => {

--- a/components/notifications/MobileOrderToast.vue
+++ b/components/notifications/MobileOrderToast.vue
@@ -129,6 +129,7 @@ import {
   notificationDespachoPath,
   notificationDespachoTitle,
   notificationIsComandaReady,
+  notificationIsTermsAcceptanceRequired,
 } from '~/composables/useNotificationDespachoLink'
 import { useDespachoNotificationAudio } from '~/composables/useDespachoNotificationAudio'
 import { useComandaReadyAudio } from '~/composables/useComandaReadyAudio'
@@ -181,7 +182,10 @@ onMounted(() => {
     (newLen, oldLen) => {
       if (isTenantResetting.value) return // skip post-reset repopulation — not genuine new arrivals
       if (newLen > oldLen) {
-        const newNotifications = notifications.value.slice(0, newLen - oldLen)
+        const newNotifications = notifications.value
+          .slice(0, newLen - oldLen)
+          .filter(n => !notificationIsTermsAcceptanceRequired(n))
+        if (newNotifications.length === 0) return
         const hasComandaReady = newNotifications.some(notificationIsComandaReady)
         const hasDespacho = newNotifications.some(n => !notificationIsComandaReady(n))
         if (hasComandaReady) playComandaReadyChime()

--- a/components/notifications/NotificationBell.vue
+++ b/components/notifications/NotificationBell.vue
@@ -83,17 +83,22 @@
           >
             <NuxtLink
               :to="notificationDespachoPath(notification)"
-              @click="handleMarkAsRead(notification.id); close()"
+              @click="handleNotificationClick(notification)"
               class="flex gap-3 px-4 py-3 hover:bg-shell-notification-hover-bg transition-colors"
             >
               <!-- Icon -->
               <div
                 class="flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center mt-0.5"
-                :class="notificationIsComandaReady(notification) ? 'bg-success/15' : 'bg-shell-notification-accent-bg'"
+                :class="notificationIconClass(notification)"
               >
                 <BellAlertIcon
                   v-if="notificationIsComandaReady(notification)"
                   class="w-4 h-4 text-success"
+                  aria-hidden="true"
+                />
+                <DocumentTextIcon
+                  v-else-if="notificationIsTermsAcceptanceRequired(notification)"
+                  class="w-4 h-4 text-shell-notification-accent"
                   aria-hidden="true"
                 />
                 <ShoppingBagIcon v-else class="w-4 h-4 text-shell-notification-accent" aria-hidden="true" />
@@ -125,12 +130,13 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
-import { BellIcon, BellAlertIcon, ShoppingBagIcon, SpeakerWaveIcon, SpeakerXMarkIcon } from '@heroicons/vue/24/outline'
-import { useNotifications } from '~/composables/useNotifications'
+import { BellIcon, BellAlertIcon, DocumentTextIcon, ShoppingBagIcon, SpeakerWaveIcon, SpeakerXMarkIcon } from '@heroicons/vue/24/outline'
+import { useNotifications, type Notification } from '~/composables/useNotifications'
 import {
   notificationDespachoPath,
   notificationDespachoTitle,
   notificationIsComandaReady,
+  notificationIsTermsAcceptanceRequired,
 } from '~/composables/useNotificationDespachoLink'
 import { useDespachoNotificationAudio } from '~/composables/useDespachoNotificationAudio'
 
@@ -172,8 +178,20 @@ const handleMarkAsRead = async (id: string) => {
   await markAsRead(id)
 }
 
+const handleNotificationClick = async (notification: Notification) => {
+  if (!notificationIsTermsAcceptanceRequired(notification)) {
+    await handleMarkAsRead(notification.id)
+  }
+  close()
+}
+
 const handleMarkAllRead = async () => {
   await markAllRead()
+}
+
+const notificationIconClass = (notification: Notification) => {
+  if (notificationIsComandaReady(notification)) return 'bg-success/15'
+  return 'bg-shell-notification-accent-bg'
 }
 
 // Inline relative time utility (no date-fns dependency needed)

--- a/composables/useLegalTerms.ts
+++ b/composables/useLegalTerms.ts
@@ -109,6 +109,7 @@ export const useLegalTerms = () => {
     onSettled: () => {
       cache.invalidateQueries({ key: ['legal-terms'] })
       cache.invalidateQueries({ key: ['billing', 'access-status'] })
+      cache.invalidateQueries({ key: ['notifications'] })
     },
   })
 

--- a/composables/useNotificationDespachoLink.ts
+++ b/composables/useNotificationDespachoLink.ts
@@ -1,5 +1,7 @@
 import type { Notification } from '~/composables/useNotifications'
 
+export const TERMS_ACCEPTANCE_REQUIRED_TYPE = 'terms_acceptance_required'
+
 function formatComandaLabel(notification: Notification): string {
   const num = notification.payload?.comanda_number ?? '—'
   const idx = notification.payload?.comanda_index
@@ -8,6 +10,13 @@ function formatComandaLabel(notification: Notification): string {
 }
 
 export function notificationDespachoPath(notification: Notification): string {
+  if (notificationIsTermsAcceptanceRequired(notification)) {
+    const returnToPayload = notification.payload?.return_to
+    const returnTo = typeof returnToPayload === 'string' && returnToPayload
+      ? returnToPayload
+      : '/gestion/billing'
+    return `/terminos-y-condiciones?return=${encodeURIComponent(returnTo)}`
+  }
   if (notification.type === 'comanda_ready') {
     const tableId = notification.payload?.table_id
     if (typeof tableId === 'string' && tableId) {
@@ -28,6 +37,12 @@ export function notificationDespachoPath(notification: Notification): string {
 }
 
 export function notificationDespachoTitle(notification: Notification): string {
+  if (notificationIsTermsAcceptanceRequired(notification)) {
+    const versionPayload = notification.payload?.version
+    return typeof versionPayload === 'string' && versionPayload
+      ? `Acepta los TyC vigentes (${versionPayload})`
+      : 'Acepta los TyC vigentes'
+  }
   if (notification.type === 'comanda_ready') {
     const label = formatComandaLabel(notification)
     const dest = notification.payload?.table_display_name
@@ -42,4 +57,8 @@ export function notificationDespachoTitle(notification: Notification): string {
 
 export function notificationIsComandaReady(notification: Notification): boolean {
   return notification.type === 'comanda_ready'
+}
+
+export function notificationIsTermsAcceptanceRequired(notification: Notification): boolean {
+  return notification.type === TERMS_ACCEPTANCE_REQUIRED_TYPE
 }


### PR DESCRIPTION
## Summary
- add explicit routing/title handling for terms-acceptance notification items
- keep the TyC reminder unread when users only open the legal page, and refresh notifications after acceptance
- keep legal reminders out of order toast/chime behavior on desktop and mobile

## Companion
- API PR: https://github.com/uno0uno/api-warolabs/pull/451

## Tests
- npm exec nuxi prepare
- git diff --check
- npm run build was attempted but the local Vite transform phase did not finish after 8+ minutes with no new output; see notes in Codex summary

Closes #1330