### PR TITLE
Render legal terms PDF source

### DIFF
--- a/composables/useLegalTerms.ts
+++ b/composables/useLegalTerms.ts
@@ -21,6 +21,7 @@ export interface LegalTermsDocument {
   published_at?: string | null
   privacy_policy_url?: string | null
   source_url?: string | null
+  display_mode?: string | null
   body_html?: string | null
   sections?: LegalTermsSection[]
   annexes?: LegalTermsAnnex[]
@@ -108,6 +109,7 @@ const mapApiDocument = (apiDocument: ApiLegalTermsDocument | LegalTermsDocument 
     published_at: documentPayload.published_at ?? null,
     privacy_policy_url: (metadata.privacy_policy_url as string | undefined) ?? null,
     source_url: documentPayload.content_url ?? documentPayload.source_url ?? null,
+    display_mode: (metadata.display_mode as string | undefined) ?? null,
     body_html: (metadata.body_html as string | undefined) ?? null,
     sections: Array.isArray(metadata.sections) ? metadata.sections as LegalTermsSection[] : [],
     annexes: (documentPayload.annexes ?? []).map((annex: ApiLegalTermsAnnex & LegalTermsAnnex) => ({

--- a/pages/terminos-y-condiciones.vue
+++ b/pages/terminos-y-condiciones.vue
@@ -69,7 +69,7 @@
             <div class="space-y-1">
               <h2 class="text-xl font-semibold text-text-primary">Documento legal</h2>
               <p class="text-sm leading-6 text-text-secondary">
-                El contenido se carga desde el registro legal versionado cuando está disponible.
+                El documento vigente se carga desde el registro legal versionado.
               </p>
             </div>
             <a
@@ -97,7 +97,15 @@
               La versión editable del backend legal todavía no está disponible. Esta página muestra una base renderizable del borrador local `TyC_WARO_v1.0_BORRADOR.pdf`; la aceptación se registrará contra la versión indicada por el endpoint cuando esté activo.
             </div>
 
-            <div v-if="document.body_html" class="legal-html" v-html="document.body_html" />
+            <div v-if="isPdfDocument" class="overflow-hidden rounded-lg border border-border bg-surface-secondary">
+              <iframe
+                :src="document.source_url || ''"
+                title="Términos y Condiciones WARO Colombia"
+                class="h-[72vh] min-h-[640px] w-full bg-white"
+              />
+            </div>
+
+            <div v-else-if="document.body_html" class="legal-html" v-html="document.body_html" />
 
             <div v-else class="space-y-5">
               <article
@@ -316,6 +324,11 @@ const acceptErrorMessage = ref('')
 const document = computed<LegalTermsDocument>(() => currentDocument.value ?? fallbackDocument)
 const usesFallbackDocument = computed(() => !currentDocument.value)
 const applicableAnnexes = computed(() => (document.value.annexes ?? []).filter(annex => annex.applies !== false))
+const isPdfDocument = computed(() => {
+  if (document.value.display_mode === 'pdf') return true
+  const sourceUrl = document.value.source_url || ''
+  return /\.pdf($|[?#])/i.test(sourceUrl)
+})
 const isAccepted = computed(() => statusData.value?.accepted === true)
 const returnTarget = computed(() => {
   const raw = Array.isArray(route.query.return) ? route.query.return[0] : route.query.return
@@ -324,7 +337,13 @@ const returnTarget = computed(() => {
 })
 
 const loginRedirect = computed(() => {
-  const path = route.fullPath || '/terminos-y-condiciones'
+  const query = new URLSearchParams()
+  Object.entries(route.query).forEach(([key, value]) => {
+    const firstValue = Array.isArray(value) ? value[0] : value
+    if (typeof firstValue === 'string') query.set(key, firstValue)
+  })
+  const queryString = query.toString()
+  const path = `${route.path}${queryString ? `?${queryString}` : ''}` || '/terminos-y-condiciones'
   return `/auth/login?redirect=${encodeURIComponent(path)}`
 })
 


### PR DESCRIPTION
## Summary
- Render legal terms PDF sources inline on /terminos-y-condiciones.
- Use legal metadata display_mode=pdf when present, with URL PDF detection as fallback.
- Keep existing body_html and section rendering as fallback for non-PDF sources.
- Avoid login redirect hydration mismatch caused by URL hash fragments.

## Tests
- git diff --check
- NODE_OPTIONS=--max-old-space-size=4096 npx nuxi typecheck 2>&1 | rg 'pages/terminos-y-condiciones\.vue|composables/useLegalTerms\.ts' (no matching errors)

Refs uno0uno/api-warolabs#453