### PR TITLE
Update Matias client_uuid requirement copy

### DIFF
--- a/docs/usuarios/facturacion.md
+++ b/docs/usuarios/facturacion.md
@@ -14,7 +14,7 @@ En la parte superior aparece un **banner de readiness** que revisa automáticame
 
 - ✓ **Listo para facturar** — todos los checks aprobados.
 - ⚠ **Faltan datos** — el banner lista exactamente qué tienes que completar antes de poder facturar.
-- En producción, también debe estar configurado el **UUID cliente Matias** (`client_uuid`) cuando WARO emite como Casa de Software.
+- También debe estar configurado el **UUID cliente Matias** (`client_uuid`) cuando WARO emite como Casa de Software.
 
 ---
 
@@ -86,7 +86,7 @@ Si esta tarjeta muestra errores, no podrás emitir facturas hasta que el proveed
 
 WARO usa un JWT/PAT de Casa de Software para conectarse con Matias. Ese token identifica la cuenta técnica de WARO; el campo **UUID cliente Matias** (`client_uuid`) identifica cuál cliente emite la factura ante Matias y la DIAN.
 
-Este valor lo entrega Matias para cada cliente. No uses el ID del negocio en WARO ni el NIT como reemplazo. En habilitación o sandbox puede estar vacío, pero en producción debe estar configurado antes de emitir.
+Este valor lo entrega Matias para cada cliente. No uses el ID del negocio en WARO ni el NIT como reemplazo. Debe estar configurado antes de emitir en cualquier ambiente Matias.
 
 ---
 

--- a/pages/facturacion/index.vue
+++ b/pages/facturacion/index.vue
@@ -448,7 +448,7 @@ const taxLevels = [
         <ExclamationTriangleIcon class="w-5 h-5 text-state-warning-icon flex-shrink-0 mt-0.5" aria-hidden="true" />
         <div class="flex-1">
           <p class="text-sm font-semibold text-state-warning-text">Falta UUID cliente Matias</p>
-          <p class="text-xs text-state-warning-text/90 mt-0.5">Configura el <span class="font-medium">client_uuid</span> del cliente emisor en la sección <span class="font-medium">Matias API</span> antes de emitir en producción.</p>
+          <p class="text-xs text-state-warning-text/90 mt-0.5">Configura el <span class="font-medium">client_uuid</span> del cliente emisor en la sección <span class="font-medium">Matias API</span> antes de emitir con Matias.</p>
         </div>
       </div>
 
@@ -1088,7 +1088,7 @@ const taxLevels = [
         <div class="flex flex-col gap-1 pb-2">
           <label for="matias-company-id" class="text-sm font-medium text-text-primary">
             UUID cliente Matias
-            <span class="text-xs font-normal text-text-tertiary">(requerido en producción)</span>
+            <span class="text-xs font-normal text-text-tertiary">(requerido para emitir)</span>
           </label>
           <input
             id="matias-company-id"


### PR DESCRIPTION
## Summary
- update readiness banner copy to require client_uuid for Matias emission
- update user docs to remove sandbox/habilitacion optional language

## Tests
- cd front_nuxt && npm run build

Refs uno0uno/api-warolabs#521