### PR TITLE
Implement QZ Tray thermal receipt printing

### DIFF
--- a/components/pos/ComandaPrintTickets.vue
+++ b/components/pos/ComandaPrintTickets.vue
@@ -33,7 +33,8 @@ function modifierLines(item: ComandaPrintPayload['items'][0]) {
       </div>
       <div class="receipt-divider">--------------------------------</div>
       <div v-for="(item, i) in c.items" :key="i" class="receipt-item receipt-small">
-        <span>{{ item.quantity }}× {{ item.kitchen_name }}</span>
+        <span class="comanda-item-qty">{{ item.quantity }}×</span>
+        <span class="comanda-item-name">{{ item.kitchen_name }}</span>
       </div>
       <template v-for="(item, i) in c.items" :key="`mod-${i}`">
         <div
@@ -48,8 +49,6 @@ function modifierLines(item: ComandaPrintPayload['items'][0]) {
           Notas Especiales: {{ item.notes }}
         </div>
       </template>
-      <div class="receipt-divider">--------------------------------</div>
-      <div class="receipt-footer receipt-small">NO ES FACTURA — COCINA</div>
     </div>
   </div>
 </template>
@@ -66,9 +65,28 @@ function modifierLines(item: ComandaPrintPayload['items'][0]) {
 .comanda-ticket .receipt-header { font-size: 1.1em; font-weight: bold; text-align: center; margin-bottom: 4px; }
 .comanda-ticket .receipt-row { text-align: center; margin: 2px 0; }
 .comanda-ticket .receipt-divider { letter-spacing: 0; margin: 4px 0; text-align: center; }
-.comanda-ticket .receipt-item { margin: 2px 0; }
+.comanda-ticket .receipt-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 6px 0;
+  font-size: 1.12em;
+  font-weight: 700;
+}
 .comanda-ticket .receipt-footer { text-align: center; margin-top: 6px; }
 .comanda-ticket .receipt-small { font-size: 0.9em; }
+.comanda-ticket .comanda-item-qty {
+  flex-shrink: 0;
+  min-width: 9mm;
+  font-size: 1.65em;
+  font-weight: 900;
+  line-height: 1;
+  text-align: right;
+}
+.comanda-ticket .comanda-item-name {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
 
 @media print {
   body.printing-comanda * { visibility: hidden; }

--- a/composables/useQzTrayPrint.ts
+++ b/composables/useQzTrayPrint.ts
@@ -1,0 +1,68 @@
+import { buildReceiptEscpos, type EscposReceiptInput } from '~/utils/receiptEscpos'
+
+declare global {
+  interface Window {
+    qz?: any
+    __waroQzLoadPromise?: Promise<any>
+  }
+}
+
+const QZ_SCRIPT_URL = 'https://cdn.jsdelivr.net/npm/qz-tray@2.2.4/qz-tray.js'
+
+function loadQz(): Promise<any> {
+  if (!import.meta.client) return Promise.resolve(null)
+  if (window.qz) return Promise.resolve(window.qz)
+  if (window.__waroQzLoadPromise) return window.__waroQzLoadPromise
+
+  window.__waroQzLoadPromise = new Promise((resolve) => {
+    const script = document.createElement('script')
+    script.src = QZ_SCRIPT_URL
+    script.async = true
+    script.onload = () => resolve(window.qz ?? null)
+    script.onerror = () => resolve(null)
+    document.head.appendChild(script)
+  })
+
+  return window.__waroQzLoadPromise
+}
+
+async function connectQz(qz: any) {
+  qz.api?.setPromiseType?.((resolver: any) => new Promise(resolver))
+  qz.security?.setCertificatePromise?.((resolve: (cert: string) => void) => resolve(''))
+  qz.security?.setSignaturePromise?.(() => (resolve: (signature: string) => void) => resolve(''))
+  if (qz.websocket?.isActive?.()) return true
+  await qz.websocket.connect({ retries: 1, delay: 300 })
+  return qz.websocket?.isActive?.() === true
+}
+
+export function useQzTrayPrint() {
+  const toast = useToast()
+
+  const printReceiptViaQz = async (receipt: EscposReceiptInput): Promise<boolean> => {
+    if (!import.meta.client) return false
+    const qz = await loadQz()
+    if (!qz) return false
+
+    try {
+      await connectQz(qz)
+      const printer = await qz.printers.getDefault()
+      if (!printer) return false
+      const config = qz.configs.create(printer, { encoding: 'UTF-8' })
+      await qz.print(config, [{
+        type: 'raw',
+        format: 'plain',
+        data: buildReceiptEscpos(receipt),
+      }])
+      toast.success(`Enviado a ${printer}`, { title: 'Impresión térmica' })
+      return true
+    } catch (error: any) {
+      console.warn('[qz-print] Falling back to browser print', error)
+      toast.error('No se pudo imprimir directo con QZ Tray. Se abrirá la impresión del navegador.', {
+        title: 'QZ Tray no disponible',
+      })
+      return false
+    }
+  }
+
+  return { printReceiptViaQz }
+}

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -4,6 +4,7 @@ import { storeToRefs } from 'pinia'
 import { $fetch } from 'ofetch'
 import { useQuery } from '@pinia/colada'
 import QRCode from 'qrcode'
+import type { EscposReceiptInput } from '~/utils/receiptEscpos'
 import { usePOSStore, type TabItem } from '~/stores/usePOSStore'
 import { clearTableQrPaymentIntent, readTableQrPaymentIntent } from '~/composables/useTableSessionSync'
 import { useAddressStore, type AddressCreate } from '~/stores/address'
@@ -41,6 +42,7 @@ const router = useRouter()
 const posStore = usePOSStore()
 const cache = useQueryCache()
 const toast = useToast()
+const { printReceiptViaQz } = useQzTrayPrint()
 const { currentTenant, businessProfile } = useTenantReactive()
 const { singular: tableSingular } = useTableLabel()
 const tableSingularLower = computed(() => tableSingular.value.toLowerCase())
@@ -2178,6 +2180,10 @@ const printReceipt = async () => {
   if (invoiceResult.value?.cufe && !invoiceQrDataUrl.value) {
     invoiceQrDataUrl.value = await buildInvoiceQrDataUrl(invoiceResult.value.cufe)
   }
+  const qzReceipt = buildCheckoutEscposReceipt()
+  if (qzReceipt && await printReceiptViaQz(qzReceipt)) {
+    return
+  }
   await nextTick()
   window.print()
 }
@@ -2202,6 +2208,72 @@ const receiptLogoUrl = computed(() => {
   const url = settingsData.value?.data?.logo_url ?? businessProfile.value?.logo_url ?? null
   return url && String(url).startsWith('http') ? url : null
 })
+
+function buildCheckoutEscposReceipt(): EscposReceiptInput | null {
+  const result = orderResult.value
+  if (!result || cartItemsSnapshot.value.length === 0) return null
+  const context = receiptPrintContext.value
+  return {
+    businessName: fiscalData.value?.business_name || businessProfile.value?.display_name || null,
+    nit: fiscalData.value?.nit ?? null,
+    address: fiscalData.value?.fiscal_address || businessProfile.value?.address || null,
+    city: fiscalData.value?.city || businessProfile.value?.city || null,
+    phone: fiscalData.value?.phone || businessProfile.value?.phone_number || null,
+    email: fiscalData.value?.email ?? null,
+    documentLabel: receiptDocumentLabel.value,
+    orderNumber: result.order_number,
+    soldAt: context?.soldAt ?? null,
+    locationLabel: context?.wasMesa && context.tableName
+      ? [tableSingular.value, context.tableCode, context.tableName].filter(Boolean).join(' ')
+      : context?.isBar ? 'Barra' : 'Mostrador',
+    waiterName: context?.waiterName ?? null,
+    customerName: context?.customerName ?? null,
+    customerFiscalLabel: context?.customerFiscalId
+      ? `${context.customerFiscalIdType}: ${context.customerFiscalId}`
+      : null,
+    items: cartItemsSnapshot.value.map((item: any) => ({
+      name: item.product?.name || item.name || 'Producto',
+      quantity: Number(item.quantity) || 1,
+      unitPrice: getItemUnitPrice(item),
+      total: getItemTotal(item),
+      modifiers: (item.modifiers ?? []).map((mod: any) => ({
+        name: formatModifierPrintDesc(mod),
+        quantity: Number(mod.quantity) || 1,
+        price: Number(mod.price) || 0,
+        total: getModifierLineTotal(mod),
+      })),
+    })),
+    subtotal: result.subtotal ?? 0,
+    discountAmount: result.discount_amount ?? 0,
+    waroDiscountLabel: orderResultWaroLineLabel.value,
+    waroDiscountAmount: orderResultWaroDiscountCop.value,
+    standardTaxLabel: result.standard_tax_label,
+    standardTax: result.standard_tax ?? 0,
+    liquorTax: result.liquor_tax ?? 0,
+    orderTotal: result.total_amount ?? 0,
+    tipLabel: receiptTipLabel.value,
+    tipAmount: result.tip_amount ?? 0,
+    advanceApplied: result.advance_applied ?? 0,
+    chargedTotal: orderResultChargedAmount.value,
+    payments: splitPaymentsSnapshot.value.map((payment) => ({
+      label: payment.payment_method_name,
+      amount: payment.amount,
+      change: payment.change ?? null,
+    })),
+    singlePaymentLabel: result.payment_method
+      ? (result.payment_method_name
+          ? `${getPaymentMethodLabel(result.payment_method)} · ${result.payment_method_name}`
+          : getPaymentMethodLabel(result.payment_method))
+      : null,
+    invoice: invoiceResult.value
+      ? {
+          prefix: invoiceResult.value.prefix,
+          invoice_number: invoiceResult.value.invoice_number,
+          cufe: invoiceResult.value.cufe,
+        }
+      : null,
+  }
+}
 
 // warocol.com#939 — pre-bill always reads as prefactura; post-payment uses receiptDocumentLabel.
 const prefacturaDocumentLabel = computed(() => {

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, nextTick } from 'vue'
 import QRCode from 'qrcode'
+import type { EscposReceiptInput } from '~/utils/receiptEscpos'
 import { useFormatters } from '~/composables/useFormatters'
 import { formatPromoTypeLabel } from '~/utils/promotionPreview'
 import { mergePosPaymentGroupsFromApi, type ApiPaymentGroup } from '~/utils/paymentDefaults'
@@ -130,6 +131,7 @@ const invoiceQrDataUrl = ref('')
 // warocol.com#598 — invoice email modal trigger
 const showEmailModal = ref(false)
 const toast = useToast()
+const { printReceiptViaQz } = useQzTrayPrint()
 const onInvoiceEmailSent = (email: string) => {
   toast.success(`Factura enviada a ${email}`, { title: 'Enviado' })
 }
@@ -443,6 +445,43 @@ const saleReceiptInvoice = computed(() => {
   }
 })
 
+const saleReceiptEscpos = computed<EscposReceiptInput | null>(() => {
+  const o = order.value
+  if (!o) return null
+  return {
+    businessName: fiscalData.value?.business_name || businessProfile.value?.display_name || null,
+    nit: fiscalData.value?.nit ?? null,
+    address: fiscalData.value?.fiscal_address || businessProfile.value?.address || null,
+    city: fiscalData.value?.city || businessProfile.value?.city || null,
+    phone: fiscalData.value?.phone || businessProfile.value?.phone_number || null,
+    email: fiscalData.value?.email ?? null,
+    documentLabel: receiptDocumentLabel.value,
+    orderNumber: o.order_number,
+    soldAt: saleReceiptSoldAt.value,
+    locationLabel: saleReceiptLocationLabel.value,
+    waiterName: o.served_by_member_name,
+    customerName: o.customer_name,
+    customerFiscalLabel: saleReceiptCustomerFiscalLabel.value,
+    items: saleReceiptItems.value,
+    subtotal: grossSubtotal.value,
+    discountAmount: Number(o.discount_amount) || 0,
+    waroDiscountLabel: saleReceiptWaroDiscountLabel.value,
+    waroDiscountAmount: effectiveWaroDiscountCop.value,
+    standardTaxLabel: o.standard_tax_label,
+    standardTax: Number(o.standard_tax) || 0,
+    liquorTax: Number(o.liquor_tax) || 0,
+    orderTotal: Number(o.total_amount) || 0,
+    tipLabel: receiptTipLabel.value,
+    tipAmount: Number(o.tip_amount) || 0,
+    tipTaxAmount: Number(o.tip_tax_amount) || 0,
+    advanceApplied: orderAdvanceApplied.value,
+    chargedTotal: orderChargedTotal.value,
+    payments: saleReceiptPayments.value,
+    singlePaymentLabel: saleReceiptSinglePaymentLabel.value,
+    invoice: saleReceiptInvoice.value,
+  }
+})
+
 async function buildInvoiceQrDataUrl(cufe: string): Promise<string> {
   const dianUrl = `https://catalogo-vpfe.dian.gov.co/document/searchqr?documentkey=${cufe}`
   return QRCode.toDataURL(dianUrl, { width: 150, margin: 1 })
@@ -488,6 +527,10 @@ const printReceipt = async () => {
   }
   if (invoiceData.value?.cufe && !invoiceQrDataUrl.value) {
     invoiceQrDataUrl.value = await buildInvoiceQrDataUrl(invoiceData.value.cufe)
+  }
+
+  if (saleReceiptEscpos.value && await printReceiptViaQz(saleReceiptEscpos.value)) {
+    return
   }
 
   document.body.classList.add('printing-receipt-ticket')

--- a/utils/receiptEscpos.ts
+++ b/utils/receiptEscpos.ts
@@ -1,0 +1,229 @@
+type ReceiptModifier = {
+  name: string
+  quantity?: number | string | null
+  price?: number | string | null
+  total?: number | string | null
+}
+
+export type EscposReceiptItem = {
+  name: string
+  quantity: number | string
+  unitPrice: number
+  total: number
+  modifiers?: ReceiptModifier[]
+}
+
+export type EscposReceiptPayment = {
+  label: string
+  amount: number
+  change?: number | null
+}
+
+export type EscposReceiptInvoice = {
+  prefix?: string | null
+  invoice_number?: string | number | null
+  cufe?: string | null
+}
+
+export type EscposReceiptInput = {
+  businessName?: string | null
+  nit?: string | null
+  address?: string | null
+  city?: string | null
+  phone?: string | null
+  email?: string | null
+  documentLabel: string
+  orderNumber?: string | number | null
+  soldAt?: string | null
+  locationLabel?: string | null
+  waiterName?: string | null
+  customerName?: string | null
+  customerFiscalLabel?: string | null
+  items: EscposReceiptItem[]
+  subtotal?: number
+  discountAmount?: number
+  waroDiscountLabel?: string
+  waroDiscountAmount?: number
+  standardTaxLabel?: string | null
+  standardTax?: number
+  liquorTax?: number
+  orderTotal: number
+  tipLabel?: string
+  tipAmount?: number
+  tipTaxAmount?: number
+  advanceApplied?: number
+  chargedTotal?: number | null
+  payments?: EscposReceiptPayment[]
+  singlePaymentLabel?: string | null
+  invoice?: EscposReceiptInvoice | null
+}
+
+const ESC = '\x1B'
+const GS = '\x1D'
+const WIDTH = 42
+
+const cmd = {
+  init: `${ESC}@`,
+  alignLeft: `${ESC}a\x00`,
+  alignCenter: `${ESC}a\x01`,
+  boldOn: `${ESC}E\x01`,
+  boldOff: `${ESC}E\x00`,
+  doubleOn: `${GS}!\x11`,
+  doubleOff: `${GS}!\x00`,
+  feed: '\n\n\n',
+  cut: `${GS}VA\x00`,
+}
+
+function text(value: unknown): string {
+  return String(value ?? '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^\x20-\x7E\n]/g, '')
+    .trim()
+}
+
+function money(value: number | string | null | undefined): string {
+  const n = Number(value) || 0
+  return `$ ${new Intl.NumberFormat('es-CO', { maximumFractionDigits: 0 }).format(n)}`
+}
+
+function center(value: string): string {
+  const clean = text(value)
+  if (clean.length >= WIDTH) return clean
+  return `${' '.repeat(Math.floor((WIDTH - clean.length) / 2))}${clean}`
+}
+
+function wrap(value: string, width: number): string[] {
+  const clean = text(value)
+  if (!clean) return []
+  const words = clean.split(/\s+/)
+  const lines: string[] = []
+  let current = ''
+  for (const word of words) {
+    if (word.length > width) {
+      if (current) lines.push(current)
+      for (let i = 0; i < word.length; i += width) lines.push(word.slice(i, i + width))
+      current = ''
+      continue
+    }
+    const next = current ? `${current} ${word}` : word
+    if (next.length > width) {
+      if (current) lines.push(current)
+      current = word
+    } else {
+      current = next
+    }
+  }
+  if (current) lines.push(current)
+  return lines
+}
+
+function pair(label: string, value: string): string {
+  const left = text(label)
+  const right = text(value)
+  const space = Math.max(1, WIDTH - left.length - right.length)
+  return `${left}${' '.repeat(space)}${right}`
+}
+
+function itemLine(desc: string, qty: string, price: string, total: string): string[] {
+  const qtyWidth = 4
+  const priceWidth = 10
+  const totalWidth = 10
+  const descWidth = WIDTH - qtyWidth - priceWidth - totalWidth - 3
+  const lines = wrap(desc, descWidth)
+  if (lines.length === 0) lines.push('')
+  const first = `${lines[0].padEnd(descWidth)} ${qty.padStart(qtyWidth)} ${price.padStart(priceWidth)} ${total.padStart(totalWidth)}`
+  return [first, ...lines.slice(1).map(line => line.padEnd(descWidth))]
+}
+
+function qr(data: string): string {
+  const payload = text(data)
+  if (!payload || payload.length > 700) return ''
+  const storeLen = payload.length + 3
+  const pL = String.fromCharCode(storeLen % 256)
+  const pH = String.fromCharCode(Math.floor(storeLen / 256))
+  return [
+    `${GS}(k\x04\x001A2\x00`,
+    `${GS}(k\x03\x001C\x06`,
+    `${GS}(k\x03\x001E0`,
+    `${GS}(k${pL}${pH}1P0${payload}`,
+    `${GS}(k\x03\x001Q0`,
+  ].join('')
+}
+
+export function buildReceiptEscpos(receipt: EscposReceiptInput): string {
+  const lines: string[] = []
+  lines.push(cmd.init)
+  lines.push(cmd.alignCenter)
+  if (receipt.businessName) lines.push(cmd.boldOn + center(receipt.businessName) + cmd.boldOff)
+  if (receipt.nit) lines.push(center(`NIT: ${receipt.nit}`))
+  if (receipt.address || receipt.city) lines.push(center([receipt.address, receipt.city].filter(Boolean).join(', ')))
+  if (receipt.phone) lines.push(center(`Tel: ${receipt.phone}`))
+  if (receipt.email) lines.push(center(receipt.email))
+  lines.push('='.repeat(WIDTH))
+  lines.push(cmd.boldOn + center(`${receipt.documentLabel}${receipt.orderNumber ? ` #${receipt.orderNumber}` : ''}`) + cmd.boldOff)
+  if (receipt.soldAt) lines.push(center(receipt.soldAt))
+  if (receipt.locationLabel) lines.push(center(receipt.locationLabel))
+  if (receipt.waiterName) lines.push(center(`Mesero: ${receipt.waiterName}`))
+  if (receipt.customerName) {
+    lines.push('-'.repeat(WIDTH))
+    lines.push(cmd.boldOn + center('Datos cliente') + cmd.boldOff)
+    lines.push(center(receipt.customerName))
+    if (receipt.customerFiscalLabel) lines.push(center(receipt.customerFiscalLabel))
+  }
+  lines.push('-'.repeat(WIDTH))
+  lines.push(cmd.alignLeft)
+  lines.push(cmd.boldOn + itemLine('Descripcion', 'Cant', 'Precio', 'Total')[0] + cmd.boldOff)
+  lines.push('-'.repeat(WIDTH))
+  for (const item of receipt.items) {
+    lines.push(...itemLine(item.name, String(item.quantity), money(item.unitPrice), money(item.total)))
+    for (const mod of item.modifiers ?? []) {
+      const qty = Number(mod.quantity) || 1
+      const total = Number(mod.total) || (Number(mod.price) || 0) * qty
+      lines.push(...itemLine(`+ ${mod.name}`, qty > 1 ? String(qty) : '', money(mod.price), money(total)))
+    }
+  }
+  lines.push('-'.repeat(WIDTH))
+  if ((receipt.discountAmount || 0) > 0 || (receipt.waroDiscountAmount || 0) > 0) {
+    lines.push(pair('Subtotal', money(receipt.subtotal ?? receipt.orderTotal)))
+  }
+  if ((receipt.discountAmount || 0) > 0) lines.push(pair('Descuento', `-${money(receipt.discountAmount)}`))
+  if ((receipt.waroDiscountAmount || 0) > 0) lines.push(pair(receipt.waroDiscountLabel || 'Canje WaRo', `-${money(receipt.waroDiscountAmount)}`))
+  if ((receipt.standardTax || 0) > 0) lines.push(pair(receipt.standardTaxLabel || 'Impuesto', money(receipt.standardTax)))
+  if ((receipt.liquorTax || 0) > 0) lines.push(pair('IVA licores 5%', money(receipt.liquorTax)))
+  if ((receipt.tipAmount || 0) > 0 || (receipt.tipTaxAmount || 0) > 0 || (receipt.advanceApplied || 0) > 0) {
+    lines.push(pair('Total orden', money(receipt.orderTotal)))
+    if ((receipt.tipAmount || 0) > 0) lines.push(pair(receipt.tipLabel || 'Propina', money(receipt.tipAmount)))
+    if ((receipt.tipTaxAmount || 0) > 0) lines.push(pair('Impuesto propina', money(receipt.tipTaxAmount)))
+    if ((receipt.advanceApplied || 0) > 0) lines.push(pair('Anticipo', `-${money(receipt.advanceApplied)}`))
+  }
+  lines.push(cmd.boldOn + cmd.doubleOn + pair('TOTAL COBRADO', money(receipt.chargedTotal ?? receipt.orderTotal)) + cmd.doubleOff + cmd.boldOff)
+  lines.push('='.repeat(WIDTH))
+  lines.push(cmd.alignCenter + cmd.boldOn + 'Detalle de pago' + cmd.boldOff + cmd.alignLeft)
+  if (receipt.payments?.length) {
+    receipt.payments.forEach((payment, idx) => {
+      lines.push(pair(`#${idx + 1} ${payment.label}`, money(payment.amount)))
+      if ((payment.change || 0) > 0) lines.push(pair(`Cambio #${idx + 1}`, money(payment.change)))
+    })
+  } else {
+    lines.push(pair(receipt.singlePaymentLabel || 'Pendiente por definir', money(receipt.chargedTotal ?? receipt.orderTotal)))
+  }
+  lines.push('='.repeat(WIDTH))
+  lines.push(cmd.alignCenter + 'Gracias por tu compra')
+  if (receipt.invoice) {
+    lines.push('='.repeat(WIDTH))
+    lines.push(cmd.boldOn + 'FACTURA ELECTRONICA' + cmd.boldOff)
+    if (receipt.invoice.prefix || receipt.invoice.invoice_number) {
+      lines.push([receipt.invoice.prefix, receipt.invoice.invoice_number].filter(Boolean).join('-'))
+    }
+    if (receipt.invoice.cufe) {
+      const dianUrl = `https://catalogo-vpfe.dian.gov.co/document/searchqr?documentkey=${receipt.invoice.cufe}`
+      lines.push(...wrap(`CUFE: ${receipt.invoice.cufe}`, WIDTH))
+      lines.push(qr(dianUrl))
+      lines.push('Verificar en DIAN')
+    }
+  }
+  lines.push(cmd.feed)
+  lines.push(cmd.cut)
+  return `${lines.join('\n')}\n`
+}


### PR DESCRIPTION
## Summary
- add browser-only QZ Tray direct ESC/POS printing with fallback to existing window.print flows
- build shared ESC/POS receipt payloads for sale detail and POS checkout receipts
- improve kitchen comanda readability by removing non-invoice footer and emphasizing quantities

## Tests
- npm exec nuxi -- prepare
- git diff --check

Closes #1388
