### PR TITLE
Use tenant timezone for frontend date filters

### DIFF
--- a/components/payments/PaymentForm.vue
+++ b/components/payments/PaymentForm.vue
@@ -155,6 +155,7 @@ const formData = ref({
 })
 
 const selectedFiles = ref<File[]>([])
+const { todayISO, timeHHMMFromISO, combineDateAndTimeISO } = useTenantTimezone()
 
 // Computed properties
 const isBulkPayment = computed(() => props.purchases.length > 1)
@@ -179,18 +180,20 @@ function formatCurrency(value: number): string {
   }).format(value)
 }
 
+const tenantDateTimeLocalNow = () => `${todayISO()}T${timeHHMMFromISO(new Date().toISOString())}`
+
+const paymentDateToISO = (value: string) => {
+  const [date, time] = value.split('T')
+  return combineDateAndTimeISO(date, time) ?? new Date(value).toISOString()
+}
+
 // Initialize form data
 onMounted(() => {
-  const now = new Date()
-  // Adjust to local timezone for datetime-local input
-  const offset = now.getTimezoneOffset() * 60000
-  const localISOTime = (new Date(now.getTime() - offset)).toISOString().slice(0, 16)
-  
   formData.value = {
     payment_method: '',
     payment_reference: '',
     payment_amount: totalAmount.value,
-    payment_date: localISOTime,
+    payment_date: tenantDateTimeLocalNow(),
     notes: ''
   }
 })
@@ -223,7 +226,7 @@ const handleSubmit = async () => {
           const purchase = props.purchases.find(p => p.id === purchaseId)
           const individualAmount = getPurchaseAmount(purchase)
           formDataPayload.append('payment_amount', individualAmount.toString())
-          formDataPayload.append('payment_date', new Date(formData.value.payment_date).toISOString())
+          formDataPayload.append('payment_date', paymentDateToISO(formData.value.payment_date))
 
           if (formData.value.notes) {
             formDataPayload.append('notes', formData.value.notes)
@@ -267,7 +270,7 @@ const handleSubmit = async () => {
       formDataPayload.append('payment_method', formData.value.payment_method)
       formDataPayload.append('payment_reference', formData.value.payment_reference)
       formDataPayload.append('payment_amount', formData.value.payment_amount.toString())
-      formDataPayload.append('payment_date', new Date(formData.value.payment_date).toISOString())
+      formDataPayload.append('payment_date', paymentDateToISO(formData.value.payment_date))
 
       if (formData.value.notes) {
         formDataPayload.append('notes', formData.value.notes)

--- a/composables/useDateRangePresets.ts
+++ b/composables/useDateRangePresets.ts
@@ -12,6 +12,7 @@ export function useDateRangePresets(existing?: Ref<Date[] | null>) {
   const { todayISO, addDaysISO, dateAtNoon, isoFromDate } = useTenantTimezone()
 
   const presetRange = (fromIso: string, toIso = todayISO()) => [dateAtNoon(fromIso), dateAtNoon(toIso)]
+  const maxDate = computed(() => dateAtNoon(todayISO()))
 
   const presetDates = computed(() => [
     { label: 'Hoy', value: presetRange(todayISO()) },
@@ -64,6 +65,7 @@ export function useDateRangePresets(existing?: Ref<Date[] | null>) {
   return {
     dateRangeDates,
     presetDates,
+    maxDate,
     formatDateRange,
     dateRange,
     clearDateRange,

--- a/pages/abastecimiento/compras-directas/[id]/editar.vue
+++ b/pages/abastecimiento/compras-directas/[id]/editar.vue
@@ -189,7 +189,7 @@
                   :locale="es"
                   auto-apply
                   :teleport="true"
-                  :max-date="new Date()"
+                  :max-date="maxPurchaseDate"
                   :format="formatPurchaseDate"
                   input-class-name="dp-custom-input"
                   menu-class-name="dp-custom-menu"
@@ -772,7 +772,12 @@ import { usePaymentLabel } from '~/composables/usePaymentLabel'
 import { usePaymentSelectValue } from '~/composables/usePaymentSelectValue'
 import { mergePosPaymentGroupsFromApi } from '~/utils/paymentDefaults'
 
+const { todayISO, dateAtNoon, isoFromDate, timeHHMMFromISO, combineDateAndTimeISO } = useTenantTimezone()
+
 const formatPurchaseDate = (date: Date) => fnsFormat(date, 'dd/MM/yy', { locale: es })
+const tenantNowISO = () => combineDateAndTimeISO(todayISO(), timeHHMMFromISO(new Date().toISOString())) ?? new Date().toISOString()
+const purchaseDatePayloadISO = (date: Date) => dateAtNoon(isoFromDate(date)).toISOString()
+const maxPurchaseDate = computed(() => dateAtNoon(todayISO()))
 
 const route = useRoute()
 const purchaseId = route.params.id as string
@@ -839,7 +844,7 @@ const existingPaymentAttachments = computed(() =>
 // Initialize form when purchase loads
 watch(originalPurchase, (purchase) => {
   if (purchase) {
-    form.value.purchase_date = purchase.purchase_date ? new Date(purchase.purchase_date) : new Date()
+    form.value.purchase_date = purchase.purchase_date ? new Date(purchase.purchase_date) : dateAtNoon(todayISO())
     form.value.notes = purchase.notes || ''
     form.value.invoice_number = purchase.invoice_number || ''
     form.value.payment_method = purchase.payment_method || ''
@@ -1093,14 +1098,14 @@ const handleSubmit = async () => {
         unit_cost: item.unit_cost,
         notes: item.notes
       }))),
-      purchase_date: form.value.purchase_date ? form.value.purchase_date.toISOString() : null,
+      purchase_date: form.value.purchase_date ? purchaseDatePayloadISO(form.value.purchase_date) : null,
       notes: form.value.notes,
       invoice_number: form.value.invoice_number,
       payment_method: form.value.payment_method || null,
       payment_method_id: form.value.payment_method_id || null,
       payment_reference: form.value.payment_reference || null,
       payment_amount: form.value.payment_method ? Number(totalAmount.value) : null,
-      payment_date: form.value.payment_method ? new Date().toISOString() : null
+      payment_date: form.value.payment_method ? tenantNowISO() : null
     }
 
     // 2. Update Direct Purchase (PUT - JSON)

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -198,7 +198,7 @@
                     :locale="es"
                     auto-apply
                     :teleport="true"
-                    :max-date="new Date()"
+                    :max-date="maxPurchaseDate"
                     :format="formatPurchaseDate"
                     input-class-name="dp-custom-input"
                     menu-class-name="dp-custom-menu"
@@ -698,7 +698,12 @@ import { usePaymentSelectValue } from '~/composables/usePaymentSelectValue'
 import { mergePosPaymentGroupsFromApi } from '~/utils/paymentDefaults'
 import { useInlineCatalogProductLink } from '@/composables/useInlineCatalogProductLink'
 
+const { todayISO, dateAtNoon, isoFromDate, timeHHMMFromISO, combineDateAndTimeISO } = useTenantTimezone()
+
 const formatPurchaseDate = (date: Date) => fnsFormat(date, 'dd/MM/yy', { locale: es })
+const tenantNowISO = () => combineDateAndTimeISO(todayISO(), timeHHMMFromISO(new Date().toISOString())) ?? new Date().toISOString()
+const purchaseDatePayloadISO = (date: Date) => dateAtNoon(isoFromDate(date)).toISOString()
+const maxPurchaseDate = computed(() => dateAtNoon(todayISO()))
 
 useHead({
   title: 'Nueva Compra Directa - Abastecimiento'
@@ -743,7 +748,7 @@ const localPurchaseUnits = ref<LocalPurchaseUnit[]>([])
 const form = ref({
   supplier_id: '',
   payment_type: 'contado',
-  purchase_date: new Date() as Date | null,
+  purchase_date: dateAtNoon(todayISO()) as Date | null,
   notes: '',
   invoice_number: '',
   invoice_files: [] as File[],
@@ -1589,7 +1594,7 @@ const handleSubmit = async () => {
       payment_type: form.value.payment_type
     }
 
-    if (form.value.purchase_date) payload.purchase_date = form.value.purchase_date.toISOString()
+    if (form.value.purchase_date) payload.purchase_date = purchaseDatePayloadISO(form.value.purchase_date)
     if (form.value.notes) payload.notes = form.value.notes
     if (form.value.invoice_number) payload.invoice_number = form.value.invoice_number
     if (form.value.payment_method) {
@@ -1598,7 +1603,7 @@ const handleSubmit = async () => {
         payload.payment_method_id = form.value.payment_method_id
       }
       payload.payment_amount = totalAmount.value
-      payload.payment_date = new Date().toISOString()
+      payload.payment_date = tenantNowISO()
     }
     if (form.value.payment_reference) payload.payment_reference = form.value.payment_reference
 

--- a/pages/analitica/clientes/index.vue
+++ b/pages/analitica/clientes/index.vue
@@ -13,7 +13,7 @@ const { setRefreshHandler, clearRefreshHandler, setLastUpdateText, registerProgr
 const lastUpdate = ref<Date>(new Date());
 
 // ── Filters ──────────────────────────────────────────────────────────────
-const dateRangeDates = ref<Date[] | null>(null);
+const { dateRangeDates, presetDates, maxDate, formatDateRange, dateRange } = useDateRangePresets()
 
 // ── Search ────────────────────────────────────────────────────────────────
 const searchQuery = ref('')
@@ -30,29 +30,6 @@ watch(searchQuery, () => {
   isSearchPending.value = !!searchQuery.value.trim()
   commitSearch()
 })
-
-const presetDates = ref([
-  { label: 'Hoy', value: [new Date(), new Date()] },
-  { label: 'Ayer', value: (() => { const d = new Date(); d.setDate(d.getDate() - 1); return [d, d] })() },
-  { label: 'Última semana', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 7); return d })(), new Date()] },
-  { label: 'Últimos 15 días', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 15); return d })(), new Date()] },
-  { label: 'Último mes', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 30); return d })(), new Date()] },
-  { label: 'Últimos 90 días', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 90); return d })(), new Date()] },
-]);
-
-const formatDateRange = (dates: Date[]) => {
-  if (!dates || !dates[0]) return ''
-  const from = fnsFormat(dates[0], 'dd/MM/yy', { locale: es })
-  if (!dates[1]) return from
-  return `${from} - ${fnsFormat(dates[1], 'dd/MM/yy', { locale: es })}`
-};
-
-const dateRange = computed(() => {
-  if (!dateRangeDates.value || dateRangeDates.value.length < 2) return { from: null, to: null }
-  const [from, to] = dateRangeDates.value
-  if (!from || !to) return { from: null, to: null }
-  return { from: fnsFormat(from, 'yyyy-MM-dd'), to: fnsFormat(to, 'yyyy-MM-dd') }
-});
 
 // ── Pagination ────────────────────────────────────────────────────────────
 const currentPage = ref(1)
@@ -228,7 +205,7 @@ onUnmounted(() => {
             placeholder="Rango de fechas"
             auto-apply
             :teleport="true"
-            :max-date="new Date()"
+            :max-date="maxDate"
             :format="formatDateRange"
             input-class-name="dp-custom-input"
             menu-class-name="dp-custom-menu"

--- a/pages/analitica/rentabilidad.vue
+++ b/pages/analitica/rentabilidad.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch, onMounted, onUnmounted } from 'vue'
 import { es } from 'date-fns/locale'
-import { format as fnsFormat, formatDistanceToNow } from 'date-fns'
+import { formatDistanceToNow } from 'date-fns'
 import HealthSemaphore from '~/components/analytics/HealthSemaphore.vue'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
@@ -11,30 +11,7 @@ const { currentTenant } = useTenantReactive()
 const lastUpdate = ref<Date>(new Date())
 const lastUpdateText = computed(() => formatDistanceToNow(lastUpdate.value, { addSuffix: true, locale: es }))
 
-const dateRangeDates = ref<Date[] | null>(null)
-
-const presetDates = ref([
-  { label: 'Hoy', value: [new Date(), new Date()] },
-  { label: 'Ayer', value: (() => { const d = new Date(); d.setDate(d.getDate() - 1); return [d, d] })() },
-  { label: 'Última semana', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 7); return d })(), new Date()] },
-  { label: 'Últimos 15 días', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 15); return d })(), new Date()] },
-  { label: 'Último mes', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 30); return d })(), new Date()] },
-  { label: 'Últimos 90 días', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 90); return d })(), new Date()] },
-])
-
-const formatDateRange = (dates: Date[]) => {
-  if (!dates || !dates[0]) return ''
-  const from = fnsFormat(dates[0], 'dd/MM/yy', { locale: es })
-  if (!dates[1]) return from
-  return `${from} - ${fnsFormat(dates[1], 'dd/MM/yy', { locale: es })}`
-}
-
-const dateRange = computed(() => {
-  if (!dateRangeDates.value || dateRangeDates.value.length < 2) return { from: null, to: null }
-  const [from, to] = dateRangeDates.value
-  if (!from || !to) return { from: null, to: null }
-  return { from: fnsFormat(from, 'yyyy-MM-dd'), to: fnsFormat(to, 'yyyy-MM-dd') }
-})
+const { dateRangeDates, presetDates, maxDate, formatDateRange, dateRange } = useDateRangePresets()
 
 const { data: foodCostData, status: foodCostStatus, asyncStatus: foodCostAsyncStatus, error: foodCostError, refetch: refetchFoodCost } = useQuery({
   key: () => ['analytics', 'food-cost', currentTenant.value?.id, { from: dateRange.value.from, to: dateRange.value.to }],
@@ -181,7 +158,7 @@ onUnmounted(() => {
           placeholder="Rango de fechas"
           auto-apply
           :teleport="true"
-          :max-date="new Date()"
+          :max-date="maxDate"
           :format="formatDateRange"
           input-class-name="dp-custom-input"
           menu-class-name="dp-custom-menu"

--- a/pages/analitica/ventas.vue
+++ b/pages/analitica/ventas.vue
@@ -13,30 +13,7 @@ const currentTime = ref<Date>(new Date());
 
 const paymentMethodFilter = ref<string | null>(null);
 const statusFilter = ref<string | null>(null);
-const dateRangeDates = ref<Date[] | null>(null);
-
-const presetDates = ref([
-  { label: 'Hoy', value: [new Date(), new Date()] },
-  { label: 'Ayer', value: (() => { const d = new Date(); d.setDate(d.getDate() - 1); return [d, d] })() },
-  { label: 'Última semana', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 7); return d })(), new Date()] },
-  { label: 'Últimos 15 días', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 15); return d })(), new Date()] },
-  { label: 'Último mes', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 30); return d })(), new Date()] },
-  { label: 'Últimos 90 días', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 90); return d })(), new Date()] },
-]);
-
-const formatDateRange = (dates: Date[]) => {
-  if (!dates || !dates[0]) return ''
-  const from = fnsFormat(dates[0], 'dd/MM/yy', { locale: es })
-  if (!dates[1]) return from
-  return `${from} - ${fnsFormat(dates[1], 'dd/MM/yy', { locale: es })}`
-};
-
-const dateRange = computed(() => {
-  if (!dateRangeDates.value || dateRangeDates.value.length < 2) return { from: null, to: null }
-  const [from, to] = dateRangeDates.value
-  if (!from || !to) return { from: null, to: null }
-  return { from: fnsFormat(from, 'yyyy-MM-dd'), to: fnsFormat(to, 'yyyy-MM-dd') }
-});
+const { dateRangeDates, presetDates, maxDate, formatDateRange, dateRange } = useDateRangePresets()
 
 const hasDateFilter = computed(() =>
   dateRangeDates.value && dateRangeDates.value.length === 2 && dateRangeDates.value[0] && dateRangeDates.value[1]
@@ -289,7 +266,7 @@ const formatCurrency = (value: number) =>
           placeholder="Rango de fechas"
           auto-apply
           :teleport="true"
-          :max-date="new Date()"
+          :max-date="maxDate"
           :format="formatDateRange"
           input-class-name="dp-custom-input"
           menu-class-name="dp-custom-menu"

--- a/pages/cocina/[id].vue
+++ b/pages/cocina/[id].vue
@@ -46,15 +46,16 @@ watch(station, (s) => {
 useHead({ title: computed(() => station.value ? `KDS · ${station.value.name}` : 'KDS') })
 
 // ── Comandas fetch ──────────────────────────────────────────────────────────
-const today = new Date().toISOString().split('T')[0]
+const { todayISO } = useTenantTimezone()
+const today = computed(() => todayISO())
 
 const { data: comandasData, status: comandasStatus, asyncStatus: comandasAsyncStatus, refetch } = useQuery({
-  key: () => ['kds-comandas', stationId.value],
+  key: () => ['kds-comandas', stationId.value, today.value],
   query: () => $fetch<{ success: boolean; data: any[] }>('/api/api/comandas', {
     params: {
       station_id: stationId.value,
       status: 'pending,preparing,ready',
-      date: today,
+      date: today.value,
       token: kdsToken.value || undefined,
     },
   }),

--- a/pages/pagos/index.vue
+++ b/pages/pagos/index.vue
@@ -276,6 +276,7 @@ if (route.query.highlight) {
 
 // Tenant reactivity
 const { currentTenant } = useTenantReactive()
+const { todayISO } = useTenantTimezone()
 
 // Fetch suppliers (static lookup per tenant)
 const { data: suppliersData } = useQuery({
@@ -517,9 +518,8 @@ function formatCurrency(value: number): string {
 
 function isOverdue(dueDate: string | null | undefined): boolean {
   if (!dueDate) return false
-  const today = new Date()
-  const due = new Date(dueDate)
-  return due < today
+  const dueIso = dueDate.match(/^\d{4}-\d{2}-\d{2}/)?.[0]
+  return !!dueIso && dueIso < todayISO()
 }
 
 // Selection functions


### PR DESCRIPTION
## Summary
- migrate analytics date presets to shared tenant-aware range helpers
- use tenant today for KDS/comandas and overdue payment comparisons
- convert direct-purchase and payment dates through tenant timezone helpers

## Tests
- git diff --check
- build skipped per request (sin build)

Closes uno0uno/api-warolabs#543