### PR TITLE
Fix tenant timezone and promotion UI flows

### DIFF
--- a/components/Finanzas/contabilidad/AsientoDetailPanel.vue
+++ b/components/Finanzas/contabilidad/AsientoDetailPanel.vue
@@ -48,6 +48,7 @@ const emit = defineEmits<{
 }>()
 
 const close = () => emit('update:modelValue', false)
+const { formatDateTime } = useFormatters()
 
 const formatCOP = (v: number) =>
   new Intl.NumberFormat('es-CO', {
@@ -338,10 +339,10 @@ watch(
             <!-- Timestamps -->
             <div class="text-xs text-text-secondary space-y-1 pt-2 border-t border-border/50">
               <p v-if="entry.postedAt">
-                <span class="font-medium">Publicado:</span> {{ new Date(entry.postedAt).toLocaleString('es-CO') }}
+                <span class="font-medium">Publicado:</span> {{ formatDateTime(entry.postedAt) }}
               </p>
               <p v-if="entry.voidedAt">
-                <span class="font-medium text-destructive">Anulado:</span> {{ new Date(entry.voidedAt).toLocaleString('es-CO') }}
+                <span class="font-medium text-destructive">Anulado:</span> {{ formatDateTime(entry.voidedAt) }}
               </p>
             </div>
 

--- a/components/promociones/PromocionPanel.vue
+++ b/components/promociones/PromocionPanel.vue
@@ -334,7 +334,7 @@
               type="button"
               :disabled="isSaving"
               class="h-10 w-full rounded-lg border border-destructive/40 text-sm font-medium text-destructive hover:bg-destructive/5 transition-colors focus:outline-none focus:ring-2 focus:ring-destructive/20 disabled:opacity-50"
-              @click="onDelete"
+              @click="openDeleteConfirm"
             >
               Eliminar promoción
             </button>
@@ -348,6 +348,18 @@
       :products="selectedProducts"
       @remove="removeProduct"
       @clear-all="clearAllProducts"
+    />
+
+    <PosDestructiveReasonModal
+      v-model="deleteConfirmOpen"
+      :title="deleteConfirmTitle"
+      message="Se eliminará la promoción y el motivo quedará registrado en la bitácora de operaciones."
+      confirm-label="Sí, eliminar"
+      reason-placeholder="Ej: promoción vencida, regla duplicada, campaña finalizada"
+      :loading="isSaving"
+      :error="deleteError"
+      @confirm="onDelete"
+      @cancel="cancelDeleteConfirm"
     />
   </Teleport>
 </template>
@@ -406,9 +418,10 @@ const emit = defineEmits<Emits>()
 const toast = useToast()
 const cache = useQueryCache()
 const { currentTenant } = useTenantReactive()
-const { combineDateAndTimeISO, dateAtNoon } = useTenantTimezone()
+const { combineDateAndTimeISO, dateAtNoon, isoFromDate } = useTenantTimezone()
 
 const isEdit = computed(() => !!props.promotionId)
+const deleteConfirmTitle = computed(() => form.name.trim() ? `¿Eliminar ${form.name.trim()}?` : '¿Eliminar promoción?')
 const inputClass = 'h-10 w-full rounded-lg border-2 border-border bg-background px-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 transition-colors'
 
 const promoTypeOptions: {
@@ -477,6 +490,8 @@ const validationErrors = ref<string[]>([])
 const isSaving = ref(false)
 const loadError = ref(false)
 const loadingPromotion = ref(false)
+const deleteConfirmOpen = ref(false)
+const deleteError = ref('')
 
 function resetForm() {
   form.name = ''
@@ -495,6 +510,8 @@ function resetForm() {
   selectedProducts.value = []
   scopePickerOpen.value = false
   validationErrors.value = []
+  deleteConfirmOpen.value = false
+  deleteError.value = ''
   loadError.value = false
 }
 
@@ -531,8 +548,8 @@ async function loadPromotion(id: string) {
         end_time: (s.end_time || '18:00').slice(0, 5),
         crosses_midnight: !!s.crosses_midnight,
       }))
-    form.startsAtDate = p.starts_at ? p.starts_at.slice(0, 10) : ''
-    form.endsAtDate = p.ends_at ? p.ends_at.slice(0, 10) : ''
+    form.startsAtDate = p.starts_at ? isoFromDate(new Date(p.starts_at)) : ''
+    form.endsAtDate = p.ends_at ? isoFromDate(new Date(p.ends_at)) : ''
     const cats = catsRes.data ?? []
     selectedCategories.value = (p.category_ids ?? [])
       .map((cid: string) => cats.find((c) => c.id === cid))
@@ -781,17 +798,35 @@ async function onSubmit() {
   }
 }
 
-async function onDelete() {
-  if (!props.promotionId || !confirm('¿Eliminar esta promoción?')) return
+function openDeleteConfirm() {
+  if (!props.promotionId || isSaving.value) return
+  deleteError.value = ''
+  deleteConfirmOpen.value = true
+}
+
+function cancelDeleteConfirm() {
+  if (isSaving.value) return
+  deleteError.value = ''
+  deleteConfirmOpen.value = false
+}
+
+async function onDelete(reason: string) {
+  if (!props.promotionId) return
   isSaving.value = true
+  deleteError.value = ''
   try {
-    await $fetch(`/api/api/promotions/${props.promotionId}`, { method: 'DELETE' })
+    await $fetch(`/api/api/promotions/${props.promotionId}`, {
+      method: 'DELETE',
+      body: { reason: reason.trim() },
+    })
     toast.success('Promoción eliminada')
     await invalidatePromotionCaches()
+    deleteConfirmOpen.value = false
     close()
     emit('deleted')
   } catch (e: any) {
-    toast.error(e?.data?.detail ?? 'No se pudo eliminar', { title: 'Error' })
+    deleteError.value = e?.data?.detail ?? 'No se pudo eliminar'
+    toast.error(deleteError.value, { title: 'Error' })
   } finally {
     isSaving.value = false
   }

--- a/composables/useActivePromotions.ts
+++ b/composables/useActivePromotions.ts
@@ -25,7 +25,8 @@ function tenantNowParts(now = new Date(), timezone = DEFAULT_TENANT_TIMEZONE) {
     Sun: 6,
   }
   const weekday = weekdayMap[parts.weekday ?? ''] ?? 0
-  const [hour, minute] = parts.hour.split(':').map(Number)
+  const hour = Number(parts.hour)
+  const minute = Number(parts.minute)
   return { weekday, minutes: hour * 60 + minute }
 }
 

--- a/composables/useOperationEvents.ts
+++ b/composables/useOperationEvents.ts
@@ -42,6 +42,7 @@ export const OPERATION_EVENT_ACTIONS = [
   'cart_cleared',
   'payment_voided',
   'comanda_line_cancelled',
+  'promotion_deleted',
 ] as const
 
 export const ACTION_LABELS: Record<string, string> = {
@@ -55,6 +56,7 @@ export const ACTION_LABELS: Record<string, string> = {
   cart_cleared: 'Carrito vaciado',
   payment_voided: 'Pago anulado',
   comanda_line_cancelled: 'Línea de comanda cancelada',
+  promotion_deleted: 'Promoción eliminada',
 }
 
 export const CHANNEL_LABELS: Record<string, string> = {
@@ -93,6 +95,13 @@ export function formatOperationEventSummary(
   if (action === 'tab_cleared' || action === 'cart_cleared') {
     const count = payload.items_count as number | undefined
     if (count != null) return `${count} línea${count === 1 ? '' : 's'}`
+  }
+
+  if (action === 'promotion_deleted') {
+    const promotionName = payload.promotion_name as string | undefined
+    const promoType = payload.promo_type as string | undefined
+    if (promotionName && promoType) return `${promotionName} · ${promoType}`
+    if (promotionName) return promotionName
   }
 
   if (payload.order_number != null) {

--- a/pages/finanzas/contabilidad/cuentas/[id].vue
+++ b/pages/finanzas/contabilidad/cuentas/[id].vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, nextTick, onMounted, onUnmounted } from 'vue'
 import { es } from 'date-fns/locale'
-import { format as fnsFormat, startOfMonth } from 'date-fns'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
 definePageMeta({ layout: 'dashboard' })
@@ -10,6 +9,8 @@ const route = useRoute()
 const accountId = computed(() => route.params.id as string)
 const { currentTenant } = useTenantReactive()
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
+const { addDaysISO, dateAtNoon, isoFromDate, monthBounds, timezone, todayISO } = useTenantTimezone()
+const { formatCalendarDate } = useFormatters()
 const formatCOP = (v: number) =>
   new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(v ?? 0)
 
@@ -224,30 +225,32 @@ const saveSubAccount = async () => {
 }
 
 // ── Date range filter (default: current month) ─────────────────────────────
-const now = new Date()
-const dateRangeDates = ref<Date[] | null>([startOfMonth(now), now])
+const today = todayISO()
+const currentMonth = monthBounds(today)
+const maxDate = computed(() => dateAtNoon(todayISO()))
+const dateRangeDates = ref<Date[] | null>([dateAtNoon(currentMonth.first), dateAtNoon(today)])
 
 const presetDates = [
-  { label: 'Hoy',           value: [new Date(), new Date()] },
-  { label: 'Ayer',          value: (() => { const d = new Date(); d.setDate(d.getDate() - 1); return [d, d] })() },
-  { label: 'Esta semana',   value: [(() => { const d = new Date(); d.setDate(d.getDate() - 7); return d })(), new Date()] },
-  { label: 'Este mes',      value: [startOfMonth(new Date()), new Date()] },
-  { label: 'Último mes',    value: [(() => { const d = new Date(); d.setDate(d.getDate() - 30); return d })(), new Date()] },
-  { label: 'Últimos 90 días', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 90); return d })(), new Date()] },
+  { label: 'Hoy',             value: [dateAtNoon(today), dateAtNoon(today)] },
+  { label: 'Ayer',            value: [dateAtNoon(addDaysISO(today, -1)), dateAtNoon(addDaysISO(today, -1))] },
+  { label: 'Esta semana',     value: [dateAtNoon(addDaysISO(today, -7)), dateAtNoon(today)] },
+  { label: 'Este mes',        value: [dateAtNoon(currentMonth.first), dateAtNoon(today)] },
+  { label: 'Último mes',      value: [dateAtNoon(addDaysISO(today, -30)), dateAtNoon(today)] },
+  { label: 'Últimos 90 días', value: [dateAtNoon(addDaysISO(today, -90)), dateAtNoon(today)] },
 ]
 
 const formatDateRange = (dates: Date[]) => {
   if (!dates || !dates[0]) return ''
-  const from = fnsFormat(dates[0], 'dd/MM/yy', { locale: es })
+  const from = formatCalendarDate(isoFromDate(dates[0]))
   if (!dates[1]) return from
-  return `${from} - ${fnsFormat(dates[1], 'dd/MM/yy', { locale: es })}`
+  return `${from} - ${formatCalendarDate(isoFromDate(dates[1]))}`
 }
 
 const dateRange = computed(() => {
   if (!dateRangeDates.value || dateRangeDates.value.length < 2) return { from: null, to: null }
   const [from, to] = dateRangeDates.value
   if (!from || !to) return { from: null, to: null }
-  return { from: fnsFormat(from, 'yyyy-MM-dd'), to: fnsFormat(to, 'yyyy-MM-dd') }
+  return { from: isoFromDate(from), to: isoFromDate(to) }
 })
 
 // ── Journal entries filters ────────────────────────────────────────────────
@@ -584,7 +587,8 @@ const openEntryDetail = (entry: { id: string }) => {
           placeholder="Rango de fechas"
           auto-apply
           :teleport="true"
-          :max-date="new Date()"
+          :timezone="timezone"
+          :max-date="maxDate"
           :format="formatDateRange"
           input-class-name="dp-custom-input"
           menu-class-name="dp-custom-menu"

--- a/pages/finanzas/contabilidad/cuentas/index.vue
+++ b/pages/finanzas/contabilidad/cuentas/index.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { es } from 'date-fns/locale'
-import { format as fnsFormat } from 'date-fns'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
 definePageMeta({ layout: 'dashboard' })
@@ -9,7 +8,8 @@ useHead({ title: 'Cuentas contables' })
 
 const { currentTenant } = useTenantReactive()
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
-const { addDaysISO, dateAtNoon, isoFromDate, monthBounds, todayISO } = useTenantTimezone()
+const { addDaysISO, dateAtNoon, isoFromDate, monthBounds, timezone, todayISO } = useTenantTimezone()
+const { formatCalendarDate } = useFormatters()
 const formatCOP = (v: number) =>
   new Intl.NumberFormat('es-CO', { style: 'currency', currency: 'COP', minimumFractionDigits: 0 }).format(v ?? 0)
 
@@ -19,6 +19,7 @@ const showAll = ref(false)
 // ── Date range filter (default: current month) ─────────────────────────────
 const today = todayISO()
 const currentMonth = monthBounds(today)
+const maxDate = computed(() => dateAtNoon(todayISO()))
 const dateRangeDates = ref<Date[] | null>([dateAtNoon(currentMonth.first), dateAtNoon(today)])
 
 const presetDates = [
@@ -31,9 +32,9 @@ const presetDates = [
 
 const formatDateRange = (dates: Date[]) => {
   if (!dates || !dates[0]) return ''
-  const from = fnsFormat(dates[0], 'dd/MM/yy', { locale: es })
+  const from = formatCalendarDate(isoFromDate(dates[0]))
   if (!dates[1]) return from
-  return `${from} - ${fnsFormat(dates[1], 'dd/MM/yy', { locale: es })}`
+  return `${from} - ${formatCalendarDate(isoFromDate(dates[1]))}`
 }
 
 const dateRange = computed(() => {
@@ -259,7 +260,8 @@ onUnmounted(() => { clearRefreshHandler(refetchAll) })
           placeholder="Rango de fechas"
           auto-apply
           :teleport="true"
-          :max-date="new Date()"
+          :timezone="timezone"
+          :max-date="maxDate"
           :format="formatDateRange"
           input-class-name="dp-custom-input"
           menu-class-name="dp-custom-menu"

--- a/pages/operaciones/promociones/index.vue
+++ b/pages/operaciones/promociones/index.vue
@@ -145,7 +145,7 @@
                   type="button"
                   class="text-xs text-left text-primary hover:underline truncate max-w-full min-h-[44px]"
                   :aria-label="`Ver alcance de ${item.name}`"
-                  @click="openScopePopover(item)"
+                  @click.stop="openScopePopover(item)"
                 >
                   {{ rowScope(item) }}
                 </button>
@@ -163,10 +163,25 @@
                 type="button"
                 :aria-label="`Editar ${item.name}`"
                 title="Editar"
-                class="flex-shrink-0 min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 transition-colors"
-                @click="openEdit(item)"
+                class="group flex-shrink-0 min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary focus:outline-none transition-colors"
+                @click.stop="openEdit(item)"
               >
-                <PencilSquareIcon class="w-4 h-4" />
+                <PencilOutlineIcon class="w-4 h-4 group-hover:hidden" />
+                <PencilSolidIcon class="hidden w-4 h-4 group-hover:block" />
+              </button>
+              <button
+                type="button"
+                :aria-label="`Eliminar ${item.name}`"
+                title="Eliminar"
+                class="group flex-shrink-0 min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-destructive focus:outline-none transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                :disabled="deletingPromotionId === item.id"
+                @click.stop="openDeletePromotion(item)"
+              >
+                <UiLoadingDots v-if="deletingPromotionId === item.id" size="12px" />
+                <template v-else>
+                  <TrashOutlineIcon class="w-4 h-4 group-hover:hidden" />
+                  <TrashSolidIcon class="hidden w-4 h-4 group-hover:block" />
+                </template>
               </button>
             </div>
           </template>
@@ -199,7 +214,7 @@
               type="button"
               class="text-sm text-left text-primary hover:underline min-h-[44px]"
               :aria-label="`Ver alcance de ${item.name}`"
-              @click="openScopePopover(item)"
+              @click.stop="openScopePopover(item)"
             >
               {{ rowScope(item) }}
             </button>
@@ -233,10 +248,25 @@
                 type="button"
                 :aria-label="`Editar ${item.name}`"
                 title="Editar"
-                class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 transition-colors"
-                @click="openEdit(item)"
+                class="group min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-text-secondary hover:text-text-primary focus:outline-none transition-colors"
+                @click.stop="openEdit(item)"
               >
-                <PencilSquareIcon class="w-4 h-4" />
+                <PencilOutlineIcon class="w-4 h-4 group-hover:hidden" />
+                <PencilSolidIcon class="hidden w-4 h-4 group-hover:block" />
+              </button>
+              <button
+                type="button"
+                :aria-label="`Eliminar ${item.name}`"
+                title="Eliminar"
+                class="group min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-lg text-destructive focus:outline-none transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                :disabled="deletingPromotionId === item.id"
+                @click.stop="openDeletePromotion(item)"
+              >
+                <UiLoadingDots v-if="deletingPromotionId === item.id" size="12px" />
+                <template v-else>
+                  <TrashOutlineIcon class="w-4 h-4 group-hover:hidden" />
+                  <TrashSolidIcon class="hidden w-4 h-4 group-hover:block" />
+                </template>
               </button>
             </div>
           </template>
@@ -256,13 +286,26 @@
       :promotion-name="scopePopoverPromo?.name ?? ''"
       :scope-type="scopePopoverPromo?.scope_type ?? ''"
     />
+
+    <PosDestructiveReasonModal
+      v-model="deleteModalOpen"
+      :title="deleteModalTitle"
+      :message="deleteModalMessage"
+      confirm-label="Sí, eliminar"
+      reason-placeholder="Ej: promoción vencida, regla duplicada, campaña finalizada"
+      :loading="!!deletingPromotionId"
+      :error="deleteError"
+      @confirm="confirmDeletePromotion"
+      @cancel="cancelDeletePromotion"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
 import { useQuery, useQueryCache } from '@pinia/colada'
-import { PencilSquareIcon } from '@heroicons/vue/24/outline'
+import { PencilIcon as PencilOutlineIcon, TrashIcon as TrashOutlineIcon } from '@heroicons/vue/24/outline'
+import { PencilIcon as PencilSolidIcon, TrashIcon as TrashSolidIcon } from '@heroicons/vue/24/solid'
 import {
   formatPromoTypeLabel,
   formatPromoValue,
@@ -336,9 +379,31 @@ const togglePromoLineOptOutSetting = async () => {
 
 const showPanel = ref(false)
 const panelPromotionId = ref<string | null>(null)
+const deletingPromotionId = ref<string | null>(null)
+const deletePromotionTarget = ref<PromotionRow | null>(null)
+const deleteError = ref('')
 const skipOpenFromQuery = ref(false)
 const scopePopoverOpen = ref(false)
 const scopePopoverPromo = ref<PromotionRow | null>(null)
+const deleteModalOpen = computed({
+  get: () => deletePromotionTarget.value !== null,
+  set: (open: boolean) => {
+    if (!open && !deletingPromotionId.value) {
+      deletePromotionTarget.value = null
+      deleteError.value = ''
+    }
+  },
+})
+const deleteModalTitle = computed(() =>
+  deletePromotionTarget.value
+    ? `¿Eliminar ${deletePromotionTarget.value.name}?`
+    : '¿Eliminar promoción?',
+)
+const deleteModalMessage = computed(() =>
+  deletePromotionTarget.value
+    ? 'Se eliminará la promoción y el motivo quedará registrado en la bitácora de operaciones.'
+    : '',
+)
 
 const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
 const statusFilter = ref<'' | 'active' | 'inactive'>('')
@@ -514,6 +579,44 @@ function openPanel(item: PromotionRow | null) {
 
 function openEdit(item: PromotionRow) {
   openPanel(item)
+}
+
+function openDeletePromotion(item: PromotionRow) {
+  if (deletingPromotionId.value) return
+  deletePromotionTarget.value = item
+  deleteError.value = ''
+}
+
+function cancelDeletePromotion() {
+  if (deletingPromotionId.value) return
+  deletePromotionTarget.value = null
+  deleteError.value = ''
+}
+
+async function confirmDeletePromotion(reason: string) {
+  const item = deletePromotionTarget.value
+  if (!item) return
+  await deletePromotion(item, reason)
+}
+
+async function deletePromotion(item: PromotionRow, reason: string) {
+  if (deletingPromotionId.value) return
+  deletingPromotionId.value = item.id
+  deleteError.value = ''
+  try {
+    await $fetch(`/api/api/promotions/${item.id}`, {
+      method: 'DELETE',
+      body: { reason: reason.trim() },
+    })
+    toast.success('Promoción eliminada')
+    deletePromotionTarget.value = null
+    await refreshHandler()
+  } catch (error: any) {
+    deleteError.value = error?.data?.detail ?? 'No se pudo eliminar la promoción'
+    toast.error(deleteError.value, { title: 'Error' })
+  } finally {
+    deletingPromotionId.value = null
+  }
 }
 
 async function onPanelSaved() {

--- a/pages/ventas/propinas/index.vue
+++ b/pages/ventas/propinas/index.vue
@@ -45,8 +45,9 @@ const channelFilter = ref<'pos' | 'mesa' | 'online' | null>(null)
 const dateRangeDates = ref<Date[] | null>(null)
 const sortField = ref<'order_number' | 'order_date' | 'total_amount' | 'tip_amount' | 'payment_method'>('order_date')
 const sortDirection = ref<'asc' | 'desc'>('desc')
-const { todayISO, addDaysISO, dateAtNoon, isoFromDate } = useTenantTimezone()
+const { timezone, todayISO, addDaysISO, dateAtNoon, isoFromDate } = useTenantTimezone()
 const presetRange = (fromIso: string, toIso = todayISO()) => [dateAtNoon(fromIso), dateAtNoon(toIso)]
+const maxDate = computed(() => dateAtNoon(todayISO()))
 const formatIsoShort = (iso: string) => {
   const [year, month, day] = iso.split('-')
   return `${day}/${month}/${year.slice(2)}`
@@ -303,9 +304,9 @@ onMounted(() => {
   const qFrom = route.query.date_from as string | undefined
   const qTo = route.query.date_to as string | undefined
   if (qFrom && qTo) {
-    const from = new Date(`${qFrom}T00:00:00`)
-    const to = new Date(`${qTo}T00:00:00`)
-    if (!isNaN(from.getTime()) && !isNaN(to.getTime())) {
+    const from = /^\d{4}-\d{2}-\d{2}$/.test(qFrom) ? dateAtNoon(qFrom) : null
+    const to = /^\d{4}-\d{2}-\d{2}$/.test(qTo) ? dateAtNoon(qTo) : null
+    if (from && to && !isNaN(from.getTime()) && !isNaN(to.getTime())) {
       dateRangeDates.value = [from, to]
     }
   }
@@ -403,7 +404,8 @@ onUnmounted(() => clearRefreshHandler(refetch))
           placeholder="Rango de fechas"
           auto-apply
           :teleport="true"
-          :max-date="new Date()"
+          :timezone="timezone"
+          :max-date="maxDate"
           :format="formatDateRange"
           input-class-name="dp-custom-input"
           menu-class-name="dp-custom-menu"


### PR DESCRIPTION
## Summary\n- make accounting date displays/datepickers use the tenant timezone\n- keep sales tips datepicker tenant-aware\n- add promotion delete modal/action polish and operation event client flow\n\n## Tests\n- git diff --check\n- not run: frontend has no test/lint script and build was intentionally skipped