### PR TITLE
Handle unlimited billing quota usage

### DIFF
--- a/composables/useBilling.ts
+++ b/composables/useBilling.ts
@@ -90,10 +90,16 @@ export interface ScanMonthlyEntry {
 
 export interface BillingUsageMetric {
   used: number
-  limit: number
-  remaining: number
+  limit: number | null
+  remaining: number | null
   period_start: string
   period_end: string
+  plan_limit?: number
+  override?: {
+    id: string
+    disabled: boolean
+    reason: string | null
+  } | null
 }
 
 export type BillingQuotaUsage = Partial<Record<BillingQuotaKey, BillingUsageMetric>>

--- a/pages/gestion/billing/index.vue
+++ b/pages/gestion/billing/index.vue
@@ -80,8 +80,35 @@ const electronicInvoiceUsage = computed<BillingUsageMetric>(() =>
   remainingUsage.value?.electronic_invoice_usage ?? fallbackUsageMetric()
 )
 
-const usagePercentage = (metric: BillingUsageMetric) =>
-  metric.limit > 0 ? (metric.used / metric.limit) * 100 : 0
+type UsageMetricValue = Pick<BillingUsageMetric, 'used' | 'limit' | 'remaining'>
+
+const hasLimitedQuota = (metric: UsageMetricValue) =>
+  typeof metric.limit === 'number' && metric.limit > 0
+
+const usagePercentage = (metric: UsageMetricValue) =>
+  hasLimitedQuota(metric) ? (metric.used / metric.limit!) * 100 : 0
+
+const metricLimitLabel = (metric: UsageMetricValue, zeroLabel = 'No incluido') => {
+  if (metric.limit === null) return 'Sin límite'
+  if (typeof metric.limit !== 'number') return zeroLabel
+  if (metric.limit <= 0) return zeroLabel
+  return metric.limit.toLocaleString('es-CO')
+}
+
+const metricRemainingLabel = (metric: UsageMetricValue, zeroLabel = 'No incluido') => {
+  if (metric.limit === null) return 'Sin límite'
+  if (typeof metric.limit !== 'number') return zeroLabel
+  if (metric.limit <= 0) return zeroLabel
+  return (metric.remaining ?? 0).toLocaleString('es-CO')
+}
+
+const metricUsageLabel = (metric: UsageMetricValue, unit: string, zeroLabel = 'No incluido') => {
+  const used = metric.used ?? 0
+  if (metric.limit === null) {
+    return `${used.toLocaleString('es-CO')} ${unit} usados - sin límite`
+  }
+  return `${used.toLocaleString('es-CO')} de ${metricLimitLabel(metric, zeroLabel)} ${unit} usados`
+}
 
 const scanPercentage = computed(() => usagePercentage(scanUsage.value))
 const electronicInvoicePercentage = computed(() => usagePercentage(electronicInvoiceUsage.value))
@@ -664,8 +691,8 @@ watch(() => currentTenant.value?.id, async () => {
               role="progressbar"
               :aria-valuenow="scanUsage.used"
               aria-valuemin="0"
-              :aria-valuemax="scanUsage.limit"
-              :aria-label="`${scanUsage.used} de ${scanUsage.limit} escaneos usados`"
+              :aria-valuemax="scanUsage.limit ?? scanUsage.used"
+              :aria-label="metricUsageLabel(scanUsage, 'escaneos')"
             >
               <div
                 :class="['h-full rounded-full transition-all duration-500', scanBarColorClass]"
@@ -675,11 +702,11 @@ watch(() => currentTenant.value?.id, async () => {
             <p class="mt-2 text-sm text-text-secondary">
               <span class="font-semibold text-text-primary">{{ scanUsage.used.toLocaleString('es-CO') }}</span>
               de
-              <span class="font-semibold text-text-primary">{{ scanUsage.limit.toLocaleString('es-CO') }}</span>
+              <span class="font-semibold text-text-primary">{{ metricLimitLabel(scanUsage) }}</span>
               escaneos usados
             </p>
             <p class="mt-1 text-xs text-text-secondary">
-              {{ scanUsage.remaining.toLocaleString('es-CO') }} restantes
+              {{ metricRemainingLabel(scanUsage) }} restantes
             </p>
           </div>
 
@@ -693,8 +720,8 @@ watch(() => currentTenant.value?.id, async () => {
               role="progressbar"
               :aria-valuenow="electronicInvoiceUsage.used"
               aria-valuemin="0"
-              :aria-valuemax="electronicInvoiceUsage.limit"
-              :aria-label="`${electronicInvoiceUsage.used} de ${electronicInvoiceUsage.limit} facturas electronicas usadas`"
+              :aria-valuemax="electronicInvoiceUsage.limit ?? electronicInvoiceUsage.used"
+              :aria-label="metricUsageLabel(electronicInvoiceUsage, 'facturas electrónicas', 'Sin cupo pagado')"
             >
               <div
                 :class="['h-full rounded-full transition-all duration-500', electronicInvoiceBarColorClass]"
@@ -704,12 +731,12 @@ watch(() => currentTenant.value?.id, async () => {
             <p class="mt-2 text-sm text-text-secondary">
               <span class="font-semibold text-text-primary">{{ electronicInvoiceUsage.used.toLocaleString('es-CO') }}</span>
               de
-              <span class="font-semibold text-text-primary">{{ electronicInvoiceUsage.limit.toLocaleString('es-CO') }}</span>
+              <span class="font-semibold text-text-primary">{{ metricLimitLabel(electronicInvoiceUsage, 'Sin cupo pagado') }}</span>
               facturas usadas
             </p>
             <p class="mt-1 text-xs text-text-secondary">
-              <template v-if="electronicInvoiceUsage.limit > 0">
-                {{ electronicInvoiceUsage.remaining.toLocaleString('es-CO') }} restantes
+              <template v-if="hasLimitedQuota(electronicInvoiceUsage)">
+                {{ metricRemainingLabel(electronicInvoiceUsage) }} restantes
               </template>
               <template v-else>
                 Sin cupo pagado - 0 restantes
@@ -737,8 +764,8 @@ watch(() => currentTenant.value?.id, async () => {
                 role="progressbar"
                 :aria-valuenow="row.metric.used"
                 aria-valuemin="0"
-                :aria-valuemax="row.metric.limit"
-                :aria-label="`${row.metric.used} de ${row.metric.limit} ${row.unit} usados`"
+                :aria-valuemax="row.metric.limit ?? row.metric.used"
+                :aria-label="metricUsageLabel(row.metric, row.unit, row.zeroLabel)"
               >
                 <div
                   :class="['h-full rounded-full transition-all duration-500', row.barClass]"
@@ -746,14 +773,14 @@ watch(() => currentTenant.value?.id, async () => {
                 />
               </div>
               <p class="mt-2 text-sm text-text-secondary">
-                <span class="font-semibold text-text-primary">{{ row.metric.used.toLocaleString('es-CO') }}</span>
-                de
-                <span class="font-semibold text-text-primary">{{ row.metric.limit.toLocaleString('es-CO') }}</span>
-                usados
+                {{ metricUsageLabel(row.metric, row.unit, row.zeroLabel) }}
               </p>
               <p class="mt-1 text-xs text-text-secondary">
-                <template v-if="row.metric.limit > 0">
-                  {{ row.metric.remaining.toLocaleString('es-CO') }} restantes
+                <template v-if="hasLimitedQuota(row.metric)">
+                  {{ metricRemainingLabel(row.metric) }} restantes
+                </template>
+                <template v-else-if="row.metric.limit === null">
+                  Sin límite por override
                 </template>
                 <template v-else>
                   {{ row.zeroLabel ?? 'No incluido' }}

--- a/pages/gestion/billing/uso.vue
+++ b/pages/gestion/billing/uso.vue
@@ -42,8 +42,51 @@ const fallbackUsageMetric = (used = 0, limit = 0): BillingUsageMetric => ({
   period_end: subscription.value?.current_period_end ?? '',
 })
 
-const usagePercentage = (metric: BillingUsageMetric) =>
-  metric.limit > 0 ? Math.min(Math.round((metric.used / metric.limit) * 100), 100) : 0
+type UsageMetricValue = {
+  used?: number
+  limit?: number | null
+  remaining?: number | null
+}
+
+interface UsageDisplayRow {
+  resource: string
+  description: string
+  used: number
+  limit: number | null
+  remaining: number | null
+  percentage: number
+  unit: string
+  emptyMessage: string | null
+  zeroLabel?: string
+}
+
+const hasLimitedQuota = (metric: UsageMetricValue) =>
+  typeof metric.limit === 'number' && metric.limit > 0
+
+const usagePercentage = (metric: UsageMetricValue) =>
+  hasLimitedQuota(metric) ? Math.min(Math.round(((metric.used ?? 0) / metric.limit!) * 100), 100) : 0
+
+const metricLimitLabel = (metric: UsageMetricValue, zeroLabel = 'No incluido') => {
+  if (metric.limit === null) return 'Sin límite'
+  if (typeof metric.limit !== 'number') return zeroLabel
+  if (metric.limit <= 0) return zeroLabel
+  return metric.limit.toLocaleString('es-CO')
+}
+
+const metricRemainingLabel = (metric: UsageMetricValue, zeroLabel = 'No incluido') => {
+  if (metric.limit === null) return 'Sin límite'
+  if (typeof metric.limit !== 'number') return zeroLabel
+  if (metric.limit <= 0) return zeroLabel
+  return (metric.remaining ?? 0).toLocaleString('es-CO')
+}
+
+const metricUsageLabel = (metric: UsageMetricValue, unit: string, zeroLabel = 'No incluido') => {
+  const used = metric.used ?? 0
+  if (metric.limit === null) {
+    return `${used.toLocaleString('es-CO')} ${unit} usados - sin límite`
+  }
+  return `${used.toLocaleString('es-CO')} de ${metricLimitLabel(metric, zeroLabel)} ${unit} usados`
+}
 
 const scanUsage = computed<BillingUsageMetric>(() =>
   remainingUsage.value?.scan_usage ??
@@ -73,30 +116,30 @@ const quotaDisplayConfig: QuotaDisplayConfig[] = [
 
 const quotaUsageRows = computed(() =>
   quotaDisplayConfig
-    .map((config) => {
+    .map((config): UsageDisplayRow | null => {
       const metric = remainingUsage.value?.quota_usage?.[config.key]
       if (!metric) return null
       return {
         resource: config.label,
-        description: metric.limit > 0 ? config.description : config.zeroLabel ?? 'No incluido',
+        description: hasLimitedQuota(metric)
+          ? config.description
+          : metric.limit === null
+            ? 'Sin límite por override'
+            : config.zeroLabel ?? 'No incluido',
         used: metric.used,
         limit: metric.limit,
         remaining: metric.remaining,
         percentage: usagePercentage(metric),
         unit: config.unit,
-        emptyMessage: metric.limit > 0 ? null : '0 disponibles',
+        emptyMessage: hasLimitedQuota(metric)
+          ? null
+          : metric.limit === null
+            ? 'Sin límite'
+            : '0 disponibles',
+        zeroLabel: config.zeroLabel,
       }
     })
-    .filter((row): row is {
-      resource: string
-      description: string
-      used: number
-      limit: number
-      remaining: number
-      percentage: number
-      unit: string
-      emptyMessage: string | null
-    } => row !== null)
+    .filter((row): row is UsageDisplayRow => row !== null)
 )
 
 const columns: Column[] = [
@@ -121,7 +164,7 @@ const tableData = computed(() => {
     },
     {
       resource: 'Facturación electrónica',
-      description: electronicInvoiceUsage.value.limit > 0
+      description: hasLimitedQuota(electronicInvoiceUsage.value)
         ? 'Facturas incluidas en el período actual'
         : 'Sin cupo pagado - 0 restantes',
       used: electronicInvoiceUsage.value.used,
@@ -129,7 +172,8 @@ const tableData = computed(() => {
       remaining: electronicInvoiceUsage.value.remaining,
       percentage: usagePercentage(electronicInvoiceUsage.value),
       unit: 'facturas',
-      emptyMessage: electronicInvoiceUsage.value.limit > 0 ? null : '0 disponibles',
+      emptyMessage: hasLimitedQuota(electronicInvoiceUsage.value) ? null : '0 disponibles',
+      zeroLabel: 'Sin cupo pagado',
     },
     ...quotaRows.filter((row) => row.resource !== 'Facturación electrónica'),
   ]
@@ -178,12 +222,14 @@ const periodLabel = computed(() => {
                 <p class="text-sm font-semibold text-text-primary leading-tight">{{ item.resource }}</p>
                 <p class="text-xs text-text-secondary mt-0.5">{{ item.description }}</p>
                 <p class="text-xs text-text-secondary mt-2">
-                  {{ item.used.toLocaleString('es-CO') }} de {{ item.limit.toLocaleString('es-CO') }} {{ item.unit }} usados
+                  {{ metricUsageLabel(item, item.unit, item.zeroLabel) }}
                 </p>
               </div>
               <div class="text-right flex-shrink-0">
-                <p class="text-sm font-bold text-text-primary">{{ item.remaining.toLocaleString('es-CO') }}</p>
-                <p class="text-xs text-text-secondary">restantes</p>
+                <p class="text-sm font-bold text-text-primary">{{ metricRemainingLabel(item, item.zeroLabel) }}</p>
+                <p class="text-xs text-text-secondary">
+                  {{ item.remaining === null ? 'sin tope' : 'restantes' }}
+                </p>
               </div>
             </div>
           </template>
@@ -204,14 +250,14 @@ const periodLabel = computed(() => {
 
           <template #cell-limit="{ item }">
             <span class="text-sm text-text-secondary">
-              {{ item.limit.toLocaleString('es-CO') }}
+              {{ metricLimitLabel(item, item.zeroLabel) }}
             </span>
             <span v-if="item.emptyMessage" class="block text-xs text-text-secondary">{{ item.emptyMessage }}</span>
           </template>
 
           <template #cell-remaining="{ item }">
             <span class="text-sm font-semibold text-text-primary">
-              {{ item.remaining.toLocaleString('es-CO') }}
+              {{ metricRemainingLabel(item, item.zeroLabel) }}
             </span>
             <span class="block text-xs text-text-secondary">{{ item.percentage }}% usado</span>
           </template>


### PR DESCRIPTION
## Summary
- update billing usage types for unlimited/override quota metrics
- render unlimited and not-included quota states safely in billing usage panels
- keep customer/admin quota error messaging paths safe without exposing raw quota keys

## Tests
- git diff --check
- NODE_OPTIONS=--max-old-space-size=8192 npm exec nuxi -- typecheck (fails on existing unrelated project-wide TS errors; no errors for touched billing/checkout paths after filtering)
- skipped npm run build per request

Manual QA checklist for reviewer:
- /gestion/billing plan cards show quotas and no raw quotas object
- payment modal steps 1 and 2 show quotas before redirect
- /gestion/billing/uso handles 0, not-included, and unlimited override quota states
- public checkout quota errors use customer_message instead of raw code/resource

Closes uno0uno/api-warolabs#577