### PR TITLE
Reflect table minimum advances in POS close

### DIFF
--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1733,7 +1733,11 @@ const processOrder = async () => {
       document.body.classList.remove('printing-prefactura')
       prefacturaPrintSnapshot.value = null
     } catch (error: any) {
-      processingError.value = error.data?.message || error.message || `Error al cerrar la ${tableSingularLower.value}`
+      const detail = error.data?.detail
+      processingError.value = error.data?.message
+        || (typeof detail === 'string' ? detail : null)
+        || error.message
+        || `Error al cerrar la ${tableSingularLower.value}`
     } finally {
       isProcessing.value = false
     }
@@ -1945,10 +1949,25 @@ watch(deliveryEnabled, (enabled) => {
 // order_payments (split lines) or orders (single payment).
 const isCashMethod = computed(() => selectedGroup.value?.slug === 'cash')
 const cashReceivedInput = ref<number>(0)
+const mesaMinimumConsumption = computed(() =>
+  mesaCurrentData.value?.data?.session?.minimum_consumption
+  ?? posStore.activeTableSession?.minimumConsumption
+  ?? null
+)
+const mesaAdvanceAvailable = computed(() =>
+  Number(mesaMinimumConsumption.value?.advance_total ?? mesaMinimumConsumption.value?.advance ?? 0) || 0
+)
+const mesaAdvanceAppliedEstimate = computed(() => {
+  if (!isKitchenServiceMode.value || splitMode.value) return 0
+  return Math.min(discountedTotal.value, mesaAdvanceAvailable.value)
+})
+const finalAmountToCollect = computed(() =>
+  Math.max(0, finalChargedAmount.value - mesaAdvanceAppliedEstimate.value)
+)
 
 // warocol.com#639 — single-payment cash flow must cover total + tip (#737: split too).
 const cashAmountToCharge = computed(() =>
-  splitMode.value ? splitAmountToCharge.value : finalChargedAmount.value
+  splitMode.value ? splitAmountToCharge.value : finalAmountToCollect.value
 )
 
 const cashChange = computed(() =>
@@ -3782,8 +3801,8 @@ onUnmounted(() => {
                 ? 'Dejar venta pendiente'
                 : selectedPaymentMethod === 'credit'
                 ? 'Registrar como crédito'
-                : tipAmount > 0
-                  ? `Confirmar — ${formatCurrency(finalChargedAmount)}`
+                : tipAmount > 0 || mesaAdvanceAppliedEstimate > 0
+                  ? `Confirmar — ${formatCurrency(finalAmountToCollect)}`
                   : 'Confirmar Orden' }}
             </span>
             <svg v-if="!isProcessing" class="h-5 w-5 opacity-0 -ml-4 group-hover:opacity-100 group-hover:ml-0 transition-all" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -482,7 +482,12 @@ const mapMinimumConsumptionFromApi = (raw: any) => {
     restrictive: raw.restrictive === true,
     consumed: Number(raw.consumed) || 0,
     paid: Number(raw.paid) || 0,
+    advance: Number(raw.advance ?? raw.advance_total) || 0,
+    advanceTotal: Number(raw.advance_total ?? raw.advance) || 0,
+    coveredAmount: Number(raw.covered_amount) || 0,
     remaining: Number(raw.remaining) || 0,
+    missing: Number(raw.missing ?? raw.remaining) || 0,
+    overageDue: Number(raw.overage_due) || 0,
     covered: raw.covered === true,
   }
 }
@@ -677,7 +682,7 @@ const activeMinimumRemainingLabel = computed(() => {
   const state = activeMinimumConsumption.value
   if (!state) return ''
   if (state.covered || state.remaining <= 0) return 'Mínimo cubierto'
-  return `${formatCurrencyPOS(state.remaining)} por consumir`
+  return `${formatCurrencyPOS(state.remaining)} faltante`
 })
 
 // Issue #956 — unified destructive-action confirmation with required motivo

--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -48,7 +48,12 @@ export interface MinimumConsumptionState {
     restrictive: boolean
     consumed: number
     paid: number
+    advance: number
+    advanceTotal: number
+    coveredAmount: number
     remaining: number
+    missing: number
+    overageDue: number
     covered: boolean
 }
 


### PR DESCRIPTION
## Summary
- include advance coverage in POS minimum-consumption state
- show remaining minimum as faltante after advances
- reduce single-payment cash amount to the overage when an advance is available

## Tests
- npm run test -- --run (not available: package has no test script)
- npm run build (started but remained running silently; terminated after long quiet stretch)
- npx nuxi typecheck (started but remained running silently; terminated after long quiet stretch)

Closes #1371