### PR TITLE
test: add decimal policy validation

### DIFF
--- a/utils/domainNumberFormat.test.ts
+++ b/utils/domainNumberFormat.test.ts
@@ -9,6 +9,12 @@ describe('formatDomainQuantity', () => {
     assert.equal(formatDomainQuantity(0.3333333333333, 6), '0,333333')
   })
 
+  it('supports a six-decimal quantity policy while trimming insignificant zeros', () => {
+    assert.equal(formatDomainQuantity('1.345678', 6), '1,345678')
+    assert.equal(formatDomainQuantity('1.340000', 6), '1,34')
+    assert.equal(formatDomainQuantity('1000', 6), '1.000')
+  })
+
   it('formats tiny float residue as a clean zero', () => {
     assert.equal(formatDomainQuantity(0.1 + 0.2 - 0.3), '0')
   })
@@ -17,5 +23,10 @@ describe('formatDomainQuantity', () => {
 describe('normalizeDomainNumber', () => {
   it('rounds calculation inputs to the requested precision', () => {
     assert.equal(normalizeDomainNumber(0.1 + 0.2, 6), 0.3)
+  })
+
+  it('normalizes physical quantities to 6 decimals without carrying float tails', () => {
+    assert.equal(normalizeDomainNumber('0.3333334', 6), 0.333333)
+    assert.equal(normalizeDomainNumber(1.3456789, 6), 1.345679)
   })
 })

--- a/utils/parseLocaleDecimal.test.ts
+++ b/utils/parseLocaleDecimal.test.ts
@@ -19,6 +19,11 @@ describe('parseLocaleDecimal', () => {
     assert.equal(parseLocaleDecimal('1,234.56'), 1234.56)
   })
 
+  it('preserves six-decimal physical quantities from comma and dot input', () => {
+    assert.equal(parseLocaleDecimal('0,333333'), 0.333333)
+    assert.equal(parseLocaleDecimal('1.345678'), 1.345678)
+  })
+
   it('strips whitespace and currency symbol', () => {
     assert.equal(parseLocaleDecimal('  $ 2,5 '), 2.5)
   })
@@ -47,6 +52,7 @@ describe('parseReceiptDecimal', () => {
   it('parses decimal produce quantities from POS receipts', () => {
     assert.equal(parseReceiptDecimal('1.345', 'quantity'), 1.345)
     assert.equal(parseReceiptDecimal('1,345', 'quantity'), 1.345)
+    assert.equal(parseReceiptDecimal('0,333333', 'quantity'), 0.333333)
     assert.equal(parseReceiptDecimal(1, 'quantity'), 1)
   })
 
@@ -63,6 +69,11 @@ describe('roundToPrecision', () => {
 
   it('rounds to 3 decimals', () => {
     assert.equal(roundToPrecision(1.23456, 3), 1.235)
+  })
+
+  it('rounds quantity-style values to 6 decimals', () => {
+    assert.equal(roundToPrecision(0.3333334, 6), 0.333333)
+    assert.equal(roundToPrecision(0.3333336, 6), 0.333334)
   })
 
   it('rounds to 1 decimal', () => {


### PR DESCRIPTION
## Summary
- Add frontend regression coverage for six-decimal quantity parsing, receipt quantity parsing, rounding, and domain quantity formatting.
- Document the field-role policy in tests: quantities/conversions up to 6, technical unit cost precision handled separately, COP money not globally expanded.

## Tests
- node --test utils/parseLocaleDecimal.test.ts utils/domainNumberFormat.test.ts

No build run per request.

Closes #1430