### PR TITLE
Refresh Kali feature access on tenant switch

### DIFF
--- a/stores/tenants.ts
+++ b/stores/tenants.ts
@@ -50,6 +50,7 @@ export interface Tenant {
 
 export const useTenantsStore = defineStore('tenants', () => {
   const cache = useQueryCache()
+  const accessStore = useAccessStore()
 
   // ── UI state ──────────────────────────────────────────────────────────────────
   const selectedTenant = ref<Tenant | null>(null)
@@ -175,7 +176,16 @@ export const useTenantsStore = defineStore('tenants', () => {
       error.value = err?.message ?? 'Failed to switch tenant'
       return null
     })
-    return !!res?.success
+    if (!res?.success) return false
+
+    try {
+      await accessStore.load()
+    } catch (err: any) {
+      error.value = err?.message ?? 'Failed to refresh tenant access'
+      return false
+    }
+
+    return true
   }
 
   const selectTenantBySlug = async (slug: string): Promise<boolean> => {


### PR DESCRIPTION
## Summary
- Refresh frontend access/features immediately after a successful tenant switch.
- Keeps Kali feature visibility and the `/asistente/kali` guard aligned with the newly selected tenant.

## Tests
- `npx nuxi prepare`
- `npm run build` started twice but was manually stopped after staying at Vite `transforming...` for several minutes with only existing warnings.

Closes #1411
