### PR TITLE
Show table session minimum consumption in POS

### DIFF
--- a/components/pos/MesasFloorPlan.vue
+++ b/components/pos/MesasFloorPlan.vue
@@ -160,6 +160,17 @@ const formatDuration = (openedAt: string): string => {
   return m > 0 ? `${h}h ${m}m` : `${h}h`
 }
 
+const formatCurrency = (amount: number): string =>
+  `$${Math.round(amount).toLocaleString('es-CO')}`
+
+const minimumConsumptionLabel = (table: any): string | null => {
+  const state = table.session?.minimum_consumption
+  if (!state?.enabled || !(Number(state.amount) > 0)) return null
+  const remaining = Number(state.remaining) || 0
+  if (state.covered || remaining <= 0) return 'Mínimo cubierto'
+  return `${formatCurrency(remaining)} faltante`
+}
+
 const badgeLabel = (status: string) => {
   if (status === 'open') return 'En servicio'
   if (status === 'bill_requested') return 'Cuenta'
@@ -353,6 +364,13 @@ onUnmounted(() => {
               </div>
               <span class="text-xs sm:text-sm font-medium text-center leading-snug line-clamp-2 w-full min-h-[2.5rem]" :class="tableNameClass(table.status)">
                 {{ table.name }}
+              </span>
+              <span
+                v-if="minimumConsumptionLabel(table)"
+                class="text-[11px] font-semibold text-center tabular-nums -mt-2"
+                :class="tableNameClass(table.status)"
+              >
+                {{ minimumConsumptionLabel(table) }}
               </span>
             </div>
 

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -474,6 +474,19 @@ const mapTabItemsFromApi = (rows: any[]): TabItem[] =>
     sentAt: i.sentAt ?? i.sent_at ?? null,
   }))
 
+const mapMinimumConsumptionFromApi = (raw: any) => {
+  if (!raw) return null
+  return {
+    enabled: raw.enabled === true,
+    amount: Number(raw.amount) || 0,
+    restrictive: raw.restrictive === true,
+    consumed: Number(raw.consumed) || 0,
+    paid: Number(raw.paid) || 0,
+    remaining: Number(raw.remaining) || 0,
+    covered: raw.covered === true,
+  }
+}
+
 const applyTableSessionFromApi = (
   data: { session?: any; tab_items?: any[] } | undefined,
   fetchGen: number,
@@ -494,6 +507,7 @@ const applyTableSessionFromApi = (
     attendedByMemberName: s.attended_by_member_name ?? null,
     effectiveWaiterMemberId: s.effective_waiter_member_id ?? null,
     effectiveWaiterMemberName: s.effective_waiter_member_name ?? null,
+    minimumConsumption: mapMinimumConsumptionFromApi(s.minimum_consumption),
   })
   posStore.setTabItems(mapTabItemsFromApi(data.tab_items ?? []))
 }
@@ -654,6 +668,17 @@ registerTableSessionRefresh(
 
 const formatCurrencyPOS = (amount: number): string =>
   `$${Math.round(amount).toLocaleString('es-CO')}`
+
+const activeMinimumConsumption = computed(() => posStore.activeTableSession?.minimumConsumption ?? null)
+const showActiveMinimumConsumption = computed(() =>
+  !!activeMinimumConsumption.value?.enabled && activeMinimumConsumption.value.amount > 0,
+)
+const activeMinimumRemainingLabel = computed(() => {
+  const state = activeMinimumConsumption.value
+  if (!state) return ''
+  if (state.covered || state.remaining <= 0) return 'Mínimo cubierto'
+  return `${formatCurrencyPOS(state.remaining)} por consumir`
+})
 
 // Issue #956 — unified destructive-action confirmation with required motivo
 type DestructiveFlow =
@@ -1613,6 +1638,14 @@ onUnmounted(() => {
               </div>
               <p class="text-xs text-text-secondary tabular-nums mt-1">
                 {{ formatCurrencyPOS(posStore.activeTableSession.runningTotal) }} acumulado · {{ formatDuration(posStore.activeTableSession.openedAt) }}
+              </p>
+              <p
+                v-if="showActiveMinimumConsumption && activeMinimumConsumption"
+                class="text-xs text-text-secondary tabular-nums mt-1"
+              >
+                Mínimo {{ formatCurrencyPOS(activeMinimumConsumption.amount) }} ·
+                Consumido {{ formatCurrencyPOS(activeMinimumConsumption.consumed) }} ·
+                {{ activeMinimumRemainingLabel }}
               </p>
               <p
                 v-if="comandasEnabled && unfiredCount > 0"

--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -42,6 +42,16 @@ export interface Customer {
     email: string | null
 }
 
+export interface MinimumConsumptionState {
+    enabled: boolean
+    amount: number
+    restrictive: boolean
+    consumed: number
+    paid: number
+    remaining: number
+    covered: boolean
+}
+
 export interface ActiveTableSession {
     tableId: string
     sessionId: string
@@ -55,6 +65,7 @@ export interface ActiveTableSession {
     attendedByMemberName?: string | null
     effectiveWaiterMemberId?: string | null
     effectiveWaiterMemberName?: string | null
+    minimumConsumption?: MinimumConsumptionState | null
 }
 
 export interface TabItemModifier {


### PR DESCRIPTION
## Summary\n- type and map table-session minimum consumption state in POS store\n- show minimum/consumed/remaining in the active mesa banner\n- add a compact floor-plan minimum indicator for occupied tables\n\n## Tests\n- git diff --check\n- npm run test -- --run (fails: package has no test script)\n- npm run lint (fails: package has no lint script)\n- npm run build (hung during Nuxt build after warnings; stopped the validation process)\n\nCloses #1369