### PR TITLE
Make front dates tenant-timezone aware

### DIFF
--- a/components/promociones/PromocionPanel.vue
+++ b/components/promociones/PromocionPanel.vue
@@ -371,7 +371,6 @@ import {
 
 /** Above this count, panel shows summary + modal instead of chips. */
 const PRODUCT_CHIP_THRESHOLD = 15
-import { bogotaDateAtNoon, combineBogotaDateAndTimeISO } from '~/utils/bogotaDate'
 
 interface OverlapWarning {
   promotion_id: string
@@ -407,6 +406,7 @@ const emit = defineEmits<Emits>()
 const toast = useToast()
 const cache = useQueryCache()
 const { currentTenant } = useTenantReactive()
+const { combineDateAndTimeISO, dateAtNoon } = useTenantTimezone()
 
 const isEdit = computed(() => !!props.promotionId)
 const inputClass = 'h-10 w-full rounded-lg border-2 border-border bg-background px-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 transition-colors'
@@ -666,10 +666,10 @@ function buildPayload() {
   let starts_at: string | null = null
   let ends_at: string | null = null
   if (form.startsAtDate) {
-    starts_at = combineBogotaDateAndTimeISO(form.startsAtDate, '00:00') ?? bogotaDateAtNoon(form.startsAtDate).toISOString()
+    starts_at = combineDateAndTimeISO(form.startsAtDate, '00:00') ?? dateAtNoon(form.startsAtDate).toISOString()
   }
   if (form.endsAtDate) {
-    ends_at = combineBogotaDateAndTimeISO(form.endsAtDate, '23:59') ?? null
+    ends_at = combineDateAndTimeISO(form.endsAtDate, '23:59') ?? null
   }
 
   return {

--- a/composables/useActivePromotions.ts
+++ b/composables/useActivePromotions.ts
@@ -1,7 +1,7 @@
 import { computed, onUnmounted, ref, watch, type ComputedRef, type Ref } from 'vue'
 import { $fetch } from 'ofetch'
 import type { PromotionScheduleRow } from '~/utils/promotionPreview'
-import { BOGOTA_TZ } from '~/utils/bogotaDate'
+import { DEFAULT_TENANT_TIMEZONE, zonedParts } from '~/utils/bogotaDate'
 import {
   normalizePromoTypeBlockMap,
   type ActivePromotionRow,
@@ -13,17 +13,8 @@ export type { ActivePromotionRow }
 const MIN_REFETCH_MS = 30_000
 const MAX_REFETCH_MS = 5 * 60_000
 
-function bogotaNowParts(now = new Date()) {
-  const fmt = new Intl.DateTimeFormat('en-CA', {
-    timeZone: BOGOTA_TZ,
-    weekday: 'short',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  })
-  const parts = Object.fromEntries(
-    fmt.formatToParts(now).map((p) => [p.type, p.value]),
-  ) as Record<string, string>
+function tenantNowParts(now = new Date(), timezone = DEFAULT_TENANT_TIMEZONE) {
+  const parts = zonedParts(now, timezone)
   const weekdayMap: Record<string, number> = {
     Mon: 0,
     Tue: 1,
@@ -33,7 +24,7 @@ function bogotaNowParts(now = new Date()) {
     Sat: 5,
     Sun: 6,
   }
-  const weekday = weekdayMap[parts.weekday] ?? 0
+  const weekday = weekdayMap[parts.weekday ?? ''] ?? 0
   const [hour, minute] = parts.hour.split(':').map(Number)
   return { weekday, minutes: hour * 60 + minute }
 }
@@ -43,14 +34,15 @@ function timeToMinutes(t: string): number {
   return h * 60 + m
 }
 
-/** Ms until the next schedule start/end in Bogotá (for mid-shift refresh). */
+/** Ms until the next schedule start/end in tenant local time (for mid-shift refresh). */
 export function msUntilNextPromoBoundary(
   schedules: PromotionScheduleRow[],
   now = new Date(),
+  timezone = DEFAULT_TENANT_TIMEZONE,
 ): number {
   if (schedules.length === 0) return MAX_REFETCH_MS
 
-  const { weekday, minutes: nowMin } = bogotaNowParts(now)
+  const { weekday, minutes: nowMin } = tenantNowParts(now, timezone)
   const todayBit = 1 << weekday
   let bestMs = MAX_REFETCH_MS
 
@@ -86,6 +78,7 @@ export function useActivePromotions(options?: {
   onActivePromosChanged?: () => void
 }) {
   const { currentTenant } = useTenantReactive()
+  const { timezone } = useTenantTimezone()
   const activeSignature = ref('')
   let boundaryTimer: ReturnType<typeof setTimeout> | null = null
 
@@ -128,15 +121,15 @@ export function useActivePromotions(options?: {
     if (boundaryTimer) clearTimeout(boundaryTimer)
     if (!hasActivePromos.value) return
     const allSchedules = activePromos.value.flatMap((p) => p.schedules ?? [])
-    const delay = msUntilNextPromoBoundary(allSchedules)
+    const delay = msUntilNextPromoBoundary(allSchedules, new Date(), timezone.value)
     boundaryTimer = setTimeout(() => {
       refetch()
     }, delay)
   }
 
   watch(
-    activePromos,
-    (promos) => {
+    [activePromos, timezone],
+    ([promos]) => {
       const nextSig = promos.map((p) => p.id).sort().join(',')
       if (activeSignature.value && nextSig !== activeSignature.value) {
         options?.onActivePromosChanged?.()

--- a/composables/useCierrePeriod.ts
+++ b/composables/useCierrePeriod.ts
@@ -10,15 +10,16 @@ export interface CierrePeriodLike {
   shiftTemplateName?: string | null
 }
 
-const _timeFormatter = new Intl.DateTimeFormat('es-CO', {
-  hour: '2-digit',
-  minute: '2-digit',
-  hour12: false,
-  timeZone: 'America/Bogota',
-})
-
 export function useCierrePeriod() {
   const { formatDate } = useFormatters()
+  const { timezone } = useTenantTimezone()
+
+  const timeFormatter = computed(() => new Intl.DateTimeFormat('es-CO', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: timezone.value,
+  }))
 
   const hasTimeWindow = (cierre: CierrePeriodLike | null | undefined): boolean =>
     !!(cierre?.periodStartTime || cierre?.periodEndTime)
@@ -38,9 +39,9 @@ export function useCierrePeriod() {
     if (!hasTimeWindow(cierre)) return null
     const start = cierre?.periodStartTime
     const end = cierre?.periodEndTime
-    if (start && end) return `${_timeFormatter.format(new Date(start))} – ${_timeFormatter.format(new Date(end))}`
-    if (start) return `Desde ${_timeFormatter.format(new Date(start))}`
-    if (end) return `Hasta ${_timeFormatter.format(new Date(end))}`
+    if (start && end) return `${timeFormatter.value.format(new Date(start))} – ${timeFormatter.value.format(new Date(end))}`
+    if (start) return `Desde ${timeFormatter.value.format(new Date(start))}`
+    if (end) return `Hasta ${timeFormatter.value.format(new Date(end))}`
     return null
   }
 

--- a/composables/useDateRangePresets.ts
+++ b/composables/useDateRangePresets.ts
@@ -1,45 +1,47 @@
 import { ref, computed, type Ref } from 'vue'
-import { es } from 'date-fns/locale'
-import { format as fnsFormat } from 'date-fns'
 
 export type DateRangeApi = { from: string | null; to: string | null }
 
+const formatIsoShort = (iso: string) => {
+  const [year, month, day] = iso.split('-')
+  return `${day}/${month}/${year.slice(2)}`
+}
+
 export function useDateRangePresets(existing?: Ref<Date[] | null>) {
   const dateRangeDates = existing ?? ref<Date[] | null>(null)
+  const { todayISO, addDaysISO, dateAtNoon, isoFromDate } = useTenantTimezone()
 
-  const presetDates = ref([
-    { label: 'Hoy', value: [new Date(), new Date()] },
+  const presetRange = (fromIso: string, toIso = todayISO()) => [dateAtNoon(fromIso), dateAtNoon(toIso)]
+
+  const presetDates = computed(() => [
+    { label: 'Hoy', value: presetRange(todayISO()) },
     {
       label: 'Ayer',
-      value: (() => {
-        const d = new Date()
-        d.setDate(d.getDate() - 1)
-        return [d, d]
-      })(),
+      value: presetRange(addDaysISO(todayISO(), -1), addDaysISO(todayISO(), -1)),
     },
     {
       label: 'Última semana',
-      value: [(() => { const d = new Date(); d.setDate(d.getDate() - 7); return d })(), new Date()],
+      value: presetRange(addDaysISO(todayISO(), -7)),
     },
     {
       label: 'Últimos 15 días',
-      value: [(() => { const d = new Date(); d.setDate(d.getDate() - 15); return d })(), new Date()],
+      value: presetRange(addDaysISO(todayISO(), -15)),
     },
     {
       label: 'Último mes',
-      value: [(() => { const d = new Date(); d.setDate(d.getDate() - 30); return d })(), new Date()],
+      value: presetRange(addDaysISO(todayISO(), -30)),
     },
     {
       label: 'Últimos 90 días',
-      value: [(() => { const d = new Date(); d.setDate(d.getDate() - 90); return d })(), new Date()],
+      value: presetRange(addDaysISO(todayISO(), -90)),
     },
   ])
 
   const formatDateRange = (dates: Date[]) => {
     if (!dates || !dates[0]) return ''
-    const from = fnsFormat(dates[0], 'dd/MM/yy', { locale: es })
+    const from = formatIsoShort(isoFromDate(dates[0]))
     if (!dates[1]) return from
-    const to = fnsFormat(dates[1], 'dd/MM/yy', { locale: es })
+    const to = formatIsoShort(isoFromDate(dates[1]))
     return `${from} - ${to}`
   }
 
@@ -50,8 +52,8 @@ export function useDateRangePresets(existing?: Ref<Date[] | null>) {
     const [from, to] = dateRangeDates.value
     if (!from || !to) return { from: null, to: null }
     return {
-      from: fnsFormat(from, 'yyyy-MM-dd'),
-      to: fnsFormat(to, 'yyyy-MM-dd'),
+      from: isoFromDate(from),
+      to: isoFromDate(to),
     }
   })
 

--- a/composables/useFormatters.ts
+++ b/composables/useFormatters.ts
@@ -1,35 +1,35 @@
-import { bogotaDateAtNoon } from '~/utils/bogotaDate'
-
-const _dateFormatter = new Intl.DateTimeFormat('es-CO', {
-  day: '2-digit', month: '2-digit', year: '2-digit',
-  timeZone: 'America/Bogota',
-})
-
-const _dateTimeFormatter = new Intl.DateTimeFormat('es-CO', {
-  day: '2-digit', month: '2-digit', year: '2-digit',
-  hour: '2-digit', minute: '2-digit', hour12: false,
-  timeZone: 'America/Bogota',
-})
-
 export const useFormatters = () => {
+  const { timezone, dateAtNoon } = useTenantTimezone()
+
+  const dateFormatter = computed(() => new Intl.DateTimeFormat('es-CO', {
+    day: '2-digit', month: '2-digit', year: '2-digit',
+    timeZone: timezone.value,
+  }))
+
+  const dateTimeFormatter = computed(() => new Intl.DateTimeFormat('es-CO', {
+    day: '2-digit', month: '2-digit', year: '2-digit',
+    hour: '2-digit', minute: '2-digit', hour12: false,
+    timeZone: timezone.value,
+  }))
+
   const formatDate = (dateString: string | null | undefined): string => {
     if (!dateString) return 'No especificada'
-    return _dateFormatter.format(new Date(dateString))
+    return dateFormatter.value.format(new Date(dateString))
   }
 
-  /** YYYY-MM-DD (or API date field) → calendar day in Bogotá — matches arqueo transaction_date. */
+  /** YYYY-MM-DD (or API date field) -> tenant calendar day. */
   const formatCalendarDate = (dateString: string | null | undefined): string => {
     if (!dateString) return 'No especificada'
     const day = dateString.split('T')[0]
     if (/^\d{4}-\d{2}-\d{2}$/.test(day)) {
-      return _dateFormatter.format(bogotaDateAtNoon(day))
+      return dateFormatter.value.format(dateAtNoon(day))
     }
     return formatDate(dateString)
   }
 
   const formatDateShort = (dateString: string | null | undefined): string => {
     if (!dateString) return 'N/A'
-    return _dateFormatter.format(new Date(dateString))
+    return dateFormatter.value.format(new Date(dateString))
   }
 
   const formatCurrency = (value: number | null): string => {
@@ -43,7 +43,7 @@ export const useFormatters = () => {
 
   const formatDateTime = (dateString: string | null | undefined): string => {
     if (!dateString) return 'No especificada'
-    return _dateTimeFormatter.format(new Date(dateString))
+    return dateTimeFormatter.value.format(new Date(dateString))
   }
 
   const formatRelativeDate = (dateString: string): string => {

--- a/composables/useTenantReactive.ts
+++ b/composables/useTenantReactive.ts
@@ -2,26 +2,26 @@ const DAY_NAMES = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'frid
 
 export const useTenantReactive = () => {
   const tenantsStore = useTenantsStore()
+  const { timezone, zonedParts } = useTenantTimezone()
 
   // Referencias reactivas del store
   const currentTenant = computed(() => tenantsStore.selectedTenant)
   const businessProfile = computed(() => tenantsStore.businessProfile)
 
   /**
-   * Returns today's business hours entry using Colombia timezone (America/Bogota, UTC-5).
+   * Returns today's business hours entry using the tenant operational timezone.
    * Returns null if no profile or no hours configured for today.
    */
   const currentDayHours = computed(() => {
     const hours = businessProfile.value?.business_hours
     if (!hours) return null
-    const bogotaDate = new Date(
-      new Date().toLocaleString('en-US', { timeZone: 'America/Bogota' })
-    )
-    return hours[DAY_NAMES[bogotaDate.getDay()]] ?? null
+    const weekday = zonedParts(new Date()).weekday
+    const weekdayIndex = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].indexOf(weekday ?? '')
+    return hours[DAY_NAMES[Math.max(weekdayIndex, 0)]] ?? null
   })
 
   /**
-   * Whether the restaurant is currently open in Colombia time.
+   * Whether the restaurant is currently open in tenant local time.
    * Fail-open: returns true when no profile or no hours configured.
    * Note: recomputes when businessProfile changes (tenant switch / fetch),
    * not on a live clock — suitable for dashboard load and tenant switches.
@@ -33,10 +33,8 @@ export const useTenantReactive = () => {
     if (!hours) return true
     if (hours.closed) return false
     if (!hours.open || !hours.close) return true   // missing times → fail-open
-    const bogotaDate = new Date(
-      new Date().toLocaleString('en-US', { timeZone: 'America/Bogota' })
-    )
-    const now = bogotaDate.getHours() * 60 + bogotaDate.getMinutes()
+    const nowParts = zonedParts(new Date())
+    const now = Number(nowParts.hour) * 60 + Number(nowParts.minute)
     const [oH, oM] = hours.open.split(':').map(Number)
     const [cH, cM] = hours.close.split(':').map(Number)
     const open = oH * 60 + oM
@@ -47,6 +45,7 @@ export const useTenantReactive = () => {
   return {
     currentTenant,
     businessProfile,
+    timezone,
     isOpenNow,
     currentDayHours,
   }

--- a/composables/useTenantTimezone.ts
+++ b/composables/useTenantTimezone.ts
@@ -1,0 +1,31 @@
+import {
+  addDaysISO,
+  combineDateAndTimeISO,
+  dateAtNoon,
+  DEFAULT_TENANT_TIMEZONE,
+  isoFromDate,
+  monthBounds,
+  normalizeTimezone,
+  timeHHMMFromISO,
+  todayISO,
+  zonedParts,
+} from '~/utils/bogotaDate'
+
+export function useTenantTimezone() {
+  const tenantsStore = useTenantsStore()
+  const timezone = computed(() => normalizeTimezone(tenantsStore.businessProfile?.timezone))
+
+  return {
+    timezone,
+    defaultTimezone: DEFAULT_TENANT_TIMEZONE,
+    normalizeTimezone,
+    todayISO: (now?: Date) => todayISO(timezone.value, now),
+    isoFromDate: (date: Date) => isoFromDate(date, timezone.value),
+    dateAtNoon: (iso: string) => dateAtNoon(iso, timezone.value),
+    combineDateAndTimeISO: (iso: string, hhmm: string) => combineDateAndTimeISO(iso, hhmm, timezone.value),
+    addDaysISO: (iso: string, days: number) => addDaysISO(iso, days, timezone.value),
+    timeHHMMFromISO: (iso: string) => timeHHMMFromISO(iso, timezone.value),
+    monthBounds: (iso?: string) => monthBounds(iso, timezone.value),
+    zonedParts: (date: Date) => zonedParts(date, timezone.value),
+  }
+}

--- a/layouts/customer-portal.vue
+++ b/layouts/customer-portal.vue
@@ -204,6 +204,7 @@ async function handleLogout() {
 
 // Date/time
 const currentDateTime = ref('')
+const { timezone } = useTenantTimezone()
 const updateDateTime = () => {
   const now = new Date()
   currentDateTime.value = now.toLocaleDateString('es-CO', {
@@ -213,7 +214,7 @@ const updateDateTime = () => {
     day: 'numeric',
     hour: '2-digit',
     minute: '2-digit',
-    timeZone: 'America/Bogota'
+    timeZone: timezone.value
   })
 }
 let dateTimeInterval: ReturnType<typeof setInterval> | null = null

--- a/layouts/supplier-portal.vue
+++ b/layouts/supplier-portal.vue
@@ -164,6 +164,7 @@ const goBack = () => {
 
 // Date and time functionality
 const currentDateTime = ref('')
+const { timezone } = useTenantTimezone()
 
 const updateDateTime = () => {
   const now = new Date()
@@ -174,7 +175,7 @@ const updateDateTime = () => {
     day: 'numeric',
     hour: '2-digit',
     minute: '2-digit',
-    timeZone: 'America/Bogota'
+    timeZone: timezone.value
   }
   currentDateTime.value = now.toLocaleDateString('es-CO', options)
 }

--- a/pages/equipo/nomina.vue
+++ b/pages/equipo/nomina.vue
@@ -9,6 +9,8 @@ useHead({ title: 'Nómina — Equipo' })
 
 const { currentTenant } = useTenantReactive()
 const { formatCurrency } = useFormatters()
+const { todayISO } = useTenantTimezone()
+const tenantToday = computed(() => todayISO())
 
 // ── Filters ───────────────────────────────────────────────────────────────
 const currentYear = new Date().getFullYear()
@@ -243,7 +245,7 @@ const pilaForm = reactive({
   employer_ss_amount: 0,
   total_amount: 0,
   payment_method: 'transfer',
-  payment_date: new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Bogota' }).format(new Date()),
+  payment_date: todayISO(),
   notes: '',
 })
 
@@ -440,10 +442,8 @@ const selectedByEmployee = computed(() => {
 const { paymentGroups, fetchPaymentMethods } = usePaymentMethods()
 
 // ── Slide-over state ──────────────────────────────────────────────────────
-const TODAY_STR = new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Bogota' }).format(new Date())
-
 const showSlideOver = ref(false)
-const slideDate    = ref(TODAY_STR)
+const slideDate    = ref(tenantToday.value)
 const slideMethod  = ref('')
 const isSlideSubmitting = ref(false)
 const slideError   = ref<string | null>(null)
@@ -451,6 +451,11 @@ const slideSuccess = ref<string | null>(null)
 
 function openSlideOver() { showSlideOver.value = true }
 function closeSlideOver() { showSlideOver.value = false; slideError.value = null; slideSuccess.value = null }
+
+watch(tenantToday, (next, prev) => {
+  if (pilaForm.payment_date === prev) pilaForm.payment_date = next
+  if (slideDate.value === prev) slideDate.value = next
+})
 
 type EmpSlideData = {
   gross_salary: number

--- a/pages/equipo/salarios/[id]/pago.vue
+++ b/pages/equipo/salarios/[id]/pago.vue
@@ -410,6 +410,8 @@ import { SLUG_ICON_MAP, SLUG_ICON_FALLBACK } from '~/utils/paymentDefaults'
 
 const { paymentGroups, fetchPaymentMethods, isLoading: isLoadingMethods } = usePaymentMethods()
 fetchPaymentMethods()
+const { todayISO } = useTenantTimezone()
+const tenantToday = computed(() => todayISO())
 
 const paymentMethods = computed(() => {
   const items: { value: string; label: string; icon: any }[] = []
@@ -431,8 +433,8 @@ const form = reactive({
   payment_amount: null as number | null,
   payment_method: 'cash',
   payment_reference: '',
-  payment_date: new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Bogota' }).format(new Date()),
-  period_month: new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Bogota' }).format(new Date()).slice(0, 7),
+  payment_date: tenantToday.value,
+  period_month: tenantToday.value.slice(0, 7),
   attachments: [],
   notes: '',
   withholding_enabled: false,
@@ -440,6 +442,11 @@ const form = reactive({
   ss_enabled: false,
   arl_rate_pct: 0.522,  // ARL clase I default
   caja_rate_pct: 4
+})
+
+watch(tenantToday, (next, prev) => {
+  if (form.payment_date === prev) form.payment_date = next
+  if (form.period_month === prev.slice(0, 7)) form.period_month = next.slice(0, 7)
 })
 
 // Computed withholding and net amounts (only for contractors)

--- a/pages/equipo/salarios/[id]/prestaciones/cesantias.vue
+++ b/pages/equipo/salarios/[id]/prestaciones/cesantias.vue
@@ -398,6 +398,7 @@ const { formatDate } = useFormatters()
 // Payment methods
 const { paymentGroups, fetchPaymentMethods, isLoading: isLoadingMethods } = usePaymentMethods()
 fetchPaymentMethods()
+const { todayISO } = useTenantTimezone()
 
 const paymentMethods = computed(() => {
   const items: { value: string; label: string; icon: any }[] = []
@@ -434,7 +435,7 @@ const form = reactive({
   days_worked: 360,
   fondo_name: '',
   payment_method: 'transfer',
-  payment_date: new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Bogota' }).format(new Date()),
+  payment_date: todayISO(),
   notes: '',
 })
 

--- a/pages/equipo/salarios/[id]/prestaciones/dotacion.vue
+++ b/pages/equipo/salarios/[id]/prestaciones/dotacion.vue
@@ -378,6 +378,7 @@ const { formatDate } = useFormatters()
 // Payment methods
 const { paymentGroups, fetchPaymentMethods, isLoading: isLoadingMethods } = usePaymentMethods()
 fetchPaymentMethods()
+const { todayISO } = useTenantTimezone()
 
 const paymentMethods = computed(() => {
   const items: { value: string; label: string; icon: any }[] = []
@@ -422,7 +423,7 @@ const form = reactive({
   items_description: '',
   total_amount: null as number | null,
   payment_method: 'transfer',
-  payment_date: new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Bogota' }).format(new Date()),
+  payment_date: todayISO(),
   notes: '',
 })
 

--- a/pages/equipo/salarios/[id]/prestaciones/horas-extras.vue
+++ b/pages/equipo/salarios/[id]/prestaciones/horas-extras.vue
@@ -388,13 +388,10 @@ const { formatDate } = useFormatters()
 
 const { paymentGroups, fetchPaymentMethods } = usePaymentMethods()
 fetchPaymentMethods()
+const { todayISO } = useTenantTimezone()
 
 // Default period_month = current YYYY-MM
-const defaultPeriodMonth = new Intl.DateTimeFormat('en-CA', {
-  timeZone: 'America/Bogota',
-  year: 'numeric',
-  month: '2-digit',
-}).format(new Date())
+const defaultPeriodMonth = todayISO().slice(0, 7)
 
 // Form state
 const form = reactive({
@@ -405,7 +402,7 @@ const form = reactive({
   hours_dominical_diurna: 0,
   hours_dominical_nocturna: 0,
   payment_method: 'transfer',
-  payment_date: new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Bogota' }).format(new Date()),
+  payment_date: todayISO(),
   notes: '',
 })
 

--- a/pages/equipo/salarios/[id]/prestaciones/int-cesantias.vue
+++ b/pages/equipo/salarios/[id]/prestaciones/int-cesantias.vue
@@ -368,6 +368,7 @@ const { formatDate } = useFormatters()
 // Payment methods
 const { paymentGroups, fetchPaymentMethods, isLoading: isLoadingMethods } = usePaymentMethods()
 fetchPaymentMethods()
+const { todayISO } = useTenantTimezone()
 
 const paymentMethods = computed(() => {
   const items: { value: string; label: string; icon: any }[] = []
@@ -403,7 +404,7 @@ const form = reactive({
   cesantias_base: null as number | null,
   int_cesantias_amount: null as number | null,  // null = auto-calculate
   payment_method: 'transfer',
-  payment_date: new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Bogota' }).format(new Date()),
+  payment_date: todayISO(),
   notes: '',
 })
 

--- a/pages/equipo/salarios/[id]/prestaciones/liquidacion.vue
+++ b/pages/equipo/salarios/[id]/prestaciones/liquidacion.vue
@@ -3,6 +3,7 @@ definePageMeta({ layout: 'dashboard' })
 
 const route = useRoute()
 const employeeId = route.params.id
+const { todayISO } = useTenantTimezone()
 
 // ── Employee & existing liquidación ──────────────────────────────────────────
 const { data: employeeData } = await useAsyncData(
@@ -31,7 +32,7 @@ const form = reactive({
   base_salary: '',
   employment_type: '',
   payment_method: '',
-  payment_date: new Date().toISOString().split('T')[0],
+  payment_date: todayISO(),
   notes: '',
 })
 
@@ -47,7 +48,7 @@ watch(employee, (emp) => {
   if (emp.employment_type) {
     form.employment_type = emp.employment_type
   }
-  form.termination_date = new Date().toISOString().split('T')[0]
+  form.termination_date = todayISO()
 }, { immediate: true })
 
 // ── Breakdown preview ────────────────────────────────────────────────────────

--- a/pages/equipo/salarios/[id]/prestaciones/prima.vue
+++ b/pages/equipo/salarios/[id]/prestaciones/prima.vue
@@ -380,6 +380,7 @@ const { formatDate } = useFormatters()
 // Payment methods
 const { paymentGroups, fetchPaymentMethods, isLoading: isLoadingMethods } = usePaymentMethods()
 fetchPaymentMethods()
+const { todayISO } = useTenantTimezone()
 
 const paymentMethods = computed(() => {
   const items: { value: string; label: string; icon: any }[] = []
@@ -422,7 +423,7 @@ const form = reactive({
   gross_salary: null as number | null,
   days_worked: 180,
   payment_method: 'transfer',
-  payment_date: new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Bogota' }).format(new Date()),
+  payment_date: todayISO(),
   notes: '',
 })
 

--- a/pages/equipo/salarios/[id]/prestaciones/vacaciones.vue
+++ b/pages/equipo/salarios/[id]/prestaciones/vacaciones.vue
@@ -375,6 +375,7 @@ const { formatDate } = useFormatters()
 // Payment methods
 const { paymentGroups, fetchPaymentMethods, isLoading: isLoadingMethods } = usePaymentMethods()
 fetchPaymentMethods()
+const { todayISO } = useTenantTimezone()
 
 const paymentMethods = computed(() => {
   const items: { value: string; label: string; icon: any }[] = []
@@ -410,7 +411,7 @@ const form = reactive({
   gross_salary: null as number | null,
   days_worked: 360,
   payment_method: 'transfer',
-  payment_date: new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Bogota' }).format(new Date()),
+  payment_date: todayISO(),
   notes: '',
 })
 

--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -398,14 +398,6 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useQueryCache } from '@pinia/colada'
 import { useFormatters } from '~/composables/useFormatters'
 import { es } from 'date-fns/locale'
-import { format as fnsFormat } from 'date-fns'
-import {
-  addDaysBogotaISO,
-  bogotaDateAtNoon,
-  bogotaISOFromDate,
-  bogotaMonthBounds,
-  todayBogotaISO,
-} from '~/utils/bogotaDate'
 import MetricCard from '~/components/shared/MetricCard.vue'
 import { buildCierreCloseRoute, isCierreOpen } from '~/composables/useCierreShiftWindow'
 
@@ -414,32 +406,37 @@ useHead({ title: 'Arqueo de caja - Warocol' })
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 const { currentTenant } = useTenantReactive()
+const { todayISO, addDaysISO, dateAtNoon, isoFromDate, monthBounds } = useTenantTimezone()
 const { singular: tableSingular, plural: tablePlural } = useTableLabel()
+const formatIsoShort = (iso: string) => {
+  const [year, month, day] = iso.split('-')
+  return `${day}/${month}/${year.slice(2)}`
+}
 
-const today = todayBogotaISO()
-const todayNoon = bogotaDateAtNoon(today)
+const today = computed(() => todayISO())
+const todayNoon = computed(() => dateAtNoon(today.value))
 
 const dateRangeDates = ref<Date[] | null>(null)
 
-const presetDates = ref([
-  { label: 'Hoy',           value: [new Date(todayNoon), new Date(todayNoon)] },
-  { label: 'Ayer',          value: (() => { const d = bogotaDateAtNoon(addDaysBogotaISO(today, -1)); return [d, d] })() },
-  { label: 'Última semana', value: [bogotaDateAtNoon(addDaysBogotaISO(today, -7)), new Date(todayNoon)] },
-  { label: 'Último mes',    value: [bogotaDateAtNoon(addDaysBogotaISO(today, -30)), new Date(todayNoon)] },
+const presetDates = computed(() => [
+  { label: 'Hoy',           value: [new Date(todayNoon.value), new Date(todayNoon.value)] },
+  { label: 'Ayer',          value: (() => { const d = dateAtNoon(addDaysISO(today.value, -1)); return [d, d] })() },
+  { label: 'Última semana', value: [dateAtNoon(addDaysISO(today.value, -7)), new Date(todayNoon.value)] },
+  { label: 'Último mes',    value: [dateAtNoon(addDaysISO(today.value, -30)), new Date(todayNoon.value)] },
 ])
 
 const formatDateRange = (dates: Date[]) => {
   if (!dates || !dates[0]) return ''
-  const from = fnsFormat(dates[0], 'dd/MM/yy', { locale: es })
+  const from = formatIsoShort(isoFromDate(dates[0]))
   if (!dates[1]) return from
-  return `${from} - ${fnsFormat(dates[1], 'dd/MM/yy', { locale: es })}`
+  return `${from} - ${formatIsoShort(isoFromDate(dates[1]))}`
 }
 
 const periodStart = computed(() =>
-  dateRangeDates.value?.[0] ? bogotaISOFromDate(dateRangeDates.value[0]) : today
+  dateRangeDates.value?.[0] ? isoFromDate(dateRangeDates.value[0]) : today.value
 )
 const periodEnd = computed(() =>
-  dateRangeDates.value?.[1] ? bogotaISOFromDate(dateRangeDates.value[1]) : today
+  dateRangeDates.value?.[1] ? isoFromDate(dateRangeDates.value[1]) : today.value
 )
 
 const activeStart = computed(() => dateRangeDates.value ? periodStart.value : null)
@@ -449,7 +446,7 @@ const activeEnd   = computed(() => dateRangeDates.value ? periodEnd.value   : nu
 const { data: todayPreview } = useQuery({
   key: () => ['cierre', 'open-tables', currentTenant.value?.id],
   query: () => $fetch<{ success: boolean; data: Record<string, any> }>('/api/cierre/preview', {
-    params: { period_start: today, period_end: today, completed_only: false },
+    params: { period_start: today.value, period_end: today.value, completed_only: false },
   }),
   enabled: () => !!currentTenant.value,
   staleTime: 60_000,
@@ -505,13 +502,13 @@ const formatCurrency = (value?: number) =>
   new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(value ?? 0)
 
 const filterCurrentMonth = () => {
-  const { first, last } = bogotaMonthBounds(today)
-  dateRangeDates.value = [bogotaDateAtNoon(first), bogotaDateAtNoon(last)]
+  const { first, last } = monthBounds(today.value)
+  dateRangeDates.value = [dateAtNoon(first), dateAtNoon(last)]
 }
 
 const isCurrentMonthActive = computed(() => {
   if (!dateRangeDates.value?.[0] || !dateRangeDates.value?.[1]) return false
-  const { first, last } = bogotaMonthBounds(today)
+  const { first, last } = monthBounds(today.value)
   return activeStart.value === first && activeEnd.value === last
 })
 

--- a/pages/ventas/propinas/index.vue
+++ b/pages/ventas/propinas/index.vue
@@ -46,21 +46,27 @@ const channelFilter = ref<'pos' | 'mesa' | 'online' | null>(null)
 const dateRangeDates = ref<Date[] | null>(null)
 const sortField = ref<'order_number' | 'order_date' | 'total_amount' | 'tip_amount' | 'payment_method'>('order_date')
 const sortDirection = ref<'asc' | 'desc'>('desc')
+const { todayISO, addDaysISO, dateAtNoon, isoFromDate } = useTenantTimezone()
+const presetRange = (fromIso: string, toIso = todayISO()) => [dateAtNoon(fromIso), dateAtNoon(toIso)]
+const formatIsoShort = (iso: string) => {
+  const [year, month, day] = iso.split('-')
+  return `${day}/${month}/${year.slice(2)}`
+}
 
-const presetDates = ref([
-  { label: 'Hoy', value: [new Date(), new Date()] },
-  { label: 'Ayer', value: (() => { const d = new Date(); d.setDate(d.getDate() - 1); return [d, d] })() },
-  { label: 'Última semana', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 7); return d })(), new Date()] },
-  { label: 'Últimos 15 días', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 15); return d })(), new Date()] },
-  { label: 'Último mes', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 30); return d })(), new Date()] },
-  { label: 'Últimos 90 días', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 90); return d })(), new Date()] },
+const presetDates = computed(() => [
+  { label: 'Hoy', value: presetRange(todayISO()) },
+  { label: 'Ayer', value: presetRange(addDaysISO(todayISO(), -1), addDaysISO(todayISO(), -1)) },
+  { label: 'Última semana', value: presetRange(addDaysISO(todayISO(), -7)) },
+  { label: 'Últimos 15 días', value: presetRange(addDaysISO(todayISO(), -15)) },
+  { label: 'Último mes', value: presetRange(addDaysISO(todayISO(), -30)) },
+  { label: 'Últimos 90 días', value: presetRange(addDaysISO(todayISO(), -90)) },
 ])
 
 const formatDateRange = (dates: Date[]) => {
   if (!dates || !dates[0]) return ''
-  const from = fnsFormat(dates[0], 'dd/MM/yy', { locale: es })
+  const from = formatIsoShort(isoFromDate(dates[0]))
   if (!dates[1]) return from
-  const to = fnsFormat(dates[1], 'dd/MM/yy', { locale: es })
+  const to = formatIsoShort(isoFromDate(dates[1]))
   return `${from} - ${to}`
 }
 
@@ -68,7 +74,7 @@ const dateRange = computed(() => {
   if (!dateRangeDates.value || dateRangeDates.value.length < 2) return { from: null as string | null, to: null as string | null }
   const [from, to] = dateRangeDates.value
   if (!from || !to) return { from: null, to: null }
-  return { from: fnsFormat(from, 'yyyy-MM-dd'), to: fnsFormat(to, 'yyyy-MM-dd') }
+  return { from: isoFromDate(from), to: isoFromDate(to) }
 })
 
 // Pagination

--- a/stores/tenants.ts
+++ b/stores/tenants.ts
@@ -29,6 +29,7 @@ export interface TenantBusinessProfile {
   neighborhood: string | null
   latitude: number | null
   longitude: number | null
+  timezone?: string | null
   business_hours: Record<string, BusinessHours> | null
   social_media: Record<string, string> | null
   accepts_online_orders: boolean

--- a/utils/bogotaDate.test.ts
+++ b/utils/bogotaDate.test.ts
@@ -2,37 +2,72 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   addDaysBogotaISO,
+  addDaysISO,
   bogotaDateAtNoon,
   bogotaISOFromDate,
   combineBogotaDateAndTimeISO,
+  combineDateAndTimeISO,
+  dateAtNoon,
+  DEFAULT_TENANT_TIMEZONE,
+  isoFromDate,
+  normalizeTimezone,
   todayBogotaISO,
+  todayISO,
 } from './bogotaDate.ts'
 
-describe('bogotaDate', () => {
-  it('bogotaISOFromDate uses Bogotá calendar day not UTC', () => {
-    // 2026-05-19 01:30 UTC = 2026-05-18 20:30 Bogotá
-    const d = new Date('2026-05-19T01:30:00Z')
-    assert.equal(bogotaISOFromDate(d), '2026-05-18')
+describe('tenant date helpers', () => {
+  it('normalizes missing and invalid timezones to Colombia', () => {
+    assert.equal(normalizeTimezone(null), DEFAULT_TENANT_TIMEZONE)
+    assert.equal(normalizeTimezone(''), DEFAULT_TENANT_TIMEZONE)
+    assert.equal(normalizeTimezone('Nope/Nowhere'), DEFAULT_TENANT_TIMEZONE)
+    assert.equal(normalizeTimezone('America/Mexico_City'), 'America/Mexico_City')
   })
 
-  it('combineBogotaDateAndTimeISO builds -05:00 offset', () => {
+  it('uses the requested timezone calendar day instead of UTC', () => {
+    const d = new Date('2026-05-19T01:30:00Z')
+    assert.equal(isoFromDate(d, 'America/Bogota'), '2026-05-18')
+    assert.equal(isoFromDate(d, 'Europe/Madrid'), '2026-05-19')
+  })
+
+  it('builds tenant-local wall clock instants as UTC ISO timestamps', () => {
+    assert.equal(
+      combineDateAndTimeISO('2026-05-18', '14:01', 'America/Bogota'),
+      '2026-05-18T19:01:00.000Z',
+    )
+    assert.equal(
+      combineDateAndTimeISO('2026-01-15', '09:00', 'America/New_York'),
+      '2026-01-15T14:00:00.000Z',
+    )
+  })
+
+  it('adds calendar days in the requested timezone', () => {
+    assert.equal(addDaysISO('2026-05-18', 1, 'America/Bogota'), '2026-05-19')
+    assert.equal(addDaysISO('2026-05-18', -1, 'America/Bogota'), '2026-05-17')
+  })
+
+  it('anchors datepicker dates at tenant-local noon', () => {
+    const d = dateAtNoon('2026-05-18', 'America/Bogota')
+    assert.equal(isoFromDate(d, 'America/Bogota'), '2026-05-18')
+  })
+
+  it('todayISO returns YYYY-MM-DD for any valid timezone', () => {
+    assert.match(todayISO('America/Mexico_City'), /^\d{4}-\d{2}-\d{2}$/)
+  })
+})
+
+describe('legacy Bogotá wrappers', () => {
+  it('keeps existing Bogotá calendar behavior', () => {
+    const d = new Date('2026-05-19T01:30:00Z')
+    assert.equal(bogotaISOFromDate(d), '2026-05-18')
+    assert.equal(addDaysBogotaISO('2026-05-18', 1), '2026-05-19')
+    assert.equal(bogotaDateAtNoon('2026-05-18').toISOString(), '2026-05-18T17:00:00.000Z')
+    assert.match(todayBogotaISO(), /^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('preserves the old offset string helper', () => {
     assert.equal(
       combineBogotaDateAndTimeISO('2026-05-18', '14:01'),
       '2026-05-18T14:01:00-05:00',
     )
-  })
-
-  it('addDaysBogotaISO shifts calendar days', () => {
-    assert.equal(addDaysBogotaISO('2026-05-18', 1), '2026-05-19')
-    assert.equal(addDaysBogotaISO('2026-05-18', -1), '2026-05-17')
-  })
-
-  it('bogotaDateAtNoon parses anchor', () => {
-    const d = bogotaDateAtNoon('2026-05-18')
-    assert.equal(bogotaISOFromDate(d), '2026-05-18')
-  })
-
-  it('todayBogotaISO returns YYYY-MM-DD', () => {
-    assert.match(todayBogotaISO(), /^\d{4}-\d{2}-\d{2}$/)
   })
 })

--- a/utils/bogotaDate.ts
+++ b/utils/bogotaDate.ts
@@ -1,18 +1,39 @@
-/** Business calendar dates/times for Colombia (America/Bogota). Issue #698 */
+/** Tenant operational calendar helpers. Legacy Bogotá wrappers remain for old callers. */
 
-export const BOGOTA_TZ = 'America/Bogota'
+export const DEFAULT_TENANT_TIMEZONE = 'America/Bogota'
+export const BOGOTA_TZ = DEFAULT_TENANT_TIMEZONE
 
-type DateParts = {
+export type DateParts = {
   year: string
   month: string
   day: string
   hour: string
   minute: string
+  weekday?: string
 }
 
-function bogotaParts(date: Date): DateParts {
+const dateTimeFormatters = new Map<string, Intl.DateTimeFormat>()
+const dateTimeWeekdayFormatters = new Map<string, Intl.DateTimeFormat>()
+
+export function normalizeTimezone(value?: string | null): string {
+  const tz = typeof value === 'string' ? value.trim() : ''
+  if (!tz) return DEFAULT_TENANT_TIMEZONE
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz }).format(new Date())
+    return tz
+  } catch {
+    return DEFAULT_TENANT_TIMEZONE
+  }
+}
+
+function formatterFor(timezone: string, weekday = false): Intl.DateTimeFormat {
+  const tz = normalizeTimezone(timezone)
+  const cache = weekday ? dateTimeWeekdayFormatters : dateTimeFormatters
+  const cached = cache.get(tz)
+  if (cached) return cached
   const fmt = new Intl.DateTimeFormat('en-CA', {
-    timeZone: BOGOTA_TZ,
+    timeZone: tz,
+    ...(weekday ? { weekday: 'short' as const } : {}),
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
@@ -20,8 +41,13 @@ function bogotaParts(date: Date): DateParts {
     minute: '2-digit',
     hour12: false,
   })
+  cache.set(tz, fmt)
+  return fmt
+}
+
+export function zonedParts(date: Date, timezone = DEFAULT_TENANT_TIMEZONE): DateParts {
   const parts = Object.fromEntries(
-    fmt.formatToParts(date).map((p) => [p.type, p.value]),
+    formatterFor(timezone, true).formatToParts(date).map((p) => [p.type, p.value]),
   ) as Record<string, string>
   return {
     year: parts.year,
@@ -29,27 +55,80 @@ function bogotaParts(date: Date): DateParts {
     day: parts.day,
     hour: parts.hour,
     minute: parts.minute,
+    weekday: parts.weekday,
   }
 }
 
-/** Today's calendar date in Bogotá as YYYY-MM-DD. */
-export function todayBogotaISO(): string {
-  const p = bogotaParts(new Date())
+export function todayISO(timezone = DEFAULT_TENANT_TIMEZONE, now = new Date()): string {
+  const p = zonedParts(now, timezone)
   return `${p.year}-${p.month}-${p.day}`
 }
 
-/** Calendar day in Bogotá for any instant (e.g. date-picker value). */
-export function bogotaISOFromDate(date: Date): string {
-  const p = bogotaParts(date)
+export function isoFromDate(date: Date, timezone = DEFAULT_TENANT_TIMEZONE): string {
+  const p = zonedParts(date, timezone)
   return `${p.year}-${p.month}-${p.day}`
 }
 
-/** Stable noon anchor for date pickers (avoids DST edge cases; Colombia has no DST). */
-export function bogotaDateAtNoon(iso: string): Date {
-  return new Date(`${iso}T12:00:00-05:00`)
+function zonedWallTimeToDate(iso: string, hhmm: string, timezone = DEFAULT_TENANT_TIMEZONE): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(iso) || !hhmm || hhmm.length < 5) return null
+  const [year, month, day] = iso.split('-').map(Number)
+  const [hour, minute] = hhmm.slice(0, 5).split(':').map(Number)
+  if ([year, month, day, hour, minute].some(Number.isNaN)) return null
+
+  const targetWallUtc = Date.UTC(year, month - 1, day, hour, minute)
+  let utc = targetWallUtc
+  for (let i = 0; i < 3; i++) {
+    const p = zonedParts(new Date(utc), timezone)
+    const actualWallUtc = Date.UTC(
+      Number(p.year),
+      Number(p.month) - 1,
+      Number(p.day),
+      Number(p.hour),
+      Number(p.minute),
+    )
+    const diff = targetWallUtc - actualWallUtc
+    if (diff === 0) break
+    utc += diff
+  }
+  return new Date(utc)
 }
 
-/** ISO timestamp for API period_*_time params (Bogotá wall clock). */
+export function dateAtNoon(iso: string, timezone = DEFAULT_TENANT_TIMEZONE): Date {
+  return zonedWallTimeToDate(iso, '12:00', timezone) ?? new Date(`${iso}T12:00:00-05:00`)
+}
+
+export function combineDateAndTimeISO(
+  iso: string,
+  hhmm: string,
+  timezone = DEFAULT_TENANT_TIMEZONE,
+): string | null {
+  return zonedWallTimeToDate(iso, hhmm, timezone)?.toISOString() ?? null
+}
+
+export function addDaysISO(iso: string, days: number, timezone = DEFAULT_TENANT_TIMEZONE): string {
+  const base = dateAtNoon(iso, timezone)
+  const next = new Date(base.getTime() + days * 24 * 60 * 60 * 1000)
+  return isoFromDate(next, timezone)
+}
+
+export function timeHHMMFromISO(iso: string, timezone = DEFAULT_TENANT_TIMEZONE): string {
+  const p = zonedParts(new Date(iso), timezone)
+  return `${p.hour}:${p.minute}`
+}
+
+export function monthBounds(iso?: string, timezone = DEFAULT_TENANT_TIMEZONE): { first: string; last: string } {
+  const base = iso ?? todayISO(timezone)
+  const [y, m] = base.split('-').map(Number)
+  const first = `${y}-${String(m).padStart(2, '0')}-01`
+  const lastDay = new Date(y, m, 0).getDate()
+  const last = `${y}-${String(m).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
+  return { first, last }
+}
+
+export const todayBogotaISO = () => todayISO(BOGOTA_TZ)
+export const bogotaISOFromDate = (date: Date) => isoFromDate(date, BOGOTA_TZ)
+export const bogotaDateAtNoon = (iso: string) => dateAtNoon(iso, BOGOTA_TZ)
+
 export function combineBogotaDateAndTimeISO(iso: string, hhmm: string): string | null {
   if (!hhmm || hhmm.length < 5) return null
   const [h, m] = hhmm.split(':').map(Number)
@@ -59,25 +138,6 @@ export function combineBogotaDateAndTimeISO(iso: string, hhmm: string): string |
   return `${iso}T${hh}:${mm}:00-05:00`
 }
 
-/** Add calendar days to a Bogotá ISO date string. */
-export function addDaysBogotaISO(iso: string, days: number): string {
-  const base = bogotaDateAtNoon(iso)
-  const next = new Date(base.getTime() + days * 24 * 60 * 60 * 1000)
-  return bogotaISOFromDate(next)
-}
-
-/** HH:mm in Bogotá from an ISO timestamp string. */
-export function bogotaTimeHHMMFromISO(iso: string): string {
-  const p = bogotaParts(new Date(iso))
-  return `${p.hour}:${p.minute}`
-}
-
-/** First and last calendar day of the month containing `iso` (Bogotá). */
-export function bogotaMonthBounds(iso?: string): { first: string; last: string } {
-  const base = iso ?? todayBogotaISO()
-  const [y, m] = base.split('-').map(Number)
-  const first = `${y}-${String(m).padStart(2, '0')}-01`
-  const lastDay = new Date(y, m, 0).getDate()
-  const last = `${y}-${String(m).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
-  return { first, last }
-}
+export const addDaysBogotaISO = (iso: string, days: number) => addDaysISO(iso, days, BOGOTA_TZ)
+export const bogotaTimeHHMMFromISO = (iso: string) => timeHHMMFromISO(iso, BOGOTA_TZ)
+export const bogotaMonthBounds = (iso?: string) => monthBounds(iso, BOGOTA_TZ)


### PR DESCRIPTION
## Summary
- Add tenant timezone normalization/date helpers and expose a `useTenantTimezone` composable.
- Move operational front dates, clocks, business hours, cierre/promo timing, and payroll defaults off hardcoded Bogotá behavior.
- Keep legacy Bogotá wrappers for untouched callers and preserve es-CO/COP presentation formatting.

## Tests
- `node --test utils/bogotaDate.test.ts`
- `node --test utils/*.test.ts`
- `git diff --check`
- Skipped `npm run build` per request (`sin build`).
- Tried `npm exec nuxi -- typecheck`; stopped after it produced no result for ~2 minutes.

Refs uno0uno/api-warolabs#532
