### PR TITLE
Fix legal terms PDF loading

### DIFF
--- a/composables/useLegalTerms.ts
+++ b/composables/useLegalTerms.ts
@@ -152,13 +152,14 @@ const mapAcceptResponseToStatus = (response: ApiEnvelope<{ current?: ApiLegalTer
 
 export const useLegalTerms = () => {
   const cache = useQueryCache()
+  const authStore = useAuthStore()
 
-  const { data: sessionData, status: sessionStatus } = useQuery({
+  const { data: sessionData } = useQuery({
     key: ['legal-terms', 'session'],
-    enabled: () => import.meta.client,
+    enabled: () => import.meta.client && !(authStore as any).session?.currentTenant?.id,
     query: async () => {
       try {
-        return await $fetch<AuthSessionResponse>('/api/auth/session', { credentials: 'include', timeout: 3000 })
+        return await $fetch<AuthSessionResponse>('/api/auth/session', { credentials: 'include', timeout: 10000 })
       } catch (err: any) {
         if (isAuthError(err)) return { success: false, currentTenant: null }
         return { success: false, currentTenant: null }
@@ -166,15 +167,16 @@ export const useLegalTerms = () => {
     },
   })
 
-  const tenantId = computed(() => sessionData.value?.currentTenant?.id ?? 'public')
-  const hasTenantSession = computed(() => !!sessionData.value?.success && !!sessionData.value?.currentTenant?.id)
+  const activeSession = computed<AuthSessionResponse | null>(() => (authStore as any).session ?? sessionData.value ?? null)
+  const tenantId = computed(() => activeSession.value?.currentTenant?.id ?? 'public')
+  const hasTenantSession = computed(() => !!activeSession.value?.success && !!activeSession.value?.currentTenant?.id)
 
   const { data: currentDocument, status: documentStatus, asyncStatus: documentAsyncStatus } = useQuery({
-    key: ['legal-terms', 'current'],
+    key: ['legal-terms', 'current', 'pdf-v11'],
     enabled: () => import.meta.client,
     query: async () => {
       try {
-        const response = await $fetch<ApiEnvelope<ApiLegalTermsDocument | null> | ApiLegalTermsDocument | null>('/api/legal/terms/current', { credentials: 'include', timeout: 4000 })
+        const response = await $fetch<ApiEnvelope<ApiLegalTermsDocument | null> | ApiLegalTermsDocument | null>(`/api/legal/terms/current?_=${Date.now()}`, { credentials: 'include', timeout: 10000 })
         return mapApiDocument(unwrapApiData(response))
       } catch (err: any) {
         if (isAuthError(err) || err?.status === 404 || err?.statusCode === 404) return null
@@ -183,7 +185,7 @@ export const useLegalTerms = () => {
     },
   })
 
-  const { data: statusData, status: termsStatus, asyncStatus: termsAsyncStatus } = useQuery({
+  const { data: statusData, asyncStatus: termsAsyncStatus } = useQuery({
     key: () => ['legal-terms', 'status', tenantId.value],
     enabled: () => import.meta.client && hasTenantSession.value,
     query: async () => {
@@ -217,11 +219,7 @@ export const useLegalTerms = () => {
     },
   })
 
-  const isInitialLoading = computed(() =>
-    documentStatus.value === 'pending' ||
-    sessionStatus.value === 'pending' ||
-    (hasTenantSession.value && termsStatus.value === 'pending')
-  )
+  const isInitialLoading = computed(() => documentStatus.value === 'pending')
 
   const isRefreshing = computed(() =>
     documentAsyncStatus.value === 'loading' ||

--- a/middleware/billing-gate.global.ts
+++ b/middleware/billing-gate.global.ts
@@ -22,7 +22,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
     // base URL variants (e.g. /waro-colombia/billing/...)
     '/waro-colombia/billing',
   ]
-  const skipExact = ['/', '/bogota']
+  const skipExact = ['/', '/bogota', '/terminos-y-condiciones']
 
   if (
     skipExact.includes(to.path) ||
@@ -36,7 +36,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   const authStore = useAuthStore()
 
   // Same check used by tenants.global.js
-  if (!authStore.session?.success) return
+  if (!(authStore as any).session?.success) return
 
   const { currentTenant } = useTenantReactive()
   const tenantId = currentTenant.value?.id ?? 'none'

--- a/pages/terminos-y-condiciones.vue
+++ b/pages/terminos-y-condiciones.vue
@@ -1,18 +1,7 @@
 <template>
-  <main class="min-h-screen bg-background text-text-primary">
-    <header class="border-b border-border bg-surface">
-      <div class="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-5 sm:px-6 md:flex-row md:items-center md:justify-between lg:px-8">
-        <NuxtLink to="/" class="inline-flex items-center gap-3 text-text-primary">
-          <span class="flex h-10 w-10 items-center justify-center rounded-md bg-primary text-sm font-bold text-primary-foreground">
-            W
-          </span>
-          <span class="min-w-0">
-            <span class="block text-sm font-semibold leading-tight">WARO Colombia</span>
-            <span class="block text-xs text-text-secondary">Términos y Condiciones</span>
-          </span>
-        </NuxtLink>
-
-        <div class="flex flex-wrap items-center gap-2">
+  <div class="mx-auto grid w-full max-w-6xl gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
+      <section class="min-w-0 space-y-6">
+        <div class="space-y-4">
           <NuxtLink
             v-if="returnTarget"
             :to="returnTarget"
@@ -21,20 +10,7 @@
             <ArrowLeftIcon class="h-4 w-4" />
             Volver
           </NuxtLink>
-          <NuxtLink
-            v-if="!hasTenantSession"
-            :to="loginRedirect"
-            class="inline-flex min-h-10 items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-          >
-            Iniciar sesión
-          </NuxtLink>
-        </div>
-      </div>
-    </header>
 
-    <div class="mx-auto grid w-full max-w-6xl gap-6 px-4 py-6 sm:px-6 lg:grid-cols-[minmax(0,1fr)_340px] lg:px-8">
-      <section class="min-w-0 space-y-6">
-        <div class="space-y-4">
           <div class="flex flex-wrap items-center gap-2">
             <UiStatusBadge :value="documentVersionLabel" variant="primary" size="sm" />
             <UiStatusBadge :value="documentStatusLabel" :variant="documentStatusVariant" size="sm" />
@@ -59,8 +35,8 @@
             <p class="mt-2 text-lg font-semibold text-text-primary">{{ effectiveDateLabel }}</p>
           </div>
           <div class="rounded-lg border border-border bg-surface p-4">
-            <p class="text-xs font-medium uppercase text-text-tertiary">Anexos aplicables</p>
-            <p class="mt-2 text-lg font-semibold text-text-primary">{{ applicableAnnexes.length }}</p>
+            <p class="text-xs font-medium uppercase text-text-tertiary">Formato</p>
+            <p class="mt-2 text-lg font-semibold text-text-primary">PDF</p>
           </div>
         </section>
 
@@ -72,92 +48,27 @@
                 El documento vigente se carga desde el registro legal versionado.
               </p>
             </div>
-            <a
-              v-if="document.source_url"
-              :href="document.source_url"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex min-h-10 items-center gap-2 rounded-md border border-border px-3 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-secondary hover:text-text-primary"
-            >
-              <DocumentTextIcon class="h-4 w-4" />
-              Fuente
-              <ArrowTopRightOnSquareIcon class="h-4 w-4" />
-            </a>
           </div>
 
-          <div v-if="isInitialLoading" class="flex min-h-64 items-center justify-center">
+          <div v-if="!currentDocument && isInitialLoading" class="flex min-h-64 items-center justify-center">
             <div class="flex items-center gap-3 text-sm text-text-secondary">
               <UiLoadingDots size="8px" color="currentColor" />
               Cargando términos
             </div>
           </div>
 
-          <div v-else class="mt-6 space-y-6">
-            <div v-if="usesFallbackDocument" class="rounded-lg border border-status-warning-text/30 bg-status-warning-bg p-4 text-sm leading-6 text-status-warning-text">
-              La versión editable del backend legal todavía no está disponible. Esta página muestra una base renderizable del borrador local `TyC_WARO_v1.0_BORRADOR.pdf`; la aceptación se registrará contra la versión indicada por el endpoint cuando esté activo.
-            </div>
-
+          <div v-else class="mt-6">
             <div v-if="isPdfDocument" class="overflow-hidden rounded-lg border border-border bg-surface-secondary">
               <iframe
-                :src="document.source_url || ''"
+                :src="pdfViewerUrl"
                 title="Términos y Condiciones WARO Colombia"
                 class="h-[72vh] min-h-[640px] w-full bg-white"
               />
             </div>
 
-            <div v-else-if="document.body_html" class="legal-html" v-html="document.body_html" />
-
-            <div v-else class="space-y-5">
-              <article
-                v-for="section in document.sections"
-                :id="section.id"
-                :key="section.id || section.title"
-                class="scroll-mt-6 border-b border-border pb-5 last:border-b-0 last:pb-0"
-              >
-                <h3 class="text-lg font-semibold leading-snug text-text-primary">{{ section.title }}</h3>
-                <p class="mt-2 whitespace-pre-line text-sm leading-7 text-text-secondary">{{ section.body }}</p>
-              </article>
+            <div v-else class="rounded-lg border border-status-warning-text/30 bg-status-warning-bg p-4 text-sm leading-6 text-status-warning-text">
+              No se pudo cargar el PDF vigente de términos y condiciones.
             </div>
-          </div>
-        </section>
-
-        <section id="anexos" class="space-y-3">
-          <div>
-            <h2 class="text-xl font-semibold text-text-primary">Anexos y política de datos</h2>
-            <p class="mt-1 text-sm leading-6 text-text-secondary">
-              Estos elementos forman parte de la lectura previa a la aceptación.
-            </p>
-          </div>
-
-          <div class="grid gap-3 md:grid-cols-2">
-            <article
-              v-for="annex in applicableAnnexes"
-              :key="annex.id || annex.title"
-              class="rounded-lg border border-border bg-surface p-4"
-            >
-              <div class="flex items-start justify-between gap-3">
-                <h3 class="text-base font-semibold leading-snug text-text-primary">{{ annex.title }}</h3>
-                <UiStatusBadge v-if="annex.version" :value="annex.version" variant="secondary" size="sm" />
-              </div>
-              <p v-if="annex.description" class="mt-2 text-sm leading-6 text-text-secondary">{{ annex.description }}</p>
-            </article>
-
-            <article id="politica-datos-personales" class="rounded-lg border border-border bg-surface p-4">
-              <div class="flex items-start justify-between gap-3">
-                <h3 class="text-base font-semibold leading-snug text-text-primary">Política de Tratamiento de Datos Personales</h3>
-                <UiStatusBadge value="Referencia" variant="info" size="sm" />
-              </div>
-              <p class="mt-2 text-sm leading-6 text-text-secondary">
-                La aceptación de los términos debe leerse junto con la política de tratamiento de datos personales publicada por WARO.
-              </p>
-              <a
-                :href="privacyPolicyUrl"
-                class="mt-3 inline-flex min-h-10 items-center gap-2 rounded-md border border-border px-3 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-secondary hover:text-text-primary"
-              >
-                Ver política
-                <ArrowTopRightOnSquareIcon v-if="isExternalPrivacyPolicy" class="h-4 w-4" />
-              </a>
-            </article>
           </div>
         </section>
       </section>
@@ -185,14 +96,14 @@
                 class="mt-1 h-4 w-4 flex-shrink-0 rounded border-border text-primary focus:ring-primary"
               />
               <span>
-                He leído la versión {{ document.version }}, sus anexos aplicables y la referencia de tratamiento de datos personales.
+                He leído el PDF vigente de Términos y Condiciones versión {{ document.version }}.
               </span>
             </label>
 
             <button
               type="button"
               class="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
-              :disabled="!hasConfirmedRead || isAccepting"
+              :disabled="!canAcceptTerms || !hasConfirmedRead || isAccepting"
               @click="handleAccept"
             >
               <UiLoadingDots v-if="isAccepting" size="7px" color="currentColor" />
@@ -202,18 +113,6 @@
 
             <p v-if="acceptErrorMessage" class="rounded-lg bg-status-critical-bg p-3 text-sm leading-6 text-status-critical-text">
               {{ acceptErrorMessage }}
-            </p>
-          </div>
-
-          <div v-else class="mt-5 space-y-3">
-            <NuxtLink
-              :to="loginRedirect"
-              class="inline-flex min-h-11 w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-            >
-              Iniciar sesión para aceptar
-            </NuxtLink>
-            <p class="text-xs leading-5 text-text-tertiary">
-              Puedes leer el documento sin iniciar sesión. La aceptación requiere un establecimiento activo.
             </p>
           </div>
 
@@ -227,22 +126,19 @@
           </NuxtLink>
         </section>
       </aside>
-    </div>
-  </main>
+  </div>
 </template>
 
 <script setup lang="ts">
 import {
   ArrowLeftIcon,
-  ArrowTopRightOnSquareIcon,
   CheckCircleIcon,
-  DocumentTextIcon,
   ExclamationTriangleIcon,
 } from '@heroicons/vue/24/outline'
 import { extractApiError } from '~/composables/useQueryError'
 import type { LegalTermsDocument } from '~/composables/useLegalTerms'
 
-definePageMeta({ layout: false, publicAccess: true })
+definePageMeta({ layout: 'dashboard' })
 
 const route = useRoute()
 const toast = useToast()
@@ -256,99 +152,39 @@ const {
   acceptTerms,
 } = useLegalTerms()
 
-const fallbackDocument: LegalTermsDocument = {
-  version: 'v1.0-borrador',
-  status: 'draft',
+const placeholderDocument: LegalTermsDocument = {
+  version: '-',
+  status: 'published',
   title: 'Términos y Condiciones de Uso de la Plataforma WARO',
   effective_date: null,
-  privacy_policy_url: '#politica-datos-personales',
   source_url: null,
-  annexes: [
-    {
-      id: 'facturacion-electronica',
-      title: 'Anexo de Facturación Electrónica',
-      version: 'v1.0',
-      applies: true,
-      description: 'Define el rol de WARO frente a MATÍAS API, DIAN, firma digital y emisión de documentos electrónicos.',
-    },
-    {
-      id: 'servicios-complementarios',
-      title: 'Anexo de Servicios Complementarios',
-      version: 'v1.0',
-      applies: true,
-      description: 'Cubre billetera digital, consumos adicionales, procesamiento con IA y servicios debitables fuera del plan base.',
-    },
-  ],
-  sections: [
-    {
-      id: 'partes',
-      title: 'Identificación de las partes',
-      body: 'El proveedor opera la plataforma tecnológica WARO disponible en warocol.com. El establecimiento es la persona natural o jurídica que adquiere uno o más planes de suscripción y cuyos datos se capturan electrónicamente al registrarse y aceptar estos términos.',
-    },
-    {
-      id: 'aceptacion',
-      title: 'Aceptación digital',
-      body: 'La contratación y uso de WARO está condicionada a la aceptación previa, expresa e informada. La plataforma debe conservar evidencia electrónica de aceptación, incluyendo establecimiento, documento de identificación, correo, fecha y hora, IP de origen y versión aceptada.',
-    },
-    {
-      id: 'servicio',
-      title: 'Objeto y naturaleza del servicio',
-      body: 'WARO concede una licencia no exclusiva, no transferible y limitada a la vigencia del plan contratado para usar la plataforma SaaS de gestión gastronómica: POS, mesas, comandas, domicilios, inventario, recetas, QR, reportes y módulos habilitados por plan.',
-    },
-    {
-      id: 'facturacion',
-      title: 'Facturación electrónica y proveedor tecnológico aliado',
-      body: 'WARO integra funcionalidades de facturación electrónica mediante un proveedor tecnológico aliado. La emisión, transmisión, validación y respuesta ante la DIAN dependen de esa integración y de los sistemas externos involucrados.',
-    },
-    {
-      id: 'planes',
-      title: 'Planes, precios y cobro',
-      body: 'Los planes se contratan en modalidad anual anticipada. El borrador base describe un Plan Básico y un Plan con Facturación Electrónica, además de reglas de renovación, precio, pasarelas de pago y posibles servicios complementarios.',
-    },
-    {
-      id: 'datos',
-      title: 'Datos personales y contenido del establecimiento',
-      body: 'El tratamiento de datos personales y el contenido cargado por el establecimiento deben leerse junto con la política de tratamiento de datos personales de WARO y los anexos aplicables publicados para la versión vigente.',
-    },
-    {
-      id: 'soporte',
-      title: 'Disponibilidad, soporte y responsabilidades',
-      body: 'El documento base define alcance de soporte, continuidad del servicio, propiedad intelectual, responsabilidades, causales de terminación y condiciones generales de uso de la plataforma.',
-    },
-  ],
+  annexes: [],
+  sections: [],
 }
 
 const hasConfirmedRead = ref(false)
 const acceptErrorMessage = ref('')
 
-const document = computed<LegalTermsDocument>(() => currentDocument.value ?? fallbackDocument)
-const usesFallbackDocument = computed(() => !currentDocument.value)
-const applicableAnnexes = computed(() => (document.value.annexes ?? []).filter(annex => annex.applies !== false))
+const document = computed<LegalTermsDocument>(() => currentDocument.value ?? placeholderDocument)
 const isPdfDocument = computed(() => {
   if (document.value.display_mode === 'pdf') return true
   const sourceUrl = document.value.source_url || ''
   return /\.pdf($|[?#])/i.test(sourceUrl)
 })
+const pdfViewerUrl = computed(() => {
+  const sourceUrl = document.value.source_url || ''
+  if (!sourceUrl) return ''
+  const separator = sourceUrl.includes('#') ? '&' : '#'
+  return `${sourceUrl}${separator}navpanes=0&toolbar=1&view=FitH`
+})
 const isAccepted = computed(() => statusData.value?.accepted === true)
+const canAcceptTerms = computed(() => hasTenantSession.value && !!currentDocument.value && isPdfDocument.value)
 const returnTarget = computed(() => {
   const raw = Array.isArray(route.query.return) ? route.query.return[0] : route.query.return
   if (!raw || !raw.startsWith('/') || raw.startsWith('//')) return ''
   return raw
 })
 
-const loginRedirect = computed(() => {
-  const query = new URLSearchParams()
-  Object.entries(route.query).forEach(([key, value]) => {
-    const firstValue = Array.isArray(value) ? value[0] : value
-    if (typeof firstValue === 'string') query.set(key, firstValue)
-  })
-  const queryString = query.toString()
-  const path = `${route.path}${queryString ? `?${queryString}` : ''}` || '/terminos-y-condiciones'
-  return `/auth/login?redirect=${encodeURIComponent(path)}`
-})
-
-const privacyPolicyUrl = computed(() => document.value.privacy_policy_url || '#politica-datos-personales')
-const isExternalPrivacyPolicy = computed(() => /^https?:\/\//.test(privacyPolicyUrl.value))
 const documentVersionLabel = computed(() => `Versión ${document.value.version}`)
 const documentStatusLabel = computed(() => document.value.status === 'draft' ? 'Borrador' : 'Vigente')
 const documentStatusVariant = computed(() => document.value.status === 'draft' ? 'warning' : 'success')
@@ -358,14 +194,12 @@ const acceptedAtLabel = computed(() => statusData.value?.accepted_at ? ` el ${fo
 
 const acceptanceTitle = computed(() => {
   if (isAccepted.value) return 'Aceptación registrada'
-  if (hasTenantSession.value) return 'Aceptación pendiente'
-  return 'Lectura pública'
+  return 'Aceptación pendiente'
 })
 
 const acceptanceDescription = computed(() => {
   if (isAccepted.value) return 'Tu establecimiento ya aceptó la versión vigente registrada para estos términos.'
-  if (hasTenantSession.value) return 'Marca la casilla solo después de revisar la versión vigente, los anexos y la política de datos.'
-  return 'Inicia sesión con un establecimiento activo para registrar la aceptación de la versión vigente.'
+  return 'Marca la casilla solo después de revisar el PDF vigente.'
 })
 
 watch(() => statusData.value?.accepted, (accepted) => {
@@ -402,45 +236,9 @@ useHead({
   meta: [
     {
       name: 'description',
-      content: 'Consulta la versión vigente de los Términos y Condiciones de WARO Colombia, anexos aplicables y aceptación explícita.',
+      content: 'Consulta el PDF vigente de los Términos y Condiciones de WARO Colombia y registra su aceptación explícita.',
     },
     { name: 'robots', content: 'noindex, follow' },
   ],
 })
 </script>
-
-<style scoped>
-.legal-html :deep(h1),
-.legal-html :deep(h2),
-.legal-html :deep(h3) {
-  margin-top: 1.5rem;
-  color: hsl(var(--text-primary));
-  font-weight: 700;
-  line-height: 1.25;
-}
-
-.legal-html :deep(h1) {
-  font-size: 1.875rem;
-}
-
-.legal-html :deep(h2) {
-  font-size: 1.25rem;
-}
-
-.legal-html :deep(h3) {
-  font-size: 1.125rem;
-}
-
-.legal-html :deep(p),
-.legal-html :deep(li) {
-  color: hsl(var(--text-secondary));
-  font-size: 0.875rem;
-  line-height: 1.75;
-}
-
-.legal-html :deep(ul),
-.legal-html :deep(ol) {
-  margin-top: 0.75rem;
-  padding-left: 1.25rem;
-}
-</style>

--- a/pages/terminos-y-condiciones.vue
+++ b/pages/terminos-y-condiciones.vue
@@ -2,15 +2,6 @@
   <div class="mx-auto grid w-full max-w-6xl gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
       <section class="min-w-0 space-y-6">
         <div class="space-y-4">
-          <NuxtLink
-            v-if="returnTarget"
-            :to="returnTarget"
-            class="inline-flex min-h-10 items-center gap-2 rounded-md border border-border px-3 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-secondary hover:text-text-primary"
-          >
-            <ArrowLeftIcon class="h-4 w-4" />
-            Volver
-          </NuxtLink>
-
           <div class="flex flex-wrap items-center gap-2">
             <UiStatusBadge :value="documentVersionLabel" variant="primary" size="sm" />
             <UiStatusBadge :value="documentStatusLabel" :variant="documentStatusVariant" size="sm" />


### PR DESCRIPTION
## Summary
- Keep /terminos-y-condiciones inside the dashboard session flow while skipping billing redirects for the terms page.
- Render only the current legal PDF and avoid blocking the iframe on the acceptance status request.
- Use the dashboard session when available and cache-bust the current legal document query for the PDF version.

## Tests
- git diff --check
- NODE_OPTIONS=--max-old-space-size=4096 npx nuxi typecheck 2>&1 | rg 'pages/terminos-y-condiciones\.vue|composables/useLegalTerms\.ts|middleware/billing-gate\.global\.ts' (no matching errors)

Closes #1338