### PR TITLE
Refine POS layout and accounting entry grid

### DIFF
--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="flex flex-col min-h-0 h-full lg:w-96 border border-border rounded-2xl bg-surface overflow-hidden shadow-sm">
+  <div
+    class="flex flex-col min-h-0 lg:w-96 border border-border rounded-2xl bg-surface overflow-hidden shadow-sm"
+    :class="fitHeight ? 'h-fit' : 'h-full'"
+  >
     <!-- Cart Header -->
     <div class="px-4 py-3.5 border-b border-border bg-surface">
       <div class="flex items-center justify-between gap-2">
@@ -445,6 +448,7 @@ interface Props {
   hideProcessOrder?: boolean
   openSaleTooltip?: string | null
   showBarProcessOrder?: boolean
+  fitHeight?: boolean
 }
 
 interface Emits {
@@ -492,6 +496,7 @@ const props = withDefaults(defineProps<Props>(), {
   hideProcessOrder: false,
   openSaleTooltip: null,
   showBarProcessOrder: false,
+  fitHeight: false,
 })
 
 const hasCartItems = computed(() => props.items.length > 0)

--- a/pages/finanzas/contabilidad/asientos/crear.vue
+++ b/pages/finanzas/contabilidad/asientos/crear.vue
@@ -250,9 +250,10 @@ const onCreditInput = (line: EntryLine) => {
         </div>
 
         <!-- Lines list -->
-        <div v-else class="divide-y divide-border">
+        <div v-else class="overflow-x-auto">
+          <div class="min-w-[1080px] divide-y divide-border">
           <!-- Column headers (desktop) -->
-          <div class="hidden sm:grid grid-cols-[2rem_1fr_9rem_9rem_1fr_2.25rem] gap-2 px-4 py-2 bg-surface-secondary">
+          <div class="hidden sm:grid grid-cols-[2rem_minmax(22rem,1.35fr)_10rem_10rem_minmax(18rem,1fr)_2.75rem] gap-2 px-4 py-2 bg-surface-secondary">
             <span class="text-xs font-medium text-text-secondary">#</span>
             <span class="text-xs font-medium text-text-secondary">Cuenta</span>
             <span class="text-xs font-medium text-text-secondary text-right">Débito</span>
@@ -264,7 +265,7 @@ const onCreditInput = (line: EntryLine) => {
           <div
             v-for="(line, idx) in lines"
             :key="line._id"
-            class="grid grid-cols-1 sm:grid-cols-[2rem_1fr_9rem_9rem_1fr_2.25rem] gap-2 px-4 py-2 items-center"
+            class="grid grid-cols-1 sm:grid-cols-[2rem_minmax(22rem,1.35fr)_10rem_10rem_minmax(18rem,1fr)_2.75rem] gap-2 px-4 py-2.5 items-center"
             :class="idx % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'"
           >
             <!-- # -->
@@ -275,7 +276,7 @@ const onCreditInput = (line: EntryLine) => {
               <span class="text-xs text-text-secondary sm:hidden">Cuenta</span>
               <select
                 v-model="line.accountId"
-                class="h-8 pl-2 pr-6 rounded-lg border border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer"
+                class="h-10 min-w-0 w-full pl-3 pr-8 rounded-lg border border-border bg-background text-sm leading-5 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer"
                 :aria-label="`Cuenta de la línea ${idx + 1}`"
               >
                 <option value="">Seleccionar cuenta...</option>
@@ -294,7 +295,7 @@ const onCreditInput = (line: EntryLine) => {
                 min="0"
                 step="1"
                 placeholder="0"
-                class="h-8 px-2 rounded-lg border border-border bg-background text-sm text-right tabular-nums text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
+                class="h-10 px-3 rounded-lg border border-border bg-background text-sm leading-5 text-right tabular-nums text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
                 :aria-label="`Débito línea ${idx + 1}`"
                 @input="onDebitInput(line)"
               />
@@ -309,7 +310,7 @@ const onCreditInput = (line: EntryLine) => {
                 min="0"
                 step="1"
                 placeholder="0"
-                class="h-8 px-2 rounded-lg border border-border bg-background text-sm text-right tabular-nums text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
+                class="h-10 px-3 rounded-lg border border-border bg-background text-sm leading-5 text-right tabular-nums text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
                 :aria-label="`Crédito línea ${idx + 1}`"
                 @input="onCreditInput(line)"
               />
@@ -322,7 +323,7 @@ const onCreditInput = (line: EntryLine) => {
                 v-model="line.description"
                 type="text"
                 placeholder="Descripción (opcional)"
-                class="h-8 px-2 rounded-lg border border-border bg-background text-sm text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
+                class="h-10 px-3 rounded-lg border border-border bg-background text-sm leading-5 text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
                 :aria-label="`Descripción línea ${idx + 1}`"
               />
             </div>
@@ -331,7 +332,7 @@ const onCreditInput = (line: EntryLine) => {
             <button
               type="button"
               :disabled="lines.length <= 2"
-              class="h-8 w-9 flex items-center justify-center rounded-lg border border-border text-text-secondary hover:text-destructive hover:border-destructive transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              class="h-10 w-10 flex items-center justify-center rounded-lg border border-border text-text-secondary hover:text-destructive hover:border-destructive transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
               :aria-label="`Eliminar línea ${idx + 1}`"
               @click="removeLine(line._id)"
             >
@@ -342,13 +343,14 @@ const onCreditInput = (line: EntryLine) => {
           </div>
 
           <!-- Totals row -->
-          <div class="hidden sm:grid grid-cols-[2rem_1fr_9rem_9rem_1fr_2.25rem] gap-2 px-4 py-2 bg-surface-secondary border-t-2 border-border">
+          <div class="hidden sm:grid grid-cols-[2rem_minmax(22rem,1.35fr)_10rem_10rem_minmax(18rem,1fr)_2.75rem] gap-2 px-4 py-2 bg-surface-secondary border-t-2 border-border">
             <span />
             <span class="text-xs font-semibold text-text-primary">Total</span>
             <span class="text-sm font-bold tabular-nums text-right text-text-primary">{{ formatCurrency(totalDebits) }}</span>
             <span class="text-sm font-bold tabular-nums text-right text-text-primary">{{ formatCurrency(totalCredits) }}</span>
             <span />
             <span />
+          </div>
           </div>
         </div>
       </div>

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -1885,36 +1885,38 @@ onUnmounted(() => {
 
 
       <!-- Main POS Container -->
-    <div class="flex flex-col lg:flex-row gap-4 md:gap-6 lg:max-h-[calc(100vh-10rem)]">
+    <div class="grid w-full grid-cols-1 items-start gap-4 md:gap-6 lg:grid-cols-[minmax(0,1fr)_24rem]">
       <!-- Products Panel (Left) -->
-      <div class="flex-1 flex flex-col space-y-4 min-h-0 lg:overflow-hidden">
-        <!-- Search and Filters -->
-        <div class="flex flex-col sm:flex-row gap-3">
-          <div class="flex-1">
-            <UiSearchBar
-              v-model="searchQuery"
-              placeholder="Buscar productos..."
-            />
+      <div class="min-w-0 flex flex-col space-y-4">
+        <div class="lg:sticky lg:top-0 lg:z-20 flex flex-col gap-3 bg-background pt-2 pb-1">
+          <!-- Search and Filters -->
+          <div class="flex flex-col sm:flex-row gap-3">
+            <div class="flex-1">
+              <UiSearchBar
+                v-model="searchQuery"
+                placeholder="Buscar productos..."
+              />
+            </div>
+          </div>
+
+          <!-- Category Tabs -->
+          <div class="flex gap-2 overflow-x-auto scrollbar-hide pb-1">
+            <button
+              v-for="cat in categories"
+              :key="cat"
+              class="px-3.5 py-1.5 rounded-xl text-sm font-medium whitespace-nowrap theme-transition"
+              :class="selectedCategory === cat
+                ? 'bg-action-primary-bg text-action-primary-text shadow-md'
+                : 'bg-surface border border-border text-text-secondary hover:border-border hover:text-text-primary hover:bg-surface-secondary'"
+              @click="selectedCategory = cat"
+            >
+              {{ cat === 'all' ? 'Todos' : cat }}
+            </button>
           </div>
         </div>
 
-        <!-- Category Tabs -->
-        <div class="flex gap-2 overflow-x-auto scrollbar-hide pb-1">
-          <button
-            v-for="cat in categories"
-            :key="cat"
-            class="px-3.5 py-1.5 rounded-xl text-sm font-medium whitespace-nowrap theme-transition"
-            :class="selectedCategory === cat
-              ? 'bg-action-primary-bg text-action-primary-text shadow-md'
-              : 'bg-surface border border-border text-text-secondary hover:border-border hover:text-text-primary hover:bg-surface-secondary'"
-            @click="selectedCategory = cat"
-          >
-            {{ cat === 'all' ? 'Todos' : cat }}
-          </button>
-        </div>
-
         <!-- Products Grid — page scroll on mobile; inner scroll on desktop (#1032) -->
-        <div class="lg:flex-1 lg:min-h-0 lg:overflow-y-auto">
+        <div>
           <!-- Empty State -->
           <div v-if="filteredProducts.length === 0" class="flex flex-col items-center justify-center h-64 text-text-secondary">
             <svg class="w-16 h-16 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1925,7 +1927,7 @@ onUnmounted(() => {
           </div>
 
           <!-- Products Grid -->
-          <div v-else class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-3 gap-2 md:gap-4 p-1 pb-4">
+          <div v-else class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2 md:gap-4 p-1 pb-4">
             <PosProductCard
               v-for="product in filteredProducts"
               :key="product.id"
@@ -1940,6 +1942,7 @@ onUnmounted(() => {
       <!-- Cart Panel — desktop sidebar only; mobile uses bottom bar + sheet (#1032) -->
       <PosCartPanel
         class="hidden lg:flex"
+        fit-height
         :items="posStore.cart"
         :total="cartTotal"
         :mesa-mode="isKitchenServiceMode"


### PR DESCRIPTION
## Summary
- Simplify POS desktop layout into left products and right order columns.
- Keep POS search and categories sticky with a plain background.
- Allow the POS order panel to fit its content on desktop.
- Prevent accounting journal entry selectors from clipping by widening the row grid and control heights.

## Validation
- SFC compile checks for modified Vue files
- git diff --check

No build run.