### PR TITLE
Validar directorio y sitemap para municipios

### DIFF
--- a/components/directory/DirectoryView.vue
+++ b/components/directory/DirectoryView.vue
@@ -37,6 +37,8 @@ const {
 
 const restaurants = computed(() => (responseData.value as { data?: unknown[] } | null)?.data ?? [])
 const error = computed(() => (fetchError.value as { message?: string } | null)?.message ?? null)
+const hasRestaurants = computed(() => restaurants.value.length > 0)
+const isEmptyDirectory = computed(() => !pending.value && !error.value && !hasRestaurants.value)
 
 useSeoMeta({
   title: () => `Restaurantes en ${cityName.value} - Waro Colombia`,
@@ -53,9 +55,12 @@ useSeoMeta({
   twitterDescription: () => `Descubre los mejores restaurantes en ${cityName.value}.`,
 })
 
-useHead({
-  link: [{ rel: 'canonical', href: () => `${siteUrl}/${props.citySlug}` }],
-})
+useHead(() => ({
+  link: [{ rel: 'canonical', href: `${siteUrl}/${props.citySlug}` }],
+  meta: isEmptyDirectory.value
+    ? [{ name: 'robots', content: 'noindex,follow' }]
+    : [],
+}))
 </script>
 
 <template>
@@ -77,7 +82,7 @@ useHead({
           Descubre los mejores restaurantes de la ciudad
         </p>
         <span
-          v-if="!pending && restaurants.length > 0"
+          v-if="!pending && hasRestaurants"
           class="inline-block px-4 py-1.5 bg-surface/20 backdrop-blur-sm rounded-full text-sm font-semibold text-action-primary-text"
         >
           {{ restaurants.length }} restaurante{{ restaurants.length !== 1 ? 's' : '' }}
@@ -109,7 +114,7 @@ useHead({
     </div>
 
     <!-- Restaurants Grid -->
-    <div v-else-if="restaurants.length > 0" class="max-w-6xl mx-auto px-4 py-10">
+    <div v-else-if="hasRestaurants" class="max-w-6xl mx-auto px-4 py-10">
       <div class="flex items-center gap-4 mb-8">
         <h2 class="text-xl font-semibold text-foreground whitespace-nowrap">
           Todos los restaurantes · {{ cityName }}

--- a/docs/usuarios/negocio.md
+++ b/docs/usuarios/negocio.md
@@ -30,12 +30,12 @@ Define cómo te ven los clientes que te encuentran en WARO o en tu enlace direct
 
 ## Visibilidad en el directorio
 
-Toggle que controla si tu negocio aparece listado en `warocol.com/{ciudad}` para que clientes nuevos te descubran.
+Toggle que controla si tu negocio aparece listado en `warocol.com/{ciudad-o-municipio}` para que clientes nuevos te descubran.
 
-- **Activado** — apareces en el directorio público de tu ciudad.
+- **Activado** — apareces en el directorio público de tu ciudad o municipio cuando tu perfil está listo para mostrarse.
 - **Desactivado** — solo te encuentran quienes tengan tu enlace directo.
 
-> Si activas el directorio pero **no tienes ciudad seleccionada**, aparece una advertencia. Sin ciudad no apareces en ningún listado.
+> Si activas el directorio pero **no tienes ciudad o municipio seleccionado**, aparece una advertencia. Sin ubicación no apareces en ningún listado.
 
 ---
 
@@ -57,7 +57,7 @@ Comparte este link en tus redes y QR para que los clientes hagan pedidos online.
 | **Dirección** | Calle, número, complemento |
 | **Barrio** | Zona del local |
 | **País** | Bloqueado en Colombia |
-| **Ciudad** | Obligatoria si quieres aparecer en el directorio. Se elige de un catálogo |
+| **Ciudad o municipio** | Obligatorio si quieres aparecer en el directorio. Se elige del catálogo de Colombia |
 | **Teléfono** | Para que clientes te contacten |
 | **Email** | Para comunicaciones del negocio |
 
@@ -103,8 +103,8 @@ Links a tus cuentas. Aparecen como íconos en tu storefront público.
 
 ## Preguntas frecuentes
 
-**¿Por qué mi negocio no aparece en `warocol.com/{ciudad}`?**
-Revisa: (1) que la **ciudad** esté seleccionada, (2) que el toggle **Visibilidad en el directorio** esté activo, y (3) que tengas al menos un horario abierto en la semana.
+**¿Por qué mi negocio no aparece en `warocol.com/{ciudad-o-municipio}`?**
+Revisa: (1) que la **ciudad o municipio** esté seleccionada, (2) que el toggle **Visibilidad en el directorio** esté activo, y (3) que tengas al menos un horario abierto en la semana.
 
 **¿Puedo recibir pedidos sin tener menú en línea?**
 Necesitas tener al menos productos publicados en el [Menú](./menu) para que aparezcan en tu storefront.

--- a/pages/[tenant]/index.vue
+++ b/pages/[tenant]/index.vue
@@ -312,8 +312,8 @@ const cancelSwitch = () => {
 </script>
 
 <template>
-  <!-- City directory dispatch (warocol.com#615). When the URL slug matches an
-       active public_cities entry, render the generic directory instead of the
+  <!-- City directory dispatch (warocol.com#615). When the URL slug matches a
+       known public_cities entry, render the generic directory instead of the
        tenant profile. The catalog is prefetched on SSR so this branches
        synchronously and Vue does not see a hydration mismatch. -->
   <NuxtLayout v-if="isCity" name="default">

--- a/pages/ciudades.vue
+++ b/pages/ciudades.vue
@@ -4,9 +4,10 @@ import { MapPinIcon } from '@heroicons/vue/24/outline'
 import { useCityCatalog, type PublicCity } from '~/composables/useCityCatalog'
 
 /**
- * Directory hub (warocol.com#619). Lists every city in the curated
- * `public_cities` catalog: cities with active tenants get a count badge;
- * cities seeded for future expansion get a muted "Próximamente" tag.
+ * Directory hub (warocol.com#619). Lists cities/municipalities in the
+ * `public_cities` catalog only when they have active tenants. Empty catalog
+ * rows remain valid for operators and direct routes, but are not mass-linked
+ * here.
  *
  * The hub complements the discovery section on `/` — that one is a
  * marketing teaser, this one is the canonical entry point linked from
@@ -40,11 +41,12 @@ const CITY_VISUALS: Record<string, { displayName: string; imageUrl: string }> = 
 const cityDisplayName = (city: PublicCity) => CITY_VISUALS[city.city_slug]?.displayName ?? city.city
 const cityImageUrl = (city: PublicCity) => CITY_VISUALS[city.city_slug]?.imageUrl ?? null
 
-// The SSR plugin already prefetches with include_empty=true, so the
-// catalog is populated by the time this page renders. Sort: active first,
-// then by sort_order from the backend (already applied server-side).
+// The SSR plugin already prefetches with include_empty=true, so the catalog is
+// populated by the time this page renders. Only link populated directories:
+// sitemap.xml uses the same active-only intent with include_empty=false.
 const activeCities = computed(() => cities.value.filter((c) => c.tenant_count > 0))
 const upcomingCities = computed(() => cities.value.filter((c) => c.tenant_count === 0))
+const hasHiddenUpcomingCities = computed(() => upcomingCities.value.length > 0)
 
 useSeoMeta({
   title: 'Ciudades · WaRo Colombia',
@@ -70,7 +72,7 @@ useHead({
     <section class="ciudades-hero">
       <h1 class="ciudades-title font-quantico">RESTAURANTES POR CIUDAD</h1>
       <p class="ciudades-subtitle">
-        Descubre los restaurantes en cada ciudad donde WaRo está presente.
+        Descubre restaurantes en las ciudades y municipios donde WaRo está presente.
       </p>
     </section>
 
@@ -113,43 +115,11 @@ useHead({
       </div>
     </section>
 
-    <!-- Upcoming cities -->
-    <section v-if="upcomingCities.length > 0" class="ciudades-section">
-      <h2 class="ciudades-section-title">
-        <MapPinIcon class="ciudades-section-icon" aria-hidden="true" />
-        Próximamente
-      </h2>
-      <div class="ciudades-row">
-        <NuxtLink
-          v-for="city in upcomingCities"
-          :key="city.city_slug"
-          :to="`/${city.city_slug}`"
-          class="city-card city-card--upcoming"
-        >
-          <div class="city-card__image">
-            <div
-              :class="[
-                'city-card__gradient',
-                cityImageUrl(city) ? '' : 'city-card__gradient--upcoming',
-              ]"
-            >
-              <img
-                v-if="cityImageUrl(city)"
-                :src="cityImageUrl(city) || undefined"
-                alt=""
-                aria-hidden="true"
-                class="city-card__photo"
-              >
-              <span class="city-card__overlay-name">{{ cityDisplayName(city) }}</span>
-            </div>
-            <span class="city-card__badge">Próximamente</span>
-          </div>
-          <div class="city-card__meta">
-            <MapPinIcon class="city-card__meta-icon" aria-hidden="true" />
-            <span class="city-card__meta-text">{{ cityDisplayName(city) }}, {{ city.country }}</span>
-          </div>
-        </NuxtLink>
-      </div>
+    <section v-if="hasHiddenUpcomingCities" class="ciudades-note">
+      <MapPinIcon class="ciudades-note__icon" aria-hidden="true" />
+      <p>
+        El catálogo de WARO cubre municipios de Colombia. Aquí solo enlazamos lugares con restaurantes activos.
+      </p>
     </section>
 
     <!-- Defensive empty state (only fires if the catalog is unreachable) -->
@@ -266,13 +236,6 @@ useHead({
   outline: 2px solid hsl(262, 83%, 58%);
   outline-offset: 2px;
 }
-.city-card--upcoming {
-  opacity: 0.85;
-}
-.city-card--upcoming:hover {
-  opacity: 1;
-}
-
 /* Image area inside the card. Uses uploaded city artwork when available,
    otherwise falls back to the previous gradient placeholder. */
 .city-card__image {
@@ -307,10 +270,6 @@ useHead({
     linear-gradient(180deg, rgba(15, 23, 42, 0.04) 0%, rgba(15, 23, 42, 0.42) 100%),
     radial-gradient(circle at 70% 110%, rgba(255,255,255,0.18), transparent 55%);
   pointer-events: none;
-}
-.city-card__gradient--upcoming {
-  background:
-    linear-gradient(160deg, hsl(220, 18%, 70%) 0%, hsl(220, 14%, 45%) 100%);
 }
 .city-card__overlay-name {
   position: relative;
@@ -352,21 +311,6 @@ useHead({
   color: hsl(250, 10%, 35%);
 }
 
-/* "Próximamente" badge bottom-right (upcoming cities) */
-.city-card__badge {
-  position: absolute;
-  bottom: 12px;
-  right: 12px;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(4px);
-  color: hsl(28, 80%, 32%);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-}
-
 /* Meta row: pin + location text. */
 .city-card__meta {
   display: flex;
@@ -385,6 +329,28 @@ useHead({
   font-weight: 500;
   color: hsl(250, 30%, 30%);
   line-height: 1.25;
+}
+
+.ciudades-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  max-width: 680px;
+  margin: 8px auto 48px;
+  padding: 16px 18px;
+  border: 1px solid hsl(220, 14%, 88%);
+  border-radius: 8px;
+  background: #ffffff;
+  color: hsl(250, 10%, 35%);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+.ciudades-note__icon {
+  width: 20px;
+  height: 20px;
+  flex: 0 0 auto;
+  margin-top: 1px;
+  color: hsl(262, 83%, 58%);
 }
 
 /* Empty (defensive) */

--- a/server/routes/sitemap.xml.ts
+++ b/server/routes/sitemap.xml.ts
@@ -68,9 +68,9 @@ export default defineEventHandler(async (event) => {
     console.error('Error fetching restaurants for sitemap:', error)
   }
 
-  // URLs de directorios por ciudad (warocol.com#615) — un entry por ciudad
-  // con tenants activos. Sin estas entries el directorio /<ciudad> existe
-  // pero no llega a Google.
+  // URLs de directorios por ciudad/municipio (warocol.com#615) — solo
+  // entries con tenants activos. Los municipios vacios pueden resolver por
+  // ruta directa, pero no se indexan masivamente desde el sitemap.
   let cityUrls: Array<{ loc: string; lastmod: string; changefreq: string; priority: string }> = []
   try {
     const fetchHeaders = { 'Origin': siteUrl, 'Referer': `${siteUrl}/` }


### PR DESCRIPTION
## Summary
- Hide zero-tenant municipalities from the public /ciudades card grid while keeping active city links visible.
- Add noindex,follow to direct empty municipality directory pages.
- Clarify Mi Negocio docs around ciudad o municipio directory selection.

## Validation
- git diff --check
- Build intentionally not run per request: sin build.

Closes #1479