### PR TITLE
Support six-decimal legacy purchase inputs

### DIFF
--- a/components/purchases/CompletePricesForm.vue
+++ b/components/purchases/CompletePricesForm.vue
@@ -11,7 +11,7 @@
           <div>
             <h4 class="font-semibold text-text-primary">{{ item.ingredient_name }}</h4>
             <p class="text-sm text-text-secondary">
-              Cantidad: {{ item.quantity }} {{ item.unit }}
+              Cantidad: {{ formatQuantity(item.quantity) }} {{ item.unit }}
             </p>
             <p v-if="item.weight_info" class="text-xs text-text-secondary mt-1">
               {{ item.weight_info }}
@@ -35,7 +35,7 @@
             <UiDecimalInput
               v-model="item.unit_cost"
               :min="0"
-              :precision="2"
+              :precision="TECHNICAL_UNIT_COST_PRECISION"
               required
               class="input-base w-full px-4 py-2"
               placeholder="0.00"
@@ -133,6 +133,13 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import { formatDomainQuantity } from '~/utils/domainNumberFormat'
+
+const TECHNICAL_UNIT_COST_PRECISION = 6
+const QUANTITY_PRECISION = 6
+
+const formatQuantity = (value: number | string | null | undefined) =>
+  formatDomainQuantity(value, QUANTITY_PRECISION)
 
 const props = defineProps<{
   purchase: any

--- a/components/purchases/CompletePricesModal.vue
+++ b/components/purchases/CompletePricesModal.vue
@@ -47,7 +47,7 @@
                 <div>
                   <h4 class="font-semibold text-text-primary">{{ getIngredientName(item.ingredient_id) }}</h4>
                   <p class="text-sm text-text-secondary">
-                    Cantidad: {{ item.quantity }} {{ item.unit }}
+                    Cantidad: {{ formatQuantity(item.quantity) }} {{ item.unit }}
                   </p>
                 </div>
                 <span class="text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded">
@@ -63,7 +63,7 @@
                   <UiDecimalInput
                     v-model="item.unit_cost"
                     :min="0"
-                    :precision="2"
+                    :precision="TECHNICAL_UNIT_COST_PRECISION"
                     required
                     class="input-base w-full px-4 py-2"
                     placeholder="0.00"
@@ -183,6 +183,13 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import { formatDomainQuantity } from '~/utils/domainNumberFormat'
+
+const TECHNICAL_UNIT_COST_PRECISION = 6
+const QUANTITY_PRECISION = 6
+
+const formatQuantity = (value: number | string | null | undefined) =>
+  formatDomainQuantity(value, QUANTITY_PRECISION)
 
 const props = defineProps<{
   isOpen: boolean

--- a/components/purchases/PurchaseDetailsModal.vue
+++ b/components/purchases/PurchaseDetailsModal.vue
@@ -276,7 +276,7 @@
                 <div class="flex-1">
                   <p class="font-medium text-text-primary">{{ item.ingredient_name }}</p>
                   <p class="text-sm text-text-secondary">
-                    Cantidad: {{ item.quantity }} {{ item.unit }}
+                    Cantidad: {{ formatQuantity(item.quantity) }} {{ item.unit }}
                   </p>
                   <p v-if="item.notes" class="text-xs text-text-secondary mt-1">
                     Nota: {{ item.notes }}
@@ -330,6 +330,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
+import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 
 const props = defineProps<{
   isOpen: boolean
@@ -429,6 +430,10 @@ const { formatDate } = useFormatters()
 function formatCurrency(value: number | null): string {
   if (value === null || value === undefined) return '$0'
   return new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(value)
+}
+
+function formatQuantity(value: number | string | null | undefined): string {
+  return formatDomainQuantity(value, 6)
 }
 
 const closeModal = () => {

--- a/components/purchases/ReceiveForm.vue
+++ b/components/purchases/ReceiveForm.vue
@@ -30,7 +30,7 @@
               <UiDecimalInput
                 v-model="item.quantity_received"
                 :min="0"
-                :precision="3"
+                :precision="QUANTITY_PRECISION"
                 required
                 class="w-full px-3 py-2 rounded-lg text-text-primary transition-all border-2"
                 style="background-color: hsl(var(--surface)); border-color: hsl(var(--crocus-600) / 0.3);"
@@ -132,6 +132,8 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
+
+const QUANTITY_PRECISION = 6
 
 const props = defineProps<{
   purchaseId: string

--- a/components/purchases/ReceivePurchaseModal.vue
+++ b/components/purchases/ReceivePurchaseModal.vue
@@ -64,7 +64,7 @@
                     <UiDecimalInput
                       v-model="item.quantity_received"
                       :min="0"
-                      :precision="3"
+                      :precision="QUANTITY_PRECISION"
                       required
                       class="w-full px-3 py-2 rounded-lg text-text-primary transition-all border-2"
                       style="background-color: hsl(var(--surface)); border-color: hsl(var(--crocus-600) / 0.3);"
@@ -173,6 +173,8 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue'
+
+const QUANTITY_PRECISION = 6
 
 const props = defineProps<{
   isOpen: boolean

--- a/pages/abastecimiento/compra/[id]/index.vue
+++ b/pages/abastecimiento/compra/[id]/index.vue
@@ -156,8 +156,8 @@
                   <label class="block text-sm font-medium text-text-primary mb-2">Cantidad *</label>
                   <UiDecimalInput
                     v-model="item.purchase_quantity"
-                    :min="0.01"
-                    :precision="2"
+                    :min="0.000001"
+                    :precision="QUANTITY_PRECISION"
                     required
                     class="w-full px-4 py-2"
                   />
@@ -342,10 +342,10 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                               d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
                           </svg>
-                          <span class="text-text-primary font-semibold text-xs">{{ item.purchase_quantity || item.quantity }} {{ item.purchase_unit || item.unit }}</span>
+                          <span class="text-text-primary font-semibold text-xs">{{ formatQuantity(item.purchase_quantity || item.quantity) }} {{ item.purchase_unit || item.unit }}</span>
                         </div>
                         <span v-if="item.weight_value && item.weight_unit" class="text-text-secondary text-xs ml-5">
-                          Peso: {{ item.weight_value }} {{ item.weight_unit }}
+                          Peso: {{ formatQuantity(item.weight_value) }} {{ item.weight_unit }}
                         </span>
                       </div>
 
@@ -404,9 +404,9 @@
                       </div>
                     </td>
                     <td class="px-4 py-3 text-sm text-text-primary text-right font-medium">
-                      <div>{{ item.purchase_quantity || item.quantity }} {{ item.purchase_unit || item.unit }}</div>
+                      <div>{{ formatQuantity(item.purchase_quantity || item.quantity) }} {{ item.purchase_unit || item.unit }}</div>
                       <div v-if="item.weight_value && item.weight_unit" class="text-xs text-text-secondary mt-1">
-                        Peso: {{ item.weight_value }} {{ item.weight_unit }} ({{ item.weight_per_unit_grams }} gr/und)
+                        Peso: {{ formatQuantity(item.weight_value) }} {{ item.weight_unit }} ({{ formatQuantity(item.weight_per_unit_grams) }} gr/und)
                       </div>
                     </td>
                     <td v-if="form.status !== 'quotation'" class="px-4 py-3 text-sm text-text-primary text-right">
@@ -676,11 +676,16 @@ import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import { usePurchasesStore } from '~/stores/purchases'
 import { storeToRefs } from 'pinia'
 import { INGREDIENTS_FETCH_LIMIT } from '@/composables/useMenuIngredients'
+import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 
 // Get order ID from route
 const route = useRoute()
 const router = useRouter()
 const purchaseId = route.params.id as string
+const QUANTITY_PRECISION = 6
+
+const formatQuantity = (value: number | string | null | undefined) =>
+  formatDomainQuantity(value, QUANTITY_PRECISION)
 
 useHead({
   title: `Editar Orden ${purchaseId} - Abastecimiento`

--- a/pages/abastecimiento/compra/crear.vue
+++ b/pages/abastecimiento/compra/crear.vue
@@ -397,8 +397,8 @@
                     <div class="flex gap-2">
                       <UiDecimalInput
                         v-model="item.quantity"
-                        :min="0.01"
-                        :precision="2"
+                        :min="0.000001"
+                        :precision="QUANTITY_PRECISION"
                         required
                         class="flex-1 px-4 py-2"
                         @update:model-value="updateItemTotal(index)"
@@ -544,7 +544,7 @@
                     <div>
                       <p class="text-xs text-text-secondary mb-1">Cantidad Solicitada</p>
                       <p class="text-sm text-text-primary font-semibold">
-                        {{ item.quantity }} {{ item.purchase_unit }}
+                        {{ formatQuantity(item.quantity) }} {{ item.purchase_unit }}
                       </p>
                     </div>
                     <div>
@@ -557,10 +557,10 @@
                   <div v-if="shouldShowWeightPerUnit(index)" class="col-span-2 bg-background/50 p-2 rounded border border-border">
                     <p class="text-xs text-text-secondary mb-1">Detalles del Paquete</p>
                     <p class="text-xs text-text-primary">
-                      Peso total: {{ item.quantity }} {{ item.weight_unit }}
+                      Peso total: {{ formatQuantity(item.quantity) }} {{ item.weight_unit }}
                     </p>
                     <p class="text-xs text-text-secondary mt-1">
-                      ≈ {{ (convertWeightToGrams(item.quantity, item.weight_unit) / getConversionFactor(item.purchase_unit, item.ingredient_id)).toFixed(2) }} gr por unidad
+                      ≈ {{ formatQuantity(convertWeightToGrams(item.quantity, item.weight_unit) / getConversionFactor(item.purchase_unit, item.ingredient_id)) }} gr por unidad
                     </p>
                   </div>
                 </div>
@@ -596,7 +596,7 @@
                     <p v-if="item.notes" class="text-xs text-text-secondary mt-1">{{ item.notes }}</p>
                   </td>
                   <td class="text-right py-4 text-text-primary font-semibold">
-                    {{ item.quantity }} {{ item.purchase_unit }}
+                    {{ formatQuantity(item.quantity) }} {{ item.purchase_unit }}
                   </td>
                   <td class="text-right py-4 text-text-secondary text-sm">
                     {{ getConvertedQuantity(index) }} {{ getIngredientUnit(item.ingredient_id) }}
@@ -604,10 +604,10 @@
                   <td class="text-right py-4">
                     <div v-if="shouldShowWeightPerUnit(index)" class="text-xs space-y-1">
                       <p class="text-text-primary">
-                        Peso: {{ item.quantity }} {{ item.weight_unit }}
+                        Peso: {{ formatQuantity(item.quantity) }} {{ item.weight_unit }}
                       </p>
                       <p class="text-text-secondary">
-                        ({{ (convertWeightToGrams(item.quantity, item.weight_unit) / getConversionFactor(item.purchase_unit, item.ingredient_id)).toFixed(2) }} gr/und)
+                        ({{ formatQuantity(convertWeightToGrams(item.quantity, item.weight_unit) / getConversionFactor(item.purchase_unit, item.ingredient_id)) }} gr/und)
                       </p>
                     </div>
                     <span v-else class="text-text-secondary text-xs">-</span>
@@ -674,10 +674,13 @@
 <script setup lang="ts">
 import { INGREDIENTS_FETCH_LIMIT } from '@/composables/useMenuIngredients'
 import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
+import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 
 useHead({
   title: 'Crear Cotización - Abastecimiento'
 })
+
+const QUANTITY_PRECISION = 6
 
 // Tenant reactivity
 const { currentTenant } = useTenantReactive()
@@ -915,6 +918,9 @@ const formatPrice = (price) => {
   return price.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',')
 }
 
+const formatQuantity = (value: number | string | null | undefined) =>
+  formatDomainQuantity(value, QUANTITY_PRECISION)
+
 const formatDate = (dateString) => {
   if (!dateString) return ''
   const date = new Date(dateString)
@@ -979,7 +985,7 @@ const getConvertedQuantity = (index) => {
   const factor = getConversionFactor(item.purchase_unit, item.ingredient_id)
   const converted = item.quantity * factor
 
-  return converted.toLocaleString('es-CO', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+  return formatQuantity(converted)
 }
 
 // Get dynamic label for quantity field
@@ -1031,7 +1037,7 @@ const getWeightPerUnitText = (index) => {
   const weightInGrams = convertWeightToGrams(item.quantity, item.weight_unit || 'gr')
   const weightPerUnit = weightInGrams / conversionFactor
 
-  return `≈ ${weightPerUnit.toFixed(2)} gr por unidad (${conversionFactor} unidades)`
+  return `≈ ${formatQuantity(weightPerUnit)} gr por unidad (${formatQuantity(conversionFactor)} unidades)`
 }
 
 // Convert weight to grams
@@ -1282,7 +1288,7 @@ const handleSubmit = async () => {
         weight_value: baseUnit === 'und' && factor > 1 ? item.quantity : null,
         weight_unit: baseUnit === 'und' && factor > 1 ? item.weight_unit : null,
         weight_per_unit_grams: baseUnit === 'und' && factor > 1
-          ? (convertWeightToGrams(item.quantity, item.weight_unit || 'gr') / factor).toFixed(2)
+          ? formatQuantity(convertWeightToGrams(item.quantity, item.weight_unit || 'gr') / factor)
           : null
       }
     })


### PR DESCRIPTION
## Summary
- allow six-decimal quantities in legacy purchase create/edit and receiving flows
- allow six-decimal technical unit costs in supplier price completion forms
- format physical purchase quantities with trimmed max-6 precision while leaving COP totals/taxes as human money

## Tests
- git diff --check
- Not run: npm run build (skipped per request)

Closes #1428