### PR TITLE
Clarify fiscal model in invoicing UI

### DIFF
--- a/docs/usuarios/facturacion.md
+++ b/docs/usuarios/facturacion.md
@@ -1,6 +1,6 @@
 # Facturación electrónica DIAN
 
-Desde **Facturación** configuras todo lo que tu negocio necesita para emitir facturas electrónicas válidas ante la DIAN: resolución, datos fiscales, impuestos y estado del proveedor técnico.
+Desde **Facturación** configuras todo lo que tu negocio necesita para emitir facturas electrónicas válidas ante la DIAN: resolución, identidad fiscal, impuestos aplicados a ventas y estado del proveedor técnico.
 
 ## Cómo acceder
 
@@ -10,7 +10,7 @@ Menú lateral → **Facturación**. La pantalla es una sola vista con varias tar
 
 ## Lista de verificación para empezar a facturar
 
-En la parte superior aparece un **banner de readiness** que revisa automáticamente si tu negocio tiene todo lo necesario para emitir facturas (resolución activa, datos fiscales completos, configuración fiscal definida).
+En la parte superior aparece un **banner de readiness** que revisa automáticamente si tu negocio tiene todo lo necesario para emitir facturas: resolución activa, datos fiscales completos, impuesto aplicado a ventas definido bajo el guardrail actual de WARO y proveedor técnico configurado.
 
 - ✓ **Listo para facturar** — todos los checks aprobados.
 - ⚠ **Faltan datos** — el banner lista exactamente qué tienes que completar antes de poder facturar.
@@ -38,7 +38,7 @@ Solo una resolución del mismo tipo puede estar activa a la vez. Al activar una,
 
 ## Datos fiscales del negocio
 
-Formulario con la información que aparecerá en cada factura emitida:
+Formulario con la información que identifica al emisor y aparece en cada factura emitida. Estos campos describen tu identidad y responsabilidad fiscal; no activan por sí solos IVA, INC ni facturación electrónica.
 
 | Campo | Obligatorio |
 |-------|:-----------:|
@@ -52,29 +52,29 @@ Formulario con la información que aparecerá en cada factura emitida:
 | Teléfono | Sí |
 | Email de facturación | Sí |
 
-Presiona **Guardar datos fiscales** para aplicar los cambios.
+Presiona **Guardar datos fiscales** para aplicar los cambios. Si cambias tipo de organización, régimen tributario o nivel de responsabilidad, revisa también los impuestos aplicados a ventas con tu contador.
 
 ---
 
-## Configuración fiscal
+## Impuestos aplicados a ventas
 
-Toggles por impuesto. Cada uno permite elegir si el valor del impuesto **está incluido en el precio del producto** o si **se suma al precio** al cobrar.
+Toggles por impuesto. Cada uno afecta el cálculo y desglose de impuestos en POS y facturas. No cambian por sí solos tu tipo de organización, tu régimen tributario ni tu obligación de facturar electrónicamente.
 
 | Impuesto | Aplica a | Modo |
 |----------|----------|------|
-| **INC 8%** | Restaurantes y bares sin franquicia | Incluido / Sumado |
-| **IVA 19%** | Franquicias y negocios responsables de IVA | Incluido / Sumado |
-| **IVA Licores 5%** | Botellas de licor para llevar | Siempre se suma |
+| **INC 8%** | Ventas que deben liquidar Impoconsumo | Incluido / Sumado |
+| **IVA 19%** | Ventas de negocios responsables de IVA | Incluido / Sumado |
+| **IVA Licores 5%** | Botellas de licor para llevar cuando corresponda | Siempre se suma |
 
 Presiona **Guardar configuración** después de cualquier cambio.
 
-> Cambiar de "incluido" a "sumado" (o viceversa) afecta cómo se desglosa el precio final en el checkout. Coordina con tu contador antes de modificarlo.
+> Cambiar de "incluido" a "sumado" (o viceversa), o activar un impuesto, afecta cómo se calcula y desglosa el precio final en el checkout y en la factura. Coordina con tu contador antes de modificarlo.
 
 ---
 
-## Estado de Matias API
+## Proveedor de facturación electrónica
 
-Tarjeta de salud del proveedor técnico de facturación:
+Tarjeta de salud del proveedor técnico de facturación. Esta sección valida la conexión operativa con Matias; es distinta de tu régimen fiscal y de los impuestos que aplicas a ventas.
 
 - **Entorno** — Habilitación (pruebas) o Producción
 - **UUID cliente Matias** — `client_uuid` del cliente emisor en Matias
@@ -86,7 +86,7 @@ Si esta tarjeta muestra errores, no podrás emitir facturas hasta que el proveed
 
 WARO usa un JWT/PAT de Casa de Software para conectarse con Matias. Ese token identifica la cuenta técnica de WARO; el campo **UUID cliente Matias** (`client_uuid`) identifica cuál cliente emite la factura ante Matias y la DIAN.
 
-Este valor lo entrega Matias para cada cliente. No uses el ID del negocio en WARO ni el NIT como reemplazo. Debe estar configurado antes de emitir en cualquier ambiente Matias.
+Este valor lo entrega Matias para cada cliente. No uses el ID del negocio en WARO ni el NIT como reemplazo. Debe estar configurado antes de emitir en cualquier ambiente Matias, pero no define si tu negocio es responsable de IVA o INC.
 
 ---
 
@@ -127,7 +127,7 @@ Revisa el banner de readiness arriba: lista exactamente qué falta (resolución 
 Solicítalo o consúltalo en Matias para el cliente emisor. Es el `client_uuid` de Matias, no el identificador interno de WARO.
 
 **¿Cambié de régimen tributario, qué hago?**
-Actualiza el campo **Régimen tributario** en Datos fiscales y revisa la **Configuración fiscal** — los impuestos aplicables suelen cambiar.
+Actualiza el campo **Régimen tributario** en Datos fiscales y revisa **Impuestos aplicados a ventas**. El régimen describe tu responsabilidad fiscal; los toggles de impuestos controlan el cálculo aplicado en POS y facturas.
 
 **¿Qué pasa si se acaba el rango de mi resolución?**
 Solicita una nueva resolución en la DIAN, regístrala aquí con su propio prefijo y rango, y actívala. La anterior queda en histórico.

--- a/pages/facturacion/index.vue
+++ b/pages/facturacion/index.vue
@@ -227,9 +227,9 @@ const saveTaxConfig = async () => {
     await $fetch('/api/api/tenant/tax-config', { method: 'PUT', body: { ...taxForm } })
     await refreshTaxConfig()
     invalidateReadiness()
-    toast.success('Configuración fiscal guardada correctamente', { title: 'Guardado' })
+    toast.success('Impuestos aplicados a ventas guardados correctamente', { title: 'Guardado' })
   } catch (error: any) {
-    toast.error(error.data?.detail || 'Error al guardar configuración fiscal', { title: 'Error' })
+    toast.error(error.data?.detail || 'Error al guardar impuestos aplicados a ventas', { title: 'Error' })
   } finally {
     isSavingTax.value = false
   }
@@ -434,8 +434,8 @@ const taxLevels = [
       >
         <InformationCircleIcon class="w-5 h-5 text-state-info-icon flex-shrink-0 mt-0.5" aria-hidden="true" />
         <div class="flex-1">
-          <p class="text-sm font-semibold text-state-info-text">No hay impuestos configurados</p>
-          <p class="text-xs text-state-info-text/90 mt-0.5">Activa <span class="font-medium">INC</span> o <span class="font-medium">IVA</span> en la sección <span class="font-medium">Configuración fiscal</span> para poder emitir facturas.</p>
+          <p class="text-sm font-semibold text-state-info-text">Falta definir el impuesto aplicado a ventas</p>
+          <p class="text-xs text-state-info-text/90 mt-0.5">Por ahora WARO requiere seleccionar <span class="font-medium">INC</span> o <span class="font-medium">IVA</span> para calcular y desglosar impuestos al emitir. Si tu negocio no debe aplicar ninguno, valida la configuración con soporte o tu contador antes de activar un impuesto.</p>
         </div>
       </div>
 
@@ -448,7 +448,7 @@ const taxLevels = [
         <ExclamationTriangleIcon class="w-5 h-5 text-state-warning-icon flex-shrink-0 mt-0.5" aria-hidden="true" />
         <div class="flex-1">
           <p class="text-sm font-semibold text-state-warning-text">Falta UUID cliente Matias</p>
-          <p class="text-xs text-state-warning-text/90 mt-0.5">Configura el <span class="font-medium">client_uuid</span> del cliente emisor en la sección <span class="font-medium">Matias API</span> antes de emitir con Matias.</p>
+          <p class="text-xs text-state-warning-text/90 mt-0.5">Configura el <span class="font-medium">client_uuid</span> del cliente emisor en la sección <span class="font-medium">Proveedor de facturación electrónica</span> antes de emitir con Matias.</p>
         </div>
       </div>
 
@@ -739,10 +739,13 @@ const taxLevels = [
 
     <!-- ══════ DATOS FISCALES ══════ -->
     <div class="bg-surface border-2 border-border rounded-xl p-4 sm:p-6">
-      <h3 class="text-base sm:text-lg font-semibold text-text-primary mb-4 flex items-center gap-2">
+      <h3 class="text-base sm:text-lg font-semibold text-text-primary mb-1 flex items-center gap-2">
         <svg class="w-5 h-5 text-primary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 9h3.75M15 12h3.75M15 15h3.75M4.5 19.5h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Zm6-10.125a1.875 1.875 0 1 1-3.75 0 1.875 1.875 0 0 1 3.75 0Zm1.294 6.336a6.721 6.721 0 0 1-3.17.789 6.721 6.721 0 0 1-3.168-.789 3.376 3.376 0 0 1 6.338 0Z" /></svg>
         Datos Fiscales del Negocio
       </h3>
+      <p class="text-xs text-text-secondary mb-4">
+        Identifican al emisor ante DIAN y Matias. No activan impuestos por sí solos ni cambian el cálculo de IVA o INC.
+      </p>
 
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <!-- NIT -->
@@ -779,6 +782,7 @@ const taxLevels = [
           >
             <option v-for="opt in orgTypes" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
           </select>
+          <p class="text-[11px] text-text-tertiary leading-snug">Define si el emisor factura como persona natural o jurídica.</p>
         </div>
 
         <!-- Régimen tributario -->
@@ -791,6 +795,7 @@ const taxLevels = [
           >
             <option v-for="opt in taxRegimes" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
           </select>
+          <p class="text-[11px] text-text-tertiary leading-snug">Describe la responsabilidad fiscal del emisor; no reemplaza los toggles de impuestos de ventas.</p>
         </div>
 
         <!-- Nivel de responsabilidad -->
@@ -803,6 +808,7 @@ const taxLevels = [
           >
             <option v-for="opt in taxLevels" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
           </select>
+          <p class="text-[11px] text-text-tertiary leading-snug">Registra responsabilidades adicionales del emisor, como gran contribuyente o régimen simple.</p>
         </div>
 
         <!-- Dirección fiscal -->
@@ -940,10 +946,13 @@ const taxLevels = [
 
     <!-- ══════ CONFIGURACIÓN FISCAL ══════ -->
     <div class="bg-surface border-2 border-border rounded-xl p-4 sm:p-6">
-      <h3 class="text-base sm:text-lg font-semibold text-text-primary mb-4 flex items-center gap-2">
+      <h3 class="text-base sm:text-lg font-semibold text-text-primary mb-1 flex items-center gap-2">
         <ReceiptPercentIcon class="w-5 h-5 text-primary flex-shrink-0" />
-        Configuración fiscal
+        Impuestos aplicados a ventas
       </h3>
+      <p class="text-xs text-text-secondary mb-4">
+        Estos controles afectan el cálculo y desglose de impuestos en POS y facturas. No cambian por sí solos tu tipo de organización ni tu responsabilidad fiscal.
+      </p>
 
       <div class="space-y-5">
 
@@ -952,7 +961,7 @@ const taxLevels = [
           <div class="flex items-center justify-between py-1">
             <div>
               <p class="text-sm font-medium text-text-primary">INC — Impoconsumo 8%</p>
-              <p class="text-xs text-text-secondary mt-0.5">Restaurantes y bares sin franquicia (Art. 512-1 ET)</p>
+              <p class="text-xs text-text-secondary mt-0.5">Aplica cuando tus ventas deben liquidar Impoconsumo. Afecta el total y el desglose de la factura.</p>
             </div>
             <label class="relative inline-flex items-center cursor-pointer flex-shrink-0 ml-4">
               <input v-model="taxForm.inc_applicable" type="checkbox" class="sr-only peer" />
@@ -1003,7 +1012,7 @@ const taxLevels = [
           <div class="flex items-center justify-between py-1">
             <div>
               <p class="text-sm font-medium text-text-primary">IVA — 19%</p>
-              <p class="text-xs text-text-secondary mt-0.5">Solo para establecimientos bajo franquicia (Form. DIAN 300)</p>
+              <p class="text-xs text-text-secondary mt-0.5">Actívalo solo si tus ventas deben llevar IVA 19%. Afecta el total y el desglose de la factura.</p>
             </div>
             <label class="relative inline-flex items-center cursor-pointer flex-shrink-0 ml-4">
               <input v-model="taxForm.iva_applicable" type="checkbox" class="sr-only peer" />
@@ -1053,7 +1062,7 @@ const taxLevels = [
         <div class="flex items-center justify-between py-1">
           <div>
             <p class="text-sm font-medium text-text-primary">IVA Licores para llevar — 5%</p>
-            <p class="text-xs text-text-secondary mt-0.5">Si vendés botellas o licores para llevar (siempre se suma al precio base)</p>
+            <p class="text-xs text-text-secondary mt-0.5">Para botellas o licores para llevar cuando corresponda; siempre se suma al precio base.</p>
           </div>
           <label class="relative inline-flex items-center cursor-pointer flex-shrink-0 ml-4">
             <input v-model="taxForm.liquor_tax_applicable" type="checkbox" class="sr-only peer" />
@@ -1080,7 +1089,7 @@ const taxLevels = [
     <div class="bg-surface border-2 border-border rounded-xl p-4 sm:p-6">
       <h3 class="text-base sm:text-lg font-semibold text-text-primary mb-4 flex items-center gap-2">
         <SignalIcon class="w-5 h-5 text-primary flex-shrink-0" />
-        Matias API
+        Proveedor de facturación electrónica
       </h3>
 
       <div class="space-y-3">
@@ -1100,7 +1109,7 @@ const taxLevels = [
             class="min-h-[44px] px-3 py-2 border border-border rounded-lg text-sm text-text-primary bg-background focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
           />
           <p class="text-xs text-text-secondary leading-snug">
-            Identificador client_uuid del cliente emisor en Matias para Casa de Software. No es el ID del negocio en WARO.
+            Identificador client_uuid del cliente emisor en Matias para Casa de Software. Es un requisito técnico del proveedor; no define tu régimen fiscal ni los impuestos de venta.
           </p>
           <div class="mt-2 flex justify-end">
             <button


### PR DESCRIPTION
## Summary
- Clarifies `/facturacion` copy so issuer identity, fiscal responsibility, sales taxes, and electronic invoicing provider setup are distinct.
- Rewords the missing-tax readiness banner to describe the current WARO technical guardrail without recommending IVA/INC as a legal choice.
- Updates user docs to mirror the clarified model.

## Tests
- `git diff --check -- pages/facturacion/index.vue docs/usuarios/facturacion.md`
- `npm run build`

Closes #1453