### PR TITLE
Document POS manual checkout contract

### DIFF
--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -635,6 +635,8 @@ const discountAmount = computed(() => {
   if (!discountEnabled.value || !discountInput.value) return 0
   const val = Number(discountInput.value)
   if (isNaN(val) || val <= 0) return 0
+  // POS contract: automatic line promos reduce subtotalAfterPromos first;
+  // manual fixed/percent discounts are order-level discounts on that subtotal.
   if (discountType.value === 'percent') {
     return Math.min(Math.round(subtotalAfterPromos.value * val / 100), Math.round(subtotalAfterPromos.value))
   }
@@ -954,6 +956,8 @@ const addSplitPayment = async () => {
             ...(discountEnabled.value && _discountAmtPos > 0
               ? { discount_type: discountType.value, discount_value: Number(discountInput.value) }
               : {}),
+            // POS split contract: first tender creates a partial order; later
+            // tenders go to /payments and are the source of truth in order_payments.
             split_mode: true,
             split_first_amount: amountToCharge,
             // Issue #524 — cash tender on the first split when method is cash
@@ -976,6 +980,8 @@ const addSplitPayment = async () => {
           method: 'POST',
           body: {
             amount: amountToCharge,
+            // Wallet participates here as payment_method='customer_wallet',
+            // never as a discount and never with cash_received.
             payment_method: selectedPaymentMethod.value,
             payment_method_id: selectedPaymentMethodId.value ?? undefined,
             ...(isCashMethod.value

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -629,6 +629,8 @@ function promoFieldsFromCloseResponse(
     subtotal: Number(data?.subtotal) || fallbackSubtotal,
   }
 }
+// Manual checkout contract (#1397): automatic promos are evaluated first;
+// manual discounts use subtotalAfterPromos, then WaRo redemption is applied.
 const discountAmount = computed(() => {
   if (!discountEnabled.value || !discountInput.value) return 0
   const val = Number(discountInput.value)
@@ -1283,6 +1285,8 @@ function isPaymentGroupVisible(group: PosPaymentGroup) {
   if (group.triggersCartera) {
     return !!(selectedCustomer.value && !isAnonymousCustomer.value)
   }
+  // Wallet is a tender, not a discount. Only show it when the backend can debit
+  // a real customer wallet and the cashier has a positive balance to apply.
   if (group.slug === WALLET_PAYMENT_SLUG || group.triggersWallet) {
     return !!(selectedCustomer.value && !isAnonymousCustomer.value && walletBalanceCop.value > 0)
   }

--- a/utils/paymentDefaults.ts
+++ b/utils/paymentDefaults.ts
@@ -28,6 +28,7 @@ export type ApiPaymentGroup = Omit<PosPaymentGroup, 'triggersCartera' | 'trigger
   methods?: PosPaymentMethod[]
 }
 
+// POS contract: wallet is a payment tender slug, not a discount or WaRo redemption.
 export const WALLET_PAYMENT_SLUG = 'customer_wallet'
 
 export const PAYMENT_DEFAULTS: PosPaymentGroup[] = [


### PR DESCRIPTION
Summary
- Document the POS checkout manual-discount order in the front checkout code.
- Mark wallet as a payment tender slug, not a discount or WaRo redemption.
- Clarify split-payment first/subsequent tender contract in checkout payload comments.

Tests
- npm run build: stopped after several minutes with no output after Nuxt/Vite warnings; no completion summary.
- API focused smoke in api-warolabs: pytest tests/test_pos_cart.py tests/test_customer_wallet.py tests/test_order_promo_persist.py tests/test_waro_wallet_checkout.py (34 passed).
- API full pytest: 1033 passed, 23 failed, 11 skipped; failures are unrelated pre-existing areas outside this comment-only contract change.

Closes #1397