### PR TITLE
Allow pending delivery sales to be finalized

### DIFF
--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -98,8 +98,10 @@ const showSuccessModal = ref(false)
 const orderResult = ref<{
   order_number: number
   total_amount: number
-  payment_method: string
+  payment_method?: string | null
   payment_method_name?: string
+  status?: string
+  payment_status?: string | null
   customer_id?: string
   discount_amount?: number
   subtotal?: number
@@ -1689,10 +1691,14 @@ const processOrder = async () => {
     const response = await $fetch(`/api/pos/cart/${posStore.cartId}/complete`, {
       method: 'POST',
       body: {
-        payment_method: selectedPaymentMethod.value,
+        ...(isDeferredDeliveryPayment.value
+          ? {}
+          : {
+              payment_method: selectedPaymentMethod.value,
+              payment_method_id: selectedPaymentMethodId.value ?? null,
+            }),
         customer_id: selectedCustomer.value.id,
-        payment_method_id: selectedPaymentMethodId.value ?? null,
-        ...(selectedGroup.value?.triggersCartera && creditDueDate.value
+        ...(selectedGroup.value?.triggersCartera && creditDueDate.value && !isDeferredDeliveryPayment.value
           ? { credit_due_date: creditDueDate.value }
           : {}),
         ...(discountEnabled.value && _discountAmtPos > 0
@@ -1702,7 +1708,7 @@ const processOrder = async () => {
           ? { table_session_id: posStore.activeTableSession.sessionId }
           : {}),
         // Issue #524 — single-payment cash sale: capture cash_received on the order
-        ...(isCashMethod.value
+        ...(isCashMethod.value && !isDeferredDeliveryPayment.value
           ? { cash_received: Number(cashReceivedInput.value) }
           : {}),
         ...(deliveryEnabled.value && addressStore.selectedAddressId
@@ -1728,7 +1734,9 @@ const processOrder = async () => {
         tip_amount?: number
         tip_source?: string
         charged_amount?: number
-        payment_method: string
+        payment_method?: string | null
+        payment_status?: string | null
+        status?: string
         items_count: number
         standard_tax?: number
         liquor_tax?: number
@@ -1751,6 +1759,8 @@ const processOrder = async () => {
         total_amount: response.data.total_amount,
         payment_method: response.data.payment_method,
         payment_method_name: subMethodName,
+        status: response.data.status,
+        payment_status: response.data.payment_status,
         customer_id: selectedCustomer.value?.id,
         standard_tax: response.data.standard_tax ?? 0,
         liquor_tax: response.data.liquor_tax ?? 0,
@@ -1824,11 +1834,22 @@ const onCustomerIdentified = async (customer: { id: string; name: string | null;
 const selectedGroup = computed(() =>
   posPaymentGroups.value.find(g => g.slug === selectedPaymentMethod.value) ?? null
 )
+const canDeferDeliveryPayment = computed(() =>
+  deliveryEnabled.value && !isKitchenServiceMode.value
+)
+const isDeferredDeliveryPayment = computed(() =>
+  canDeferDeliveryPayment.value && !selectedPaymentMethod.value
+)
 
 // Reset sub-method and search when group changes
 watch(selectedPaymentMethod, () => {
   selectedPaymentMethodId.value = null
   methodSearch.value = ''
+})
+watch(deliveryEnabled, (enabled) => {
+  if (!enabled && !selectedPaymentMethod.value) {
+    selectedPaymentMethod.value = 'cash'
+  }
 })
 
 // ── Issue #524 — Cash tender + change calculation ────────────────────────────
@@ -2788,8 +2809,33 @@ onUnmounted(() => {
             </div>
           </div>
 
+          <button
+            v-if="!isLoadingPaymentMethods && canDeferDeliveryPayment"
+            type="button"
+            @click="selectedPaymentMethod = ''"
+            class="w-full mb-3 min-h-[56px] px-4 py-3 rounded-xl border-2 text-left transition-all active:scale-[0.99] flex items-center justify-between gap-3"
+            :class="isDeferredDeliveryPayment
+              ? 'border-status-warning-text/50 bg-status-warning-bg text-status-warning-text shadow-sm'
+              : 'border-border bg-surface text-text-secondary hover:border-status-warning-text/40 hover:text-text-primary'"
+          >
+            <span class="min-w-0">
+              <span class="block text-sm font-bold leading-tight">Definir método al entregar</span>
+              <span class="block text-xs leading-snug mt-0.5">La venta quedará pendiente hasta finalizarla en ventas.</span>
+            </span>
+            <svg
+              class="w-5 h-5 flex-shrink-0"
+              :class="isDeferredDeliveryPayment ? 'opacity-100' : 'opacity-40'"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 6v6l4 2m5-2a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+            </svg>
+          </button>
+
           <!-- Dynamic payment method groups — loaded from API, falls back to 4 defaults -->
-          <div v-else class="grid gap-2 md:gap-4" :class="paymentGridClass">
+          <div v-if="!isLoadingPaymentMethods" class="grid gap-2 md:gap-4" :class="paymentGridClass">
             <label
               v-for="group in posPaymentGroups"
               :key="group.slug"
@@ -3942,7 +3988,9 @@ onUnmounted(() => {
           <svg v-else class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
           </svg>
-          <span v-if="!isProcessing">{{ selectedPaymentMethod === 'credit' ? 'Registrar como crédito' : 'Confirmar Orden' }}</span>
+          <span v-if="!isProcessing">
+            {{ isDeferredDeliveryPayment ? 'Dejar venta pendiente' : selectedPaymentMethod === 'credit' ? 'Registrar como crédito' : 'Confirmar Orden' }}
+          </span>
         </button>
         <p v-if="!selectedCustomer && !isProcessing" class="text-center text-xs text-text-tertiary">Identifica al cliente para continuar</p>
 
@@ -4081,10 +4129,22 @@ onUnmounted(() => {
 
           <!-- Title -->
           <h3 class="text-xl font-bold text-text-primary text-center mb-2">
-            {{ orderResult?.payment_method === 'credit' ? 'Orden registrada como crédito' : 'Venta Completada' }}
+            {{
+              orderResult?.status === 'pending'
+                ? 'Venta pendiente'
+                : orderResult?.payment_method === 'credit'
+                  ? 'Orden registrada como crédito'
+                  : 'Venta Completada'
+            }}
           </h3>
           <p class="text-text-secondary text-center mb-4">
-            {{ orderResult?.payment_method === 'credit' ? 'El pago queda pendiente para el cliente' : 'La orden ha sido procesada exitosamente' }}
+            {{
+              orderResult?.status === 'pending'
+                ? 'Podrás finalizarla desde ventas cuando conozcas el método de pago.'
+                : orderResult?.payment_method === 'credit'
+                  ? 'El pago queda pendiente para el cliente'
+                  : 'La orden ha sido procesada exitosamente'
+            }}
           </p>
 
           <!-- Credit notice banner -->
@@ -4150,15 +4210,19 @@ onUnmounted(() => {
             <div class="flex items-center justify-between">
               <span class="text-sm text-text-secondary">Método de Pago</span>
               <span class="text-sm font-medium text-text-primary">
-                {{ orderResult.payment_method_name
-                    ? `${getPaymentMethodLabel(orderResult.payment_method)} · ${orderResult.payment_method_name}`
-                    : getPaymentMethodLabel(orderResult.payment_method) }}
+                {{
+                  orderResult.payment_method
+                    ? (orderResult.payment_method_name
+                        ? `${getPaymentMethodLabel(orderResult.payment_method)} · ${orderResult.payment_method_name}`
+                        : getPaymentMethodLabel(orderResult.payment_method))
+                    : 'Pendiente por definir'
+                }}
               </span>
             </div>
           </div>
 
           <!-- Electronic invoice (DIAN) — cashier triggers emission, but never sees CUFE/PDF -->
-          <div v-if="orderResult?.order_id || (orderResult?.order_ids?.length ?? 0) > 0" class="mb-4">
+          <div v-if="orderResult?.status !== 'pending' && (orderResult?.order_id || (orderResult?.order_ids?.length ?? 0) > 0)" class="mb-4">
             <!-- Not requested yet — gated on tenant readiness (#450) -->
             <template v-if="isInvoicingReady && !isReadinessLoading && !invoiceResult && !invoiceLoading && !invoiceError && !fiscalWizardOpen">
               <button
@@ -4631,9 +4695,11 @@ onUnmounted(() => {
     <template v-else>
       <div class="receipt-item receipt-small">
         <span>{{
-          orderResult?.payment_method_name
-            ? `${getPaymentMethodLabel(orderResult.payment_method)} · ${orderResult.payment_method_name}`
-            : getPaymentMethodLabel(orderResult?.payment_method ?? '')
+          orderResult?.payment_method
+            ? (orderResult?.payment_method_name
+                ? `${getPaymentMethodLabel(orderResult.payment_method)} · ${orderResult.payment_method_name}`
+                : getPaymentMethodLabel(orderResult.payment_method))
+            : 'Pendiente por definir'
         }}</span>
         <span>{{ formatCurrency(orderResult?.charged_amount ?? orderResult?.total_amount ?? 0) }}</span>
       </div>

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -41,6 +41,23 @@ const modifiersToDelete = ref<Map<string, Set<string>>>(new Map())
 const isUpdatingStatus = ref(false)
 const selectedNewStatus = ref('')
 const selectedPaymentMethod = ref('')
+const selectedPaymentMethodId = ref<string | null>(null)
+const showFinalizeSalePanel = ref(false)
+const isFinalizingSale = ref(false)
+const finalizeSaleError = ref('')
+const finalizeMethodSearch = ref('')
+const finalizeSelectedGroup = computed(() =>
+  paymentGroups.value.find(group => group.slug === selectedPaymentMethod.value) ?? null
+)
+const finalizeFilteredMethods = computed(() => {
+  const methods = finalizeSelectedGroup.value?.methods ?? []
+  const q = finalizeMethodSearch.value.trim().toLowerCase()
+  if (!q) return methods
+  return methods.filter(method => method.name.toLowerCase().includes(q))
+})
+const finalizeRequiresMethodSelection = computed(() =>
+  (finalizeSelectedGroup.value?.methods?.length ?? 0) > 0 && !selectedPaymentMethodId.value
+)
 
 // Load order details
 const { data: orderData, status: orderStatus, asyncStatus: orderAsyncStatus, error: fetchError, refetch: refetchOrder } = useQuery({
@@ -371,6 +388,60 @@ const updateStatus = async () => {
   }
 }
 
+const openFinalizeSalePanel = () => {
+  selectedNewStatus.value = ''
+  selectedPaymentMethod.value = ''
+  selectedPaymentMethodId.value = null
+  finalizeMethodSearch.value = ''
+  finalizeSaleError.value = ''
+  showFinalizeSalePanel.value = true
+}
+
+const closeFinalizeSalePanel = () => {
+  if (isFinalizingSale.value) return
+  showFinalizeSalePanel.value = false
+  finalizeSaleError.value = ''
+}
+
+watch(selectedPaymentMethod, () => {
+  selectedPaymentMethodId.value = null
+  finalizeMethodSearch.value = ''
+})
+
+const finalizePendingSale = async () => {
+  if (!selectedPaymentMethod.value) {
+    finalizeSaleError.value = 'Selecciona un método de pago'
+    return
+  }
+  if (finalizeRequiresMethodSelection.value) {
+    finalizeSaleError.value = 'Selecciona el método específico'
+    return
+  }
+  isFinalizingSale.value = true
+  finalizeSaleError.value = ''
+  try {
+    await $fetch(`/api/orders/${orderId.value}/status`, {
+      method: 'PATCH',
+      body: {
+        status: 'completed',
+        payment_method: selectedPaymentMethod.value,
+        payment_method_id: selectedPaymentMethodId.value || undefined,
+        customer_id: order.value?.customer?.id || undefined,
+      },
+    })
+    await refetchOrder()
+    await refetchInvoice()
+    showFinalizeSalePanel.value = false
+    selectedPaymentMethod.value = ''
+    selectedPaymentMethodId.value = null
+    useToast().success('Venta finalizada correctamente', { title: 'Listo' })
+  } catch (error: any) {
+    finalizeSaleError.value = error.data?.message || error.data?.detail || 'Error al finalizar la venta'
+  } finally {
+    isFinalizingSale.value = false
+  }
+}
+
 // Save changes - backend handles inventory restock automatically
 const saveChanges = async () => {
   if (!hasChanges.value) return
@@ -524,7 +595,7 @@ onUnmounted(() => {
                 Cobro dividido · {{ order.split_payments.length }} pagos
               </template>
               <template v-else>
-                {{ resolveLabel(order.payment_method, order.payment_method_id) }}
+                {{ order.payment_method ? resolveLabel(order.payment_method, order.payment_method_id) : 'Sin registrar' }}
               </template>
             </p>
             <svg v-if="order.split_payments && order.split_payments.length > 0" class="w-4 h-4 text-info flex-shrink-0"
@@ -533,6 +604,21 @@ onUnmounted(() => {
             </svg>
           </div>
         </component>
+
+        <button
+          v-if="order.status === 'pending'"
+          type="button"
+          @click="openFinalizeSalePanel"
+          class="bg-status-success-bg border-2 border-status-success-text/30 rounded-xl p-4 text-left w-full hover:bg-status-success-text hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-status-success-text/30 group"
+        >
+          <p class="text-xs font-semibold uppercase tracking-wider mb-2">Acción pendiente</p>
+          <div class="flex items-center justify-between gap-3">
+            <span class="text-lg font-bold leading-tight">Finalizar venta</span>
+            <svg class="w-5 h-5 flex-shrink-0 transition-transform group-hover:translate-x-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+            </svg>
+          </div>
+        </button>
 
         <!-- Source / Origin -->
         <div class="bg-surface border border-border rounded-xl p-4">
@@ -1252,6 +1338,106 @@ onUnmounted(() => {
       </div>
 
     </div>
+
+    <!-- Finalize Pending Sale Slide-over -->
+    <Teleport to="body">
+      <Transition enter-active-class="transition-opacity duration-200" enter-from-class="opacity-0"
+        enter-to-class="opacity-100" leave-active-class="transition-opacity duration-200" leave-from-class="opacity-100"
+        leave-to-class="opacity-0">
+        <div v-if="showFinalizeSalePanel" class="fixed inset-0 z-40 bg-black/40"
+          @click="closeFinalizeSalePanel" aria-hidden="true" />
+      </Transition>
+
+      <Transition name="panel">
+        <div v-if="showFinalizeSalePanel" role="dialog" aria-modal="true" aria-label="Finalizar venta pendiente"
+          class="fixed z-50 flex flex-col bg-surface shadow-2xl
+                 inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh]
+                 md:inset-y-0 md:right-0 md:bottom-auto md:left-auto md:inset-x-auto md:rounded-none md:w-full md:max-w-md md:max-h-none md:h-full">
+          <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
+            <div class="w-10 h-1 rounded-full bg-slate-300" aria-hidden="true" />
+          </div>
+
+          <div class="flex-shrink-0 bg-surface-secondary/40 border-b border-border px-6 py-4">
+            <div class="flex items-start justify-between gap-3">
+              <div class="min-w-0">
+                <h2 class="text-base font-bold text-text-primary leading-tight">Finalizar venta</h2>
+                <p class="text-xs text-text-secondary leading-snug mt-0.5">
+                  Orden #{{ order.order_number }} · {{ formatCurrency(order.total_amount) }}
+                </p>
+              </div>
+              <button @click="closeFinalizeSalePanel" type="button" aria-label="Cerrar panel"
+                class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <div class="flex-1 overflow-y-auto px-6 py-4 space-y-5">
+            <div>
+              <p class="text-xs font-semibold text-text-tertiary uppercase tracking-wider mb-2">Método de pago</p>
+              <div class="grid grid-cols-2 gap-2">
+                <button
+                  v-for="group in paymentGroups"
+                  :key="group.slug"
+                  type="button"
+                  @click="selectedPaymentMethod = selectedPaymentMethod === group.slug ? '' : group.slug"
+                  class="min-h-[48px] px-3 py-2.5 rounded-xl border-2 text-sm font-semibold transition-all text-center active:scale-95"
+                  :class="selectedPaymentMethod === group.slug
+                    ? 'border-primary bg-primary/10 text-primary shadow-sm'
+                    : 'border-border bg-background text-text-secondary hover:border-primary/30 hover:text-text-primary'"
+                >
+                  {{ group.name }}
+                </button>
+              </div>
+            </div>
+
+            <div v-if="finalizeSelectedGroup?.methods?.length" class="space-y-2">
+              <p class="text-xs font-semibold text-text-tertiary uppercase tracking-wider">Método específico</p>
+              <div v-if="finalizeSelectedGroup.methods.length > 10" class="relative">
+                <input
+                  v-model="finalizeMethodSearch"
+                  type="text"
+                  placeholder="Buscar método..."
+                  class="w-full h-10 px-3 rounded-lg border border-border bg-background text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+              </div>
+              <div class="grid grid-cols-2 gap-2 max-h-[260px] overflow-y-auto pr-1">
+                <button
+                  v-for="method in finalizeFilteredMethods"
+                  :key="method.id"
+                  type="button"
+                  @click="selectedPaymentMethodId = selectedPaymentMethodId === method.id ? null : method.id"
+                  class="min-h-[44px] px-3 py-2 rounded-lg border-2 text-sm font-medium transition-all text-center active:scale-95"
+                  :class="selectedPaymentMethodId === method.id
+                    ? 'border-primary bg-primary/10 text-primary shadow-sm'
+                    : 'border-border bg-background text-text-secondary hover:border-primary/30 hover:text-text-primary'"
+                >
+                  {{ method.name }}
+                </button>
+              </div>
+            </div>
+
+            <p v-if="finalizeSaleError" class="text-sm text-destructive bg-destructive/10 border border-destructive/20 rounded-lg px-3 py-2">
+              {{ finalizeSaleError }}
+            </p>
+          </div>
+
+          <div class="flex-shrink-0 border-t border-border p-6">
+            <button
+              type="button"
+              @click="finalizePendingSale"
+              :disabled="isFinalizingSale || !selectedPaymentMethod || finalizeRequiresMethodSelection"
+              class="w-full min-h-[44px] rounded-xl bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition-all flex items-center justify-center gap-2"
+            >
+              <UiLoadingDots v-if="isFinalizingSale" size="9px" />
+              <span v-else>Finalizar venta</span>
+            </button>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
 
     <!-- Split Payments Slide-over -->
     <Teleport to="body">


### PR DESCRIPTION
## Summary\n- add a POS delivery option to leave payment method pending until delivery\n- show pending sale payment as unregistered and add Finalizar venta action\n- use a Slideover to capture payment group/submethod before completing the sale\n\n## Tests\n- npx nuxi prepare\n- npm run build (interrupted after long Vite build with no errors emitted; warnings only before interruption)\n\nCloses #1353\n\nCompanion API PR: uno0uno/api-warolabs#461