### PR TITLE
Fix OTP resend countdown

### DIFF
--- a/stores/otp_auth.ts
+++ b/stores/otp_auth.ts
@@ -26,6 +26,13 @@ export const useOtpAuthStore = defineStore('otpAuth', () => {
   const otpSentAt = ref<Date | null>(null)
   const otpExpiresAt = ref<Date | null>(null)
   const pickupPin = ref<string | null>(null)
+  const cooldownTick = ref(Date.now())
+
+  if (import.meta.client) {
+    setInterval(() => {
+      cooldownTick.value = Date.now()
+    }, 1000)
+  }
 
   // ── Mutations ──────────────────────────────────────────────────────────
 
@@ -91,7 +98,7 @@ export const useOtpAuthStore = defineStore('otpAuth', () => {
 
   const otpCooldownRemaining = computed(() => {
     if (!otpSentAt.value) return 0
-    const elapsed = Date.now() - otpSentAt.value.getTime()
+    const elapsed = cooldownTick.value - otpSentAt.value.getTime()
     const cooldown = 60000 // 60 seconds
     return Math.ceil(Math.max(0, cooldown - elapsed) / 1000)
   })


### PR DESCRIPTION
## Summary
- Make OTP cooldown depend on a reactive one-second tick
- Keep resend button state tied to the existing cooldown calculation

## Tests
- NODE_OPTIONS=--max-old-space-size=4096 npx nuxi typecheck (fails on existing repo-wide TS errors; no errors reported for stores/otp_auth.ts)

Closes #1363