### PR TITLE
Add POS-style printing for sale details

### DIFF
--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -1,0 +1,420 @@
+<script setup lang="ts">
+interface ReceiptItemModifier {
+  id?: string | number | null
+  name: string
+  quantity?: number | string | null
+  price?: number | string | null
+  total?: number | string | null
+}
+
+interface ReceiptItem {
+  id?: string | number | null
+  name: string
+  quantity: number | string
+  unitPrice: number
+  total: number
+  modifiers?: ReceiptItemModifier[]
+}
+
+interface ReceiptPaymentLine {
+  id?: string | number | null
+  label: string
+  amount: number
+  change?: number | null
+}
+
+interface PromoLine {
+  promotion_id?: string | number | null
+  promotion_name?: string | null
+  savings: number
+}
+
+const props = defineProps<{
+  fiscalData?: {
+    business_name?: string | null
+    nit?: string | null
+    fiscal_address?: string | null
+    city?: string | null
+    phone?: string | null
+    email?: string | null
+  } | null
+  displayName?: string | null
+  address?: string | null
+  city?: string | null
+  phone?: string | null
+  logoUrl?: string | null
+  documentLabel: string
+  orderNumber?: string | number | null
+  soldAt?: string | null
+  locationLabel?: string | null
+  waiterName?: string | null
+  customerName?: string | null
+  customerFiscalLabel?: string | null
+  items: ReceiptItem[]
+  subtotal?: number
+  promoBreakdown?: PromoLine[]
+  discountAmount?: number
+  waroDiscountLabel?: string
+  waroDiscountAmount?: number
+  standardTaxLabel?: string | null
+  standardTax?: number
+  liquorTax?: number
+  orderTotal: number
+  tipLabel?: string
+  tipAmount?: number
+  tipTaxAmount?: number
+  advanceApplied?: number
+  chargedTotal?: number | null
+  payments?: ReceiptPaymentLine[]
+  singlePaymentLabel?: string | null
+  invoice?: {
+    prefix?: string | null
+    invoice_number?: string | number | null
+    cufe?: string | null
+    status?: string | null
+  } | null
+}>()
+
+const money = (value: number | string | null | undefined) => {
+  const n = Number(value) || 0
+  return new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    minimumFractionDigits: 0,
+  }).format(n)
+}
+
+const modifierTotal = (modifier: ReceiptItemModifier) => {
+  const explicitTotal = Number(modifier.total)
+  if (Number.isFinite(explicitTotal) && explicitTotal > 0) return explicitTotal
+  return (Number(modifier.price) || 0) * (Number(modifier.quantity) || 1)
+}
+
+const modifierDescription = (modifier: ReceiptItemModifier) => {
+  const qty = Number(modifier.quantity) || 1
+  return qty > 1 ? `+ ${modifier.name} x${qty}` : `+ ${modifier.name}`
+}
+
+const hasBreakdownSubtotal = computed(() =>
+  (props.promoBreakdown?.length ?? 0) > 0
+  || Number(props.discountAmount) > 0
+  || Number(props.waroDiscountAmount) > 0,
+)
+
+const hasTaxBreakdown = computed(() =>
+  Number(props.standardTax) > 0 || Number(props.liquorTax) > 0,
+)
+
+const hasSettlementBreakdown = computed(() =>
+  Number(props.tipAmount) > 0 || Number(props.tipTaxAmount) > 0 || Number(props.advanceApplied) > 0,
+)
+
+const finalTotal = computed(() =>
+  props.chargedTotal != null ? Number(props.chargedTotal) : Number(props.orderTotal) || 0,
+)
+</script>
+
+<template>
+  <div class="receipt-print-ticket" aria-hidden="true">
+    <PosReceiptPrintHeader
+      :fiscal-data="fiscalData"
+      :display-name="displayName"
+      :address="address"
+      :city="city"
+      :phone="phone"
+      :logo-url="logoUrl"
+    />
+
+    <div class="receipt-divider">================================</div>
+    <div class="receipt-row receipt-small" style="font-weight:bold;">
+      {{ documentLabel }}<span v-if="orderNumber"> #{{ orderNumber }}</span>
+    </div>
+    <div v-if="soldAt" class="receipt-row receipt-small">{{ soldAt }}</div>
+    <div v-if="locationLabel" class="receipt-row receipt-small">{{ locationLabel }}</div>
+    <div v-if="waiterName" class="receipt-row receipt-small">Mesero: {{ waiterName }}</div>
+
+    <template v-if="customerName">
+      <div class="receipt-divider receipt-small">--------------------------------</div>
+      <div class="receipt-row receipt-small" style="font-weight:bold;">Datos cliente</div>
+      <div class="receipt-row receipt-small">{{ customerName }}</div>
+      <div v-if="customerFiscalLabel" class="receipt-row receipt-small">{{ customerFiscalLabel }}</div>
+    </template>
+
+    <div class="receipt-divider">--------------------------------</div>
+    <div class="receipt-grid-header receipt-small">
+      <span class="receipt-col-desc">Descripcion</span>
+      <span class="receipt-col-qty">Cant</span>
+      <span class="receipt-col-price">Precio</span>
+      <span class="receipt-col-total">Total</span>
+    </div>
+
+    <template v-for="item in items" :key="item.id ?? item.name">
+      <div class="receipt-grid-row receipt-small">
+        <span class="receipt-col-desc">{{ item.name }}</span>
+        <span class="receipt-col-qty">{{ item.quantity }}</span>
+        <span class="receipt-col-price">{{ money(item.unitPrice) }}</span>
+        <span class="receipt-col-total">{{ money(item.total) }}</span>
+      </div>
+      <div
+        v-for="modifier in (item.modifiers ?? [])"
+        :key="`${item.id ?? item.name}-${modifier.id ?? modifier.name}`"
+        class="receipt-grid-row receipt-small receipt-modifier-row"
+      >
+        <span class="receipt-col-desc">{{ modifierDescription(modifier) }}</span>
+        <span class="receipt-col-qty">{{ (Number(modifier.quantity) || 1) > 1 ? modifier.quantity : '' }}</span>
+        <span class="receipt-col-price">{{ money(modifier.price) }}</span>
+        <span class="receipt-col-total">{{ money(modifierTotal(modifier)) }}</span>
+      </div>
+    </template>
+
+    <div class="receipt-divider">--------------------------------</div>
+
+    <div v-if="hasBreakdownSubtotal && subtotal != null" class="receipt-item">
+      <span>Subtotal</span>
+      <span>{{ money(subtotal) }}</span>
+    </div>
+    <div
+      v-for="promo in (promoBreakdown ?? [])"
+      :key="promo.promotion_id ?? promo.promotion_name"
+      class="receipt-item"
+    >
+      <span>{{ promo.promotion_name || 'Promocion' }}</span>
+      <span>-{{ money(promo.savings) }}</span>
+    </div>
+    <div v-if="Number(discountAmount) > 0" class="receipt-item">
+      <span>Descuento manual</span>
+      <span>-{{ money(discountAmount) }}</span>
+    </div>
+    <div v-if="Number(waroDiscountAmount) > 0" class="receipt-item">
+      <span>{{ waroDiscountLabel || 'Canje WaRo' }}</span>
+      <span>-{{ money(waroDiscountAmount) }}</span>
+    </div>
+
+    <template v-if="hasTaxBreakdown">
+      <div class="receipt-row receipt-small" style="font-weight:bold;">Detalle de impuestos</div>
+      <div v-if="Number(standardTax) > 0" class="receipt-item receipt-small">
+        <span>{{ standardTaxLabel || 'Impuesto' }}</span>
+        <span>{{ money(standardTax) }}</span>
+      </div>
+      <div v-if="Number(liquorTax) > 0" class="receipt-item receipt-small">
+        <span>IVA licores 5%</span>
+        <span>{{ money(liquorTax) }}</span>
+      </div>
+    </template>
+
+    <template v-if="hasSettlementBreakdown">
+      <div class="receipt-item">
+        <span>Total orden</span>
+        <span>{{ money(orderTotal) }}</span>
+      </div>
+      <div v-if="Number(tipAmount) > 0" class="receipt-item">
+        <span>{{ tipLabel || 'Propina' }}</span>
+        <span>{{ money(tipAmount) }}</span>
+      </div>
+      <div v-if="Number(tipTaxAmount) > 0" class="receipt-item">
+        <span>Impuesto propina</span>
+        <span>{{ money(tipTaxAmount) }}</span>
+      </div>
+      <div v-if="Number(advanceApplied) > 0" class="receipt-item">
+        <span>Anticipo mesa</span>
+        <span>-{{ money(advanceApplied) }}</span>
+      </div>
+      <div class="receipt-total">
+        <span>TOTAL COBRADO</span>
+        <span>{{ money(finalTotal) }}</span>
+      </div>
+    </template>
+    <div v-else class="receipt-total">
+      <span>TOTAL</span>
+      <span>{{ money(orderTotal) }}</span>
+    </div>
+
+    <div class="receipt-divider">--------------------------------</div>
+    <div class="receipt-row receipt-small" style="font-weight:bold;">Detalle de pago</div>
+    <template v-if="(payments?.length ?? 0) > 0">
+      <template v-for="(payment, idx) in payments" :key="payment.id ?? idx">
+        <div class="receipt-item receipt-small">
+          <span>#{{ idx + 1 }} · {{ payment.label }}</span>
+          <span>{{ money(payment.amount) }}</span>
+        </div>
+        <div v-if="payment.change && payment.change > 0" class="receipt-item receipt-small">
+          <span>Cambio (#{{ idx + 1 }})</span>
+          <span>{{ money(payment.change) }}</span>
+        </div>
+      </template>
+    </template>
+    <template v-else>
+      <div class="receipt-item receipt-small">
+        <span>{{ singlePaymentLabel || 'Pendiente por definir' }}</span>
+        <span>{{ money(finalTotal) }}</span>
+      </div>
+    </template>
+
+    <div class="receipt-divider">================================</div>
+    <div class="receipt-footer">Gracias por tu compra</div>
+
+    <template v-if="invoice">
+      <div class="receipt-divider">================================</div>
+      <div class="receipt-row" style="font-weight:bold;">FACTURA ELECTRONICA</div>
+      <div v-if="invoice.prefix || invoice.invoice_number" class="receipt-row">
+        {{ [invoice.prefix, invoice.invoice_number].filter(Boolean).join('-') }}
+      </div>
+      <div v-if="invoice.cufe" class="receipt-row receipt-small receipt-cufe">
+        CUFE: {{ invoice.cufe }}
+      </div>
+      <div class="receipt-divider">================================</div>
+    </template>
+  </div>
+</template>
+
+<style>
+.receipt-print-ticket {
+  display: none;
+}
+
+.receipt-print-ticket .receipt-logo {
+  max-width: 22mm;
+  max-height: 11mm;
+  display: block;
+  margin: 0 auto 4px;
+  object-fit: contain;
+  filter: grayscale(100%);
+  -webkit-filter: grayscale(100%);
+}
+
+.receipt-print-ticket .receipt-header {
+  font-size: 1.1em;
+  font-weight: bold;
+  text-align: center;
+  margin-bottom: 4px;
+}
+
+.receipt-print-ticket .receipt-row {
+  text-align: center;
+  margin: 2px 0;
+}
+
+.receipt-print-ticket .receipt-divider {
+  letter-spacing: 0;
+  margin: 4px 0;
+}
+
+.receipt-print-ticket .receipt-item {
+  display: flex;
+  justify-content: space-between;
+  margin: 2px 0;
+  gap: 4px;
+}
+
+.receipt-print-ticket .receipt-item span:first-child {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.receipt-print-ticket .receipt-item span:last-child {
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.receipt-print-ticket .receipt-total {
+  display: flex;
+  justify-content: space-between;
+  font-weight: bold;
+  font-size: 1.1em;
+  margin: 4px 0;
+}
+
+.receipt-print-ticket .receipt-cufe {
+  word-break: break-all;
+  text-align: center;
+}
+
+.receipt-print-ticket .receipt-footer {
+  text-align: center;
+  margin-top: 8px;
+}
+
+.receipt-print-ticket .receipt-small {
+  font-size: 0.85em;
+}
+
+.receipt-print-ticket .receipt-grid-header,
+.receipt-print-ticket .receipt-grid-row {
+  display: grid;
+  grid-template-columns: 1fr 7mm 14mm 16mm;
+  gap: 1mm;
+  align-items: start;
+  margin: 2px 0;
+}
+
+.receipt-print-ticket .receipt-col-desc {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.receipt-print-ticket .receipt-col-qty,
+.receipt-print-ticket .receipt-col-price,
+.receipt-print-ticket .receipt-col-total {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.receipt-print-ticket .receipt-grid-header {
+  font-weight: bold;
+  border-bottom: 1px dashed #000;
+  padding-bottom: 2px;
+  margin-bottom: 4px;
+}
+
+.receipt-print-ticket .receipt-modifier-row .receipt-col-desc {
+  padding-left: 8px;
+  font-size: 0.92em;
+}
+
+@media print {
+  body.printing-receipt-ticket {
+    margin: 0;
+    padding: 0;
+  }
+
+  body.printing-receipt-ticket * {
+    visibility: hidden;
+  }
+
+  body.printing-receipt-ticket .receipt-print-ticket,
+  body.printing-receipt-ticket .receipt-print-ticket * {
+    visibility: visible !important;
+  }
+
+  body.printing-receipt-ticket .receipt-print-ticket {
+    display: block !important;
+    font-family: 'Courier New', Courier, monospace;
+    font-size: 9pt;
+    line-height: 1.2;
+    letter-spacing: 0;
+    width: 72mm;
+    color: #000;
+    background: #fff;
+    padding: 2mm;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+
+  body.printing-receipt-ticket .receipt-print-ticket .receipt-logo {
+    filter: grayscale(100%) !important;
+    -webkit-filter: grayscale(100%) !important;
+  }
+
+  body.printing-receipt-ticket .receipt-print-ticket .receipt-item {
+    page-break-inside: avoid;
+  }
+
+  @page {
+    size: 80mm auto;
+    margin: 2mm;
+  }
+}
+</style>

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, nextTick } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 import { formatPromoTypeLabel } from '~/utils/promotionPreview'
 import { mergePosPaymentGroupsFromApi, type ApiPaymentGroup } from '~/utils/paymentDefaults'
@@ -11,8 +11,13 @@ definePageMeta({
 useHead({ title: 'Detalle de Venta' })
 
 // Tenant reactivity
-const { currentTenant } = useTenantReactive()
+const { currentTenant, businessProfile } = useTenantReactive()
 const { singular: tableSingular } = useTableLabel()
+const {
+  receiptPrintSettings,
+  receiptLogoUrl,
+  settingsData,
+} = useReceiptPrintSettings()
 
 // Payment groups for label resolution and method buttons
 const { data: paymentGroupsData } = useQuery({
@@ -113,6 +118,7 @@ const { data: posContextRes, asyncStatus: posContextAsyncStatus } = useQuery({
 })
 const isInvoicingReady = computed(() => posContextRes.value?.data?.invoicing_ready === true)
 const isReadinessLoading = computed(() => posContextAsyncStatus.value === 'loading' && !posContextRes.value)
+const fiscalData = computed(() => settingsData.value?.data?.fiscal_data ?? null)
 
 // Invoice emit state
 const isEmittingInvoice = ref(false)
@@ -315,6 +321,125 @@ const formatCurrency = (value: number) => {
 
 const { formatDateTime: formatDate } = useFormatters()
 
+type SaleReceiptModifier = {
+  id?: string | number | null
+  name: string
+  quantity?: number | string | null
+  price?: number | string | null
+  total?: number | string | null
+}
+
+const receiptDocumentLabel = computed(() => {
+  const label = (receiptPrintSettings.value.document_label || '').trim()
+  if (!label || /prefactura|pre-cuenta|pre cuenta|precuenta|pre-factura|pre factura/i.test(label)) return 'Factura'
+  if (/factura/i.test(label)) return label
+  return label
+})
+
+const receiptTipLabel = computed(() => {
+  const label = (receiptPrintSettings.value.tip_label || 'Propina').trim()
+  return label || 'Propina'
+})
+
+const itemModifierTotal = (modifier: SaleReceiptModifier) =>
+  (Number(modifier.price) || 0) * (Number(modifier.quantity) || 1)
+
+const itemReceiptTotal = (item: any) => {
+  const explicitSubtotal = Number(item.subtotal ?? item.net_total)
+  if (Number.isFinite(explicitSubtotal) && explicitSubtotal > 0) return explicitSubtotal
+  const modifiersTotal = (item.modifiers ?? []).reduce(
+    (sum: number, modifier: SaleReceiptModifier) => sum + itemModifierTotal(modifier),
+    0,
+  )
+  return (Number(item.price_at_purchase) + modifiersTotal) * (Number(item.quantity) || 1)
+}
+
+const saleReceiptItems = computed(() =>
+  items.value.map((item: any) => {
+    const quantity = Number(item.quantity) || 1
+    const total = itemReceiptTotal(item)
+    return {
+      id: item.id,
+      name: item.product?.name || item.name || 'Producto',
+      quantity,
+      unitPrice: total / quantity,
+      total,
+      modifiers: (item.modifiers ?? []).map((modifier: any) => ({
+        id: modifier.id,
+        name: modifier.name || 'Adicion',
+        quantity: modifier.quantity ?? 1,
+        price: Number(modifier.price) || 0,
+        total: itemModifierTotal(modifier),
+      })),
+    }
+  }),
+)
+
+const saleReceiptPromoBreakdown = computed(() => {
+  const breakdown = order.value?.promo_breakdown ?? []
+  if (breakdown.length > 0) return breakdown
+  const savings = Number(order.value?.promo_savings) || 0
+  if (savings <= 0) return []
+  return [{ promotion_name: 'Promocion', savings }]
+})
+
+const saleReceiptWaroDiscountLabel = computed(() => {
+  const firstLine = effectiveWaroBreakdown.value.find((line: any) => Number(line.cop_discount) > 0)
+  return firstLine ? orderWaroLineLabel(firstLine) : 'Canje WaRo'
+})
+
+const saleReceiptLocationLabel = computed(() => {
+  const o = order.value
+  if (!o) return null
+  if (o.is_delivery) return 'Domicilio'
+  if (o.source === 'barra') return 'Barra'
+  if (o.source === 'mesa') {
+    const tableName = o.table_display_name || o.table_name || o.table?.name || null
+    const tableCode = o.table_code || o.table?.code || null
+    return [tableSingular.value, tableCode, tableName].filter(Boolean).join(' ')
+  }
+  return 'Mostrador'
+})
+
+const saleReceiptSoldAt = computed(() => {
+  const o = order.value
+  if (!o) return null
+  const date = o.completed_at || o.closed_at || o.created_at || o.updated_at
+  return date ? formatDate(date) : null
+})
+
+const saleReceiptCustomerFiscalLabel = computed(() => {
+  const customer = order.value?.customer
+  const type = customer?.fiscal_id_type || customer?.document_type || customer?.identification_type
+  const number = customer?.fiscal_id || customer?.document_number || customer?.identification_number
+  return type && number ? `${type}: ${number}` : null
+})
+
+const saleReceiptPayments = computed(() =>
+  (order.value?.split_payments ?? []).map((payment: any) => ({
+    id: payment.id,
+    label: resolveLabel(payment.payment_method, payment.payment_method_id),
+    amount: Number(payment.amount) || 0,
+    change: Number(payment.change) || null,
+  })),
+)
+
+const saleReceiptSinglePaymentLabel = computed(() => {
+  const o = order.value
+  if (!o?.payment_method) return null
+  return resolveLabel(o.payment_method, o.payment_method_id)
+})
+
+const saleReceiptInvoice = computed(() => {
+  if (!invoiceData.value) return null
+  return {
+    prefix: invoiceData.value.prefix,
+    invoice_number: invoiceData.value.invoice_number,
+    cufe: invoiceData.value.cufe,
+    status: invoiceData.value.status,
+  }
+})
+
 
 // ── Credit panel state ──────────────────────────────────────────────────────
 
@@ -340,8 +465,26 @@ const goBack = () => {
   router.push('/ventas')
 }
 
-const printReceipt = () => {
+const printReceipt = async () => {
+  if (!order.value) {
+    useToast().error('No se pudo cargar la venta para imprimir.', { title: 'Sin datos' })
+    return
+  }
+  if (itemsLoading.value) {
+    useToast().error('Espera a que carguen los productos antes de imprimir.', { title: 'Cargando venta' })
+    return
+  }
+  if (saleReceiptItems.value.length === 0) {
+    useToast().error('La venta no tiene productos para imprimir.', { title: 'Sin productos' })
+    return
+  }
+
+  document.body.classList.add('printing-receipt-ticket')
+  await nextTick()
   window.print()
+  window.setTimeout(() => {
+    document.body.classList.remove('printing-receipt-ticket')
+  }, 250)
 }
 
 // Edit mode functions
@@ -1497,6 +1640,41 @@ onUnmounted(() => {
       :invoice-label="`${invoiceData.prefix}-${invoiceData.invoice_number}`"
       :customer="orderData?.customer ?? null"
       @sent="onInvoiceEmailSent"
+    />
+
+    <PosReceiptPrintTicket
+      v-if="order"
+      :fiscal-data="fiscalData"
+      :display-name="businessProfile?.display_name"
+      :address="businessProfile?.address"
+      :city="businessProfile?.city"
+      :phone="businessProfile?.phone_number"
+      :logo-url="receiptLogoUrl"
+      :document-label="receiptDocumentLabel"
+      :order-number="order.order_number"
+      :sold-at="saleReceiptSoldAt"
+      :location-label="saleReceiptLocationLabel"
+      :waiter-name="order.served_by_member_name"
+      :customer-name="order.customer_name"
+      :customer-fiscal-label="saleReceiptCustomerFiscalLabel"
+      :items="saleReceiptItems"
+      :subtotal="grossSubtotal"
+      :promo-breakdown="saleReceiptPromoBreakdown"
+      :discount-amount="Number(order.discount_amount) || 0"
+      :waro-discount-label="saleReceiptWaroDiscountLabel"
+      :waro-discount-amount="effectiveWaroDiscountCop"
+      :standard-tax-label="order.standard_tax_label"
+      :standard-tax="Number(order.standard_tax) || 0"
+      :liquor-tax="Number(order.liquor_tax) || 0"
+      :order-total="Number(order.total_amount) || 0"
+      :tip-label="receiptTipLabel"
+      :tip-amount="Number(order.tip_amount) || 0"
+      :tip-tax-amount="Number(order.tip_tax_amount) || 0"
+      :advance-applied="orderAdvanceApplied"
+      :charged-total="orderChargedTotal"
+      :payments="saleReceiptPayments"
+      :single-payment-label="saleReceiptSinglePaymentLabel"
+      :invoice="saleReceiptInvoice"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- add a reusable thermal receipt ticket component with POS-style 80mm print CSS
- wire `/ventas/[id]` print action to the hidden receipt instead of generic page printing
- include business/logo, items, modifiers, discounts, taxes, tip, advances, split payments, totals, and invoice metadata when available

## Tests
- npm exec nuxi -- prepare
- git diff --check -- pages/ventas/[id].vue components/pos/ReceiptPrintTicket.vue
- npm run build (client and server builds completed; Nitro packaging stalled without error and was cancelled)

Closes #1383