### PR TITLE
Support six-decimal inventory inputs

### DIFF
--- a/components/abastecimiento/AbastecimientoStockAdjustmentFullForm.vue
+++ b/components/abastecimiento/AbastecimientoStockAdjustmentFullForm.vue
@@ -179,7 +179,7 @@
                   <UiDecimalInput
                     v-model="form.quantity"
                     :min="0"
-                    :precision="2"
+                    :precision="INVENTORY_QUANTITY_PRECISION"
                     required
                     class="w-full px-4 py-2"
                     :placeholder="form.adjustmentType === 'set' ? 'Ingrese el stock correcto' : 'Ingrese la cantidad'"
@@ -226,7 +226,7 @@
                   <UiDecimalInput
                     v-model="form.cost_per_unit"
                     :min="0"
-                    :precision="2"
+                    :precision="TECHNICAL_UNIT_COST_PRECISION"
                     class="w-full px-4 py-2 pl-8"
                     placeholder="Ingrese el costo unitario (opcional)"
                   />
@@ -244,7 +244,7 @@
                   <span class="font-bold">{{ formatNumber(newStockInBase) }} {{ selectedIngredient?.unit }}</span>
                 </p>
                 <p v-if="form.cost_per_unit && form.adjustmentType === 'increment'" class="text-xs text-state-info-text mt-1">
-                  Costo unitario: ${{ form.cost_per_unit.toLocaleString('es-CO') }} por {{ form.unit }}
+                  Costo unitario: ${{ formatTechnicalUnitCost(form.cost_per_unit) }} por {{ form.unit }}
                 </p>
               </div>
 
@@ -380,9 +380,12 @@ import { INGREDIENTS_FETCH_LIMIT } from '@/composables/useMenuIngredients'
 import { useIngredientPurchaseUnits } from '~/composables/useIngredientPurchaseUnits'
 import {
   ADJUSTMENT_REASONS,
+  INVENTORY_QUANTITY_PRECISION,
+  TECHNICAL_UNIT_COST_PRECISION,
   useInventoryAdjustment,
 } from '~/composables/useInventoryAdjustment'
 import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
+import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 
 interface Props {
   cancelRedirectUrl: string
@@ -432,8 +435,11 @@ const REASON_LABELS = ADJUSTMENT_REASONS.reduce((acc, r) => {
 const reasonLabel = (value: string) => REASON_LABELS[value] || value
 
 const formatNumber = (value: number | null | undefined) => {
-  const v = Number(value ?? 0)
-  return new Intl.NumberFormat('es-CO', { minimumFractionDigits: 0, maximumFractionDigits: 2 }).format(v)
+  return formatDomainQuantity(value, INVENTORY_QUANTITY_PRECISION)
+}
+
+const formatTechnicalUnitCost = (value: number | null | undefined) => {
+  return formatDomainQuantity(value, TECHNICAL_UNIT_COST_PRECISION)
 }
 
 const purchaseUnitOptions = computed(() =>

--- a/components/abastecimiento/StockAdjustmentPanel.vue
+++ b/components/abastecimiento/StockAdjustmentPanel.vue
@@ -185,7 +185,7 @@
                 :id="qtyId"
                 v-model="form.quantity"
                 :min="0"
-                :precision="2"
+                :precision="INVENTORY_QUANTITY_PRECISION"
                 class="w-full px-3 py-2 min-h-[44px]"
                 :placeholder="form.adjustmentType === 'set' ? 'Stock objetivo' : 'Cantidad'"
               />
@@ -257,7 +257,7 @@
                 :id="costId"
                 v-model="form.cost_per_unit"
                 :min="0"
-                :precision="2"
+                :precision="TECHNICAL_UNIT_COST_PRECISION"
                 class="w-full pl-7 pr-3 py-2 min-h-[44px]"
                 placeholder="0"
               />
@@ -392,8 +392,11 @@ import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import {
   useInventoryAdjustment,
   ADJUSTMENT_REASONS,
+  INVENTORY_QUANTITY_PRECISION,
+  TECHNICAL_UNIT_COST_PRECISION,
   type SelectedIngredient,
 } from '~/composables/useInventoryAdjustment'
+import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 
 interface Props {
   modelValue: boolean
@@ -569,8 +572,7 @@ const close = () => {
 }
 
 const formatNumber = (value: number | null | undefined) => {
-  const v = Number(value ?? 0)
-  return new Intl.NumberFormat('es-CO', { minimumFractionDigits: 0, maximumFractionDigits: 2 }).format(v)
+  return formatDomainQuantity(value, INVENTORY_QUANTITY_PRECISION)
 }
 </script>
 

--- a/components/ingredientes/IngredientPurchaseUnitsField.vue
+++ b/components/ingredientes/IngredientPurchaseUnitsField.vue
@@ -26,7 +26,7 @@
             <span v-else class="text-[10px] text-primary bg-primary/10 rounded px-1.5 py-0.5 flex-shrink-0">predeterminado</span>
           </div>
           <span class="text-xs text-text-tertiary font-mono flex-shrink-0">
-            {{ Number(u.conversion_factor).toLocaleString('es-CO') }} {{ baseUnit }}
+            {{ formatConversionFactor(u.conversion_factor) }} {{ baseUnit }}
           </span>
           <button
             v-if="draftUnits.length > 1"
@@ -59,8 +59,8 @@
             <label class="text-xs text-text-tertiary font-medium">Cant. ({{ baseUnit }})</label>
             <UiDecimalInput
               v-model="newUnit.conversion_factor"
-              :min="0.001"
-              :precision="3"
+              :min="0.000001"
+              :precision="CONVERSION_PRECISION"
               :placeholder="factorPlaceholder"
               :class="inputClass"
               @keyup.enter="addDraftUnit"
@@ -111,7 +111,7 @@
             </button>
             <span v-else class="text-[10px] text-primary bg-primary/10 rounded px-1.5 py-0.5 flex-shrink-0">predeterminado</span>
           </div>
-          <span class="text-xs text-text-tertiary font-mono flex-shrink-0">{{ Number(u.conversion_factor).toLocaleString('es-CO') }} {{ baseUnit }}</span>
+          <span class="text-xs text-text-tertiary font-mono flex-shrink-0">{{ formatConversionFactor(u.conversion_factor) }} {{ baseUnit }}</span>
           <button
             type="button"
             :disabled="deletingUnitId === u.id"
@@ -132,7 +132,7 @@
             <span class="text-sm text-text-primary">{{ s.label }}</span>
             <span v-if="i === 0" class="text-[10px] text-primary bg-primary/10 rounded px-1.5 py-0.5 flex-shrink-0">predeterminado</span>
           </div>
-          <span class="text-xs text-text-tertiary font-mono flex-shrink-0 ml-2">{{ s.conversion_factor.toLocaleString('es-CO') }} {{ baseUnit }}</span>
+          <span class="text-xs text-text-tertiary font-mono flex-shrink-0 ml-2">{{ formatConversionFactor(s.conversion_factor) }} {{ baseUnit }}</span>
         </div>
       </div>
 
@@ -153,8 +153,8 @@
             <label class="text-xs text-text-tertiary font-medium">Cant. ({{ baseUnit }})</label>
             <UiDecimalInput
               v-model="newUnit.conversion_factor"
-              :min="0.001"
-              :precision="3"
+              :min="0.000001"
+              :precision="CONVERSION_PRECISION"
               placeholder="Ej: 12"
               :class="inputClass"
               @keyup.enter="addPurchaseUnit"
@@ -187,6 +187,9 @@
 
 <script setup lang="ts">
 import type { DraftPurchaseUnit, PurchaseUnitSuggestion } from '@/composables/useIngredientPurchaseUnitsDraft'
+import { formatDomainQuantity } from '~/utils/domainNumberFormat'
+
+const CONVERSION_PRECISION = 6
 
 const props = withDefaults(defineProps<{
   mode: 'create' | 'edit'
@@ -221,6 +224,10 @@ const savingUnit = ref(false)
 const deletingUnitId = ref<string | null>(null)
 const formError = ref('')
 const newUnit = ref({ purchase_unit_label: '', conversion_factor: null as number | null })
+
+function formatConversionFactor(value: number | string | null | undefined) {
+  return formatDomainQuantity(value, CONVERSION_PRECISION)
+}
 
 function slugifyPurchaseUnit(label: string) {
   return label.toLowerCase().replace(/\s+/g, '_')

--- a/components/ingredientes/IngredientePropioPanel.vue
+++ b/components/ingredientes/IngredientePropioPanel.vue
@@ -348,7 +348,7 @@
                 id="ing-weight"
                 v-model="form.unitWeightGr"
                 :min="0"
-                :precision="1"
+                :precision="6"
                 :placeholder="`Ej: 400 (1 und = 400 ${unitWeightUnit})`"
                 :class="inputClass + ' flex-1'"
               />

--- a/composables/useInventoryAdjustment.ts
+++ b/composables/useInventoryAdjustment.ts
@@ -13,6 +13,9 @@ import { computed, reactive, ref } from 'vue'
 
 export type AdjustmentType = 'increment' | 'decrement' | 'set'
 
+export const INVENTORY_QUANTITY_PRECISION = 6
+export const TECHNICAL_UNIT_COST_PRECISION = 6
+
 export interface AdjustmentReason {
   value: string
   label: string

--- a/pages/abastecimiento/movimientos.vue
+++ b/pages/abastecimiento/movimientos.vue
@@ -296,7 +296,7 @@ const getMovementTypeVariant = (type: string) => {
 }
 
 const formatNumber = (value: number) => {
-  return formatDomainQuantity(value)
+  return formatDomainQuantity(value, 6)
 }
 
 const { formatDate } = useFormatters()

--- a/pages/inventario/ajustes/index.vue
+++ b/pages/inventario/ajustes/index.vue
@@ -186,6 +186,7 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 import { INGREDIENTS_FETCH_LIMIT } from '@/composables/useMenuIngredients'
+import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 
 useHead({ title: 'Ajustes de Inventario' })
 
@@ -406,12 +407,7 @@ const adjustmentsTableColumns = [
   }
 ]
 
-const formatNumber = (value: number) => {
-  return new Intl.NumberFormat('es-CO', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2
-  }).format(value)
-}
+const formatNumber = (value: number) => formatDomainQuantity(value, 6)
 
 const { formatDateTime: formatDate } = useFormatters()
 

--- a/pages/inventario/movimientos.vue
+++ b/pages/inventario/movimientos.vue
@@ -356,7 +356,7 @@ const getMovementTypeVariant = (type: string) => {
 }
 
 const formatNumber = (value: number) => {
-  return formatDomainQuantity(value)
+  return formatDomainQuantity(value, 6)
 }
 
 const { formatDate } = useFormatters()

--- a/utils/domainNumberFormat.test.ts
+++ b/utils/domainNumberFormat.test.ts
@@ -6,6 +6,7 @@ describe('formatDomainQuantity', () => {
   it('keeps meaningful sub-unit precision without long tails', () => {
     assert.equal(formatDomainQuantity(1.345), '1,345')
     assert.equal(formatDomainQuantity(0.3333333333333), '0,3333')
+    assert.equal(formatDomainQuantity(0.3333333333333, 6), '0,333333')
   })
 
   it('formats tiny float residue as a clean zero', () => {


### PR DESCRIPTION
## Summary
- allow six-decimal physical quantities and conversion factors in ingredient/unit and stock adjustment flows
- format inventory quantities with trimmed max-6 precision in adjustment and movement displays
- keep technical stock-adjustment unit cost separate from COP total/payment formatting

## Tests
- node --test utils/domainNumberFormat.test.ts
- Not run: npm run build (skipped per request)

Closes #1427