### PR TITLE
Fit Kali markdown tables to content

### DIFF
--- a/pages/asistente/kali.vue
+++ b/pages/asistente/kali.vue
@@ -776,8 +776,8 @@ onBeforeUnmount(() => {
 }
 
 .kali-report-markdown :deep(table) {
-  display: block;
-  width: 100%;
+  display: inline-block;
+  width: max-content;
   max-width: 100%;
   overflow-x: auto;
   border-collapse: collapse;


### PR DESCRIPTION
## Summary
- make Kali markdown tables size to content instead of filling the full response width
- preserve max-width and horizontal scrolling for wide tables

## Tests
- npx nuxi prepare