### PR TITLE
Render explicit printer header icon

### DIFF
--- a/components/dashboard/DashboardShellHeader.vue
+++ b/components/dashboard/DashboardShellHeader.vue
@@ -51,7 +51,10 @@
           v-if="headerAction"
           key="dynamic-header-action"
           :class="[
-            'h-11 flex-shrink-0 bg-shell-cta-bg text-shell-cta-text rounded-lg font-medium hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring transition-colors flex items-center justify-center gap-2',
+            'h-11 flex-shrink-0 rounded-lg font-medium focus:outline-none focus:ring-2 transition-colors flex items-center justify-center gap-2',
+            headerAction.iconOnly
+              ? 'bg-shell-icon-bg text-shell-icon-text hover:bg-shell-icon-hover-bg focus:ring-shell-action-focus-ring'
+              : 'bg-shell-cta-bg text-shell-cta-text hover:bg-shell-cta-hover-bg focus:ring-shell-cta-focus-ring',
             headerAction.iconOnly ? 'w-11 px-0' : 'max-w-48 px-3 lg:px-4',
           ]"
           :aria-label="headerAction.ariaLabel || headerAction.label"
@@ -59,7 +62,9 @@
           @click="headerAction.handler"
         >
           <svg v-if="headerAction.icon === 'printer' || headerAction.icon === true" class="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 0 2 2-2v-4a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2h2m2 4h6a2 2 0 0 0 2-2v-4a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2zm8-12V5a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2v4h10z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 9V3h12v6" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 14h12v7H6z" />
           </svg>
           <span v-if="!headerAction.iconOnly" class="truncate">{{ headerAction.label }}</span>
         </button>

--- a/components/dashboard/DashboardShellHeader.vue
+++ b/components/dashboard/DashboardShellHeader.vue
@@ -58,7 +58,7 @@
           :title="headerAction.ariaLabel || headerAction.label"
           @click="headerAction.handler"
         >
-          <svg v-if="headerAction.icon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg v-if="headerAction.icon === 'printer' || headerAction.icon === true" class="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 0 2 2-2v-4a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2h2m2 4h6a2 2 0 0 0 2-2v-4a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2zm8-12V5a2 2 0 0 0-2-2H9a2 2 0 0 0-2 2v4h10z" />
           </svg>
           <span v-if="!headerAction.iconOnly" class="truncate">{{ headerAction.label }}</span>
@@ -106,7 +106,7 @@ import logoSrc from '~/public/logo_waro_colombia.png'
 
 defineProps<{
   status?: { label: string; color: string }
-  headerAction?: { label: string; ariaLabel?: string; icon?: boolean; iconOnly?: boolean; handler: () => void }
+  headerAction?: { label: string; ariaLabel?: string; icon?: boolean | 'printer'; iconOnly?: boolean; handler: () => void }
   isRefreshing?: boolean
   isProgressiveLoading?: boolean
   hideLogo?: boolean

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -169,7 +169,7 @@ provide('setBackHandler', (handler: (() => void) | undefined) => {
 })
 
 // Dynamic header action (like print button) - can be set by child pages
-type HeaderAction = { label: string; ariaLabel?: string; icon?: boolean; iconOnly?: boolean; handler: () => void }
+type HeaderAction = { label: string; ariaLabel?: string; icon?: boolean | 'printer'; iconOnly?: boolean; handler: () => void }
 const dynamicHeaderAction = ref<HeaderAction | undefined>(undefined)
 
 // Provide header action setter for child pages

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -657,7 +657,7 @@ const saveChanges = async () => {
 const setPageStatus = inject<(status: { label: string; color: string } | undefined) => void>('setPageStatus')
 const setShowBackButton = inject<(show: boolean) => void>('setShowBackButton')
 const setBackHandler = inject<(handler: (() => void) | undefined) => void>('setBackHandler')
-const setHeaderAction = inject<(action: { label: string; ariaLabel?: string; icon?: boolean; iconOnly?: boolean; handler: () => void } | undefined) => void>('setHeaderAction')
+const setHeaderAction = inject<(action: { label: string; ariaLabel?: string; icon?: boolean | 'printer'; iconOnly?: boolean; handler: () => void } | undefined) => void>('setHeaderAction')
 
 // Watch order data and update layout header
 watch(order, (newOrder) => {
@@ -677,7 +677,7 @@ onMounted(() => {
   setHeaderAction?.({
     label: 'Imprimir',
     ariaLabel: 'Imprimir venta',
-    icon: true,
+    icon: 'printer',
     iconOnly: true,
     handler: printReceipt
   })


### PR DESCRIPTION
## Summary
- make dashboard header actions support explicit printer icon
- set sale detail print action to use icon: printer
- keep icon-only action accessible with aria label/title

## Tests
- npm exec nuxi -- prepare
- git diff --check
