### PR TITLE
Recover dashboard sessions on auth expiry

### DIFF
--- a/composables/useQueryError.ts
+++ b/composables/useQueryError.ts
@@ -7,7 +7,13 @@
  *     toast.error(extractApiError(err, 'No se pudo guardar'))
  *   }
  */
+import { isSessionAuthError } from './useSessionExpiry'
+
 export function extractApiError(err: unknown, fallback = 'Error inesperado'): string {
+  if (isSessionAuthError(err)) {
+    return 'Tu sesion expiro. Inicia sesion de nuevo para continuar.'
+  }
+
   const e = err as { data?: { detail?: string }; message?: string }
   return e?.data?.detail || e?.message || fallback
 }

--- a/composables/useSessionExpiry.ts
+++ b/composables/useSessionExpiry.ts
@@ -1,0 +1,96 @@
+type FetchErrorLike = {
+  status?: number
+  statusCode?: number
+  response?: { status?: number }
+  data?: { detail?: string; message?: string }
+  message?: string
+}
+
+let lastSessionExpiryHandledAt = 0
+
+const INTERNAL_PUBLIC_PREFIXES = [
+  '/auth/',
+  '/proveedor/',
+  '/blog',
+  '/docs',
+  '/public/',
+  '/403',
+]
+
+function getErrorStatus(err: unknown): number | undefined {
+  const error = err as FetchErrorLike
+  return error?.status ?? error?.statusCode ?? error?.response?.status
+}
+
+function getErrorMessage(err: unknown): string {
+  const error = err as FetchErrorLike
+  return String(error?.data?.detail ?? error?.data?.message ?? error?.message ?? '')
+}
+
+export function isSessionAuthError(err: unknown): boolean {
+  if (getErrorStatus(err) !== 401) return false
+
+  const message = getErrorMessage(err).toLowerCase()
+  if (!message) return true
+
+  return (
+    message.includes('session') ||
+    message.includes('auth') ||
+    message.includes('valid session') ||
+    message.includes('no valid session') ||
+    message.includes('no session') ||
+    message.includes('token expired')
+  )
+}
+
+function isInternalRecoveryRoute(route: ReturnType<typeof useRoute>): boolean {
+  if (route.path === '/' || route.path.startsWith('/auth/login')) return false
+  if (INTERNAL_PUBLIC_PREFIXES.some(prefix => route.path.startsWith(prefix))) return false
+
+  const layout = route.meta?.layout
+  if (layout === 'public-restaurant' || layout === 'customer-portal' || layout === 'kds') {
+    return false
+  }
+
+  return route.meta?.publicAccess !== true
+}
+
+export function useSessionExpiry() {
+  const handleSessionExpiry = async (err: unknown): Promise<boolean> => {
+    if (!import.meta.client || !isSessionAuthError(err)) return false
+
+    const route = useRoute()
+    if (!isInternalRecoveryRoute(route)) return false
+
+    const now = Date.now()
+    const shouldNotify = now - lastSessionExpiryHandledAt > 3000
+    lastSessionExpiryHandledAt = now
+
+    const authStore = useAuthStore()
+    const accessStore = useAccessStore()
+    const tenantsStore = useTenantsStore()
+
+    authStore.expireSession()
+    accessStore.clear()
+    tenantsStore.clearTenants()
+
+    if (shouldNotify) {
+      useToast().warning('Tu sesion expiro. Inicia sesion de nuevo para continuar.', {
+        title: 'Sesion expirada',
+        duration: 7000,
+      })
+    }
+
+    const redirect = route.fullPath && route.path !== '/auth/login'
+      ? `?redirect=${encodeURIComponent(route.fullPath)}`
+      : ''
+
+    await navigateTo(`/auth/login${redirect}`)
+    return true
+  }
+
+  return {
+    handleSessionExpiry,
+    isSessionAuthError,
+  }
+}

--- a/middleware/auth.global.js
+++ b/middleware/auth.global.js
@@ -5,6 +5,7 @@ import {
   getSafeInternalRedirect,
   isInternalAccessDeniedError,
 } from '~/utils/internalAccess'
+import { isSessionAuthError } from '~/composables/useSessionExpiry'
 
 export default defineNuxtRouteMiddleware(async (to, from) => {
   // Skip on server-side rendering
@@ -100,12 +101,15 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
       throw err
     }
   } catch (err) {
-    console.error('Auth middleware error:', err)
+    if (!isSessionAuthError(err)) {
+      console.error('Auth middleware error:', err)
+    }
     clearInternalState()
     if (isInternalAccessDeniedError(err)) {
       return navigateTo(CUSTOMER_PORTAL_LOGIN)
     }
-    return navigateTo('/auth/login')
+    const redirect = to.fullPath ? `?redirect=${encodeURIComponent(to.fullPath)}` : ''
+    return navigateTo(`/auth/login${redirect}`)
   } finally {
     authStore.setLoading(false)
   }

--- a/plugins/session-expiry.client.ts
+++ b/plugins/session-expiry.client.ts
@@ -1,0 +1,34 @@
+type WaroFetch = typeof globalThis.$fetch & {
+  __waroSessionExpiryWrapped?: boolean
+}
+
+export default defineNuxtPlugin(() => {
+  const originalFetch = globalThis.$fetch as WaroFetch
+
+  if (!originalFetch || originalFetch.__waroSessionExpiryWrapped) return
+
+  const wrappedFetch = (async (request: any, options?: any) => {
+    try {
+      return await originalFetch(request, options)
+    } catch (err) {
+      await useSessionExpiry().handleSessionExpiry(err)
+      throw err
+    }
+  }) as WaroFetch
+
+  Object.assign(wrappedFetch, originalFetch)
+  wrappedFetch.__waroSessionExpiryWrapped = true
+
+  if (typeof originalFetch.raw === 'function') {
+    wrappedFetch.raw = (async (request: any, options?: any) => {
+      try {
+        return await originalFetch.raw(request, options)
+      } catch (err) {
+        await useSessionExpiry().handleSessionExpiry(err)
+        throw err
+      }
+    }) as typeof originalFetch.raw
+  }
+
+  globalThis.$fetch = wrappedFetch
+})


### PR DESCRIPTION
## Summary
- Add a route-aware session-expiry recovery handler for internal dashboard routes
- Wrap client $fetch 401s to clear auth state, show one relogin toast, and preserve redirect
- Keep expected auth route middleware failures out of console error noise

## Tests
- git diff --check -- composables/useQueryError.ts middleware/auth.global.js composables/useSessionExpiry.ts plugins/session-expiry.client.ts
- Local eslint binary not installed; skipped
- Build skipped per request

Refs uno0uno/api-warolabs#563