### PR TITLE
Make terms status check resilient before checkout

### DIFF
--- a/composables/useLegalTerms.ts
+++ b/composables/useLegalTerms.ts
@@ -82,11 +82,18 @@ interface AuthSessionResponse {
   currentTenant?: { id?: string | null; slug?: string | null } | null
 }
 
+const TERMS_STATUS_TIMEOUT_MS = 12000
+
 const isAuthError = (err: any) =>
   err?.status === 401 ||
   err?.statusCode === 401 ||
   err?.status === 403 ||
   err?.statusCode === 403
+
+const isTimeoutError = (err: any) =>
+  err?.name === 'TimeoutError' ||
+  err?.name === 'AbortError' ||
+  /timeout|aborted/i.test(String(err?.message ?? ''))
 
 const unwrapApiData = <T>(response: ApiEnvelope<T> | T | null | undefined): T | null => {
   if (!response) return null
@@ -150,6 +157,26 @@ const mapAcceptResponseToStatus = (response: ApiEnvelope<{ current?: ApiLegalTer
   })
 }
 
+const fetchTermsStatus = async (retryOnTimeout = false): Promise<LegalTermsStatus | null> => {
+  try {
+    const response = await $fetch<ApiEnvelope<ApiLegalTermsStatus> | ApiLegalTermsStatus | null>('/api/legal/terms/status', {
+      credentials: 'include',
+      timeout: TERMS_STATUS_TIMEOUT_MS,
+    })
+    return mapApiStatus(unwrapApiData(response))
+  } catch (err) {
+    if (retryOnTimeout && isTimeoutError(err)) {
+      await new Promise(resolve => setTimeout(resolve, 300))
+      const response = await $fetch<ApiEnvelope<ApiLegalTermsStatus> | ApiLegalTermsStatus | null>('/api/legal/terms/status', {
+        credentials: 'include',
+        timeout: TERMS_STATUS_TIMEOUT_MS,
+      })
+      return mapApiStatus(unwrapApiData(response))
+    }
+    throw err
+  }
+}
+
 export const useLegalTerms = () => {
   const cache = useQueryCache()
   const authStore = useAuthStore()
@@ -190,8 +217,7 @@ export const useLegalTerms = () => {
     enabled: () => import.meta.client && hasTenantSession.value,
     query: async () => {
       try {
-        const response = await $fetch<ApiEnvelope<ApiLegalTermsStatus> | ApiLegalTermsStatus | null>('/api/legal/terms/status', { credentials: 'include', timeout: 4000 })
-        return mapApiStatus(unwrapApiData(response))
+        return await fetchTermsStatus(true)
       } catch (err: any) {
         if (isAuthError(err) || err?.status === 404 || err?.statusCode === 404) return null
         return null
@@ -234,8 +260,7 @@ export const useLegalTerms = () => {
   }
 
   const refreshTermsStatus = async (): Promise<LegalTermsStatus | null> => {
-    const response = await $fetch<ApiEnvelope<ApiLegalTermsStatus> | ApiLegalTermsStatus | null>('/api/legal/terms/status', { credentials: 'include', timeout: 4000 })
-    const result = mapApiStatus(unwrapApiData(response))
+    const result = await fetchTermsStatus(true)
     cache.setQueryData(['legal-terms', 'status', tenantId.value], result)
     return result
   }


### PR DESCRIPTION
## Summary\n- increase the terms status timeout used before Wompi checkout\n- retry once on timeout/abort for the critical terms status validation\n- keep checkout blocked when terms status cannot be validated\n\n## Tests\n- npx nuxi prepare\n- git diff --check