### PR TITLE
Normalize menu decimal inputs

### DIFF
--- a/components/menu/MenuModifierOptionEditor.vue
+++ b/components/menu/MenuModifierOptionEditor.vue
@@ -29,10 +29,9 @@
         <label class="block text-xs font-medium text-text-secondary mb-1">Precio venta</label>
         <div class="relative">
           <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary text-sm">$</span>
-          <input
-            v-model.number="modifier.price"
-            type="number"
-            step="100"
+          <UiDecimalInput
+            v-model="modifier.price"
+            :precision="0"
             class="input-base w-full pl-8 pr-3 py-2 text-sm"
           />
         </div>
@@ -85,11 +84,10 @@
       </div>
       <div class="md:col-span-2">
         <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad</label>
-        <input
-          v-model.number="modifier.ingredient_quantity"
-          type="number"
-          min="0.01"
-          step="any"
+        <UiDecimalInput
+          v-model="modifier.ingredient_quantity"
+          :min="0.01"
+          :precision="6"
           class="input-base w-full px-3 py-2 text-sm"
         />
       </div>
@@ -129,11 +127,10 @@
         </div>
         <div class="md:col-span-3">
           <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad × receta</label>
-          <input
-            v-model.number="modifier.recipe_base_quantity"
-            type="number"
-            min="0.01"
-            step="any"
+          <UiDecimalInput
+            v-model="modifier.recipe_base_quantity"
+            :min="0.01"
+            :precision="6"
             class="input-base w-full px-3 py-2 text-sm"
           />
         </div>
@@ -171,11 +168,10 @@
       </div>
       <div class="md:col-span-3">
         <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad × producto</label>
-        <input
-          v-model.number="modifier.linked_product_quantity"
-          type="number"
-          min="0.01"
-          step="any"
+        <UiDecimalInput
+          v-model="modifier.linked_product_quantity"
+          :min="0.01"
+          :precision="6"
           class="input-base w-full px-3 py-2 text-sm"
         />
       </div>
@@ -210,6 +206,7 @@ import {
   type ModifierFormRow,
   type ModifierOptionType,
 } from '~/composables/useModifierOptionForm'
+import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 
 const props = defineProps<{
   modifier: ModifierFormRow
@@ -276,7 +273,7 @@ const recipeBaseIngredients = computed(() => {
 
 function scaledRecipeQty(ing: Record<string, unknown>) {
   const mult = Number(props.modifier.recipe_base_quantity) || 1
-  return (Number(ing.base_quantity ?? ing.quantity ?? 0) * mult).toFixed(2)
+  return formatDomainQuantity(Number(ing.base_quantity ?? ing.quantity ?? 0) * mult, 6)
 }
 
 function estimateRecipeCost(): number | null {

--- a/components/menu/ProductQuickCreatePanel.vue
+++ b/components/menu/ProductQuickCreatePanel.vue
@@ -89,12 +89,11 @@
             </label>
             <div class="relative">
               <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
-              <input
+              <UiDecimalInput
                 id="product-quick-price"
-                v-model.number="form.price"
-                type="number"
-                min="0"
-                step="100"
+                v-model="form.price"
+                :min="0"
+                :precision="0"
                 placeholder="2500"
                 class="h-10 w-full rounded-lg border-2 border-border bg-background pl-8 pr-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 transition-colors"
                 @input="clearError('price')"
@@ -109,12 +108,11 @@
             </label>
             <div class="relative">
               <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
-              <input
+              <UiDecimalInput
                 id="product-quick-costo"
-                v-model.number="form.costo_percibido"
-                type="number"
-                min="0"
-                step="100"
+                v-model="form.costo_percibido"
+                :min="0"
+                :precision="0"
                 placeholder="Opcional"
                 class="h-10 w-full rounded-lg border-2 border-border bg-background pl-8 pr-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 transition-colors"
               />

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -182,12 +182,11 @@
                 </label>
                 <div class="relative">
                   <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
-                  <input
-                    v-model.number="form.price"
-                    type="number"
+                  <UiDecimalInput
+                    v-model="form.price"
                     required
-                    min="0"
-                    step="100"
+                    :precision="0"
+                    :min="0"
                     class="input-base w-full pl-8 pr-4 py-2"
                     placeholder="15000"
                   />
@@ -222,11 +221,10 @@
                 </label>
                 <div class="relative">
                   <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
-                  <input
-                    v-model.number="form.costo_percibido"
-                    type="number"
-                    min="0"
-                    step="100"
+                  <UiDecimalInput
+                    v-model="form.costo_percibido"
+                    :precision="0"
+                    :min="0"
                     class="input-base w-full pl-8 pr-4 py-2"
                     placeholder="Opcional"
                   />
@@ -499,12 +497,10 @@
                       </option>
                     </select>
                     <div class="flex items-center gap-1.5 sm:w-32">
-                      <input
-                        v-model.number="link.quantity"
-                        type="number"
-                        min="0"
-                        step="any"
-                        inputmode="decimal"
+                      <UiDecimalInput
+                        v-model="link.quantity"
+                        :min="0"
+                        :precision="6"
                         class="input-base w-full min-h-[44px] px-3 py-2 text-sm"
                         :aria-label="`Cantidad de la receta ${index + 1}`"
                         :title="'Cuántas unidades de esta receta consume el producto (ej. 2× = doble del rendimiento)'"
@@ -522,7 +518,7 @@
                         class="flex justify-between text-text-secondary"
                       >
                         <span>{{ ing.ingredient_name }}</span>
-                        <span>{{ (Number(ing.base_quantity) * (Number(link.quantity) || 1)).toFixed(2) }} {{ ing.unit }}</span>
+                        <span>{{ formatDomainQuantity(Number(ing.base_quantity) * (Number(link.quantity) || 1), 6) }} {{ ing.unit }}</span>
                       </div>
                     </div>
                   </div>
@@ -575,11 +571,10 @@
                     />
                   </div>
                   <div>
-                    <input
-                      v-model.number="ingredient.quantity"
-                      type="number"
-                      min="0.01"
-                      step="any"
+                    <UiDecimalInput
+                      v-model="ingredient.quantity"
+                      :min="0.01"
+                      :precision="6"
                       placeholder="Cantidad"
                       required
                       class="input-base w-full px-3 py-2 text-sm"
@@ -866,6 +861,7 @@ import {
 } from '@/composables/useIngredientPurchaseUnitsDraft'
 import { useActiveStationsQuery } from '@/composables/queries/useActiveStations'
 import { useTenantReactive } from '@/composables/useTenantReactive'
+import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -201,12 +201,11 @@
                   </label>
                   <div class="relative">
                     <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
-                    <input
-                      v-model.number="form.price"
-                      type="number"
+                    <UiDecimalInput
+                      v-model="form.price"
                       required
-                      min="0"
-                      step="100"
+                      :precision="0"
+                      :min="0"
                       class="input-base w-full pl-8 pr-4 py-2"
                       placeholder="15000"
                     />
@@ -238,11 +237,10 @@
                   </label>
                   <div class="relative">
                     <span class="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
-                    <input
-                      v-model.number="form.costo_percibido"
-                      type="number"
-                      min="0"
-                      step="100"
+                    <UiDecimalInput
+                      v-model="form.costo_percibido"
+                      :precision="0"
+                      :min="0"
                       class="input-base w-full pl-8 pr-4 py-2"
                       placeholder="Referencia interna"
                     />
@@ -387,12 +385,10 @@
                           </option>
                         </select>
                         <div class="flex items-center gap-1.5 sm:w-32">
-                          <input
-                            v-model.number="link.quantity"
-                            type="number"
-                            min="0"
-                            step="any"
-                            inputmode="decimal"
+                          <UiDecimalInput
+                            v-model="link.quantity"
+                            :min="0"
+                            :precision="6"
                             class="input-base w-full min-h-[44px] px-3 py-2 text-sm"
                             :aria-label="`Cantidad de la receta ${index + 1}`"
                             :title="'Cuántas unidades de esta receta consume el producto (ej. 2× = doble del rendimiento)'"
@@ -409,7 +405,7 @@
                             class="flex justify-between text-text-secondary"
                           >
                             <span>{{ ing.ingredient_name }}</span>
-                            <span>{{ (Number(ing.base_quantity) * (Number(link.quantity) || 1)).toFixed(2) }} {{ ing.unit }}</span>
+                            <span>{{ formatDomainQuantity(Number(ing.base_quantity) * (Number(link.quantity) || 1), 6) }} {{ ing.unit }}</span>
                           </div>
                         </div>
                       </div>
@@ -458,12 +454,11 @@
                         />
                       </div>
                       <div>
-                        <input
-                          v-model.number="ingredient.quantity"
-                          type="number"
-                          min="0.01"
-                          step="any"
+                        <UiDecimalInput
+                          v-model="ingredient.quantity"
+                          :min="0.01"
                           placeholder="Cantidad"
+                          :precision="6"
                           class="input-base w-full px-3 py-2 text-sm"
                         />
                       </div>
@@ -710,6 +705,7 @@ import {
   type DraftPurchaseUnit,
 } from '@/composables/useIngredientPurchaseUnitsDraft'
 import { resolveResaleIngredientId } from '@/composables/useResaleLinkedIngredient'
+import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -271,12 +271,11 @@
                     <div class="relative w-fit shrink-0">
                       <span class="absolute left-2 top-1/2 -translate-y-1/2 text-text-secondary text-xs pointer-events-none">$</span>
                       <label class="sr-only" :for="`mobile-price-${item.id}`">Precio</label>
-                      <input
+                      <UiDecimalInput
                         :id="`mobile-price-${item.id}`"
-                        v-model.number="ensureDraft(item).price"
-                        type="number"
-                        min="0"
-                        step="100"
+                        v-model="ensureDraft(item).price"
+                        :min="0"
+                        :precision="0"
                         class="input-base input-money w-fit min-w-[7rem] max-w-none pl-5 pr-2 py-1.5 text-sm tabular-nums text-right"
                         :style="{ width: moneyInputWidth(ensureDraft(item).price) }"
                         placeholder="Precio"
@@ -284,12 +283,11 @@
                     </div>
                     <div class="relative w-fit shrink-0">
                       <label class="sr-only" :for="`mobile-costo-${item.id}`">Mi costo</label>
-                      <input
+                      <UiDecimalInput
                         :id="`mobile-costo-${item.id}`"
-                        v-model.number="ensureDraft(item).costo_percibido"
-                        type="number"
-                        min="0"
-                        step="100"
+                        v-model="ensureDraft(item).costo_percibido"
+                        :min="0"
+                        :precision="0"
                         class="input-base input-money w-fit min-w-[7rem] max-w-none px-2 py-1.5 text-sm tabular-nums text-right"
                         :style="{ width: moneyInputWidth(ensureDraft(item).costo_percibido) }"
                         placeholder="Mi costo"
@@ -508,11 +506,10 @@
               @click.stop
             >
               <span class="absolute left-2 top-1/2 -translate-y-1/2 text-text-secondary text-xs pointer-events-none">$</span>
-              <input
-                v-model.number="ensureDraft(item).price"
-                type="number"
-                min="0"
-                step="100"
+              <UiDecimalInput
+                v-model="ensureDraft(item).price"
+                :min="0"
+                :precision="0"
                 class="input-base input-money w-fit min-w-[7rem] max-w-none pl-5 pr-2 py-1.5 text-sm text-right tabular-nums"
                 :style="{ width: moneyInputWidth(ensureDraft(item).price) }"
                 :aria-label="`Precio de ${item.name}`"
@@ -538,11 +535,10 @@
                 class="relative w-fit ml-auto shrink-0"
                 @click.stop
               >
-                <input
-                  v-model.number="ensureDraft(item).costo_percibido"
-                  type="number"
-                  min="0"
-                  step="100"
+                <UiDecimalInput
+                  v-model="ensureDraft(item).costo_percibido"
+                  :min="0"
+                  :precision="0"
                   class="input-base input-money w-fit min-w-[7rem] max-w-none px-2 py-1.5 text-sm text-right tabular-nums"
                   :style="{ width: moneyInputWidth(ensureDraft(item).costo_percibido) }"
                   :aria-label="`Mi costo de ${item.name}`"

--- a/pages/menu/recetas/[id].vue
+++ b/pages/menu/recetas/[id].vue
@@ -99,12 +99,11 @@
 
                     <div class="md:col-span-3">
                       <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad *</label>
-                      <input
-                        v-model.number="ingredient.base_quantity"
-                        type="number"
+                      <UiDecimalInput
+                        v-model="ingredient.base_quantity"
                         required
-                        min="0.01"
-                        step="any"
+                        :min="0.01"
+                        :precision="6"
                         class="input-base w-full px-3 py-2 text-sm"
                         placeholder="0"
                       />

--- a/pages/menu/recetas/crear.vue
+++ b/pages/menu/recetas/crear.vue
@@ -117,12 +117,11 @@
 
                       <div class="md:col-span-3">
                         <label class="block text-xs font-medium text-text-secondary mb-1">Cantidad *</label>
-                        <input
-                          v-model.number="ingredient.base_quantity"
-                          type="number"
+                        <UiDecimalInput
+                          v-model="ingredient.base_quantity"
                           placeholder="0"
-                          min="0.01"
-                          step="any"
+                          :min="0.01"
+                          :precision="6"
                           class="input-base w-full px-3 py-2 text-sm"
                           required
                         />


### PR DESCRIPTION
## Summary
- Replace sensitive menu money and quantity number inputs with locale-safe `UiDecimalInput`
- Preserve higher precision for recipe/modifier quantities while keeping COP fields whole-peso
- Format recipe/modifier quantity previews with `formatDomainQuantity` to avoid long decimal tails

## Tests
- `node --test utils/domainNumberFormat.test.ts utils/parseLocaleDecimal.test.ts`
- `npm run build`

Closes #1421