### PR TITLE
Stabilize notification SSE lifecycle

### DIFF
--- a/composables/useNotifications.ts
+++ b/composables/useNotifications.ts
@@ -19,8 +19,15 @@ let _queryCache: ReturnType<typeof useQueryCache> | null = null
 const initialized = ref(false)
 const isTenantResetting = ref(false)
 let eventSource: EventSource | null = null
-let connectionRefCount = 0
+const connectionOwners = new Set<string>()
 let tenantWatcherSetup = false
+let intentionalClose = false
+let lastErrorWarningAt = 0
+
+type DisconnectOptions = {
+  force?: boolean
+  clearCache?: boolean
+}
 
 export const useNotifications = () => {
   // Capture query cache for SSE callback — must be called inside setup() context
@@ -42,11 +49,33 @@ export const useNotifications = () => {
   const notifications = computed(() => data.value ?? [])
   const unreadCount = computed(() => notifications.value.filter(n => !n.read_at).length)
 
+  const canConnect = () => {
+    const authStore = useAuthStore()
+    return authStore.isSessionValid
+  }
+
+  const closeEventSource = (clearCache = false) => {
+    intentionalClose = true
+    if (eventSource) {
+      eventSource.close()
+      eventSource = null
+    }
+    initialized.value = false
+    if (clearCache) {
+      _queryCache?.setQueryData(['notifications'], [])
+    }
+    queueMicrotask(() => {
+      intentionalClose = false
+    })
+  }
+
   const connect = () => {
     if (!process.client) return
+    if (!canConnect()) return
     if (eventSource) return // Already connected — singleton guard
 
     eventSource = new EventSource('/api/notifications/stream', { withCredentials: true })
+    initialized.value = true
 
     eventSource.onmessage = async (event) => {
       if (!event.data || event.data.startsWith(':')) return // ignore heartbeat comments
@@ -57,38 +86,43 @@ export const useNotifications = () => {
     }
 
     eventSource.onerror = () => {
-      console.warn('[useNotifications] SSE connection error, will auto-reconnect')
+      if (intentionalClose || eventSource?.readyState === EventSource.CLOSED) return
+
+      const now = Date.now()
+      if (now - lastErrorWarningAt > 30000) {
+        lastErrorWarningAt = now
+        console.debug('[useNotifications] SSE reconnecting')
+      }
     }
   }
 
-  const disconnect = () => {
-    connectionRefCount--
-    if (connectionRefCount <= 0 && eventSource) {
-      eventSource.close()
-      eventSource = null
-      connectionRefCount = 0
-      _queryCache?.setQueryData(['notifications'], [])
-      initialized.value = false
+  const disconnect = (owner = 'default', options: DisconnectOptions = {}) => {
+    connectionOwners.delete(owner)
+    if (options.force) {
+      connectionOwners.clear()
+    }
+
+    if (connectionOwners.size === 0) {
+      closeEventSource(options.clearCache ?? true)
     }
   }
 
   // Hard-resets SSE on tenant change — data refresh handled by tenants.ts bulk invalidation
   const resetForTenantChange = () => {
     isTenantResetting.value = true
-    if (eventSource) {
-      eventSource.close()
-      eventSource = null
-    }
-    initialized.value = false
-    connect()
-    isTenantResetting.value = false
+    closeEventSource(false)
+    queueMicrotask(() => {
+      if (connectionOwners.size > 0) {
+        connect()
+      }
+      isTenantResetting.value = false
+    })
   }
 
-  const init = async () => {
+  const init = async (owner = 'default') => {
     if (!process.client) return
-    connectionRefCount++ // always track this caller (fixes ref-count mismatch on re-navigation)
-    if (!initialized.value) {
-      initialized.value = true
+    connectionOwners.add(owner)
+    if (!initialized.value || !eventSource) {
       connect() // open SSE only once
     }
   }

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -79,7 +79,7 @@
 </template>
 
 <script setup lang="ts">
-import { provide, ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { provide, ref, computed, watch, onMounted } from 'vue'
 import {
   ChevronRightIcon
 } from '@heroicons/vue/24/outline'
@@ -87,8 +87,8 @@ import { useNotifications } from '~/composables/useNotifications'
 import { useBilling } from '~/composables/useBilling'
 import { usePosMobileCart } from '~/composables/usePosMobileCart'
 
-// Notifications — init here so SSE starts on all screen sizes (not just when bell mounts)
-const { unreadCount: notificationsUnreadCount, init: initNotifications, disconnect: disconnectNotifications } = useNotifications()
+// Notifications SSE is owned by plugins/notifications.client.ts.
+const { unreadCount: notificationsUnreadCount } = useNotifications()
 
 // Billing access status — drives banner and blocked redirect
 const { accessStatus, fetchAccessStatus } = useBilling()
@@ -125,12 +125,7 @@ watch(accessStatus, (status) => {
 }, { immediate: true })
 
 onMounted(() => {
-  if (process.client) initNotifications()
   fetchAccessStatus()
-})
-
-onUnmounted(() => {
-  disconnectNotifications()
 })
 
 // Refresh handler - shared via composable (provide/inject unreliable in Nuxt 3 layout↔page)

--- a/plugins/notifications.client.ts
+++ b/plugins/notifications.client.ts
@@ -9,10 +9,11 @@ import { watch } from 'vue'
 export default defineNuxtPlugin(() => {
   const authStore = useAuthStore()
   const { init, disconnect } = useNotifications()
+  const owner = 'auth'
 
   // Start the SSE connection as soon as the user has a valid session
   if (authStore.isSessionValid) {
-    init()
+    init(owner)
   }
 
   // React to auth state changes (login / logout / session expiry)
@@ -20,9 +21,9 @@ export default defineNuxtPlugin(() => {
     () => authStore.isSessionValid,
     (isValid, wasValid) => {
       if (isValid && !wasValid) {
-        init()
+        init(owner)
       } else if (!isValid && wasValid) {
-        disconnect()
+        disconnect(owner, { force: true, clearCache: true })
       }
     }
   )


### PR DESCRIPTION
## Summary
- make notification SSE ownership idempotent so plugin/layout/page calls do not duplicate streams
- force-close and clear notification state on auth invalidation/logout
- move dashboard away from opening its own SSE connection

## Tests
- NODE_OPTIONS=--max-old-space-size=4096 npm exec vue-tsc -- --noEmit --pretty false 2>&1 | rg "(composables/useNotifications|plugins/notifications\.client|layouts/dashboard)"
- not run: npm run build per request

Refs uno0uno/api-warolabs#564