### PR TITLE
Add table QR comanda print action

### DIFF
--- a/components/pos/ComandaPrintTickets.vue
+++ b/components/pos/ComandaPrintTickets.vue
@@ -58,49 +58,51 @@ const printTicket = computed(() => {
 </script>
 
 <template>
-  <div id="pos-comanda-print" aria-hidden="true">
-    <div
-      v-if="printTicket"
-      class="comanda-ticket"
-    >
-      <div class="receipt-header">{{ businessName || 'WARO' }}</div>
-      <div class="receipt-row receipt-small">*** COMANDA POS ***</div>
-      <div class="receipt-row receipt-small">{{ formatTicketTime(printTicket.firedAt) }}</div>
-      <div v-if="printTicket.tableDisplayName" class="receipt-row receipt-small">
-        {{ printTicket.tableDisplayName }}
-      </div>
-      <div class="receipt-row receipt-small">
-        Comanda #{{ printTicket.comandaNumbers.join(', ') }}
-      </div>
-      <div class="receipt-divider">--------------------------------</div>
-
-      <section
-        v-for="section in printTicket.sections"
-        :key="section.key"
-        class="comanda-station-section"
+  <Teleport to="body">
+    <div id="pos-comanda-print" aria-hidden="true">
+      <div
+        v-if="printTicket"
+        class="comanda-ticket"
       >
-        <div class="receipt-row receipt-small station-title">
-          Estación: {{ section.stationName }}
+        <div class="receipt-header">{{ businessName || 'WARO' }}</div>
+        <div class="receipt-row receipt-small">*** COMANDA POS ***</div>
+        <div class="receipt-row receipt-small">{{ formatTicketTime(printTicket.firedAt) }}</div>
+        <div v-if="printTicket.tableDisplayName" class="receipt-row receipt-small">
+          {{ printTicket.tableDisplayName }}
         </div>
-        <template v-for="(item, i) in section.items" :key="`${section.key}-${i}`">
-          <div class="receipt-item receipt-small">
-            <span class="comanda-item-qty">{{ item.quantity }}×</span>
-            <span class="comanda-item-name">{{ item.kitchen_name }}</span>
+        <div class="receipt-row receipt-small">
+          Comanda #{{ printTicket.comandaNumbers.join(', ') }}
+        </div>
+        <div class="receipt-divider">--------------------------------</div>
+
+        <section
+          v-for="section in printTicket.sections"
+          :key="section.key"
+          class="comanda-station-section"
+        >
+          <div class="receipt-row receipt-small station-title">
+            Estación: {{ section.stationName }}
           </div>
-          <div
-            v-for="(mod, mi) in modifierLines(item)"
-            :key="`${section.key}-${i}-${mi}`"
-            class="receipt-row receipt-small item-detail"
-          >
-            ↳ {{ formatComandaModifierLabel(mod, { includePrice: true }) }}
-          </div>
-          <div v-if="item.notes" class="receipt-row receipt-small item-detail">
-            Notas Especiales: {{ item.notes }}
-          </div>
-        </template>
-      </section>
+          <template v-for="(item, i) in section.items" :key="`${section.key}-${i}`">
+            <div class="receipt-item receipt-small">
+              <span class="comanda-item-qty">{{ item.quantity }}×</span>
+              <span class="comanda-item-name">{{ item.kitchen_name }}</span>
+            </div>
+            <div
+              v-for="(mod, mi) in modifierLines(item)"
+              :key="`${section.key}-${i}-${mi}`"
+              class="receipt-row receipt-small item-detail"
+            >
+              ↳ {{ formatComandaModifierLabel(mod, { includePrice: true }) }}
+            </div>
+            <div v-if="item.notes" class="receipt-row receipt-small item-detail">
+              Notas Especiales: {{ item.notes }}
+            </div>
+          </template>
+        </section>
+      </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <style>
@@ -156,7 +158,11 @@ const printTicket = computed(() => {
 }
 
 @media print {
-  body.printing-comanda * { visibility: hidden; }
+  body.printing-comanda > :not(#pos-comanda-print) {
+    display: none !important;
+  }
+
+  body.printing-comanda * { visibility: hidden !important; }
   body.printing-comanda #pos-comanda-print,
   body.printing-comanda #pos-comanda-print * { visibility: visible !important; }
 
@@ -165,9 +171,9 @@ const printTicket = computed(() => {
 
   #pos-comanda-print {
     display: block !important;
-    position: absolute;
-    top: 0;
-    left: 0;
+    position: fixed !important;
+    top: 0 !important;
+    left: 0 !important;
     font-family: 'Courier New', Courier, monospace;
     font-size: 9pt;
     line-height: 1.25;
@@ -175,6 +181,7 @@ const printTicket = computed(() => {
     color: #000;
     background: #fff;
     padding: 2mm;
+    margin: 0 !important;
   }
 
   @page {

--- a/composables/useComandaPrint.ts
+++ b/composables/useComandaPrint.ts
@@ -118,6 +118,7 @@ export function orderItemIdsFromComandas(rawComandas: unknown[]): Set<string> {
 
 export function printComandaTickets(): void {
   document.body.classList.add('printing-comanda')
+  void document.body.offsetHeight
   const cleanup = () => {
     document.body.classList.remove('printing-comanda')
   }

--- a/pages/despacho/en-mesa/[id].vue
+++ b/pages/despacho/en-mesa/[id].vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-import { inject, watch, onMounted, onUnmounted } from 'vue'
+import { inject, watch, nextTick, onMounted, onUnmounted } from 'vue'
+import { Printer } from 'lucide-vue-next'
+import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
+import { printComandaTickets } from '~/composables/useComandaPrint'
 import { formatTableQrPayment } from '~/composables/formatTableQrPayment'
 import { notifyTableSessionUpdated, storeTableQrPaymentIntent } from '~/composables/useTableSessionSync'
 import { useNotifications } from '~/composables/useNotifications'
@@ -17,6 +20,7 @@ const { markAsRead, notifications } = useNotifications()
 const requestId = computed(() => route.params.id as string)
 const { formatCurrency } = useFormatters()
 const { timezone } = useTenantTimezone()
+const { businessProfile, currentTenant } = useTenantReactive()
 
 interface TableQrItem {
   product_id: string
@@ -210,6 +214,44 @@ const modifierSubtotal = (modifier: NonNullable<TableQrItem['modifiers']>[number
 
 const formatQuantity = (quantity: number) =>
   quantity % 1 === 0 ? quantity.toFixed(0) : String(quantity)
+
+const businessName = computed(() =>
+  businessProfile.value?.display_name
+  || currentTenant.value?.name
+  || 'WARO'
+)
+
+const comandaPrintPayload = computed<ComandaPrintPayload[]>(() => {
+  const req = request.value
+  if (!req) return []
+  return [{
+    id: req.id,
+    comanda_number: `QR-${req.id.slice(0, 8)}`,
+    station_name: 'Pedido QR en mesa',
+    table_display_name: req.table_name,
+    fired_at: req.created_at,
+    items: req.items.map(item => ({
+      kitchen_name: itemDisplayName(item),
+      quantity: itemQuantity(item),
+      modifiers_snapshot: item.modifiers?.map(mod => ({
+        name: mod.name,
+        price: mod.price,
+        quantity: modifierQuantity(mod),
+      })) ?? [],
+      notes: item.notes ?? null,
+    })),
+  }]
+})
+
+const canPrintComanda = computed(() =>
+  !!request.value && comandaPrintPayload.value.some(comanda => comanda.items.length > 0),
+)
+
+async function printQrComanda() {
+  if (!canPrintComanda.value) return
+  await nextTick()
+  printComandaTickets()
+}
 </script>
 
 <template>
@@ -271,6 +313,18 @@ const formatQuantity = (quantity: number) =>
           </UiButton>
           <UiButton variant="destructive" size="lg" :disabled="isWorking" @click="rejectRequest">
             {{ isWorking ? 'Procesando...' : 'Rechazar' }}
+          </UiButton>
+          <UiButton
+            variant="crocus-outline"
+            size="lg"
+            class="gap-2"
+            :disabled="isWorking || !canPrintComanda"
+            aria-label="Imprimir comanda"
+            title="Imprimir comanda"
+            @click="printQrComanda"
+          >
+            <Printer class="h-4 w-4" aria-hidden="true" />
+            <span>Imprimir</span>
           </UiButton>
         </div>
         <p v-if="actionError" role="alert" class="mt-3 text-sm text-destructive">{{ actionError }}</p>
@@ -369,5 +423,10 @@ const formatQuantity = (quantity: number) =>
         <p class="text-sm text-text-primary">{{ request.customer_notes }}</p>
       </div>
     </div>
+
+    <PosComandaPrintTickets
+      :comandas="comandaPrintPayload"
+      :business-name="businessName"
+    />
   </div>
 </template>


### PR DESCRIPTION
## Summary\n- add a labeled printer action to table QR request detail\n- reuse POS comanda ticket print format and print helper\n- make the print ticket mount at body level so only the ticket prints\n- keep the print action visually secondary using the existing outline primary variant\n\n## UX / Color\n- icon is paired with text to reduce ambiguity\n- print remains a utility action after primary/destructive decisions\n- uses existing semantic primary outline token instead of introducing new colors\n\n## Tests\n- git diff --check