### PR TITLE
Allow repeated split payment methods

### DIFF
--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -913,18 +913,6 @@ const toggleSplitMode = () => {
   }
 }
 
-const splitDuplicatePaymentMessage = computed(() => {
-  if (!splitMode.value || !selectedPaymentMethod.value || splitPayments.value.length === 0) return ''
-  const selectedMethodId = selectedPaymentMethodId.value ?? null
-  const duplicate = splitPayments.value.some(row =>
-    row.payment_method === selectedPaymentMethod.value
-    && (row.payment_method_id ?? null) === selectedMethodId
-  )
-  return duplicate
-    ? 'Este método ya fue registrado en este cobro dividido. Elige otro método para continuar.'
-    : ''
-})
-
 const splitAmountValidationMessage = computed(() => {
   if (!splitMode.value || splitIsComplete.value) return ''
   const amount = splitPartialAmount.value
@@ -937,7 +925,7 @@ const splitAmountValidationMessage = computed(() => {
 })
 
 const splitPaymentValidationMessage = computed(
-  () => splitAmountValidationMessage.value || splitDuplicatePaymentMessage.value,
+  () => splitAmountValidationMessage.value,
 )
 
 const splitAmountToCharge = computed(() =>


### PR DESCRIPTION
## Summary
- Remove the duplicate-method block from POS Cobro Parcial split payments
- Keep amount, cash, wallet, discount, customer, and cart validations intact

## Tests
- git diff --check -- pages/pos/checkout.vue
- rg -n "Este método ya fue registrado|splitDuplicatePaymentMessage" pages/pos/checkout.vue || true
- npm run build (inconclusive: Nuxt/Vite build stopped producing output and was interrupted twice after several minutes; warnings before the stall were pre-existing import/Browserslist/Tailwind warnings)

Closes #1414