### PR TITLE
Align legal terms API contract

### DIFF
--- a/composables/useLegalTerms.ts
+++ b/composables/useLegalTerms.ts
@@ -26,6 +26,46 @@ export interface LegalTermsDocument {
   annexes?: LegalTermsAnnex[]
 }
 
+interface ApiEnvelope<T> {
+  success?: boolean
+  data?: T
+}
+
+interface ApiLegalTermsAnnex {
+  id?: string
+  code?: string
+  title: string
+  version?: string | null
+  content_url?: string | null
+  metadata?: Record<string, any> | null
+}
+
+interface ApiLegalTermsDocument {
+  version_id?: string
+  version: string
+  document_title?: string
+  title?: string
+  effective_at?: string | null
+  effective_date?: string | null
+  published_at?: string | null
+  content_url?: string | null
+  source_url?: string | null
+  metadata?: Record<string, any> | null
+  annexes?: ApiLegalTermsAnnex[]
+}
+
+interface ApiLegalTermsAcceptance {
+  id?: string
+  accepted_at?: string | null
+  version?: string | null
+}
+
+interface ApiLegalTermsStatus {
+  requires_acceptance?: boolean
+  current?: ApiLegalTermsDocument | null
+  acceptance?: ApiLegalTermsAcceptance | null
+}
+
 export interface LegalTermsStatus {
   authenticated: boolean
   accepted: boolean
@@ -46,6 +86,67 @@ const isAuthError = (err: any) =>
   err?.statusCode === 401 ||
   err?.status === 403 ||
   err?.statusCode === 403
+
+const unwrapApiData = <T>(response: ApiEnvelope<T> | T | null | undefined): T | null => {
+  if (!response) return null
+  if (typeof response === 'object' && 'data' in response) {
+    return (response as ApiEnvelope<T>).data ?? null
+  }
+  return response as T
+}
+
+const mapApiDocument = (apiDocument: ApiLegalTermsDocument | LegalTermsDocument | null): LegalTermsDocument | null => {
+  if (!apiDocument) return null
+  const documentPayload = apiDocument as ApiLegalTermsDocument & LegalTermsDocument
+  const metadata = documentPayload.metadata ?? {}
+  return {
+    id: documentPayload.version_id ?? documentPayload.id,
+    version: documentPayload.version,
+    status: (metadata.status as string | undefined) ?? 'published',
+    title: documentPayload.document_title || documentPayload.title || 'Terminos y Condiciones WARO',
+    effective_date: documentPayload.effective_at ?? documentPayload.effective_date ?? null,
+    published_at: documentPayload.published_at ?? null,
+    privacy_policy_url: (metadata.privacy_policy_url as string | undefined) ?? null,
+    source_url: documentPayload.content_url ?? documentPayload.source_url ?? null,
+    body_html: (metadata.body_html as string | undefined) ?? null,
+    sections: Array.isArray(metadata.sections) ? metadata.sections as LegalTermsSection[] : [],
+    annexes: (documentPayload.annexes ?? []).map((annex: ApiLegalTermsAnnex & LegalTermsAnnex) => ({
+      id: annex.id ?? annex.code,
+      title: annex.title,
+      version: annex.version,
+      description: annex.metadata?.description ?? null,
+      applies: true,
+    })),
+  }
+}
+
+const mapApiStatus = (apiStatus: ApiLegalTermsStatus | LegalTermsStatus | null): LegalTermsStatus | null => {
+  if (!apiStatus) return null
+  if ('accepted' in apiStatus) return apiStatus
+  const acceptance = apiStatus.acceptance ?? null
+  const current = apiStatus.current ?? null
+  const accepted = !apiStatus.requires_acceptance && !!acceptance
+  return {
+    authenticated: true,
+    accepted,
+    pending: apiStatus.requires_acceptance === true,
+    accepted_version: acceptance?.version ?? (accepted ? current?.version ?? null : null),
+    accepted_at: acceptance?.accepted_at ?? null,
+    current_version: current?.version ?? null,
+    evidence_id: acceptance?.id ?? null,
+  }
+}
+
+const mapAcceptResponseToStatus = (response: ApiEnvelope<{ current?: ApiLegalTermsDocument | null; acceptance?: ApiLegalTermsAcceptance | null }> | LegalTermsStatus | null): LegalTermsStatus | null => {
+  if (!response) return null
+  if ('accepted' in response) return response
+  const data = unwrapApiData(response)
+  return mapApiStatus({
+    requires_acceptance: !data?.acceptance,
+    current: data?.current ?? null,
+    acceptance: data?.acceptance ?? null,
+  })
+}
 
 export const useLegalTerms = () => {
   const cache = useQueryCache()
@@ -71,7 +172,8 @@ export const useLegalTerms = () => {
     enabled: () => import.meta.client,
     query: async () => {
       try {
-        return await $fetch<LegalTermsDocument>('/api/legal/terms/current', { credentials: 'include', timeout: 4000 })
+        const response = await $fetch<ApiEnvelope<ApiLegalTermsDocument | null> | ApiLegalTermsDocument | null>('/api/legal/terms/current', { credentials: 'include', timeout: 4000 })
+        return mapApiDocument(unwrapApiData(response))
       } catch (err: any) {
         if (isAuthError(err) || err?.status === 404 || err?.statusCode === 404) return null
         return null
@@ -84,7 +186,8 @@ export const useLegalTerms = () => {
     enabled: () => import.meta.client && hasTenantSession.value,
     query: async () => {
       try {
-        return await $fetch<LegalTermsStatus>('/api/legal/terms/status', { credentials: 'include', timeout: 4000 })
+        const response = await $fetch<ApiEnvelope<ApiLegalTermsStatus> | ApiLegalTermsStatus | null>('/api/legal/terms/status', { credentials: 'include', timeout: 4000 })
+        return mapApiStatus(unwrapApiData(response))
       } catch (err: any) {
         if (isAuthError(err) || err?.status === 404 || err?.statusCode === 404) return null
         return null
@@ -94,15 +197,14 @@ export const useLegalTerms = () => {
 
   const acceptMutation = useMutation({
     mutation: (payload?: { document_id?: string; version?: string }) =>
-      $fetch<LegalTermsStatus>('/api/legal/terms/accept', {
+      $fetch<ApiEnvelope<{ current?: ApiLegalTermsDocument | null; acceptance?: ApiLegalTermsAcceptance | null }> | LegalTermsStatus>('/api/legal/terms/accept', {
         method: 'POST',
         credentials: 'include',
         timeout: 10000,
         body: {
-          document_id: payload?.document_id ?? currentDocument.value?.id,
-          version: payload?.version ?? currentDocument.value?.version,
+          source: 'terms_page',
         },
-      }),
+      }).then(mapAcceptResponseToStatus),
     onSuccess: (result) => {
       cache.setQueryData(['legal-terms', 'status', tenantId.value], result)
     },
@@ -129,7 +231,8 @@ export const useLegalTerms = () => {
   }
 
   const refreshTermsStatus = async (): Promise<LegalTermsStatus | null> => {
-    const result = await $fetch<LegalTermsStatus>('/api/legal/terms/status', { credentials: 'include', timeout: 4000 })
+    const response = await $fetch<ApiEnvelope<ApiLegalTermsStatus> | ApiLegalTermsStatus | null>('/api/legal/terms/status', { credentials: 'include', timeout: 4000 })
+    const result = mapApiStatus(unwrapApiData(response))
     cache.setQueryData(['legal-terms', 'status', tenantId.value], result)
     return result
   }


### PR DESCRIPTION
## Summary
- unwrap API legal envelopes in useLegalTerms
- map current/status/accept responses into the frontend legal page and billing gate shape
- keep TyC accept calls compatible with the backend source-only payload

## Tests
- npm run build: client build passed; server bundle was interrupted after transform/render stall
- NODE_OPTIONS=--max-old-space-size=4096 npx nuxi typecheck: fails on existing unrelated type backlog; no errors surfaced for composables/useLegalTerms.ts

Refs uno0uno/api-warolabs#449