### PR TITLE
Fix table QR tenant timezone display

### DIFF
--- a/pages/despacho/en-mesa/[id].vue
+++ b/pages/despacho/en-mesa/[id].vue
@@ -3,6 +3,7 @@ import { inject, watch, onMounted, onUnmounted } from 'vue'
 import { formatTableQrPayment } from '~/composables/formatTableQrPayment'
 import { notifyTableSessionUpdated, storeTableQrPaymentIntent } from '~/composables/useTableSessionSync'
 import { useNotifications } from '~/composables/useNotifications'
+import { normalizeTimezone } from '~/utils/bogotaDate'
 
 definePageMeta({ layout: 'dashboard' })
 
@@ -14,7 +15,8 @@ const toast = useToast()
 const cache = useQueryCache()
 const { markAsRead, notifications } = useNotifications()
 const requestId = computed(() => route.params.id as string)
-const { formatDateTime, formatCurrency } = useFormatters()
+const { formatCurrency } = useFormatters()
+const { timezone } = useTenantTimezone()
 
 interface TableQrItem {
   product_id: string
@@ -40,6 +42,7 @@ interface TableQrRequestDetail {
   payment_display?: string | null
   customer_notes?: string | null
   created_at: string
+  tenant_timezone?: string | null
   total_amount: number
 }
 
@@ -57,6 +60,18 @@ const {
 })
 
 const request = computed(() => requestResponse.value?.data ?? null)
+const requestTimezone = computed(() => normalizeTimezone(request.value?.tenant_timezone ?? timezone.value))
+const tenantDateTimeFormatter = computed(() => new Intl.DateTimeFormat('es-CO', {
+  day: '2-digit',
+  month: '2-digit',
+  year: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+  timeZone: requestTimezone.value,
+}))
+const formatRequestDateTime = (value: string | null | undefined) =>
+  value ? tenantDateTimeFormatter.value.format(new Date(value)) : 'No especificada'
 const isPending = computed(() => request.value?.status === 'pending')
 const isLoading = computed(() => !requestResponse.value && !fetchError.value)
 const isRefreshing = computed(() => asyncStatus.value === 'loading' && requestResponse.value != null)
@@ -222,7 +237,7 @@ const formatQuantity = (quantity: number) =>
 
         <div class="bg-surface border border-border rounded-xl p-4">
           <p class="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">Fecha</p>
-          <p class="text-lg font-bold text-text-primary">{{ formatDateTime(request.created_at) }}</p>
+          <p class="text-lg font-bold text-text-primary">{{ formatRequestDateTime(request.created_at) }}</p>
         </div>
 
         <div class="bg-surface border border-border rounded-xl p-4">

--- a/pages/despacho/en-mesa/index.vue
+++ b/pages/despacho/en-mesa/index.vue
@@ -3,6 +3,7 @@ import { onMounted, onUnmounted, watch } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
 import { formatTableQrPayment } from '~/composables/formatTableQrPayment'
+import { normalizeTimezone } from '~/utils/bogotaDate'
 
 definePageMeta({ layout: 'dashboard' })
 
@@ -10,8 +11,9 @@ useHead({ title: 'Pedidos en mesa (QR) — WARO' })
 
 const route = useRoute()
 const router = useRouter()
-const { formatCurrency, formatDateTime } = useFormatters()
+const { formatCurrency } = useFormatters()
 const { currentTenant } = useTenantReactive()
+const { timezone } = useTenantTimezone()
 
 interface TableQrRequest {
   id: string
@@ -24,6 +26,7 @@ interface TableQrRequest {
   payment_method_name?: string | null
   payment_display?: string | null
   created_at: string
+  tenant_timezone?: string | null
 }
 
 interface TableQrRequestRow extends TableQrRequest {
@@ -34,6 +37,15 @@ interface TableGroup {
   table_id: string
   table_name: string
   requests: TableQrRequest[]
+}
+
+interface TableQrRequestsResponse {
+  success: boolean
+  data: {
+    tables: TableGroup[]
+    total_pending: number
+    tenant_timezone?: string | null
+  }
 }
 
 const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
@@ -62,7 +74,7 @@ const {
   refetch: refetchPending,
 } = useQuery({
   key: () => ['table-qr-requests', 'pending', currentTenant.value?.id],
-  query: () => $fetch<{ success: boolean; data: { tables: TableGroup[]; total_pending: number } }>(
+  query: () => $fetch<TableQrRequestsResponse>(
     '/api/table-qr-requests',
     { params: { status: 'pending' } },
   ),
@@ -72,6 +84,18 @@ const {
 
 const isLoading = computed(() => pendingStatus.value === 'loading' || (!pendingData.value && !fetchError.value))
 const isRefreshing = computed(() => pendingAsyncStatus.value === 'loading' && pendingData.value != null)
+const tenantTimezone = computed(() => normalizeTimezone(pendingData.value?.data?.tenant_timezone ?? timezone.value))
+const tenantDateTimeFormatter = computed(() => new Intl.DateTimeFormat('es-CO', {
+  day: '2-digit',
+  month: '2-digit',
+  year: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+  timeZone: tenantTimezone.value,
+}))
+const formatRequestDateTime = (value: string | null | undefined) =>
+  value ? tenantDateTimeFormatter.value.format(new Date(value)) : 'No especificada'
 
 const tableOptions = computed(() =>
   (pendingData.value?.data?.tables ?? []).map(t => ({
@@ -242,7 +266,7 @@ const viewRequest = (request: TableQrRequestRow) => {
                 </p>
                 <p class="text-xs text-text-secondary mt-0.5">
                   {{ item.item_count }} item{{ item.item_count !== 1 ? 's' : '' }}
-                  · {{ formatDateTime(item.created_at) }}
+                  · {{ formatRequestDateTime(item.created_at) }}
                   <span v-if="formatTableQrPayment(item) !== '—'"> · {{ formatTableQrPayment(item) }}</span>
                 </p>
               </div>
@@ -256,7 +280,7 @@ const viewRequest = (request: TableQrRequestRow) => {
             <span class="text-sm font-semibold text-text-primary">{{ value }}</span>
           </template>
           <template #cell-created_at="{ value }">
-            <span class="text-sm text-text-secondary">{{ formatDateTime(value) }}</span>
+            <span class="text-sm text-text-secondary">{{ formatRequestDateTime(value) }}</span>
           </template>
           <template #cell-item_count="{ value }">
             <span class="text-sm text-text-secondary">{{ value }}</span>


### PR DESCRIPTION
## Summary\n- format /despacho/en-mesa request dates with tenant timezone from the QR request payload\n- keep detail and list views aligned when business profile timezone is unavailable\n\n## Tests\n- git diff --check