### PR TITLE
Gate Kali front route by tenant feature

### DIFF
--- a/app.d.ts
+++ b/app.d.ts
@@ -1,4 +1,4 @@
-import type { Module } from '~/stores/access'
+import type { AccessFeature, Module } from '~/stores/access'
 
 /**
  * TypeScript module augmentation for Nuxt 3 PageMeta.
@@ -20,6 +20,12 @@ declare module '#app' {
      * authenticated user.
      */
     module?: Module
+    /**
+     * Tenant feature capability required to access this page. Unlike module
+     * gates, missing/false capabilities deny access even when RBAC enforcement
+     * is disabled or shadowed.
+     */
+    feature?: AccessFeature
     /**
      * Public customer-facing page (menu, checkout). Skips operator auth
      * middleware even when layout is false (e.g. city/tenant dispatch).

--- a/components/DashboardBottomNav.vue
+++ b/components/DashboardBottomNav.vue
@@ -265,7 +265,10 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const { can } = useModuleAccess()
-const visibleGridItems = computed(() => dashboardMobileGridItems.filter((item) => can(item.module).value))
+const { hasFeature } = useFeatureAccess()
+const canSeeNavItem = (item: DashboardNavItem) =>
+  can(item.module).value && (!item.feature || hasFeature(item.feature).value)
+const visibleGridItems = computed(() => dashboardMobileGridItems.filter(canSeeNavItem))
 const isNavItemBlocked = (item: DashboardNavItem) =>
   props.billingBlocked && item.to !== '/gestion/billing'
 

--- a/components/DashboardSidebar.vue
+++ b/components/DashboardSidebar.vue
@@ -189,16 +189,20 @@ const authStore = useAuthStore()
 // so today's sidebar (every module visible) is preserved until Epic 6
 // flips a tenant.
 const { can } = useModuleAccess()
+const { hasFeature } = useFeatureAccess()
 const accessStore = useAccessStore()
 
+const canSeeNavItem = (item: DashboardNavItem) =>
+  can(item.module).value && (!item.feature || hasFeature(item.feature).value)
+
 const visiblePrimaryItems = computed(() =>
-  dashboardPrimaryItems.filter((item) => can(item.module).value)
+  dashboardPrimaryItems.filter(canSeeNavItem)
 )
 const visibleSecondaryItems = computed(() =>
-  dashboardSecondaryItems.filter((item) => can(item.module).value)
+  dashboardSecondaryItems.filter(canSeeNavItem)
 )
 const visibleCuentaItems = computed(() =>
-  dashboardCuentaItems.filter((item) => can(item.module).value)
+  dashboardCuentaItems.filter(canSeeNavItem)
 )
 
 // Eventos is special: Module.EVENTOS was removed from the backend enum

--- a/composables/useDashboardPageConfig.ts
+++ b/composables/useDashboardPageConfig.ts
@@ -16,6 +16,16 @@ export const useDashboardPageConfig = () => {
         breadcrumbPage: undefined,
         backButton: undefined
       }
+    } else if (path === '/asistente/kali') {
+      return {
+        pageTitle: 'Kali',
+        pageSubtitle: undefined,
+        searchPlaceholder: undefined,
+        activePage: 'asistente' as const,
+        showBreadcrumb: false,
+        breadcrumbPage: undefined,
+        backButton: undefined
+      }
     } else if (path === '/financiero/tir') {
       return {
         pageTitle: 'Análisis TIR',

--- a/composables/useFeatureAccess.ts
+++ b/composables/useFeatureAccess.ts
@@ -1,0 +1,14 @@
+import type { ComputedRef } from 'vue'
+import type { AccessFeature } from '~/stores/access'
+
+export const useFeatureAccess = () => {
+  const store = useAccessStore()
+
+  const features = computed(() => store.features)
+  const isLoaded = computed(() => store.isLoaded)
+
+  const hasFeature = (feature: AccessFeature): ComputedRef<boolean> =>
+    computed(() => store.hasFeature(feature))
+
+  return { features, isLoaded, hasFeature }
+}

--- a/constants/dashboardNavigation.ts
+++ b/constants/dashboardNavigation.ts
@@ -12,10 +12,11 @@ import {
   MapPinIcon,
   ReceiptPercentIcon,
   ShoppingCartIcon,
+  SparklesIcon,
   TruckIcon,
   UserGroupIcon,
 } from '@heroicons/vue/24/outline'
-import type { Module } from '~/stores/access'
+import type { AccessFeature, Module } from '~/stores/access'
 
 export type ActivePage =
   | 'dashboard'
@@ -23,6 +24,7 @@ export type ActivePage =
   | 'financiero' | 'finanzas' | 'facturacion'
   | 'abastecimiento' | 'inventario' | 'menu' | 'operaciones'
   | 'analytics' | 'analitica' | 'reportes' | 'pagos'
+  | 'asistente'
   | 'equipo' | 'integraciones'
   | 'negocio' | 'admin' | 'configuracion'
 
@@ -32,6 +34,7 @@ export interface DashboardNavItem {
   label: string
   icon: FunctionalComponent
   module: Module
+  feature?: AccessFeature
   showCriticalDot?: boolean
 }
 
@@ -43,6 +46,7 @@ export const dashboardPrimaryItems: DashboardNavItem[] = [
 
 export const dashboardSecondaryItems: DashboardNavItem[] = [
   { to: '/analitica', page: 'analytics', label: 'Analítica Ventas', icon: ChartBarIcon, module: 'analitica' },
+  { to: '/asistente/kali', page: 'asistente', label: 'Kali', icon: SparklesIcon, module: 'analitica', feature: 'kali_enabled' },
   { to: '/finanzas/arqueo', page: 'finanzas', label: 'Finanzas', icon: BanknotesIcon, module: 'finanzas' },
   { to: '/facturacion', page: 'facturacion', label: 'Facturación', icon: DocumentTextIcon, module: 'facturacion' },
   { to: '/menu/productos', page: 'menu', label: 'Menú', icon: CubeIcon, module: 'menu' },
@@ -64,6 +68,7 @@ export const dashboardMobileGridItems: DashboardNavItem[] = [
   { to: '/menu/productos', page: 'menu', label: 'Menú', icon: CubeIcon, module: 'menu' },
   { to: '/operaciones/comandas', page: 'operaciones', label: 'Operaciones', icon: AdjustmentsHorizontalIcon, module: 'operaciones' },
   { to: '/analitica', page: 'analytics', label: 'Analítica', icon: ChartBarIcon, module: 'analitica' },
+  { to: '/asistente/kali', page: 'asistente', label: 'Kali', icon: SparklesIcon, module: 'analitica', feature: 'kali_enabled' },
   { to: '/finanzas/cartera', page: 'finanzas', label: 'Finanzas', icon: BanknotesIcon, module: 'finanzas' },
   { to: '/facturacion', page: 'facturacion', label: 'Facturación', icon: ReceiptPercentIcon, module: 'facturacion' },
   { to: '/equipo/miembros', page: 'equipo', label: 'Equipo', icon: UserGroupIcon, module: 'equipo' },

--- a/middleware/feature-access.global.ts
+++ b/middleware/feature-access.global.ts
@@ -1,0 +1,32 @@
+export default defineNuxtRouteMiddleware(async (to) => {
+  if (process.server) return
+
+  const skipExact = ['/', '/bogota']
+  const skipPrefixes = [
+    '/auth/',
+    '/proveedor/',
+    '/blog',
+    '/docs',
+    '/403',
+  ]
+  const skipLayouts = ['public-restaurant', 'customer-portal', 'kds']
+
+  if (
+    skipExact.includes(to.path) ||
+    skipPrefixes.some((p) => to.path.startsWith(p)) ||
+    skipLayouts.includes(to.meta?.layout as string) ||
+    to.meta?.publicAccess === true
+  ) return
+
+  const feature = to.meta.feature
+  if (!feature) return
+
+  const accessStore = useAccessStore()
+  if (!accessStore.isLoaded) {
+    await accessStore.load()
+  }
+
+  if (!accessStore.hasFeature(feature)) {
+    return navigateTo('/403')
+  }
+})

--- a/pages/asistente/kali.vue
+++ b/pages/asistente/kali.vue
@@ -1,0 +1,83 @@
+<template>
+  <section class="mx-auto flex w-full max-w-6xl flex-col gap-4 md:gap-6">
+    <header class="flex flex-col gap-4 rounded-lg border border-card-border bg-card-bg p-5 shadow-sm md:flex-row md:items-center md:justify-between">
+      <div class="flex items-center gap-4">
+        <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-violet-100 text-violet-700">
+          <SparklesIcon class="h-6 w-6" aria-hidden="true" />
+        </div>
+        <div class="min-w-0">
+          <p class="text-sm font-medium text-text-secondary">Asistente</p>
+          <h1 class="text-2xl font-semibold text-text-primary">Kali</h1>
+        </div>
+      </div>
+      <span class="inline-flex w-fit items-center rounded-full border border-violet-200 bg-violet-50 px-3 py-1 text-xs font-semibold text-violet-700">
+        Beta interna
+      </span>
+    </header>
+
+    <div class="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+      <section class="min-h-[520px] rounded-lg border border-card-border bg-card-bg shadow-sm">
+        <div class="flex h-full min-h-[520px] flex-col">
+          <div class="border-b border-card-border px-5 py-4">
+            <p class="text-sm font-semibold text-text-primary">Conversacion</p>
+          </div>
+
+          <div class="flex flex-1 items-center justify-center px-5 py-10">
+            <div class="flex max-w-sm flex-col items-center gap-3 text-center">
+              <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-violet-100 text-violet-700">
+                <SparklesIcon class="h-5 w-5" aria-hidden="true" />
+              </div>
+              <div>
+                <p class="text-base font-semibold text-text-primary">Sin conversaciones</p>
+                <p class="mt-1 text-sm text-text-secondary">Kali</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="border-t border-card-border p-4">
+            <div class="flex min-h-12 items-center rounded-lg border border-dashed border-card-border bg-shell-bg px-4 text-sm text-text-tertiary">
+              Mensaje
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <aside class="flex flex-col gap-4">
+        <section class="rounded-lg border border-card-border bg-card-bg p-4 shadow-sm">
+          <p class="text-sm font-semibold text-text-primary">Workflows</p>
+          <div class="mt-3 grid gap-2">
+            <div class="rounded-lg border border-card-border bg-shell-bg px-3 py-2">
+              <p class="text-sm font-medium text-text-primary">Ventas</p>
+            </div>
+            <div class="rounded-lg border border-card-border bg-shell-bg px-3 py-2">
+              <p class="text-sm font-medium text-text-primary">Food cost</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="rounded-lg border border-card-border bg-card-bg p-4 shadow-sm">
+          <p class="text-sm font-semibold text-text-primary">Estado</p>
+          <div class="mt-3 flex items-center gap-2 text-sm text-text-secondary">
+            <span class="h-2 w-2 rounded-full bg-violet-500" aria-hidden="true" />
+            Disponible para este tenant
+          </div>
+        </section>
+      </aside>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { SparklesIcon } from '@heroicons/vue/24/outline'
+
+definePageMeta({
+  layout: 'dashboard',
+  module: 'analitica',
+  feature: 'kali_enabled',
+})
+
+useHead({
+  title: 'Kali',
+  meta: [{ name: 'robots', content: 'noindex, nofollow' }],
+})
+</script>

--- a/stores/access.ts
+++ b/stores/access.ts
@@ -32,11 +32,15 @@ export type Module =
   // EVENTOS removed in api-warolabs#212 (PR #212 merged) — Eventos lives in warotickets.com
 
 export type EnforcementMode = 'disabled' | 'shadow' | 'enforce'
+export type AccessFeature = 'kali_enabled'
+
+type AccessFeatures = Partial<Record<AccessFeature, boolean>>
 
 interface AccessResponse {
   role: string | null
   modules: string[]
   enforcement_mode: EnforcementMode
+  features?: AccessFeatures
 }
 
 // Polling handle — module scope so it survives store re-evaluation but stays
@@ -51,6 +55,7 @@ export const useAccessStore = defineStore('access', () => {
   const role = ref<string | null>(null)
   const modules = ref<string[]>([])
   const enforcementMode = ref<EnforcementMode>('disabled')
+  const features = ref<AccessFeatures>({})
   const isLoaded = ref(false)
 
   // O(1) membership lookup derived from the array.
@@ -64,6 +69,7 @@ export const useAccessStore = defineStore('access', () => {
       role.value = data.role
       modules.value = data.modules ?? []
       enforcementMode.value = data.enforcement_mode ?? 'disabled'
+      features.value = data.features ?? {}
       isLoaded.value = true
       armPolling()
     } catch (err) {
@@ -84,6 +90,7 @@ export const useAccessStore = defineStore('access', () => {
     role.value = null
     modules.value = []
     enforcementMode.value = 'disabled'
+    features.value = {}
     isLoaded.value = false
   }
 
@@ -118,13 +125,24 @@ export const useAccessStore = defineStore('access', () => {
     return modulesSet.value.has(module)
   }
 
+  /**
+   * Tenant feature capabilities are stricter than module access: missing
+   * backend values must stay false so hidden beta/internal products do not
+   * appear just because module RBAC is in shadow/disabled mode.
+   */
+  function hasFeature(feature: AccessFeature): boolean {
+    return features.value[feature] === true
+  }
+
   return {
     role: readonly(role),
     modules: readonly(modules),
     enforcementMode: readonly(enforcementMode),
+    features: readonly(features),
     isLoaded: readonly(isLoaded),
     load,
     clear,
     can,
+    hasFeature,
   }
 })


### PR DESCRIPTION
## Summary
- consume `features.kali_enabled` from `/me/access` through a strict feature-access helper
- add gated Kali navigation and direct-route protection for `/asistente/kali`
- add the initial dashboard shell for Kali without chat/SSE implementation

## Tests
- `npx nuxi prepare`
- `git diff --check`
- `npm run build` started but stalled during Vite transform with only existing project warnings
- `npx nuxi typecheck` generated Nuxt types but stalled before completion

Closes #1392