### PR TITLE
Clarify POS fiscal invoicing validation

### DIFF
--- a/composables/useInvoicingReadiness.ts
+++ b/composables/useInvoicingReadiness.ts
@@ -7,6 +7,7 @@ export interface InvoicingReadinessChecks {
   fiscal_data_complete: boolean
   active_resolution:    boolean
   taxes_configured:     boolean
+  tax_requirement_satisfied: boolean
   matias_company_id_configured: boolean
 }
 

--- a/docs/usuarios/facturacion.md
+++ b/docs/usuarios/facturacion.md
@@ -70,6 +70,14 @@ Presiona **Guardar configuración** después de cualquier cambio.
 
 > Cambiar de "incluido" a "sumado" (o viceversa), o activar un impuesto, afecta cómo se calcula y desglosa el precio final en el checkout y en la factura. Coordina con tu contador antes de modificarlo.
 
+### Cuándo dejar ventas sin IVA ni INC
+
+Si tu contador confirma que el negocio puede emitir ventas sin IVA ni INC, deja ambos toggles apagados y revisa que **Datos fiscales del negocio** refleje ese escenario: persona natural, no responsable de IVA y nivel de responsabilidad **No aplica**.
+
+En ese caso WARO no agrega impuesto estándar al POS ni fuerza IVA 19% para habilitar la emisión. La factura debe emitirse sin líneas de IVA/INC, mientras los demás requisitos siguen siendo obligatorios: resolución DIAN vigente, datos fiscales completos, facturación electrónica habilitada y UUID cliente Matias configurado.
+
+Si el negocio es responsable de IVA o sus ventas deben liquidar Impoconsumo, no uses el modo sin impuesto: activa el impuesto correspondiente antes de vender y valida el modo **Incluido** o **Sumado** con tu contador.
+
 ---
 
 ## Proveedor de facturación electrónica
@@ -128,6 +136,9 @@ Solicítalo o consúltalo en Matias para el cliente emisor. Es el `client_uuid` 
 
 **¿Cambié de régimen tributario, qué hago?**
 Actualiza el campo **Régimen tributario** en Datos fiscales y revisa **Impuestos aplicados a ventas**. El régimen describe tu responsabilidad fiscal; los toggles de impuestos controlan el cálculo aplicado en POS y facturas.
+
+**¿Puedo facturar sin IVA ni INC?**
+Sí, solo cuando la configuración fiscal del negocio permite ventas sin esos impuestos. WARO no debe activar IVA automáticamente para desbloquear la emisión; si el banner sigue marcando pendiente, revisa tipo de organización, responsabilidad IVA y nivel de responsabilidad con soporte o tu contador.
 
 **¿Qué pasa si se acaba el rango de mi resolución?**
 Solicita una nueva resolución en la DIAN, regístrala aquí con su propio prefijo y rango, y actívala. La anterior queda en histórico.

--- a/docs/usuarios/pos.md
+++ b/docs/usuarios/pos.md
@@ -148,6 +148,26 @@ Dentro de una sesión de mesa, usa el botón **Cambiar mesa** en el carrito para
 
 El modal de éxito, la **tirilla impresa** y el **correo de recibo** muestran el mismo desglose: subtotal, descuento, **propina** (si aplica) y **Total cobrado** cuando hubo propina. La factura electrónica DIAN sigue reflejando solo el total de la orden (sin propina) hasta que se implemente #740.
 
+### Generar factura electrónica DIAN
+
+Después de cobrar, si el negocio está listo para emitir, el modal muestra **Generar factura electrónica DIAN**. Presiónalo cuando el cliente solicite factura electrónica o cuando la operación del negocio lo requiera.
+
+Si el cliente identificado no tiene datos fiscales, WARO abre un formulario corto para guardar tipo de documento, número y nombre legal antes de emitir. En ventas anónimas el sistema usa el comprador final configurado para facturación.
+
+Cuando la emisión termina correctamente, el modal muestra el prefijo y número de factura. El comprobante impreso incluye el CUFE y el QR de verificación DIAN cuando están disponibles. Si Matias o DIAN rechazan la emisión, el modal muestra el error y permite **Reintentar** después de corregir la causa.
+
+### Validar impuestos al vender
+
+El POS usa los impuestos configurados en **Facturación → Impuestos aplicados a ventas**:
+
+| Configuración | Qué debes ver en POS y factura |
+|---------------|--------------------------------|
+| Sin IVA/INC para persona natural no responsable | La venta se completa sin línea de IVA o INC. No actives IVA solo para desbloquear la factura. |
+| IVA 19% | El resumen, recibo y factura muestran **IVA 19%** según el modo incluido o sumado. |
+| INC 8% | El resumen, recibo y factura muestran **INC 8%** según el modo incluido o sumado. |
+
+Para validar una configuración nueva, haz una venta de prueba desde el POS, genera la factura electrónica y revisa en **Facturación** o **Documentos** que el estado sea aceptado, que exista CUFE y que puedas consultar PDF, XML y envío por correo.
+
 ---
 
 ## Recibos y comprobantes

--- a/pages/facturacion/index.vue
+++ b/pages/facturacion/index.vue
@@ -426,16 +426,16 @@ const taxLevels = [
         </div>
       </div>
 
-      <!-- No taxes configured (4th check — added in plan amendment) -->
+      <!-- Tax requirement not satisfied: needs IVA/INC or valid no-tax fiscal setup. -->
       <div
-        v-if="!readinessChecks.taxes_configured"
+        v-if="!readinessChecks.tax_requirement_satisfied"
         class="flex items-start gap-3 rounded-lg border border-state-info-border bg-state-info-bg p-4"
         role="status"
       >
         <InformationCircleIcon class="w-5 h-5 text-state-info-icon flex-shrink-0 mt-0.5" aria-hidden="true" />
         <div class="flex-1">
-          <p class="text-sm font-semibold text-state-info-text">Falta definir el impuesto aplicado a ventas</p>
-          <p class="text-xs text-state-info-text/90 mt-0.5">Por ahora WARO requiere seleccionar <span class="font-medium">INC</span> o <span class="font-medium">IVA</span> para calcular y desglosar impuestos al emitir. Si tu negocio no debe aplicar ninguno, valida la configuración con soporte o tu contador antes de activar un impuesto.</p>
+          <p class="text-sm font-semibold text-state-info-text">Revisa el impuesto aplicado a ventas</p>
+          <p class="text-xs text-state-info-text/90 mt-0.5">Activa <span class="font-medium">INC</span> o <span class="font-medium">IVA</span> solo cuando aplique a tus ventas. Si tu negocio emite sin esos impuestos, confirma que los datos fiscales correspondan a persona natural no responsable antes de guardar.</p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Align /facturacion readiness guidance with the valid no-tax path.
- Document POS DIAN invoice flow and no-tax/IVA/INC validation steps.
- Add frontend readiness typing for tax_requirement_satisfied.

## Tests
- npm run build

Closes #1457