### PR TITLE
Stabilize analytics date filters by tenant date

### DIFF
--- a/composables/useDateRangePresets.ts
+++ b/composables/useDateRangePresets.ts
@@ -1,18 +1,24 @@
 import { ref, computed, type Ref } from 'vue'
 
 export type DateRangeApi = { from: string | null; to: string | null }
+export type DateRangeModel = Date[] | string[]
 
 const formatIsoShort = (iso: string) => {
   const [year, month, day] = iso.split('-')
   return `${day}/${month}/${year.slice(2)}`
 }
 
-export function useDateRangePresets(existing?: Ref<Date[] | null>) {
-  const dateRangeDates = existing ?? ref<Date[] | null>(null)
+export function useDateRangePresets(
+  existing?: Ref<DateRangeModel | null>,
+  options: { modelType?: 'date' | 'iso' } = {},
+) {
+  const modelType = options.modelType ?? 'date'
+  const dateRangeDates = existing ?? ref<DateRangeModel | null>(null)
   const { todayISO, addDaysISO, dateAtNoon, isoFromDate } = useTenantTimezone()
 
-  const presetRange = (fromIso: string, toIso = todayISO()) => [dateAtNoon(fromIso), dateAtNoon(toIso)]
-  const maxDate = computed(() => dateAtNoon(todayISO()))
+  const presetValue = (iso: string) => modelType === 'iso' ? iso : dateAtNoon(iso)
+  const presetRange = (fromIso: string, toIso = todayISO()) => [presetValue(fromIso), presetValue(toIso)]
+  const maxDate = computed(() => presetValue(todayISO()))
 
   const presetDates = computed(() => [
     { label: 'Hoy', value: presetRange(todayISO()) },
@@ -38,11 +44,14 @@ export function useDateRangePresets(existing?: Ref<Date[] | null>) {
     },
   ])
 
-  const formatDateRange = (dates: Date[]) => {
+  const modelValueToIso = (value: Date | string) =>
+    typeof value === 'string' ? value : isoFromDate(value)
+
+  const formatDateRange = (dates: DateRangeModel) => {
     if (!dates || !dates[0]) return ''
-    const from = formatIsoShort(isoFromDate(dates[0]))
+    const from = formatIsoShort(modelValueToIso(dates[0]))
     if (!dates[1]) return from
-    const to = formatIsoShort(isoFromDate(dates[1]))
+    const to = formatIsoShort(modelValueToIso(dates[1]))
     return `${from} - ${to}`
   }
 
@@ -53,8 +62,8 @@ export function useDateRangePresets(existing?: Ref<Date[] | null>) {
     const [from, to] = dateRangeDates.value
     if (!from || !to) return { from: null, to: null }
     return {
-      from: isoFromDate(from),
-      to: isoFromDate(to),
+      from: modelValueToIso(from),
+      to: modelValueToIso(to),
     }
   })
 

--- a/pages/analitica/clientes/[id].vue
+++ b/pages/analitica/clientes/[id].vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, reactive, inject, onMounted, onUnmounted, watch } from 'vue';
 import { es } from 'date-fns/locale';
-import { format as fnsFormat } from 'date-fns';
 import MetricCard from '~/components/shared/MetricCard.vue';
 import type { WaroTransaction } from '~/composables/useWarosCliente';
 import { resolvePaymentSelection } from '~/composables/usePaymentSelectValue';
@@ -44,30 +43,8 @@ const setBackHandler = inject<(handler: (() => void) | undefined) => void>('setB
 const goBack = () => router.push('/analitica/clientes')
 
 // ── Filters ───────────────────────────────────────────────────────────────
-const dateRangeDates = ref<Date[] | null>(null);
-
-const presetDates = ref([
-  { label: 'Hoy', value: [new Date(), new Date()] },
-  { label: 'Ayer', value: (() => { const d = new Date(); d.setDate(d.getDate() - 1); return [d, d] })() },
-  { label: 'Última semana', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 7); return d })(), new Date()] },
-  { label: 'Últimos 15 días', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 15); return d })(), new Date()] },
-  { label: 'Último mes', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 30); return d })(), new Date()] },
-  { label: 'Últimos 90 días', value: [(() => { const d = new Date(); d.setDate(d.getDate() - 90); return d })(), new Date()] },
-]);
-
-const formatDateRange = (dates: Date[]) => {
-  if (!dates || !dates[0]) return ''
-  const from = fnsFormat(dates[0], 'dd/MM/yy', { locale: es })
-  if (!dates[1]) return from
-  return `${from} - ${fnsFormat(dates[1], 'dd/MM/yy', { locale: es })}`
-};
-
-const dateRange = computed(() => {
-  if (!dateRangeDates.value || dateRangeDates.value.length < 2) return { from: null, to: null }
-  const [from, to] = dateRangeDates.value
-  if (!from || !to) return { from: null, to: null }
-  return { from: fnsFormat(from, 'yyyy-MM-dd'), to: fnsFormat(to, 'yyyy-MM-dd') }
-});
+const { dateRangeDates, presetDates, maxDate, formatDateRange, dateRange } = useDateRangePresets(undefined, { modelType: 'iso' })
+const { formatCalendarDate, formatDate: formatTenantDate } = useFormatters()
 
 // ── Pagination ────────────────────────────────────────────────────────────
 const currentPage = ref(1)
@@ -117,7 +94,11 @@ const formatCurrency = (value: number) =>
 
 const formatDate = (isoDate: string) => {
   if (!isoDate) return '-'
-  try { return fnsFormat(new Date(isoDate), 'dd/MM/yyyy', { locale: es }) }
+  try {
+    return /^\d{4}-\d{2}-\d{2}$/.test(isoDate)
+      ? formatCalendarDate(isoDate)
+      : formatTenantDate(isoDate)
+  }
   catch { return isoDate }
 }
 
@@ -278,7 +259,7 @@ const onWarosAssigned = async (payload: { newBalance: number }) => {
 
 const formatWarosDate = (isoDate: string) => {
   if (!isoDate) return '-'
-  try { return fnsFormat(new Date(isoDate), 'dd/MM/yyyy', { locale: es }) }
+  try { return formatTenantDate(isoDate) }
   catch { return isoDate }
 }
 
@@ -760,7 +741,8 @@ onUnmounted(() => {
             placeholder="Filtrar por período"
             auto-apply
             :teleport="true"
-            :max-date="new Date()"
+            model-type="yyyy-MM-dd"
+            :max-date="maxDate"
             :format="formatDateRange"
             input-class-name="dp-custom-input"
             menu-class-name="dp-custom-menu"

--- a/pages/analitica/clientes/index.vue
+++ b/pages/analitica/clientes/index.vue
@@ -3,7 +3,7 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { useDebounceFn } from '@vueuse/core'
 import { es } from 'date-fns/locale';
-import { format as fnsFormat, formatDistanceToNow } from 'date-fns';
+import { formatDistanceToNow } from 'date-fns';
 import MetricCard from '~/components/shared/MetricCard.vue';
 
 definePageMeta({ layout: 'dashboard' })
@@ -13,7 +13,8 @@ const { setRefreshHandler, clearRefreshHandler, setLastUpdateText, registerProgr
 const lastUpdate = ref<Date>(new Date());
 
 // ── Filters ──────────────────────────────────────────────────────────────
-const { dateRangeDates, presetDates, maxDate, formatDateRange, dateRange } = useDateRangePresets()
+const { dateRangeDates, presetDates, maxDate, formatDateRange, dateRange } = useDateRangePresets(undefined, { modelType: 'iso' })
+const { formatCalendarDate, formatDate: formatTenantDate } = useFormatters()
 
 // ── Search ────────────────────────────────────────────────────────────────
 const searchQuery = ref('')
@@ -142,7 +143,9 @@ const formatCurrency = (value: number) =>
 
 const formatDate = (isoDate: string) => {
   if (!isoDate) return '-'
-  return fnsFormat(new Date(isoDate), 'dd/MM/yyyy', { locale: es })
+  return /^\d{4}-\d{2}-\d{2}$/.test(isoDate)
+    ? formatCalendarDate(isoDate)
+    : formatTenantDate(isoDate)
 }
 
 const router = useRouter()
@@ -205,6 +208,7 @@ onUnmounted(() => {
             placeholder="Rango de fechas"
             auto-apply
             :teleport="true"
+            model-type="yyyy-MM-dd"
             :max-date="maxDate"
             :format="formatDateRange"
             input-class-name="dp-custom-input"

--- a/pages/analitica/cocina.vue
+++ b/pages/analitica/cocina.vue
@@ -14,11 +14,14 @@
 
       <div class="flex items-center gap-3">
         <VueDatePicker
-          v-model="dateRange"
+          v-model="dateRangeDates"
           range
           :enable-time-picker="false"
+          :preset-dates="presetDates"
           auto-apply
-          :format="dateFormat"
+          :timezone="timezone"
+          :max-date="maxDate"
+          :format="formatDateRange"
           placeholder="Seleccionar periodo"
           class="min-w-[280px]"
           @update:model-value="fetchMetrics"
@@ -211,17 +214,15 @@ useHead({
   title: 'Analítica de Cocina | WARO'
 })
 
-const dateRange = ref<[Date, Date]>([
-  new Date(new Date().setDate(new Date().getDate() - 7)),
-  new Date()
+const { timezone, todayISO, addDaysISO, dateAtNoon } = useTenantTimezone()
+const dateRangeDates = ref<Date[] | null>([
+  dateAtNoon(addDaysISO(todayISO(), -7)),
+  dateAtNoon(todayISO()),
 ])
+const { presetDates, maxDate, formatDateRange, dateRange } = useDateRangePresets(dateRangeDates)
 
 const loading = ref(false)
 const metrics = ref<any>(null)
-
-const dateFormat = (date: Date) => {
-  return date.toLocaleDateString('es-ES', { day: '2-digit', month: '2-digit', year: 'numeric' })
-}
 
 const maxOrders = computed(() => {
   if (!metrics.value) return 1
@@ -232,9 +233,9 @@ const fetchMetrics = async () => {
   loading.value = true
   try {
     const params: any = {}
-    if (dateRange.value && dateRange.value[0] && dateRange.value[1]) {
-      params.date_from = dateRange.value[0].toISOString().split('T')[0]
-      params.date_to = dateRange.value[1].toISOString().split('T')[0]
+    if (dateRange.value.from && dateRange.value.to) {
+      params.date_from = dateRange.value.from
+      params.date_to = dateRange.value.to
     }
 
     const { data } = await $fetch('/api/analytics/kitchen', { params }) as any

--- a/pages/analitica/rentabilidad.vue
+++ b/pages/analitica/rentabilidad.vue
@@ -12,6 +12,7 @@ const lastUpdate = ref<Date>(new Date())
 const lastUpdateText = computed(() => formatDistanceToNow(lastUpdate.value, { addSuffix: true, locale: es }))
 
 const { dateRangeDates, presetDates, maxDate, formatDateRange, dateRange } = useDateRangePresets()
+const { timezone } = useTenantTimezone()
 
 const { data: foodCostData, status: foodCostStatus, asyncStatus: foodCostAsyncStatus, error: foodCostError, refetch: refetchFoodCost } = useQuery({
   key: () => ['analytics', 'food-cost', currentTenant.value?.id, { from: dateRange.value.from, to: dateRange.value.to }],
@@ -158,6 +159,7 @@ onUnmounted(() => {
           placeholder="Rango de fechas"
           auto-apply
           :teleport="true"
+          :timezone="timezone"
           :max-date="maxDate"
           :format="formatDateRange"
           input-class-name="dp-custom-input"


### PR DESCRIPTION
## Summary
- use stable yyyy-MM-dd date picker model for customer analytics
- format calendar dates without browser timezone drift
- include pending analytics datepicker tenant-date updates

## Tests
- Not run per request: no build
- git diff --check