### PR TITLE
Guard Table QR checkout submit

### DIFF
--- a/pages/[tenant]/mesa/[token]/checkout.vue
+++ b/pages/[tenant]/mesa/[token]/checkout.vue
@@ -49,6 +49,8 @@ const handlePrev = () => {
 }
 
 const handleSubmit = async () => {
+  if (isSubmitting.value || submitted.value) return
+
   paymentError.value = ''
   if (!paymentSelection.value.slug) {
     paymentError.value = 'Selecciona un método de pago.'


### PR DESCRIPTION
## Summary
- Add an early in-flight/submitted guard to the public Table QR checkout submit handler

## Tests
- Backend targeted pytest suites passed in api-warolabs
- Frontend build skipped per request: sin build

Refs uno0uno/api-warolabs#566