### PR TITLE
Show Matias companyId readiness state

### DIFF
--- a/composables/useInvoicingReadiness.ts
+++ b/composables/useInvoicingReadiness.ts
@@ -7,6 +7,7 @@ export interface InvoicingReadinessChecks {
   fiscal_data_complete: boolean
   active_resolution:    boolean
   taxes_configured:     boolean
+  matias_company_id_configured: boolean
 }
 
 export interface InvoicingReadinessResponse {

--- a/docs/usuarios/facturacion.md
+++ b/docs/usuarios/facturacion.md
@@ -14,6 +14,7 @@ En la parte superior aparece un **banner de readiness** que revisa automáticame
 
 - ✓ **Listo para facturar** — todos los checks aprobados.
 - ⚠ **Faltan datos** — el banner lista exactamente qué tienes que completar antes de poder facturar.
+- En producción, también debe estar configurado el **UUID cliente Matias** (`companyId`) cuando WARO emite como Casa de Software.
 
 ---
 
@@ -76,9 +77,16 @@ Presiona **Guardar configuración** después de cualquier cambio.
 Tarjeta de salud del proveedor técnico de facturación:
 
 - **Entorno** — Habilitación (pruebas) o Producción
+- **UUID cliente Matias** — `companyId` del cliente emisor en Matias
 - **Último documento emitido** — prefijo, número y fecha
 
 Si esta tarjeta muestra errores, no podrás emitir facturas hasta que el proveedor se recupere. Contacta a soporte si la falla dura más de una hora.
+
+### UUID cliente Matias para Casa de Software
+
+WARO usa un JWT/PAT de Casa de Software para conectarse con Matias. Ese token identifica la cuenta técnica de WARO; el campo **UUID cliente Matias** (`companyId`) identifica cuál cliente emite la factura ante Matias y la DIAN.
+
+Este valor lo entrega Matias para cada cliente. No uses el ID del negocio en WARO ni el NIT como reemplazo. En habilitación o sandbox puede estar vacío, pero en producción debe estar configurado antes de emitir.
 
 ---
 
@@ -114,6 +122,9 @@ Desde el banner de alerta o yendo a `/facturacion/audit`. La pantalla muestra:
 
 **¿Por qué no puedo emitir facturas si todo parece configurado?**
 Revisa el banner de readiness arriba: lista exactamente qué falta (resolución vencida, NIT vacío, etc.).
+
+**¿Dónde consigo el UUID cliente Matias?**
+Solicítalo o consúltalo en Matias para el cliente emisor. Es el `companyId` de Matias, no el identificador interno de WARO.
 
 **¿Cambié de régimen tributario, qué hago?**
 Actualiza el campo **Régimen tributario** en Datos fiscales y revisa la **Configuración fiscal** — los impuestos aplicables suelen cambiar.

--- a/pages/facturacion/index.vue
+++ b/pages/facturacion/index.vue
@@ -439,7 +439,20 @@ const taxLevels = [
         </div>
       </div>
 
-      <!-- All four checks passed — ready to invoice -->
+      <!-- Missing Matias Casa de Software issuer id -->
+      <div
+        v-if="!readinessChecks.matias_company_id_configured"
+        class="flex items-start gap-3 rounded-lg border border-state-warning-border bg-state-warning-bg p-4"
+        role="status"
+      >
+        <ExclamationTriangleIcon class="w-5 h-5 text-state-warning-icon flex-shrink-0 mt-0.5" aria-hidden="true" />
+        <div class="flex-1">
+          <p class="text-sm font-semibold text-state-warning-text">Falta UUID cliente Matias</p>
+          <p class="text-xs text-state-warning-text/90 mt-0.5">Configura el <span class="font-medium">companyId</span> del cliente emisor en la sección <span class="font-medium">Matias API</span> antes de emitir en producción.</p>
+        </div>
+      </div>
+
+      <!-- All checks passed — ready to invoice -->
       <div
         v-if="isInvoicingReady"
         class="flex items-center gap-3 rounded-lg border border-state-success-border bg-state-success-bg p-3"
@@ -1075,7 +1088,7 @@ const taxLevels = [
         <div class="flex flex-col gap-1 pb-2">
           <label for="matias-company-id" class="text-sm font-medium text-text-primary">
             UUID cliente Matias
-            <span class="text-xs font-normal text-text-tertiary">(opcional)</span>
+            <span class="text-xs font-normal text-text-tertiary">(requerido en producción)</span>
           </label>
           <input
             id="matias-company-id"
@@ -1087,7 +1100,7 @@ const taxLevels = [
             class="min-h-[44px] px-3 py-2 border border-border rounded-lg text-sm text-text-primary bg-background focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
           />
           <p class="text-xs text-text-secondary leading-snug">
-            Identificador companyId del cliente en Matias para Casa de Software. No es el ID del negocio en WARO.
+            Identificador companyId del cliente emisor en Matias para Casa de Software. No es el ID del negocio en WARO.
           </p>
           <div class="mt-2 flex justify-end">
             <button


### PR DESCRIPTION
## Summary
- add Matias companyId to the readiness type and banner
- mark the UUID as required for production in /facturacion
- document the Casa de Software PAT vs client companyId rule

## Tests
- npm run build

Refs uno0uno/api-warolabs#516