### PR TITLE
Fix table QR orders reappearing in despacho

### DIFF
--- a/components/DashboardBottomNav.vue
+++ b/components/DashboardBottomNav.vue
@@ -150,7 +150,7 @@
         <li v-for="notification in notifications" :key="notification.id">
           <NuxtLink
             :to="notificationDespachoPath(notification)"
-            @click="handleNotificationClick(notification)"
+            @click="(event) => handleNotificationClick(notification, event)"
             class="flex items-start gap-3 px-4 py-3 hover:bg-icon-button-neutral-hover-bg transition-colors"
             :class="!notification.read_at ? 'bg-icon-button-primary-bg/40' : ''"
           >
@@ -247,6 +247,7 @@ import { computed, ref } from 'vue'
 import { useLayoutActions } from '../composables/useLayoutActions'
 import { notificationDespachoPath, notificationDespachoTitle, notificationIsTermsAcceptanceRequired } from '~/composables/useNotificationDespachoLink'
 import { useDespachoNotificationAudio } from '~/composables/useDespachoNotificationAudio'
+import { useTableQrNotificationNavigation } from '~/composables/useTableQrNotificationNavigation'
 import { dashboardMobileGridItems, type ActivePage, type DashboardNavItem } from '~/constants/dashboardNavigation'
 import type { Tenant } from '~/stores/tenants'
 import type { Notification } from '~/composables/useNotifications'
@@ -291,6 +292,7 @@ const showNotificationsModal = ref(false)
 
 // Notifications
 const { notifications, markAsRead } = useNotifications()
+const { handleDespachoNotificationClick } = useTableQrNotificationNavigation()
 const {
   enabled: despachoSoundEnabled,
   toggleEnabled: toggleDespachoSound,
@@ -301,11 +303,12 @@ const handleMarkAsRead = async (id: string) => {
   await markAsRead(id)
 }
 
-const handleNotificationClick = async (notification: Notification) => {
-  if (!notificationIsTermsAcceptanceRequired(notification)) {
-    await handleMarkAsRead(notification.id)
-  }
-  showNotificationsModal.value = false
+const handleNotificationClick = async (notification: Notification, event?: MouseEvent) => {
+  await handleDespachoNotificationClick(
+    notification,
+    event,
+    () => { showNotificationsModal.value = false },
+  )
 }
 
 const openNotificationsModal = () => {

--- a/components/notifications/MobileOrderToast.vue
+++ b/components/notifications/MobileOrderToast.vue
@@ -27,7 +27,7 @@
           />
           <NuxtLink
             :to="notificationDespachoPath(toast.notification)"
-            @click="dismiss(toast.id)"
+            @click="(event) => handleToastClick(toast, event)"
             class="flex items-center gap-2 pl-4 pr-10 py-2.5"
           >
             <div
@@ -87,7 +87,7 @@
           v-for="toast in toasts"
           :key="toast.id"
           :to="notificationDespachoPath(toast.notification)"
-          @click="dismiss(toast.id)"
+          @click="(event) => handleToastClick(toast, event)"
           class="flex items-center gap-2.5 px-3 py-2 rounded-full bg-surface/95 backdrop-blur shadow-lg overflow-hidden"
           :class="notificationIsComandaReady(toast.notification) ? 'border border-success/40' : 'border border-primary/30'"
         >
@@ -133,6 +133,7 @@ import {
 } from '~/composables/useNotificationDespachoLink'
 import { useDespachoNotificationAudio } from '~/composables/useDespachoNotificationAudio'
 import { useComandaReadyAudio } from '~/composables/useComandaReadyAudio'
+import { useTableQrNotificationNavigation } from '~/composables/useTableQrNotificationNavigation'
 
 interface MobileToast {
   id: number
@@ -146,6 +147,7 @@ const DISMISS_AFTER_MS = 8000
 const { notifications, isTenantResetting } = useNotifications()
 const { playChime: playDespachoChime, prefetchBuffer: prefetchDespachoBuffer } = useDespachoNotificationAudio()
 const { playChime: playComandaReadyChime, prefetchBuffer: prefetchComandaReadyBuffer } = useComandaReadyAudio()
+const { handleDespachoNotificationClick } = useTableQrNotificationNavigation()
 const toasts = ref<MobileToast[]>([])
 let toastIdCounter = 0
 let baselineCount = 0
@@ -156,6 +158,14 @@ const dismiss = (id: number) => {
     clearTimeout(toasts.value[index].timer)
     toasts.value.splice(index, 1)
   }
+}
+
+const handleToastClick = async (toast: MobileToast, event?: MouseEvent) => {
+  await handleDespachoNotificationClick(
+    toast.notification,
+    event,
+    () => dismiss(toast.id),
+  )
 }
 
 const addToast = (notification: Notification) => {

--- a/components/notifications/NotificationBell.vue
+++ b/components/notifications/NotificationBell.vue
@@ -83,7 +83,7 @@
           >
             <NuxtLink
               :to="notificationDespachoPath(notification)"
-              @click="handleNotificationClick(notification)"
+              @click="(event) => handleNotificationClick(notification, event)"
               class="flex gap-3 px-4 py-3 hover:bg-shell-notification-hover-bg transition-colors"
             >
               <!-- Icon -->
@@ -139,9 +139,11 @@ import {
   notificationIsTermsAcceptanceRequired,
 } from '~/composables/useNotificationDespachoLink'
 import { useDespachoNotificationAudio } from '~/composables/useDespachoNotificationAudio'
+import { useTableQrNotificationNavigation } from '~/composables/useTableQrNotificationNavigation'
 
 const { notifications, unreadCount, init, markAsRead, markAllRead } = useNotifications()
 const { enabled: soundEnabled, toggleEnabled, unlockFromGesture, prefetchBuffer } = useDespachoNotificationAudio()
+const { handleDespachoNotificationClick } = useTableQrNotificationNavigation()
 
 const isOpen = ref(false)
 const isLoading = ref(false)
@@ -178,11 +180,8 @@ const handleMarkAsRead = async (id: string) => {
   await markAsRead(id)
 }
 
-const handleNotificationClick = async (notification: Notification) => {
-  if (!notificationIsTermsAcceptanceRequired(notification)) {
-    await handleMarkAsRead(notification.id)
-  }
-  close()
+const handleNotificationClick = async (notification: Notification, event?: MouseEvent) => {
+  await handleDespachoNotificationClick(notification, event, close)
 }
 
 const handleMarkAllRead = async () => {

--- a/composables/useNotifications.ts
+++ b/composables/useNotifications.ts
@@ -53,6 +53,7 @@ export const useNotifications = () => {
       // Invalidate cache — Pinia Colada refetches automatically
       // Toast + chime are handled by MobileOrderToast.vue via its length watcher
       await _queryCache?.invalidateQueries({ key: ['notifications'] })
+      await _queryCache?.invalidateQueries({ key: ['table-qr-requests'] })
     }
 
     eventSource.onerror = () => {

--- a/composables/useTableQrNotificationNavigation.ts
+++ b/composables/useTableQrNotificationNavigation.ts
@@ -1,0 +1,55 @@
+import type { Notification } from '~/composables/useNotifications'
+import { notificationIsTermsAcceptanceRequired } from '~/composables/useNotificationDespachoLink'
+
+/**
+ * Navigate to a table QR request from a notification, or dismiss stale alerts
+ * when the request was already accepted/rejected on another device.
+ */
+export function useTableQrNotificationNavigation() {
+  const router = useRouter()
+  const toast = useToast()
+  const { markAsRead } = useNotifications()
+
+  async function navigateFromNotification(
+    notification: Notification,
+    event?: Event,
+  ): Promise<boolean> {
+    if (notification.type !== 'table_qr_request') return false
+
+    const requestId = notification.payload?.request_id
+    if (typeof requestId !== 'string' || !requestId) return false
+
+    event?.preventDefault()
+
+    try {
+      await $fetch(`/api/table-qr-requests/${requestId}`)
+      await markAsRead(notification.id)
+      await router.push(`/despacho/en-mesa/${requestId}`)
+    } catch {
+      toast.info('Este pedido ya fue aceptado o rechazado', { title: 'Pedido procesado' })
+      try {
+        await markAsRead(notification.id)
+      } catch {
+        // Notification may already be cleared server-side after accept/reject.
+      }
+    }
+    return true
+  }
+
+  async function handleDespachoNotificationClick(
+    notification: Notification,
+    event?: Event,
+    onAfter?: () => void,
+  ): Promise<void> {
+    if (await navigateFromNotification(notification, event)) {
+      onAfter?.()
+      return
+    }
+    if (!notificationIsTermsAcceptanceRequired(notification)) {
+      await markAsRead(notification.id)
+    }
+    onAfter?.()
+  }
+
+  return { navigateFromNotification, handleDespachoNotificationClick }
+}

--- a/pages/despacho/en-mesa/[id].vue
+++ b/pages/despacho/en-mesa/[id].vue
@@ -2,6 +2,7 @@
 import { inject, watch, onMounted, onUnmounted } from 'vue'
 import { formatTableQrPayment } from '~/composables/formatTableQrPayment'
 import { notifyTableSessionUpdated, storeTableQrPaymentIntent } from '~/composables/useTableSessionSync'
+import { useNotifications } from '~/composables/useNotifications'
 
 definePageMeta({ layout: 'dashboard' })
 
@@ -11,6 +12,7 @@ const route = useRoute()
 const router = useRouter()
 const toast = useToast()
 const cache = useQueryCache()
+const { markAsRead, notifications } = useNotifications()
 const requestId = computed(() => route.params.id as string)
 const { formatDateTime, formatCurrency } = useFormatters()
 
@@ -55,6 +57,7 @@ const {
 })
 
 const request = computed(() => requestResponse.value?.data ?? null)
+const isPending = computed(() => request.value?.status === 'pending')
 const isLoading = computed(() => !requestResponse.value && !fetchError.value)
 const isRefreshing = computed(() => asyncStatus.value === 'loading' && requestResponse.value != null)
 
@@ -64,13 +67,27 @@ const pendingListRoute = { path: '/despacho/en-mesa' }
 
 function invalidateAfterAction() {
   cache.invalidateQueries({ key: ['table-qr-requests'] })
+  cache.invalidateQueries({ key: ['notifications'] })
   cache.invalidateQueries({ key: ['tables'] })
   cache.invalidateQueries({ key: ['pos'] })
   cache.invalidateQueries({ key: ['comandas-monitor'] })
 }
 
+async function dismissTableQrNotification(reqId: string) {
+  const notif = notifications.value.find(
+    n => n.type === 'table_qr_request' && n.payload?.request_id === reqId,
+  )
+  if (notif) {
+    try {
+      await markAsRead(notif.id)
+    } catch {
+      // Server may have already marked it read on accept/reject.
+    }
+  }
+}
+
 async function acceptRequest() {
-  if (!request.value || isWorking.value) return
+  if (!request.value || isWorking.value || !isPending.value) return
   const acceptedTableName = request.value.table_name
   isWorking.value = true
   actionError.value = null
@@ -100,6 +117,7 @@ async function acceptRequest() {
     if (res.data?.order_number) {
       toast.success(`Comanda #${res.data.order_number} enviada a cocina`, { title: 'Comanda enviada' })
     }
+    await dismissTableQrNotification(requestId.value)
     invalidateAfterAction()
     await router.replace(pendingListRoute)
   } catch (err: any) {
@@ -113,12 +131,13 @@ async function acceptRequest() {
 }
 
 async function rejectRequest() {
-  if (!request.value || isWorking.value) return
+  if (!request.value || isWorking.value || !isPending.value) return
   isWorking.value = true
   actionError.value = null
   try {
     await $fetch(`/api/table-qr-requests/${requestId.value}/reject`, { method: 'PATCH' })
     toast.success('Pedido rechazado', { title: 'Listo' })
+    await dismissTableQrNotification(requestId.value)
     invalidateAfterAction()
     await router.replace(pendingListRoute)
   } catch (err: any) {
@@ -141,6 +160,7 @@ onMounted(() => {
   setShowBackButton?.(true)
   setBackHandler?.(goBack)
   setRefreshHandler(refetch)
+  refetch()
 })
 registerProgressiveLoading(isRefreshing)
 
@@ -216,7 +236,19 @@ const formatQuantity = (quantity: number) =>
         </div>
       </div>
 
-      <div class="bg-surface border border-border rounded-xl p-4 sm:p-6">
+      <div
+        v-if="request && !isPending"
+        class="bg-state-warning/10 border border-state-warning-border/40 rounded-xl p-4 sm:p-6"
+      >
+        <p class="text-sm font-medium text-text-primary">
+          Este pedido ya fue procesado. Vuelve al listado para ver los pendientes.
+        </p>
+        <UiButton class="mt-4" variant="secondary" @click="goBack">
+          Volver al listado
+        </UiButton>
+      </div>
+
+      <div v-else-if="isPending" class="bg-surface border border-border rounded-xl p-4 sm:p-6">
         <p class="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-4">Acciones</p>
         <div class="flex flex-col sm:flex-row gap-3">
           <UiButton size="lg" :disabled="isWorking" @click="acceptRequest">


### PR DESCRIPTION
## Summary
- Invalidate `table-qr-requests` cache when SSE notifications arrive.
- Guard despacho detail so accept/reject only shows for pending requests.
- Dismiss stale QR notifications with a toast when the request was already processed.
- Mark matching notification read after accept/reject (defense in depth with API change).

## Test plan
- [ ] Send table QR order from public menu → appears in Despacho → Pedidos en mesa.
- [ ] Accept order → disappears from list and bell without manual refresh.
- [ ] Tap old notification for already-accepted order → toast “ya fue aceptado o rechazado”, no second comanda.
- [ ] Second device receives list update via SSE without refresh.

Depends on API PR marking notifications read on accept/reject.

Made with [Cursor](https://cursor.com)