### PR TITLE
Fix sale receipt logo size and DIAN QR

### DIFF
--- a/components/dashboard/DashboardShellHeader.vue
+++ b/components/dashboard/DashboardShellHeader.vue
@@ -50,13 +50,18 @@
         <button
           v-if="headerAction"
           key="dynamic-header-action"
-          class="h-11 max-w-48 flex-shrink-0 px-3 lg:px-4 bg-shell-cta-bg text-shell-cta-text rounded-lg font-medium hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring transition-colors flex items-center gap-2"
+          :class="[
+            'h-11 flex-shrink-0 bg-shell-cta-bg text-shell-cta-text rounded-lg font-medium hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring transition-colors flex items-center justify-center gap-2',
+            headerAction.iconOnly ? 'w-11 px-0' : 'max-w-48 px-3 lg:px-4',
+          ]"
+          :aria-label="headerAction.ariaLabel || headerAction.label"
+          :title="headerAction.ariaLabel || headerAction.label"
           @click="headerAction.handler"
         >
           <svg v-if="headerAction.icon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 0 2 2-2v-4a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2h2m2 4h6a2 2 0 0 0 2-2v-4a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2zm8-12V5a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2v4h10z" />
           </svg>
-          <span class="truncate">{{ headerAction.label }}</span>
+          <span v-if="!headerAction.iconOnly" class="truncate">{{ headerAction.label }}</span>
         </button>
 
         <span
@@ -101,7 +106,7 @@ import logoSrc from '~/public/logo_waro_colombia.png'
 
 defineProps<{
   status?: { label: string; color: string }
-  headerAction?: { label: string; icon?: boolean; handler: () => void }
+  headerAction?: { label: string; ariaLabel?: string; icon?: boolean; iconOnly?: boolean; handler: () => void }
   isRefreshing?: boolean
   isProgressiveLoading?: boolean
   hideLogo?: boolean

--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -72,6 +72,7 @@ const props = defineProps<{
     invoice_number?: string | number | null
     cufe?: string | null
     status?: string | null
+    qrDataUrl?: string | null
   } | null
 }>()
 
@@ -262,6 +263,13 @@ const finalTotal = computed(() =>
       <div v-if="invoice.cufe" class="receipt-row receipt-small receipt-cufe">
         CUFE: {{ invoice.cufe }}
       </div>
+      <img
+        v-if="invoice.qrDataUrl"
+        :src="invoice.qrDataUrl"
+        alt="QR verificacion DIAN"
+        class="receipt-qr"
+      >
+      <div v-if="invoice.cufe" class="receipt-row receipt-small">Verificar en DIAN</div>
       <div class="receipt-divider">================================</div>
     </template>
   </div>
@@ -273,8 +281,9 @@ const finalTotal = computed(() =>
 }
 
 .receipt-print-ticket .receipt-logo {
+  width: 18mm;
   max-width: 22mm;
-  max-height: 11mm;
+  max-height: 18mm;
   display: block;
   margin: 0 auto 4px;
   object-fit: contain;
@@ -328,6 +337,13 @@ const finalTotal = computed(() =>
 .receipt-print-ticket .receipt-cufe {
   word-break: break-all;
   text-align: center;
+}
+
+.receipt-print-ticket .receipt-qr {
+  width: 30mm;
+  height: 30mm;
+  margin: 4px auto;
+  display: block;
 }
 
 .receipt-print-ticket .receipt-footer {

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -169,10 +169,11 @@ provide('setBackHandler', (handler: (() => void) | undefined) => {
 })
 
 // Dynamic header action (like print button) - can be set by child pages
-const dynamicHeaderAction = ref<{ label: string; icon?: boolean; handler: () => void } | undefined>(undefined)
+type HeaderAction = { label: string; ariaLabel?: string; icon?: boolean; iconOnly?: boolean; handler: () => void }
+const dynamicHeaderAction = ref<HeaderAction | undefined>(undefined)
 
 // Provide header action setter for child pages
-provide('setHeaderAction', (action: { label: string; icon?: boolean; handler: () => void } | undefined) => {
+provide('setHeaderAction', (action: HeaderAction | undefined) => {
   dynamicHeaderAction.value = action
 })
 

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -657,7 +657,7 @@ const saveChanges = async () => {
 const setPageStatus = inject<(status: { label: string; color: string } | undefined) => void>('setPageStatus')
 const setShowBackButton = inject<(show: boolean) => void>('setShowBackButton')
 const setBackHandler = inject<(handler: (() => void) | undefined) => void>('setBackHandler')
-const setHeaderAction = inject<(action: { label: string; icon?: boolean; handler: () => void } | undefined) => void>('setHeaderAction')
+const setHeaderAction = inject<(action: { label: string; ariaLabel?: string; icon?: boolean; iconOnly?: boolean; handler: () => void } | undefined) => void>('setHeaderAction')
 
 // Watch order data and update layout header
 watch(order, (newOrder) => {
@@ -676,7 +676,9 @@ onMounted(() => {
   setBackHandler?.(goBack)
   setHeaderAction?.({
     label: 'Imprimir',
+    ariaLabel: 'Imprimir venta',
     icon: true,
+    iconOnly: true,
     handler: printReceipt
   })
 })

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, nextTick } from 'vue'
+import QRCode from 'qrcode'
 import { useFormatters } from '~/composables/useFormatters'
 import { formatPromoTypeLabel } from '~/utils/promotionPreview'
 import { mergePosPaymentGroupsFromApi, type ApiPaymentGroup } from '~/utils/paymentDefaults'
@@ -124,6 +125,7 @@ const fiscalData = computed(() => settingsData.value?.data?.fiscal_data ?? null)
 const isEmittingInvoice = ref(false)
 const emitInvoiceError = ref('')
 const copiedCufe = ref(false)
+const invoiceQrDataUrl = ref('')
 
 // warocol.com#598 — invoice email modal trigger
 const showEmailModal = ref(false)
@@ -437,8 +439,14 @@ const saleReceiptInvoice = computed(() => {
     invoice_number: invoiceData.value.invoice_number,
     cufe: invoiceData.value.cufe,
     status: invoiceData.value.status,
+    qrDataUrl: invoiceQrDataUrl.value,
   }
 })
+
+async function buildInvoiceQrDataUrl(cufe: string): Promise<string> {
+  const dianUrl = `https://catalogo-vpfe.dian.gov.co/document/searchqr?documentkey=${cufe}`
+  return QRCode.toDataURL(dianUrl, { width: 150, margin: 1 })
+}
 
 
 // ── Credit panel state ──────────────────────────────────────────────────────
@@ -477,6 +485,9 @@ const printReceipt = async () => {
   if (saleReceiptItems.value.length === 0) {
     useToast().error('La venta no tiene productos para imprimir.', { title: 'Sin productos' })
     return
+  }
+  if (invoiceData.value?.cufe && !invoiceQrDataUrl.value) {
+    invoiceQrDataUrl.value = await buildInvoiceQrDataUrl(invoiceData.value.cufe)
   }
 
   document.body.classList.add('printing-receipt-ticket')


### PR DESCRIPTION
## Summary
- generate the DIAN QR in `/ventas/[id]` before printing when the invoice has CUFE
- render that QR in the shared POS-style receipt ticket
- force the printed logo to a visible thermal-ticket size instead of relying only on max dimensions

## Tests
- npm exec nuxi -- prepare
- git diff --check
- npm run build (client build completed; SSR phase stalled without error and was cancelled)
