### PR TITLE
Normalize downstream inventory precision

### DIFF
--- a/components/inventario/StockInventoryView.vue
+++ b/components/inventario/StockInventoryView.vue
@@ -284,6 +284,8 @@
 </template>
 
 <script setup lang="ts">
+import { formatDomainQuantity } from '~/utils/domainNumberFormat'
+
 interface StockStats {
   total_ingredients: number
   critical_count: number
@@ -504,9 +506,6 @@ const formatCurrency = (value: number) => {
 }
 
 const formatNumber = (value: number) => {
-  return new Intl.NumberFormat('es-CO', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  }).format(value)
+  return formatDomainQuantity(value)
 }
 </script>

--- a/components/ui/data-table/index.vue
+++ b/components/ui/data-table/index.vue
@@ -161,7 +161,7 @@ function formatValue(value: any, column: TableColumn): string {
       return `${numValue.toFixed(precision)}%`
     case 'number':
       // Formato COP: usar puntos como separadores de miles
-      return numValue.toLocaleString('es-CO', { minimumFractionDigits: 0, maximumFractionDigits: 0 })
+      return numValue.toLocaleString('es-CO', { minimumFractionDigits: 0, maximumFractionDigits: column.precision ?? 0 })
     case 'text':
     default:
       // Check if it's a numeric string that should be formatted

--- a/pages/abastecimiento/movimientos.vue
+++ b/pages/abastecimiento/movimientos.vue
@@ -149,6 +149,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
+import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 
 useHead({ title: 'Movimientos' })
 
@@ -295,10 +296,7 @@ const getMovementTypeVariant = (type: string) => {
 }
 
 const formatNumber = (value: number) => {
-  return new Intl.NumberFormat('es-CO', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2
-  }).format(value)
+  return formatDomainQuantity(value)
 }
 
 const { formatDate } = useFormatters()

--- a/pages/inventario/movimientos.vue
+++ b/pages/inventario/movimientos.vue
@@ -140,6 +140,7 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { INGREDIENTS_FETCH_LIMIT } from '@/composables/useMenuIngredients'
 import { useFormatters } from '~/composables/useFormatters'
+import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 
 useHead({ title: 'Movimientos de Inventario' })
 
@@ -355,10 +356,7 @@ const getMovementTypeVariant = (type: string) => {
 }
 
 const formatNumber = (value: number) => {
-  return new Intl.NumberFormat('es-CO', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2
-  }).format(value)
+  return formatDomainQuantity(value)
 }
 
 const { formatDate } = useFormatters()

--- a/pages/menu/recetas/index.vue
+++ b/pages/menu/recetas/index.vue
@@ -249,7 +249,7 @@
                     />
                   </td>
                   <td class="py-3 px-2 text-sm text-text-primary text-right">
-                    {{ ing.cantidad }} {{ ing.unidad }}
+                    {{ formatQuantity(ing.cantidad) }} {{ ing.unidad }}
                   </td>
                   <td class="py-3 px-2 text-sm text-text-primary text-right">
                     {{ formatCurrency(ing.costo_unitario) }}
@@ -282,6 +282,7 @@ import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import { ref, computed, onMounted, onUnmounted, inject, watch } from 'vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import { useTenantReactive } from '@/composables/useTenantReactive'
+import { formatDomainQuantity, normalizeDomainNumber } from '~/utils/domainNumberFormat'
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
@@ -370,7 +371,7 @@ const recetas = computed(() => {
     is_active: recipeBase.is_active,
     ingredientes: recipeBase.ingredients?.map((ing: any) => {
       const costoUnitario = Number(ing.costo_unitario || 0)
-      const cantidad = Number(ing.base_quantity || 0)
+      const cantidad = normalizeDomainNumber(ing.base_quantity, 6)
       return {
         ingrediente_id: ing.ingredient_id,
         ingrediente_name: ing.ingredient_name,
@@ -501,6 +502,8 @@ const formatCurrency = (value: number) => {
     minimumFractionDigits: 0
   }).format(value)
 }
+
+const formatQuantity = (value: number) => formatDomainQuantity(value, 6)
 
 const toggleExpanded = (recipeId: number) => {
   if (expandedRows.value.has(recipeId)) {

--- a/utils/domainNumberFormat.test.ts
+++ b/utils/domainNumberFormat.test.ts
@@ -1,0 +1,20 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { formatDomainQuantity, normalizeDomainNumber } from './domainNumberFormat.ts'
+
+describe('formatDomainQuantity', () => {
+  it('keeps meaningful sub-unit precision without long tails', () => {
+    assert.equal(formatDomainQuantity(1.345), '1,345')
+    assert.equal(formatDomainQuantity(0.3333333333333), '0,3333')
+  })
+
+  it('formats tiny float residue as a clean zero', () => {
+    assert.equal(formatDomainQuantity(0.1 + 0.2 - 0.3), '0')
+  })
+})
+
+describe('normalizeDomainNumber', () => {
+  it('rounds calculation inputs to the requested precision', () => {
+    assert.equal(normalizeDomainNumber(0.1 + 0.2, 6), 0.3)
+  })
+})

--- a/utils/domainNumberFormat.ts
+++ b/utils/domainNumberFormat.ts
@@ -1,0 +1,30 @@
+export function formatDomainQuantity(
+  value: number | string | null | undefined,
+  maxFractionDigits = 4,
+): string {
+  if (value === null || value === undefined || value === '') return '-'
+
+  const numericValue = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(numericValue)) return '-'
+
+  const normalized = Object.is(numericValue, -0) ? 0 : numericValue
+
+  return new Intl.NumberFormat('es-CO', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: maxFractionDigits,
+  }).format(normalized)
+}
+
+export function normalizeDomainNumber(
+  value: number | string | null | undefined,
+  maxFractionDigits = 4,
+): number {
+  if (value === null || value === undefined || value === '') return 0
+
+  const numericValue = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(numericValue)) return 0
+
+  const factor = 10 ** maxFractionDigits
+  const rounded = Math.round((numericValue + Number.EPSILON) * factor) / factor
+  return Object.is(rounded, -0) ? 0 : rounded
+}


### PR DESCRIPTION
## Summary
- Add shared quantity formatting for inventory, movement, and recipe displays
- Preserve sortable numeric table behavior while allowing explicit precision
- Cover quantity formatter edge cases

## Tests
- node --test --experimental-strip-types utils/domainNumberFormat.test.ts utils/parseLocaleDecimal.test.ts
- npm run build

Manual validation routes: /inventario/stock, /inventario/movimientos or /abastecimiento/movimientos, /menu/recetas, /menu/productos.

Closes #1420