### PR TITLE
Finish tenant timezone front migration

### DIFF
--- a/components/Finanzas/CierrePanel.vue
+++ b/components/Finanzas/CierrePanel.vue
@@ -246,13 +246,14 @@ const formatCurrency = (value?: number) =>
   new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(value ?? 0)
 
 const { formatPeriodDates, formatPeriodTimes, periodTypeLabel, periodBadgeClass } = useCierrePeriod()
+const { timezone } = useTenantTimezone()
 
 const formatDate = (iso: string) => {
   if (!iso) return ''
   return new Intl.DateTimeFormat('es-CO', {
     day: '2-digit', month: 'short', year: 'numeric',
     hour: '2-digit', minute: '2-digit', hour12: true,
-    timeZone: 'America/Bogota',
+    timeZone: timezone.value,
   }).format(new Date(iso))
 }
 </script>

--- a/composables/useCierreShiftWindow.ts
+++ b/composables/useCierreShiftWindow.ts
@@ -1,4 +1,4 @@
-import { bogotaTimeHHMMFromISO } from '~/utils/bogotaDate'
+import { DEFAULT_TENANT_TIMEZONE, timeHHMMFromISO } from '~/utils/bogotaDate'
 
 export interface CierreListRowLike {
   status?: string
@@ -15,7 +15,10 @@ export function isCierreOpen(row: CierreListRowLike | null | undefined): boolean
 }
 
 /** Deep link to the correct close wizard for an open shift list row. */
-export function buildCierreCloseRoute(row: CierreListRowLike): string {
+export function buildCierreCloseRoute(
+  row: CierreListRowLike,
+  timezone = DEFAULT_TENANT_TIMEZONE,
+): string {
   const start = row.periodStart ?? ''
   const end = row.periodEnd ?? start
 
@@ -34,8 +37,8 @@ export function buildCierreCloseRoute(row: CierreListRowLike): string {
       mode: 'custom',
       start,
       end,
-      startTime: bogotaTimeHHMMFromISO(row.periodStartTime),
-      endTime: bogotaTimeHHMMFromISO(row.periodEndTime),
+      startTime: timeHHMMFromISO(row.periodStartTime, timezone),
+      endTime: timeHHMMFromISO(row.periodEndTime, timezone),
     })
     return `/finanzas/arqueo/z?${q.toString()}`
   }

--- a/pages/finanzas/arqueo/apertura.vue
+++ b/pages/finanzas/arqueo/apertura.vue
@@ -231,7 +231,6 @@ import { useFormatters } from '~/composables/useFormatters'
 import { useCashDenominationCount } from '~/composables/useCashDenominationCount'
 import { useQueryCache } from '@pinia/colada'
 import { buildCierreWindowParams, isShiftOpen } from '~/composables/useCierreShiftWindow'
-import { bogotaDateAtNoon, bogotaISOFromDate, combineBogotaDateAndTimeISO, todayBogotaISO } from '~/utils/bogotaDate'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Abrir turno — Arqueo - Warocol' })
@@ -251,8 +250,9 @@ const route = useRoute()
 const { currentTenant } = useTenantReactive()
 const cache = useQueryCache()
 const { formatCurrency } = useFormatters()
+const { combineDateAndTimeISO, dateAtNoon, isoFromDate, todayISO } = useTenantTimezone()
 
-const today = todayBogotaISO()
+const today = todayISO()
 const initStart = (route.query.start as string) || today
 const initEnd = (route.query.end as string) || initStart
 const initTemplate = (route.query.template as string) || ''
@@ -275,7 +275,7 @@ const isDayShiftSelected = computed(() =>
 const effectiveTemplateId = computed(() =>
   isDayShiftSelected.value ? null : (selectedTemplateId.value || null),
 )
-const anchorDate = ref<Date>(bogotaDateAtNoon(initStart))
+const anchorDate = ref<Date>(dateAtNoon(initStart))
 const stepError = ref<string | null>(null)
 const submitError = ref<string | null>(null)
 const isSubmitting = ref(false)
@@ -291,7 +291,7 @@ const {
 
 const periodStart = computed(() => {
   if (aperturaMode.value === 'custom') return initStart
-  return bogotaISOFromDate(anchorDate.value)
+  return isoFromDate(anchorDate.value)
 })
 const periodEnd = computed(() => {
   if (aperturaMode.value === 'custom') return initEnd
@@ -300,11 +300,11 @@ const periodEnd = computed(() => {
 
 const periodStartTime = computed(() => {
   if (aperturaMode.value !== 'custom' || !initStartTime) return null
-  return combineBogotaDateAndTimeISO(periodStart.value, initStartTime)
+  return combineDateAndTimeISO(periodStart.value, initStartTime)
 })
 const periodEndTime = computed(() => {
   if (aperturaMode.value !== 'custom' || !initEndTime) return null
-  return combineBogotaDateAndTimeISO(periodEnd.value, initEndTime)
+  return combineDateAndTimeISO(periodEnd.value, initEndTime)
 })
 
 const { data: rawShiftTemplates } = useQuery({
@@ -375,7 +375,7 @@ const templateHoursLabel = computed(() => {
 })
 
 const customWindowLabel = computed(() => {
-  const fmt = (iso: string) => fnsFormat(bogotaDateAtNoon(iso), 'dd/MM/yyyy', { locale: es })
+  const fmt = (iso: string) => fnsFormat(dateAtNoon(iso), 'dd/MM/yyyy', { locale: es })
   const datePart = periodStart.value === periodEnd.value
     ? fmt(periodStart.value)
     : `${fmt(periodStart.value)} – ${fmt(periodEnd.value)}`

--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -514,6 +514,7 @@ const isCurrentMonthActive = computed(() => {
 
 const { formatDateTime: _fmtDateTime } = useFormatters()
 const { formatPeriodDates, formatPeriodTimes, periodTypeLabel, periodBadgeClass } = useCierrePeriod()
+const { timezone } = useTenantTimezone()
 
 const formatDay = (d: string) => {
   if (!d) return ''
@@ -532,7 +533,7 @@ const selectedCierreId = ref<string | null>(null)
 
 const onRowClick = (item: any) => {
   if (isCierreOpen(item)) {
-    navigateTo(buildCierreCloseRoute(item))
+    navigateTo(buildCierreCloseRoute(item, timezone.value))
     return
   }
   openPanel(item.id)

--- a/pages/finanzas/arqueo/nuevo.vue
+++ b/pages/finanzas/arqueo/nuevo.vue
@@ -768,12 +768,6 @@ import { es } from 'date-fns/locale'
 import { format as fnsFormat } from 'date-fns'
 import { useQueryCache } from '@pinia/colada'
 import { buildCierreWindowBody, buildCierreWindowParams, cierrePreviewShiftCacheKey, isShiftOpen } from '~/composables/useCierreShiftWindow'
-import {
-  addDaysBogotaISO,
-  bogotaDateAtNoon,
-  bogotaISOFromDate,
-  todayBogotaISO,
-} from '~/utils/bogotaDate'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Nuevo arqueo de caja - Warocol' })
@@ -783,8 +777,9 @@ const { currentTenant } = useTenantReactive()
 const { singular: tableSingular, plural: tablePlural } = useTableLabel()
 const cache = useQueryCache()
 const route = useRoute()
+const { addDaysISO, dateAtNoon, isoFromDate, todayISO } = useTenantTimezone()
 
-const today = todayBogotaISO()
+const today = todayISO()
 const initStart = (route.query.start as string) || today
 
 // ── Último cierre ──────────────────────────────────────────────────────────
@@ -817,9 +812,9 @@ onUnmounted(() => { clearRefreshHandler(refetchUltimo) })
 // Día sugerido: el día siguiente al último cierre (si es ≤ hoy)
 const suggestedRange = computed(() => {
   if (!ultimoCierre.value) return null
-  const afterIso = addDaysBogotaISO(ultimoCierre.value.periodEnd, 1)
+  const afterIso = addDaysISO(ultimoCierre.value.periodEnd, 1)
   if (afterIso > today) return null
-  return { start: afterIso, startDate: bogotaDateAtNoon(afterIso) }
+  return { start: afterIso, startDate: dateAtNoon(afterIso) }
 })
 
 const applySuggested = () => {
@@ -832,24 +827,24 @@ const applySuggested = () => {
 
 interface Preset { key: string; label: string; date: Date }
 const buildPresets = (): Preset[] => {
-  const todayNoon = bogotaDateAtNoon(today)
-  const yesterdayNoon = bogotaDateAtNoon(addDaysBogotaISO(today, -1))
+  const todayNoon = dateAtNoon(today)
+  const yesterdayNoon = dateAtNoon(addDaysISO(today, -1))
   return [
     { key: 'today',     label: 'Hoy',  date: new Date(todayNoon) },
     { key: 'yesterday', label: 'Ayer', date: yesterdayNoon },
   ]
 }
 const presets      = buildPresets()
-const selectedDate = ref<Date>(bogotaDateAtNoon(initStart))
+const selectedDate = ref<Date>(dateAtNoon(initStart))
 const activePreset = ref<string | null>(
   initStart === today ? 'today'
-    : initStart === addDaysBogotaISO(today, -1) ? 'yesterday'
+    : initStart === addDaysISO(today, -1) ? 'yesterday'
       : null,
 )
 
 const syncPresetFromDate = (iso: string) => {
   if (iso === today) activePreset.value = 'today'
-  else if (iso === addDaysBogotaISO(today, -1)) activePreset.value = 'yesterday'
+  else if (iso === addDaysISO(today, -1)) activePreset.value = 'yesterday'
   else activePreset.value = null
 }
 
@@ -860,14 +855,14 @@ const applyPreset = (p: Preset) => {
 
 const onDatePicked = (date: Date | null) => {
   if (!date) return
-  syncPresetFromDate(bogotaISOFromDate(date))
+  syncPresetFromDate(isoFromDate(date))
 }
 
 const formatSingleDate = (date: Date) =>
   date ? fnsFormat(date, 'dd/MM/yy', { locale: es }) : ''
 
 // Period — siempre un solo día
-const periodStart = computed(() => bogotaISOFromDate(selectedDate.value))
+const periodStart = computed(() => isoFromDate(selectedDate.value))
 const periodEnd   = computed(() => periodStart.value)
 
 const shiftWindowParams = computed(() =>
@@ -1148,7 +1143,7 @@ const loadFromStorage = (restorePeriod = true) => {
   try {
     const s = JSON.parse(raw)
     if (restorePeriod && s.periodStart) {
-      selectedDate.value = bogotaDateAtNoon(s.periodStart)
+      selectedDate.value = dateAtNoon(s.periodStart)
       syncPresetFromDate(s.periodStart)
     }
     // Never restore step from storage — always start at step 0 (X preview)
@@ -1173,7 +1168,7 @@ onMounted(() => {
   if (typeof window === 'undefined') return
   const queryStart = route.query.start as string | undefined
   if (queryStart) {
-    selectedDate.value = bogotaDateAtNoon(queryStart)
+    selectedDate.value = dateAtNoon(queryStart)
     syncPresetFromDate(queryStart)
     loadFromStorage(false)
   } else {

--- a/pages/finanzas/arqueo/x.vue
+++ b/pages/finanzas/arqueo/x.vue
@@ -185,12 +185,6 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 import { es } from 'date-fns/locale'
 import { format as fnsFormat } from 'date-fns'
-import {
-  addDaysBogotaISO,
-  bogotaDateAtNoon,
-  bogotaISOFromDate,
-  todayBogotaISO,
-} from '~/utils/bogotaDate'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Previsualización arqueo - Warocol' })
@@ -199,8 +193,9 @@ const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = u
 const { currentTenant } = useTenantReactive()
 const { plural: tablePlural } = useTableLabel()
 const route = useRoute()
+const { addDaysISO, dateAtNoon, isoFromDate, todayISO } = useTenantTimezone()
 
-const today = todayBogotaISO()
+const today = todayISO()
 
 // Initialise from query params if present
 const initStart     = (route.query.start     as string) || today
@@ -208,18 +203,18 @@ const initEnd       = (route.query.end       as string) || today
 const initStartTime = (route.query.startTime as string) || null
 const initEndTime   = (route.query.endTime   as string) || null
 const dateRangeDates = ref<Date[] | null>([
-  bogotaDateAtNoon(initStart),
-  bogotaDateAtNoon(initEnd),
+  dateAtNoon(initStart),
+  dateAtNoon(initEnd),
 ])
 const periodStartTime = ref<string | null>(initStartTime)
 const periodEndTime   = ref<string | null>(initEndTime)
 
-const todayNoon = bogotaDateAtNoon(today)
+const todayNoon = dateAtNoon(today)
 const presetDates = ref([
   { label: 'Hoy',           value: [new Date(todayNoon), new Date(todayNoon)] },
-  { label: 'Ayer',          value: (() => { const d = bogotaDateAtNoon(addDaysBogotaISO(today, -1)); return [d, d] })() },
-  { label: 'Última semana', value: [bogotaDateAtNoon(addDaysBogotaISO(today, -7)), new Date(todayNoon)] },
-  { label: 'Último mes',    value: [bogotaDateAtNoon(addDaysBogotaISO(today, -30)), new Date(todayNoon)] },
+  { label: 'Ayer',          value: (() => { const d = dateAtNoon(addDaysISO(today, -1)); return [d, d] })() },
+  { label: 'Última semana', value: [dateAtNoon(addDaysISO(today, -7)), new Date(todayNoon)] },
+  { label: 'Último mes',    value: [dateAtNoon(addDaysISO(today, -30)), new Date(todayNoon)] },
 ])
 
 const formatDateRange = (dates: Date[]) => {
@@ -230,10 +225,10 @@ const formatDateRange = (dates: Date[]) => {
 }
 
 const periodStart = computed(() =>
-  dateRangeDates.value?.[0] ? bogotaISOFromDate(dateRangeDates.value[0]) : today
+  dateRangeDates.value?.[0] ? isoFromDate(dateRangeDates.value[0]) : today
 )
 const periodEnd = computed(() =>
-  dateRangeDates.value?.[1] ? bogotaISOFromDate(dateRangeDates.value[1]) : today
+  dateRangeDates.value?.[1] ? isoFromDate(dateRangeDates.value[1]) : today
 )
 
 const { data: rawPreview, status: previewStatus, asyncStatus: previewAsyncStatus, error: previewErr, refetch } = useQuery({

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -941,14 +941,6 @@ import { useFormatters } from '~/composables/useFormatters'
 import { es } from 'date-fns/locale'
 import { format as fnsFormat, formatDistanceStrict } from 'date-fns'
 import { buildCierreWindowBody, buildCierreWindowParams, isShiftOpen } from '~/composables/useCierreShiftWindow'
-import {
-  addDaysBogotaISO,
-  bogotaDateAtNoon,
-  bogotaISOFromDate,
-  bogotaTimeHHMMFromISO,
-  combineBogotaDateAndTimeISO,
-  todayBogotaISO,
-} from '~/utils/bogotaDate'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Arqueo de caja - Warocol' })
@@ -958,6 +950,14 @@ const { currentTenant } = useTenantReactive()
 const cache = useQueryCache()
 const { singular: tableSingular, plural: tablePlural } = useTableLabel()
 const route = useRoute()
+const {
+  addDaysISO,
+  combineDateAndTimeISO,
+  dateAtNoon,
+  isoFromDate,
+  timeHHMMFromISO,
+  todayISO,
+} = useTenantTimezone()
 
 type ArqueoWindowMode = 'template' | 'custom'
 interface ShiftTemplateOption {
@@ -975,24 +975,24 @@ const initTemplate = (route.query.template as string) || ''
 const selectedTemplateId = ref<string>(initTemplate)
 const suggestedLoading = ref(false)
 
-const today = todayBogotaISO()
+const today = todayISO()
 
 // ── Date picker state (paso 0) ─────────────────────────────────────────────
 const initStart = (route.query.start as string) || today
 const initEnd   = (route.query.end   as string) || today
 
 const dateRangeDates = ref<Date[]>([
-  bogotaDateAtNoon(initStart),
-  bogotaDateAtNoon(initEnd),
+  dateAtNoon(initStart),
+  dateAtNoon(initEnd),
 ])
 
 interface Preset { key: string; label: string; start: Date; end: Date }
 const buildPresets = (): Preset[] => {
-  const todayNoon = bogotaDateAtNoon(today)
-  const yesterdayNoon = bogotaDateAtNoon(addDaysBogotaISO(today, -1))
-  const weekStartNoon = bogotaDateAtNoon(addDaysBogotaISO(today, -6))
+  const todayNoon = dateAtNoon(today)
+  const yesterdayNoon = dateAtNoon(addDaysISO(today, -1))
+  const weekStartNoon = dateAtNoon(addDaysISO(today, -6))
   const [y, m] = today.split('-').map(Number)
-  const monthStartNoon = bogotaDateAtNoon(`${y}-${String(m).padStart(2, '0')}-01`)
+  const monthStartNoon = dateAtNoon(`${y}-${String(m).padStart(2, '0')}-01`)
   return [
     { key: 'today',     label: 'Hoy',           start: new Date(todayNoon), end: new Date(todayNoon) },
     { key: 'yesterday', label: 'Ayer',           start: yesterdayNoon,       end: yesterdayNoon },
@@ -1066,8 +1066,8 @@ const onTimeInput = (e: Event, field: 'start' | 'end') => {
 }
 
 // Period computed from date picker (Bogotá calendar day for API)
-const periodStart = computed(() => bogotaISOFromDate(dateRangeDates.value[0]))
-const periodEnd   = computed(() => bogotaISOFromDate(dateRangeDates.value[1] ?? dateRangeDates.value[0]))
+const periodStart = computed(() => isoFromDate(dateRangeDates.value[0]))
+const periodEnd   = computed(() => isoFromDate(dateRangeDates.value[1] ?? dateRangeDates.value[0]))
 const isMultiDay  = computed(() => periodStart.value !== periodEnd.value)
 
 const previewShiftTemplateId = computed(() =>
@@ -1082,8 +1082,8 @@ watch(isMultiDay, (multi) => {
 
 watch(dateRangeDates, (dates) => {
   if (arqueoWindowMode.value !== 'template' || !dates?.[0] || !dates?.[1]) return
-  const a = bogotaISOFromDate(dates[0])
-  const b = bogotaISOFromDate(dates[1])
+  const a = isoFromDate(dates[0])
+  const b = isoFromDate(dates[1])
   if (a !== b) dateRangeDates.value = [dates[0], dates[0]]
 }, { deep: true })
 
@@ -1149,9 +1149,9 @@ const templateHoursLabel = computed(() => {
 })
 
 const onTemplateAnchorPick = () => {
-  const anchor = bogotaISOFromDate(templateAnchorDate.value)
+  const anchor = isoFromDate(templateAnchorDate.value)
   if (anchor === today) activePreset.value = 'today'
-  else if (anchor === addDaysBogotaISO(today, -1)) activePreset.value = 'yesterday'
+  else if (anchor === addDaysISO(today, -1)) activePreset.value = 'yesterday'
   else activePreset.value = null
 }
 
@@ -1167,16 +1167,16 @@ const applySuggestedWindow = async () => {
     } }>('/api/cierre/suggested-window', { params: { date: periodStart.value } })
     const d = res.data
     if (arqueoWindowMode.value === 'template') {
-      const anchor = bogotaDateAtNoon(d.periodStart)
+      const anchor = dateAtNoon(d.periodStart)
       dateRangeDates.value = [anchor, anchor]
     } else {
       dateRangeDates.value = [
-        bogotaDateAtNoon(d.periodStart),
-        bogotaDateAtNoon(d.periodEnd),
+        dateAtNoon(d.periodStart),
+        dateAtNoon(d.periodEnd),
       ]
       enableTimePicker.value = true
-      startTimeInput.value = bogotaTimeHHMMFromISO(d.periodStartTime)
-      endTimeInput.value = bogotaTimeHHMMFromISO(d.periodEndTime)
+      startTimeInput.value = timeHHMMFromISO(d.periodStartTime)
+      endTimeInput.value = timeHHMMFromISO(d.periodEndTime)
     }
     activePreset.value = null
   } catch (err: any) {
@@ -1189,12 +1189,12 @@ const applySuggestedWindow = async () => {
 const periodStartTime = computed((): string | null => {
   if (arqueoWindowMode.value === 'template') return null
   if (!enableTimePicker.value) return null
-  return combineBogotaDateAndTimeISO(periodStart.value, startTimeInput.value)
+  return combineDateAndTimeISO(periodStart.value, startTimeInput.value)
 })
 const periodEndTime = computed((): string | null => {
   if (arqueoWindowMode.value === 'template') return null
   if (!enableTimePicker.value) return null
-  return combineBogotaDateAndTimeISO(periodEnd.value, endTimeInput.value)
+  return combineDateAndTimeISO(periodEnd.value, endTimeInput.value)
 })
 
 const shiftWindowParams = computed(() =>
@@ -1522,8 +1522,8 @@ const loadFromStorage = () => {
     const hasQueryParams = !!route.query.start || !!route.query.end
     if (!hasQueryParams) {
       if (s.periodStart) {
-        const d0 = bogotaDateAtNoon(s.periodStart)
-        const d1 = s.periodEnd ? bogotaDateAtNoon(s.periodEnd) : d0
+        const d0 = dateAtNoon(s.periodStart)
+        const d1 = s.periodEnd ? dateAtNoon(s.periodEnd) : d0
         dateRangeDates.value = [d0, d1]
       }
       if (s.periodStartTime) { startTimeInput.value = s.periodStartTime; enableTimePicker.value = true }
@@ -1589,7 +1589,7 @@ const cierreWindowSummary = computed(() => {
     return {
       title: 'Ventana',
       period: formatPeriod(periodStart.value, periodEnd.value),
-      detail: `${bogotaTimeHHMMFromISO(periodStartTime.value)} – ${bogotaTimeHHMMFromISO(periodEndTime.value)}`,
+      detail: `${timeHHMMFromISO(periodStartTime.value)} – ${timeHHMMFromISO(periodEndTime.value)}`,
     }
   }
   return {

--- a/pages/finanzas/contabilidad/cuentas/index.vue
+++ b/pages/finanzas/contabilidad/cuentas/index.vue
@@ -1,11 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { es } from 'date-fns/locale'
-import { format as fnsFormat, startOfMonth } from 'date-fns'
-import { TZDate } from '@date-fns/tz'
-
-const TZ = 'America/Bogota'
-const nowCO = () => new TZDate(new Date(), TZ)
+import { format as fnsFormat } from 'date-fns'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
 definePageMeta({ layout: 'dashboard' })
@@ -13,6 +9,7 @@ useHead({ title: 'Cuentas contables' })
 
 const { currentTenant } = useTenantReactive()
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
+const { addDaysISO, dateAtNoon, isoFromDate, monthBounds, todayISO } = useTenantTimezone()
 const formatCOP = (v: number) =>
   new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(v ?? 0)
 
@@ -20,15 +17,16 @@ const formatCOP = (v: number) =>
 const showAll = ref(false)
 
 // ── Date range filter (default: current month) ─────────────────────────────
-const now = nowCO()
-const dateRangeDates = ref<Date[] | null>([startOfMonth(now), now])
+const today = todayISO()
+const currentMonth = monthBounds(today)
+const dateRangeDates = ref<Date[] | null>([dateAtNoon(currentMonth.first), dateAtNoon(today)])
 
 const presetDates = [
-  { label: 'Hoy',             value: [nowCO(), nowCO()] },
-  { label: 'Esta semana',     value: [(() => { const d = nowCO(); d.setDate(d.getDate() - 7); return d })(), nowCO()] },
-  { label: 'Este mes',        value: [startOfMonth(nowCO()), nowCO()] },
-  { label: 'Último mes',      value: [(() => { const d = nowCO(); d.setDate(d.getDate() - 30); return d })(), nowCO()] },
-  { label: 'Últimos 90 días', value: [(() => { const d = nowCO(); d.setDate(d.getDate() - 90); return d })(), nowCO()] },
+  { label: 'Hoy',             value: [dateAtNoon(today), dateAtNoon(today)] },
+  { label: 'Esta semana',     value: [dateAtNoon(addDaysISO(today, -7)), dateAtNoon(today)] },
+  { label: 'Este mes',        value: [dateAtNoon(currentMonth.first), dateAtNoon(today)] },
+  { label: 'Último mes',      value: [dateAtNoon(addDaysISO(today, -30)), dateAtNoon(today)] },
+  { label: 'Últimos 90 días', value: [dateAtNoon(addDaysISO(today, -90)), dateAtNoon(today)] },
 ]
 
 const formatDateRange = (dates: Date[]) => {
@@ -43,8 +41,8 @@ const dateRange = computed(() => {
   const [from, to] = dateRangeDates.value
   if (!from || !to) return { from: null, to: null }
   return {
-    from: fnsFormat(new TZDate(from, TZ), 'yyyy-MM-dd'),
-    to:   fnsFormat(new TZDate(to,   TZ), 'yyyy-MM-dd'),
+    from: isoFromDate(from),
+    to:   isoFromDate(to),
   }
 })
 

--- a/pages/finanzas/gastos/[id]/instancia.vue
+++ b/pages/finanzas/gastos/[id]/instancia.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { ref, reactive, computed, watch } from 'vue'
-import { todayBogotaISO } from '~/utils/bogotaDate'
 
 definePageMeta({
   layout: 'dashboard'
@@ -14,6 +13,7 @@ useHead({ title: 'Nueva Instancia de Pago' })
 
 // Tenant reactivity
 const { currentTenant } = useTenantReactive()
+const { todayISO } = useTenantTimezone()
 
 // Loading states
 const isLoading = ref(true)
@@ -34,8 +34,8 @@ const expense = computed(() => expenseData.value?.data)
 
 // Form state
 const instanceForm = reactive({
-  periodMonth: todayBogotaISO().slice(0, 7), // YYYY-MM format
-  scheduledDate: todayBogotaISO(),
+  periodMonth: todayISO().slice(0, 7), // YYYY-MM format
+  scheduledDate: todayISO(),
   amount: null as number | null,
   notes: '',
   selectedFiles: [] as File[]

--- a/pages/finanzas/gastos/crear.vue
+++ b/pages/finanzas/gastos/crear.vue
@@ -48,7 +48,7 @@
                 Fecha
               </p>
               <p class="text-sm sm:text-lg font-semibold text-text-primary">
-                {{ formatCalendarDate(todayBogotaISO()) }}
+                {{ formatCalendarDate(todayISO()) }}
               </p>
             </div>
           </div>
@@ -498,7 +498,6 @@
 <script setup lang="ts">
 import { usePaymentMethods } from '~/composables/usePaymentMethods'
 import { useFormatters } from '~/composables/useFormatters'
-import { todayBogotaISO } from '~/utils/bogotaDate'
 import { computed } from 'vue'
 
 definePageMeta({
@@ -508,6 +507,7 @@ definePageMeta({
 useHead({ title: 'Registrar Gasto' })
 
 const { currentTenant } = useTenantReactive()
+const { todayISO } = useTenantTimezone()
 
 // Payment methods
 const { paymentGroups, fetchPaymentMethods } = usePaymentMethods()
@@ -546,7 +546,7 @@ onMounted(() => {
 
 // Form state
 const form = reactive({
-  transactionDate: todayBogotaISO(),
+  transactionDate: todayISO(),
   expenseCategoryId: '',
   description: '',
   amount: null as number | null,

--- a/pages/negocio.vue
+++ b/pages/negocio.vue
@@ -746,11 +746,19 @@ const DAY_LABELS: Record<string, string> = {
   saturday: 'Sábado',
   sunday: 'Domingo',
 }
-const DAY_NAMES_JS = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday']
+const { zonedParts } = useTenantTimezone()
 
 const isToday = (i: number) => {
-  const d = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Bogota' }))
-  return DAY_ORDER[i] === DAY_NAMES_JS[d.getDay()]
+  const weekdayMap: Record<string, string> = {
+    Mon: 'monday',
+    Tue: 'tuesday',
+    Wed: 'wednesday',
+    Thu: 'thursday',
+    Fri: 'friday',
+    Sat: 'saturday',
+    Sun: 'sunday',
+  }
+  return DAY_ORDER[i] === weekdayMap[zonedParts(new Date()).weekday ?? '']
 }
 
 const hasSocialMedia = computed(() => {


### PR DESCRIPTION
## Summary
- Migrate remaining operational cierre/arquéo, gastos, contabilidad, and negocio date logic from Bogotá wrappers to tenant timezone helpers
- Pass tenant timezone into cierre close-route time extraction and panel datetime display
- Keep legacy Bogotá helpers only as compatibility utilities/tests

## Tests
- node --test utils/bogotaDate.test.ts
- node --test utils/*.test.ts
- Skipped build per request: sin build

Refs uno0uno/api-warolabs#532