### PR TITLE
Fix POS tenant timezone display

### DIFF
--- a/components/pos/CartItem.vue
+++ b/components/pos/CartItem.vue
@@ -213,6 +213,7 @@ const props = withDefaults(defineProps<Props>(), {
 })
 defineEmits<Emits>()
 
+const { timezone } = useTenantTimezone()
 const hideEdit = computed(() => props.hideEdit || props.hideEditDuplicate)
 const hideDuplicate = computed(() => props.hideDuplicate || props.hideEditDuplicate)
 
@@ -257,6 +258,7 @@ const formatTime = (isoString: string) => {
   return new Date(isoString).toLocaleTimeString('es-CO', {
     hour: '2-digit',
     minute: '2-digit',
+    timeZone: timezone.value,
   })
 }
 </script>

--- a/components/pos/ComandaPrintTickets.vue
+++ b/components/pos/ComandaPrintTickets.vue
@@ -8,8 +8,14 @@ const props = defineProps<{
   businessName?: string
 }>()
 
+const { timezone } = useTenantTimezone()
+
 function modifierLines(item: ComandaPrintPayload['items'][0]) {
   return item.modifiers_snapshot ?? []
+}
+
+function formatTicketTime(firedAt?: string | null) {
+  return formatComandaPrintTime(firedAt, timezone.value)
 }
 
 const printTicket = computed(() => {
@@ -59,7 +65,7 @@ const printTicket = computed(() => {
     >
       <div class="receipt-header">{{ businessName || 'WARO' }}</div>
       <div class="receipt-row receipt-small">*** COMANDA POS ***</div>
-      <div class="receipt-row receipt-small">{{ formatComandaPrintTime(printTicket.firedAt) }}</div>
+      <div class="receipt-row receipt-small">{{ formatTicketTime(printTicket.firedAt) }}</div>
       <div v-if="printTicket.tableDisplayName" class="receipt-row receipt-small">
         {{ printTicket.tableDisplayName }}
       </div>

--- a/composables/useComandaPrint.ts
+++ b/composables/useComandaPrint.ts
@@ -2,6 +2,8 @@
  * Kitchen comanda ticket printing (#753) — browser print via hidden DOM + body class.
  */
 
+import { DEFAULT_TENANT_TIMEZONE, normalizeTimezone } from '~/utils/bogotaDate'
+
 export type ComandaModifierSnapshot = {
   name: string
   price?: number
@@ -44,11 +46,16 @@ export type ComandaPrintPayload = {
   items: ComandaPrintItem[]
 }
 
-export function formatComandaPrintTime(firedAt?: string | null): string {
+export function formatComandaPrintTime(
+  firedAt?: string | null,
+  timezone = DEFAULT_TENANT_TIMEZONE,
+): string {
+  const timeZone = normalizeTimezone(timezone)
   if (!firedAt) {
     return new Intl.DateTimeFormat('es-CO', {
       dateStyle: 'short',
       timeStyle: 'short',
+      timeZone,
     }).format(new Date())
   }
   const d = new Date(firedAt)
@@ -56,6 +63,7 @@ export function formatComandaPrintTime(firedAt?: string | null): string {
   return new Intl.DateTimeFormat('es-CO', {
     dateStyle: 'short',
     timeStyle: 'short',
+    timeZone,
   }).format(d)
 }
 

--- a/pages/negocio.vue
+++ b/pages/negocio.vue
@@ -1006,6 +1006,12 @@ const TIMEZONE_OPTIONS = [
   { value: 'America/Caracas', label: 'Venezuela - Caracas (UTC-4)' },
   { value: 'America/Santiago', label: 'Chile - Santiago' },
   { value: 'America/New_York', label: 'Estados Unidos - New York' },
+  { value: 'Europe/Madrid', label: 'Espana - Madrid' },
+  { value: 'Asia/Kathmandu', label: 'Nepal - Kathmandu (UTC+5:45)' },
+  { value: 'Australia/Adelaide', label: 'Australia - Adelaide' },
+  { value: 'Pacific/Apia', label: 'Samoa - Apia' },
+  { value: 'Pacific/Kiritimati', label: 'Kiribati - Kiritimati (UTC+14)' },
+  { value: 'Pacific/Pago_Pago', label: 'Samoa Americana - Pago Pago (UTC-11)' },
 ]
 const { zonedParts, normalizeTimezone } = useTenantTimezone()
 

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -42,8 +42,17 @@ const posStore = usePOSStore()
 const cache = useQueryCache()
 const toast = useToast()
 const { currentTenant, businessProfile } = useTenantReactive()
+const { timezone } = useTenantTimezone()
 const { singular: tableSingular } = useTableLabel()
 const tableSingularLower = computed(() => tableSingular.value.toLowerCase())
+
+function formatTenantDateTime(date = new Date()) {
+  return date.toLocaleString('es-CO', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+    timeZone: timezone.value,
+  })
+}
 
 function invalidateCheckoutPromoPreview() {
   cache.invalidateQueries({ key: ['pos', 'cart', posStore.cartId ?? null, 'tax-preview'] })
@@ -2531,7 +2540,7 @@ function captureReceiptPrintContext(opts?: { singleCashReceived?: number | null;
   const customer = selectedCustomer.value
   const tableName = session?.tableName ?? null
   receiptPrintContext.value = {
-    soldAt: new Date().toLocaleString('es-CO', { dateStyle: 'short', timeStyle: 'short' }),
+    soldAt: formatTenantDateTime(),
     wasMesa: wasMesaMode.value || isMesaMode.value,
     isBar: session?.isBar ?? false,
     tableName,
@@ -2555,7 +2564,7 @@ function captureReceiptPrintContext(opts?: { singleCashReceived?: number | null;
 // exposed (#pos-prefactura instead of the default #pos-receipt). The post-
 // payment receipt path is undisturbed.
 const prefacturaDateTime = computed(() =>
-  new Date().toLocaleString('es-CO', { dateStyle: 'short', timeStyle: 'short' })
+  formatTenantDateTime()
 )
 // Prefactura is purely visual — never block on tax preview state. If taxes
 // haven't loaded (or the tenant has no taxes configured), the prefactura


### PR DESCRIPTION
## Summary
- Format POS fire timestamps with the tenant timezone
- Format comanda, receipt, and prefactura print timestamps with the tenant timezone
- Add validation timezones to the business timezone selector

## Validation
- git diff --check
- Intl check for America/Bogota vs Pacific/Kiritimati vs Pacific/Pago_Pago
- npm run build: client build completed; SSR phase was manually stopped after no output for several minutes