### PR TITLE
Mostrar notas bajo cada producto en comanda impresa

### DIFF
--- a/components/pos/ComandaPrintTickets.vue
+++ b/components/pos/ComandaPrintTickets.vue
@@ -32,11 +32,11 @@ function modifierLines(item: ComandaPrintPayload['items'][0]) {
         Comanda #{{ c.comanda_number }}
       </div>
       <div class="receipt-divider">--------------------------------</div>
-      <div v-for="(item, i) in c.items" :key="i" class="receipt-item receipt-small">
-        <span class="comanda-item-qty">{{ item.quantity }}×</span>
-        <span class="comanda-item-name">{{ item.kitchen_name }}</span>
-      </div>
-      <template v-for="(item, i) in c.items" :key="`mod-${i}`">
+      <template v-for="(item, i) in c.items" :key="i">
+        <div class="receipt-item receipt-small">
+          <span class="comanda-item-qty">{{ item.quantity }}×</span>
+          <span class="comanda-item-name">{{ item.kitchen_name }}</span>
+        </div>
         <div
           v-for="(mod, mi) in modifierLines(item)"
           :key="`${i}-${mi}`"


### PR DESCRIPTION
## Summary
- Render each printed comanda item with its modifiers and note in the same per-item block.
- Prevent product notes from being grouped at the end of the kitchen ticket.

## Tests
- git diff --check -- components/pos/ComandaPrintTickets.vue
- Not run: npm run build (skipped per request: sin build)
- Manual pending: POS print preview with item without note, item with note, item with modifiers + note, and multiple noted items

Closes #1467