### PR TITLE
Fix blocked billing recovery flow

### DIFF
--- a/components/DashboardBottomNav.vue
+++ b/components/DashboardBottomNav.vue
@@ -80,12 +80,18 @@
             :key="item.to"
             :to="item.to"
             class="flex flex-col items-center gap-1"
-            @click="showMenuModal = false"
+            :class="isNavItemBlocked(item) ? 'cursor-not-allowed opacity-40' : ''"
+            :aria-disabled="isNavItemBlocked(item)"
+            :tabindex="isNavItemBlocked(item) ? -1 : undefined"
+            @click="(event) => handleGridItemClick(event, item)"
           >
             <div class="relative">
               <div
                 class="w-12 h-12 rounded-full flex items-center justify-center transition-colors"
-                :class="activePage === item.page ? 'bg-icon-button-primary-bg' : 'bg-badge-neutral-bg hover:bg-badge-neutral-hover-bg'"
+                :class="[
+                  activePage === item.page ? 'bg-icon-button-primary-bg' : 'bg-badge-neutral-bg hover:bg-badge-neutral-hover-bg',
+                  isNavItemBlocked(item) ? 'hover:bg-badge-neutral-bg' : '',
+                ]"
               >
                 <component
                   :is="item.icon"
@@ -106,14 +112,14 @@
         <!-- Empty-state fallback — guarantees at least one navigation target. -->
         <div v-else class="grid grid-cols-4 gap-4">
           <NuxtLink
-            to="/"
+            to="/gestion/billing"
             class="flex flex-col items-center gap-1"
             @click="showMenuModal = false"
           >
             <div class="w-12 h-12 rounded-full flex items-center justify-center bg-icon-button-primary-bg">
-              <HomeIcon class="w-6 h-6 text-icon-button-primary-text" />
+              <CreditCardIcon class="w-6 h-6 text-icon-button-primary-text" />
             </div>
-            <span class="text-[10px] text-badge-neutral-text">Inicio</span>
+            <span class="text-[10px] text-badge-neutral-text">Mi Plan</span>
           </NuxtLink>
         </div>
       </div>
@@ -233,30 +239,42 @@ import {
   SpeakerXMarkIcon,
   CheckCircleIcon,
   Cog6ToothIcon,
+  CreditCardIcon,
   DocumentTextIcon,
-  HomeIcon,
   ShoppingBagIcon,
 } from '@heroicons/vue/24/outline'
 import { computed, ref } from 'vue'
 import { useLayoutActions } from '../composables/useLayoutActions'
 import { notificationDespachoPath, notificationDespachoTitle, notificationIsTermsAcceptanceRequired } from '~/composables/useNotificationDespachoLink'
 import { useDespachoNotificationAudio } from '~/composables/useDespachoNotificationAudio'
-import { dashboardMobileGridItems, type ActivePage } from '~/constants/dashboardNavigation'
+import { dashboardMobileGridItems, type ActivePage, type DashboardNavItem } from '~/constants/dashboardNavigation'
 import type { Tenant } from '~/stores/tenants'
 import type { Notification } from '~/composables/useNotifications'
 
 interface Props {
   activePage?: ActivePage
+  billingBlocked?: boolean
   notificationsCount?: number
 }
 
 const props = withDefaults(defineProps<Props>(), {
   activePage: 'financiero',
+  billingBlocked: false,
   notificationsCount: 0,
 })
 
 const { can } = useModuleAccess()
 const visibleGridItems = computed(() => dashboardMobileGridItems.filter((item) => can(item.module).value))
+const isNavItemBlocked = (item: DashboardNavItem) =>
+  props.billingBlocked && item.to !== '/gestion/billing'
+
+const handleGridItemClick = (event: MouseEvent, item: DashboardNavItem) => {
+  if (isNavItemBlocked(item)) {
+    event.preventDefault()
+    return
+  }
+  showMenuModal.value = false
+}
 
 // Data quality dot indicator
 const { hasCriticalAlerts } = useDataQualityStatus()

--- a/components/DashboardSidebar.vue
+++ b/components/DashboardSidebar.vue
@@ -34,8 +34,11 @@
               'nav-item group',
               collapsed ? 'justify-center' : '',
               activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
+              isNavItemBlocked(item) ? 'nav-item--disabled' : '',
             ]"
-            @click="close"
+            :aria-disabled="isNavItemBlocked(item)"
+            :tabindex="isNavItemBlocked(item) ? -1 : undefined"
+            @click="(event) => handleNavItemClick(event, item, close)"
           >
             <component :is="item.icon" class="nav-icon" />
             <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">{{ item.label }}</span>
@@ -56,8 +59,11 @@
               'nav-item',
               collapsed ? 'justify-center' : '',
               activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
+              isNavItemBlocked(item) ? 'nav-item--disabled' : '',
             ]"
-            @click="close"
+            :aria-disabled="isNavItemBlocked(item)"
+            :tabindex="isNavItemBlocked(item) ? -1 : undefined"
+            @click="(event) => handleNavItemClick(event, item, close)"
           >
             <component :is="item.icon" class="nav-icon" />
             <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">
@@ -80,8 +86,10 @@
             href="https://warotickets.com/gestion/eventos"
             target="_blank"
             title="Eventos"
-            :class="['nav-item nav-item--idle', collapsed ? 'justify-center' : '']"
-            @click="close"
+            :class="['nav-item nav-item--idle', collapsed ? 'justify-center' : '', props.billingBlocked ? 'nav-item--disabled' : '']"
+            :aria-disabled="props.billingBlocked"
+            :tabindex="props.billingBlocked ? -1 : undefined"
+            @click="(event) => handleExternalNavClick(event, close)"
           >
             <Squares2X2Icon class="nav-icon" />
             <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">Eventos</span>
@@ -104,8 +112,11 @@
               'nav-item',
               collapsed ? 'justify-center' : '',
               activePage === item.page ? 'nav-item--active' : 'nav-item--idle',
+              isNavItemBlocked(item) ? 'nav-item--disabled' : '',
             ]"
-            @click="close"
+            :aria-disabled="isNavItemBlocked(item)"
+            :tabindex="isNavItemBlocked(item) ? -1 : undefined"
+            @click="(event) => handleNavItemClick(event, item, close)"
           >
             <component :is="item.icon" class="nav-icon" />
             <span class="nav-label-text" :class="collapsed ? 'nav-label-text--hidden' : ''">{{ item.label }}</span>
@@ -148,17 +159,20 @@ import {
   dashboardPrimaryItems,
   dashboardSecondaryItems,
   type ActivePage,
+  type DashboardNavItem,
 } from '~/constants/dashboardNavigation'
 
 interface Props {
   activePage?: ActivePage
   overlay?: boolean
   toggle?: boolean
+  billingBlocked?: boolean
 }
 const props = withDefaults(defineProps<Props>(), {
   activePage: 'financiero',
   overlay: false,
   toggle: false,
+  billingBlocked: false,
 })
 
 defineEmits<{
@@ -193,6 +207,25 @@ const visibleCuentaItems = computed(() =>
 // in api-warolabs#212 (Eventos lives in warotickets.com — external product).
 // Gate by role directly. Owner-only.
 const showEventos = computed(() => accessStore.role === 'owner')
+
+const isNavItemBlocked = (item: DashboardNavItem) =>
+  props.billingBlocked && item.to !== '/gestion/billing'
+
+const handleNavItemClick = (event: MouseEvent, item: DashboardNavItem, close: () => void) => {
+  if (isNavItemBlocked(item)) {
+    event.preventDefault()
+    return
+  }
+  close()
+}
+
+const handleExternalNavClick = (event: MouseEvent, close: () => void) => {
+  if (props.billingBlocked) {
+    event.preventDefault()
+    return
+  }
+  close()
+}
 
 const handleLogout = async () => {
   try {
@@ -269,6 +302,13 @@ const handleLogout = async () => {
 }
 .nav-item--idle:hover {
   background-color: hsl(var(--nav-item-hover-bg) / 0.06);
+}
+.nav-item--disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+.nav-item--disabled:hover {
+  background-color: transparent;
 }
 .nav-item--logout {
   color: hsl(var(--nav-logout-text));

--- a/components/dashboard/DashboardMobileChrome.vue
+++ b/components/dashboard/DashboardMobileChrome.vue
@@ -17,6 +17,7 @@
     />
     <DashboardBottomNav
       :active-page="activePage"
+      :billing-blocked="billingBlocked"
       :notifications-count="notificationsCount"
     />
   </div>
@@ -27,6 +28,7 @@ import type { ActivePage } from '~/constants/dashboardNavigation'
 
 defineProps<{
   activePage: ActivePage
+  billingBlocked: boolean
   notificationsCount: number
   isSidebarExpanded: boolean
   showPosCartBar: boolean

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -3,6 +3,7 @@
     <!-- Dashboard Sidebar - Tablet/Desktop -->
     <DashboardSidebar
       :active-page="activePage"
+      :billing-blocked="isBillingBlocked"
       toggle
       class="hidden md:flex"
       @expanded-change="isSidebarExpanded = $event"
@@ -57,6 +58,7 @@
 
     <DashboardMobileChrome
       :active-page="activePage"
+      :billing-blocked="isBillingBlocked"
       :notifications-count="notificationsUnreadCount"
       :is-sidebar-expanded="isSidebarExpanded"
       :show-pos-cart-bar="showPosMobileCartBar"
@@ -90,6 +92,7 @@ const { unreadCount: notificationsUnreadCount, init: initNotifications, disconne
 
 // Billing access status — drives banner and blocked redirect
 const { accessStatus, fetchAccessStatus } = useBilling()
+const isBillingBlocked = computed(() => accessStatus.value?.level === 'blocked')
 
 // Get route-based configuration
 const route = useRoute()
@@ -190,7 +193,10 @@ const mobileContentBottomPadding = computed(() => {
   return 'pb-20 lg:pb-0'
 })
 
-const navigateToPOS = () => navigateTo('/pos')
+const navigateToPOS = () => {
+  if (isBillingBlocked.value) return
+  return navigateTo('/pos')
+}
 
 // Meta tags for dashboard
 useHead({

--- a/middleware/billing-gate.global.ts
+++ b/middleware/billing-gate.global.ts
@@ -41,12 +41,29 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   const { currentTenant } = useTenantReactive()
   const tenantId = currentTenant.value?.id ?? 'none'
   const cacheKey = ['billing', 'subscription', tenantId]
+  const accessStatusCacheKey = ['billing', 'access-status', tenantId]
 
   const cache = useQueryCache()
 
   // Invalidate subscription cache when returning from a payment flow (/billing/...)
   if (from?.path?.startsWith('/billing')) {
     await cache.invalidateQueries({ key: cacheKey })
+    await cache.invalidateQueries({ key: accessStatusCacheKey })
+  }
+
+  let accessStatus = cache.getQueryData<{ level: string } | null>(accessStatusCacheKey)
+
+  if (accessStatus === undefined) {
+    try {
+      accessStatus = await $fetch<{ level: string } | null>('/api/billing/access-status')
+      cache.setQueryData(accessStatusCacheKey, accessStatus)
+    } catch {
+      accessStatus = null
+    }
+  }
+
+  if (accessStatus?.level === 'blocked') {
+    return navigateTo('/gestion/billing')
   }
 
   // Try to get cached subscription without creating a new useQuery instance

--- a/pages/gestion/billing/index.vue
+++ b/pages/gestion/billing/index.vue
@@ -260,6 +260,12 @@ const handleExistingCheckout = async (checkoutUrl?: string | null) => {
 // ── Should show subscribe/reactivate button ──────────────────────
 const isAccessBlocked = computed(() => accessStatus.value?.level === 'blocked')
 const hasExistingCheckout = computed(() => !!subscription.value?.checkout_url)
+const showBillingRecoveryAlert = computed(() =>
+  subscription.value?.status === 'past_due' || isAccessBlocked.value
+)
+const requiresTermsAcceptance = computed(() =>
+  termsStatus.value?.pending === true || termsStatus.value?.accepted === false
+)
 const canSubscribe = computed(() => {
   const s = subscription.value?.status
   return !subscription.value ||
@@ -272,6 +278,11 @@ const primaryBillingActionLabel = computed(() => {
   if (!subscription.value) return 'Suscribirse'
   if (isAccessBlocked.value) return 'Reactivar'
   return 'Reactivar'
+})
+const recoveryActionLabel = computed(() => {
+  if (requiresTermsAcceptance.value) return 'Aceptar términos y condiciones'
+  if (hasExistingCheckout.value) return 'Pagar ahora'
+  return subscription.value ? 'Reactivar' : 'Suscribirse'
 })
 const displayedSubscriptionStatus = computed(() =>
   subscription.value
@@ -286,6 +297,19 @@ const pastDueDescription = computed(() =>
     ? 'Renueva tu plan para recuperar el acceso a las funciones protegidas.'
     : 'Tu acceso está en período de gracia'
 )
+
+const handleRecoveryAction = async () => {
+  billingActionError.value = null
+  if (requiresTermsAcceptance.value) {
+    await redirectToTermsAcceptance()
+    return
+  }
+  if (subscription.value?.checkout_url) {
+    await handleExistingCheckout(subscription.value.checkout_url)
+    return
+  }
+  await openModal()
+}
 
 // ── Table columns ────────────────────────────────────────────────
 
@@ -455,7 +479,7 @@ watch(() => currentTenant.value?.id, async () => {
 
             <!-- Subscribe / Reactivate button -->
             <button
-              v-if="canSubscribe"
+              v-if="canSubscribe && !showBillingRecoveryAlert"
               @click="openModal"
               class="min-h-[36px] px-4 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 active:scale-95 transition-all"
             >
@@ -464,7 +488,7 @@ watch(() => currentTenant.value?.id, async () => {
 
             <!-- Pending: complete payment -->
             <button
-              v-else-if="subscription?.status === 'pending' && subscription.checkout_url"
+              v-else-if="!showBillingRecoveryAlert && subscription?.status === 'pending' && subscription.checkout_url"
               type="button"
               :disabled="checkoutRedirecting"
               @click="handleExistingCheckout(subscription.checkout_url)"
@@ -527,7 +551,7 @@ watch(() => currentTenant.value?.id, async () => {
         </div>
 
         <!-- Alert: past_due -->
-        <div v-if="subscription?.status === 'past_due' || isAccessBlocked" class="px-6 py-4 border-t border-border bg-status-warning-bg/40">
+        <div v-if="showBillingRecoveryAlert" class="px-6 py-4 border-t border-border bg-status-warning-bg/40">
           <div class="flex items-center justify-between gap-4">
             <div class="flex items-start gap-2">
               <svg class="w-4 h-4 mt-0.5 shrink-0 text-status-warning-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -539,21 +563,13 @@ watch(() => currentTenant.value?.id, async () => {
               </div>
             </div>
             <button
-              v-if="hasExistingCheckout"
+              v-if="hasExistingCheckout || canSubscribe || requiresTermsAcceptance"
               type="button"
               :disabled="checkoutRedirecting"
-              @click="handleExistingCheckout(subscription.checkout_url)"
+              @click="handleRecoveryAction"
               class="shrink-0 min-h-[44px] px-5 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 active:scale-95 transition-all flex items-center"
             >
-              {{ checkoutRedirecting ? 'Validando...' : 'Pagar ahora' }}
-            </button>
-            <button
-              v-else-if="canSubscribe"
-              type="button"
-              @click="openModal"
-              class="shrink-0 min-h-[44px] px-5 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 active:scale-95 transition-all flex items-center"
-            >
-              Reactivar
+              {{ checkoutRedirecting ? 'Validando...' : recoveryActionLabel }}
             </button>
           </div>
         </div>

--- a/pages/gestion/billing/index.vue
+++ b/pages/gestion/billing/index.vue
@@ -729,7 +729,7 @@ watch(() => currentTenant.value?.id, async () => {
               v-else-if="activePlans.length > 0"
               :class="[
                 'grid gap-4',
-                activePlans.length > 1 ? 'md:grid-cols-2' : 'grid-cols-1 justify-items-center',
+                activePlans.length > 1 ? 'lg:grid-cols-2' : 'grid-cols-1 justify-items-center',
               ]"
             >
               <div

--- a/pages/gestion/billing/index.vue
+++ b/pages/gestion/billing/index.vue
@@ -705,12 +705,6 @@ watch(() => currentTenant.value?.id, async () => {
           </button>
         </div>
 
-        <!-- Step indicator -->
-        <div class="flex px-6 pt-5 gap-2">
-          <div :class="['h-1 flex-1 rounded-full transition-colors', wizardStep >= 1 ? 'bg-primary' : 'bg-border']" />
-          <div :class="['h-1 flex-1 rounded-full transition-colors', wizardStep >= 2 ? 'bg-primary' : 'bg-border']" />
-        </div>
-
         <div class="px-6 py-6 space-y-6">
 
           <!-- ── STEP 1: Plan selection ── -->

--- a/pages/gestion/billing/index.vue
+++ b/pages/gestion/billing/index.vue
@@ -669,7 +669,7 @@ watch(() => currentTenant.value?.id, async () => {
       <div class="absolute inset-0 bg-overlay-backdrop/50 backdrop-blur-sm" @click="showModal = false" />
 
       <!-- Modal -->
-      <div :class="['relative bg-surface rounded-2xl shadow-xl border border-border w-full max-h-[90vh] overflow-y-auto transition-all', wizardStep === 1 && activePlans.length > 1 ? 'max-w-2xl' : 'max-w-md']">
+      <div :class="['relative bg-surface rounded-2xl shadow-xl border border-border w-full max-h-[90vh] overflow-y-auto transition-all', wizardStep === 1 && activePlans.length > 1 ? 'max-w-4xl' : 'max-w-md']">
 
         <!-- Header -->
         <div class="flex items-center justify-between px-6 py-5 border-b border-border sticky top-0 bg-surface z-10">
@@ -725,11 +725,17 @@ watch(() => currentTenant.value?.id, async () => {
             </div>
 
             <!-- Plans grid -->
-            <div v-else-if="activePlans.length > 0" class="flex flex-wrap justify-center gap-4">
+            <div
+              v-else-if="activePlans.length > 0"
+              :class="[
+                'grid gap-4',
+                activePlans.length > 1 ? 'md:grid-cols-2' : 'grid-cols-1 justify-items-center',
+              ]"
+            >
               <div
                 v-for="plan in activePlans"
                 :key="plan.id"
-                class="bg-surface-secondary border border-border rounded-xl p-5 flex flex-col gap-4 w-full max-w-sm"
+                class="bg-surface-secondary border border-border rounded-xl p-5 flex flex-col gap-4 w-full"
               >
                 <div>
                   <h3 class="text-base font-bold text-text-primary">{{ plan.name }}</h3>

--- a/pages/gestion/billing/index.vue
+++ b/pages/gestion/billing/index.vue
@@ -258,13 +258,34 @@ const handleExistingCheckout = async (checkoutUrl?: string | null) => {
 }
 
 // ── Should show subscribe/reactivate button ──────────────────────
+const isAccessBlocked = computed(() => accessStatus.value?.level === 'blocked')
+const hasExistingCheckout = computed(() => !!subscription.value?.checkout_url)
 const canSubscribe = computed(() => {
   const s = subscription.value?.status
   return !subscription.value ||
     s === 'cancelled' ||
     s === 'expired' ||
-    (s === 'pending' && !subscription.value.checkout_url)
+    (s === 'pending' && !subscription.value.checkout_url) ||
+    (isAccessBlocked.value && !subscription.value.checkout_url)
 })
+const primaryBillingActionLabel = computed(() => {
+  if (!subscription.value) return 'Suscribirse'
+  if (isAccessBlocked.value) return 'Reactivar'
+  return 'Reactivar'
+})
+const displayedSubscriptionStatus = computed(() =>
+  subscription.value
+    ? (isAccessBlocked.value ? 'blocked' : subscription.value.status)
+    : null
+)
+const pastDueTitle = computed(() =>
+  isAccessBlocked.value ? 'Tu período de gracia terminó' : 'Tienes un pago pendiente'
+)
+const pastDueDescription = computed(() =>
+  isAccessBlocked.value
+    ? 'Renueva tu plan para recuperar el acceso a las funciones protegidas.'
+    : 'Tu acceso está en período de gracia'
+)
 
 // ── Table columns ────────────────────────────────────────────────
 
@@ -352,6 +373,7 @@ const statusStyle = (status: string) => {
     active:    { badge: 'bg-status-success-bg text-status-success-text',   dot: 'bg-status-success-text',   label: 'Activo' },
     pending:   { badge: 'bg-status-info-bg text-status-info-text',         dot: 'bg-status-info-text',       label: 'Pendiente' },
     past_due:  { badge: 'bg-status-warning-bg text-status-warning-text',   dot: 'bg-status-warning-text',   label: 'Gracia' },
+    blocked:   { badge: 'bg-status-critical-bg text-status-critical-text', dot: 'bg-status-critical-text', label: 'Bloqueado' },
     cancelled: { badge: 'bg-status-critical-bg text-status-critical-text', dot: 'bg-status-critical-text', label: 'Cancelado' },
     expired:   { badge: 'bg-surface-secondary text-text-secondary',        dot: 'bg-text-secondary',         label: 'Expirado' },
   }
@@ -425,10 +447,10 @@ watch(() => currentTenant.value?.id, async () => {
             <!-- Status badge -->
             <span
               v-if="subscription"
-              :class="['inline-flex items-center gap-1.5 text-xs font-semibold px-3 py-1.5 rounded-full', statusStyle(subscription.status).badge]"
+              :class="['inline-flex items-center gap-1.5 text-xs font-semibold px-3 py-1.5 rounded-full', statusStyle(displayedSubscriptionStatus || subscription.status).badge]"
             >
-              <span :class="['w-1.5 h-1.5 rounded-full', statusStyle(subscription.status).dot]" aria-hidden="true" />
-              {{ statusStyle(subscription.status).label }}
+              <span :class="['w-1.5 h-1.5 rounded-full', statusStyle(displayedSubscriptionStatus || subscription.status).dot]" aria-hidden="true" />
+              {{ statusStyle(displayedSubscriptionStatus || subscription.status).label }}
             </span>
 
             <!-- Subscribe / Reactivate button -->
@@ -437,7 +459,7 @@ watch(() => currentTenant.value?.id, async () => {
               @click="openModal"
               class="min-h-[36px] px-4 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 active:scale-95 transition-all"
             >
-              {{ subscription ? 'Reactivar' : 'Suscribirse' }}
+              {{ primaryBillingActionLabel }}
             </button>
 
             <!-- Pending: complete payment -->
@@ -505,25 +527,33 @@ watch(() => currentTenant.value?.id, async () => {
         </div>
 
         <!-- Alert: past_due -->
-        <div v-if="subscription?.status === 'past_due'" class="px-6 py-4 border-t border-border bg-status-warning-bg/40">
+        <div v-if="subscription?.status === 'past_due' || isAccessBlocked" class="px-6 py-4 border-t border-border bg-status-warning-bg/40">
           <div class="flex items-center justify-between gap-4">
             <div class="flex items-start gap-2">
               <svg class="w-4 h-4 mt-0.5 shrink-0 text-status-warning-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
               </svg>
               <div>
-                <p class="text-sm font-semibold text-status-warning-text">Tienes un pago pendiente</p>
-                <p class="text-xs text-text-secondary mt-0.5">Tu acceso está en período de gracia</p>
+                <p class="text-sm font-semibold text-status-warning-text">{{ pastDueTitle }}</p>
+                <p class="text-xs text-text-secondary mt-0.5">{{ pastDueDescription }}</p>
               </div>
             </div>
             <button
-              v-if="subscription.checkout_url"
+              v-if="hasExistingCheckout"
               type="button"
               :disabled="checkoutRedirecting"
               @click="handleExistingCheckout(subscription.checkout_url)"
               class="shrink-0 min-h-[44px] px-5 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 active:scale-95 transition-all flex items-center"
             >
               {{ checkoutRedirecting ? 'Validando...' : 'Pagar ahora' }}
+            </button>
+            <button
+              v-else-if="canSubscribe"
+              type="button"
+              @click="openModal"
+              class="shrink-0 min-h-[44px] px-5 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 active:scale-95 transition-all flex items-center"
+            >
+              Reactivar
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- show blocked billing state as `Bloqueado` and keep a recovery CTA available with or without an existing checkout URL
- redirect protected routes using `/api/billing/access-status` when `level=blocked`
- disable protected desktop sidebar and mobile menu navigation while keeping Mi Plan/logout available

## Tests
- `git diff --check`
- Not run: `npm run build` per request

Closes #1340
