### PR TITLE
Hide DIAN invoicing for pure credit sales

### DIFF
--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -2248,6 +2248,10 @@ async function buildInvoiceQrDataUrl(cufe: string): Promise<string> {
 
 const generateInvoice = async () => {
   if (invoiceLoading.value) return
+  if (isCreditOnlyInvoiceBlocked.value) {
+    invoiceError.value = 'Las ventas con pago solo crédito no emiten factura electrónica desde este flujo.'
+    return
+  }
 
   // Determine which order_ids to invoice
   const ids: string[] = []
@@ -2471,6 +2475,10 @@ const orderResultChargedAmount = computed(() => {
       - (Number(result.advance_applied) || 0),
   )
 })
+const isCreditOnlyInvoiceBlocked = computed(() =>
+  orderResult.value?.payment_method === 'credit'
+  && splitPaymentsSnapshot.value.length === 0
+)
 
 const receiptPromoBreakdown = computed(() => {
   const breakdown = orderResult.value?.promo_breakdown ?? []
@@ -2598,6 +2606,10 @@ const retryInvoice = async () => {
 // wizard when the customer has no fiscal data, otherwise emits directly.
 const requestInvoice = async () => {
   if (invoiceLoading.value) return
+  if (isCreditOnlyInvoiceBlocked.value) {
+    invoiceError.value = 'Las ventas con pago solo crédito no emiten factura electrónica desde este flujo.'
+    return
+  }
   if (selectedCustomer.value && !selectedCustomer.value.fiscal_id && !isAnonymousCustomer.value) {
     fiscalWizardError.value = ''
     fiscalWizardForm.value = {
@@ -4640,7 +4652,7 @@ onUnmounted(() => {
           <!-- Electronic invoice (DIAN) — cashier triggers emission, but never sees CUFE/PDF -->
           <div v-if="orderResult?.status !== 'pending' && (orderResult?.order_id || (orderResult?.order_ids?.length ?? 0) > 0)" class="mb-4">
             <!-- Not requested yet — gated on tenant readiness (#450) -->
-            <template v-if="isInvoicingReady && !isReadinessLoading && !invoiceResult && !invoiceLoading && !invoiceError && !fiscalWizardOpen">
+            <template v-if="isInvoicingReady && !isReadinessLoading && !isCreditOnlyInvoiceBlocked && !invoiceResult && !invoiceLoading && !invoiceError && !fiscalWizardOpen">
               <button
                 @click="requestInvoice"
                 class="w-full min-h-[44px] py-2 px-4 bg-surface border border-border text-text-primary text-sm font-medium rounded-lg hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-primary active:scale-95 transition-all flex items-center justify-center gap-2"
@@ -4651,6 +4663,9 @@ onUnmounted(() => {
                 {{ (orderResult?.order_ids?.length ?? 0) > 1 ? `Facturar ${orderResult?.order_ids?.length} órdenes` : 'Generar factura electrónica DIAN' }}
               </button>
             </template>
+            <div v-else-if="isCreditOnlyInvoiceBlocked" class="rounded-xl border border-state-warning-border bg-state-warning-bg px-4 py-3 text-sm text-state-warning-text">
+              Las ventas con pago solo crédito no emiten factura electrónica desde este flujo. Usa pago dividido si necesitas facturar al momento de la venta.
+            </div>
 
             <!-- Inline fiscal-data wizard -->
             <div v-else-if="fiscalWizardOpen" class="rounded-xl border border-primary/30 bg-primary/5 p-4 space-y-3">

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -136,8 +136,17 @@ const isUnrecoverableRejection = computed(() => {
   return msg.includes('ya se encuentra validado')
 })
 
+const isCreditOnlyInvoiceBlocked = computed(() => {
+  const o = orderData.value
+  if (!o) return false
+  return o.payment_method === 'credit'
+    && ((o.split_payments ?? []).length === 0)
+})
+
 const canRetryInvoice = computed(() =>
-  invoiceData.value?.status === 'rejected' && !isUnrecoverableRejection.value,
+  invoiceData.value?.status === 'rejected'
+    && !isUnrecoverableRejection.value
+    && !isCreditOnlyInvoiceBlocked.value,
 )
 
 const isMatiasAuthInvoiceError = computed(() => {
@@ -147,6 +156,10 @@ const isMatiasAuthInvoiceError = computed(() => {
 
 const emitInvoice = async () => {
   if (isEmittingInvoice.value) return
+  if (isCreditOnlyInvoiceBlocked.value) {
+    emitInvoiceError.value = 'Las ventas con pago solo crédito no emiten factura electrónica desde este flujo.'
+    return
+  }
   isEmittingInvoice.value = true
   emitInvoiceError.value = ''
   try {
@@ -204,9 +217,11 @@ const canEmitInvoiceForOrder = computed(() => Boolean(
     && isInvoicingReady.value
     && order.value?.status === 'completed'
     && orderHasInvoiceCustomer.value
+    && !isCreditOnlyInvoiceBlocked.value
 ))
 const shouldShowInvoiceSection = computed(() => Boolean(
   invoiceData.value
+    || isCreditOnlyInvoiceBlocked.value
     || (
       isInvoicingReady.value
       && !isReadinessLoading.value
@@ -1069,6 +1084,24 @@ onUnmounted(() => {
               </svg>
               {{ emitInvoiceError }}
             </p>
+          </div>
+        </template>
+
+        <!-- No invoice — pure credit orders are not emitted from this flow -->
+        <template v-else-if="isCreditOnlyInvoiceBlocked">
+          <div class="px-5 py-3 flex items-start gap-3">
+            <span class="w-9 h-9 rounded-lg bg-state-warning-bg text-state-warning-text flex items-center justify-center flex-shrink-0" aria-hidden="true">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.8">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M12 9v3.75m0 3.75h.008v.008H12v-.008Zm9-3.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+              </svg>
+            </span>
+            <div class="flex-1 min-w-0">
+              <p class="text-sm font-semibold text-text-primary leading-tight">Factura electrónica no disponible</p>
+              <p class="text-xs text-text-secondary leading-snug">
+                Las ventas con pago solo crédito no emiten factura electrónica desde este flujo. Usa pago dividido si necesitas facturar al momento de la venta.
+              </p>
+            </div>
           </div>
         </template>
 


### PR DESCRIPTION
## Summary
- block invoice emission from POS for pure credit sales
- show non-facturable messaging in sale detail
- keep split payments invoice-eligible

## Tests
- Not run per request: no build