### PR TITLE
Renombrar uso de billing a Uso restante

### DIFF
--- a/pages/gestion/billing.vue
+++ b/pages/gestion/billing.vue
@@ -12,6 +12,6 @@ const route = useRoute()
 
 const navigationItems = [
   { to: '/gestion/billing', label: 'Historial', exact: true },
-  { to: '/gestion/billing/uso', label: 'Uso de IA' },
+  { to: '/gestion/billing/uso', label: 'Uso restante' },
 ]
 </script>

--- a/pages/gestion/billing/uso.vue
+++ b/pages/gestion/billing/uso.vue
@@ -1,52 +1,91 @@
 <script setup lang="ts">
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
-import { useBilling } from '~/composables/useBilling'
+import { useBilling, type BillingUsageMetric } from '~/composables/useBilling'
 
 definePageMeta({})
-useHead({ title: 'Uso de IA — WaRo Admin' })
+useHead({ title: 'Uso restante — WaRo Admin' })
 
-const { subscription, usageHistory, loading, isRefreshing, fetchUsageHistory } = useBilling()
+const { subscription, remainingUsage, isRefreshing, fetchBillingOverview } = useBilling()
 
 const { currentTenant } = useTenantReactive()
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 
-const usageHistoryReady = ref(false)
 const isInitialLoading = computed(() =>
   !!currentTenant.value &&
-  (!usageHistoryReady.value || subscription.value === undefined)
+  (
+    subscription.value === undefined ||
+    (subscription.value !== null && remainingUsage.value === undefined)
+  )
 )
 
-const loadAll = async () => {
-  usageHistoryReady.value = false
-  await fetchUsageHistory(24)
-  usageHistoryReady.value = true
-}
+const loadAll = () => fetchBillingOverview()
 
 onMounted(() => { loadAll(); setRefreshHandler(loadAll) })
 registerProgressiveLoading(isRefreshing)
 onUnmounted(() => clearRefreshHandler(loadAll))
 watch(() => currentTenant.value?.id, loadAll)
 
-const scanLimit = computed(() => subscription.value?.scan_limit ?? 1000)
+const fallbackUsageMetric = (used = 0, limit = 0): BillingUsageMetric => ({
+  used,
+  limit,
+  remaining: Math.max(limit - used, 0),
+  period_start: subscription.value?.current_period_start ?? '',
+  period_end: subscription.value?.current_period_end ?? '',
+})
+
+const usagePercentage = (metric: BillingUsageMetric) =>
+  metric.limit > 0 ? Math.min(Math.round((metric.used / metric.limit) * 100), 100) : 0
+
+const scanUsage = computed<BillingUsageMetric>(() =>
+  remainingUsage.value?.scan_usage ??
+  fallbackUsageMetric(subscription.value?.scans_used ?? 0, subscription.value?.scan_limit ?? 0)
+)
+const electronicInvoiceUsage = computed<BillingUsageMetric>(() =>
+  remainingUsage.value?.electronic_invoice_usage ?? fallbackUsageMetric()
+)
 
 const columns: Column[] = [
-  { key: 'year_month',  title: 'Mes',       sortable: false },
-  { key: 'scans_count', title: 'Usados',    sortable: false, align: 'right' },
-  { key: 'scan_limit',  title: 'Límite',    sortable: false, align: 'right' },
-  { key: 'percentage',  title: '% Uso',     sortable: false, align: 'right' },
+  { key: 'resource', title: 'Recurso', sortable: false },
+  { key: 'used', title: 'Usado', sortable: false, align: 'right' },
+  { key: 'limit', title: 'Disponible', sortable: false, align: 'right' },
+  { key: 'remaining', title: 'Restante', sortable: false, align: 'right' },
 ]
 
 const tableData = computed(() =>
-  usageHistory.value.map(entry => ({
-    year_month:  entry.year_month,
-    scans_count: entry.scans_count,
-    scan_limit:  scanLimit.value,
-    percentage:  Math.min(Math.round((entry.scans_count / scanLimit.value) * 100), 100),
-  }))
+  [
+    {
+      resource: 'Escaneos',
+      description: 'Cupo del período actual',
+      used: scanUsage.value.used,
+      limit: scanUsage.value.limit,
+      remaining: scanUsage.value.remaining,
+      percentage: usagePercentage(scanUsage.value),
+      unit: 'escaneos',
+      emptyMessage: null,
+    },
+    {
+      resource: 'Facturación electrónica',
+      description: electronicInvoiceUsage.value.limit > 0
+        ? 'Facturas incluidas en el período actual'
+        : 'Sin cupo pagado - 0 restantes',
+      used: electronicInvoiceUsage.value.used,
+      limit: electronicInvoiceUsage.value.limit,
+      remaining: electronicInvoiceUsage.value.remaining,
+      percentage: usagePercentage(electronicInvoiceUsage.value),
+      unit: 'facturas',
+      emptyMessage: electronicInvoiceUsage.value.limit > 0 ? null : '0 disponibles',
+    },
+  ]
 )
 
-const formatMonth = (yearMonth: string) =>
-  new Date(yearMonth + 'T12:00:00').toLocaleDateString('es-CO', { month: 'long', year: 'numeric' })
+const periodLabel = computed(() => {
+  const start = remainingUsage.value?.period_start ?? subscription.value?.current_period_start
+  const end = remainingUsage.value?.period_end ?? subscription.value?.current_period_end
+  if (!start || !end) return 'Período actual'
+
+  const formatter = new Intl.DateTimeFormat('es-CO', { day: 'numeric', month: 'short', year: 'numeric' })
+  return `${formatter.format(new Date(start))} - ${formatter.format(new Date(end))}`
+})
 </script>
 
 <template>
@@ -55,45 +94,69 @@ const formatMonth = (yearMonth: string) =>
       <CommonsTheCustomLoader size="large" />
     </div>
 
-    <UiResponsiveDataView
-      row-size="sm"
-      v-else
-      :columns="columns"
-      :data="tableData"
-      empty-message="No hay registros de uso aún"
-      empty-sub-message="Los datos aparecerán aquí después del primer escaneo"
-      variant="default"
-    >
-      <template #card="{ item, index }">
-        <div
-          class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-surface-secondary"
-          :class="index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'"
-        >
-          <div class="flex-1 min-w-0">
-            <p class="text-sm font-semibold text-text-primary leading-tight capitalize">{{ formatMonth(item.year_month) }}</p>
-            <p class="text-xs text-text-secondary mt-0.5">
-              {{ item.scans_count.toLocaleString('es-CO') }} de {{ item.scan_limit.toLocaleString('es-CO') }} escaneos
-            </p>
-          </div>
-          <span class="text-sm font-bold text-primary flex-shrink-0">{{ item.percentage }}%</span>
+    <template v-else>
+      <div class="border border-border bg-surface">
+        <div class="px-4 py-3 md:px-6 md:py-4 border-b border-border">
+          <p class="text-xs font-medium text-text-secondary uppercase tracking-widest">Uso restante</p>
+          <p class="mt-1 text-sm text-text-secondary">{{ periodLabel }}</p>
         </div>
-      </template>
 
-      <template #cell-year_month="{ value }">
-        <span class="text-sm font-medium text-text-primary capitalize">{{ formatMonth(value) }}</span>
-      </template>
+        <UiResponsiveDataView
+          row-size="sm"
+          :columns="columns"
+          :data="tableData"
+          empty-message="No hay cupos disponibles"
+          empty-sub-message="Los cupos aparecerán cuando tengas una suscripción activa"
+          variant="default"
+        >
+          <template #card="{ item, index }">
+            <div
+              class="flex items-start gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-surface-secondary"
+              :class="index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'"
+            >
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-semibold text-text-primary leading-tight">{{ item.resource }}</p>
+                <p class="text-xs text-text-secondary mt-0.5">{{ item.description }}</p>
+                <p class="text-xs text-text-secondary mt-2">
+                  {{ item.used.toLocaleString('es-CO') }} de {{ item.limit.toLocaleString('es-CO') }} {{ item.unit }} usados
+                </p>
+              </div>
+              <div class="text-right flex-shrink-0">
+                <p class="text-sm font-bold text-text-primary">{{ item.remaining.toLocaleString('es-CO') }}</p>
+                <p class="text-xs text-text-secondary">restantes</p>
+              </div>
+            </div>
+          </template>
 
-      <template #cell-scans_count="{ value }">
-        <span class="text-sm font-semibold text-text-primary">{{ value.toLocaleString('es-CO') }}</span>
-      </template>
+          <template #cell-resource="{ item }">
+            <div>
+              <p class="text-sm font-semibold text-text-primary">{{ item.resource }}</p>
+              <p class="text-xs text-text-secondary mt-0.5">{{ item.description }}</p>
+            </div>
+          </template>
 
-      <template #cell-scan_limit="{ value }">
-        <span class="text-sm text-text-secondary">{{ value.toLocaleString('es-CO') }}</span>
-      </template>
+          <template #cell-used="{ item }">
+            <span class="text-sm font-semibold text-text-primary">
+              {{ item.used.toLocaleString('es-CO') }}
+            </span>
+            <span class="text-xs text-text-secondary"> {{ item.unit }}</span>
+          </template>
 
-      <template #cell-percentage="{ value }">
-        <span class="text-sm font-semibold text-text-primary">{{ value }}%</span>
-      </template>
-    </UiResponsiveDataView>
+          <template #cell-limit="{ item }">
+            <span class="text-sm text-text-secondary">
+              {{ item.limit.toLocaleString('es-CO') }}
+            </span>
+            <span v-if="item.emptyMessage" class="block text-xs text-text-secondary">{{ item.emptyMessage }}</span>
+          </template>
+
+          <template #cell-remaining="{ item }">
+            <span class="text-sm font-semibold text-text-primary">
+              {{ item.remaining.toLocaleString('es-CO') }}
+            </span>
+            <span class="block text-xs text-text-secondary">{{ item.percentage }}% usado</span>
+          </template>
+        </UiResponsiveDataView>
+      </div>
+    </template>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Rename the billing usage navigation and page title to Uso restante.
- Replace the scan-only history table with current-period remaining usage for escaneos and facturacion electronica.
- Keep non-FE tenants visible as 0 available/restantes instead of hiding the invoice quota.

## Tests
- npx nuxi prepare
- npm run build (client and server bundles completed; interrupted during final Nitro packaging after no output)

Closes #1346