### PR TITLE
Fix template shift close date anchor

### DIFF
--- a/composables/useCierreShiftWindow.ts
+++ b/composables/useCierreShiftWindow.ts
@@ -27,7 +27,6 @@ export function buildCierreCloseRoute(
       mode: 'template',
       template: row.shiftTemplateId,
       start,
-      end,
     })
     return `/finanzas/arqueo/z?${q.toString()}`
   }

--- a/pages/finanzas/arqueo/apertura.vue
+++ b/pages/finanzas/arqueo/apertura.vue
@@ -394,7 +394,7 @@ const closeLink = computed(() => {
     return `/finanzas/arqueo/z?${q.toString()}`
   }
   if (!effectiveTemplateId.value) return null
-  return `/finanzas/arqueo/z?mode=template&start=${periodStart.value}&end=${periodEnd.value}&template=${effectiveTemplateId.value}`
+  return `/finanzas/arqueo/z?mode=template&start=${periodStart.value}&template=${effectiveTemplateId.value}`
 })
 
 const closeLinkLabel = computed(() =>

--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -124,7 +124,7 @@
                 </div>
               </NuxtLink>
               <NuxtLink
-                :to="`/finanzas/arqueo/z?mode=template&start=${today}&end=${today}`"
+                :to="`/finanzas/arqueo/z?mode=template&start=${today}`"
                 class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/20 bg-surface hover:border-primary/40 hover:bg-primary/5 transition-colors min-h-[44px]"
               >
                 <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
@@ -170,7 +170,7 @@
             </div>
           </NuxtLink>
           <NuxtLink
-            :to="`/finanzas/arqueo/z?mode=template&start=${today}&end=${today}`"
+            :to="`/finanzas/arqueo/z?mode=template&start=${today}`"
             class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/20 bg-surface hover:border-primary/40 hover:bg-primary/5 transition-colors min-h-[44px]"
           >
             <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -979,7 +979,9 @@ const today = todayISO()
 
 // ── Date picker state (paso 0) ─────────────────────────────────────────────
 const initStart = (route.query.start as string) || today
-const initEnd   = (route.query.end   as string) || today
+const initEnd = arqueoWindowMode.value === 'template'
+  ? initStart
+  : ((route.query.end as string) || today)
 
 const dateRangeDates = ref<Date[]>([
   dateAtNoon(initStart),


### PR DESCRIPTION
## Summary
- use a single anchor date for template shift close links
- normalize cierre Z template URLs so start/end ranges collapse to the opening date
- keep custom window start/end behavior unchanged

## Tests
- git diff --check
- build skipped per request (sin build)

## Manual validation
- Open /finanzas/arqueo/z?mode=template&template=4f644c6a-9347-4bd8-b2d5-2fe34a33b4a6&start=2026-06-26&end=2026-06-27 and confirm the selected template day is 2026-06-26 and it does not falsely ask to open the turno.
- From /finanzas/arqueo, click Cerrar on an open template shift and confirm it lands on the opening/anchor day.

Closes #1474