### PR TITLE
Show checkout conflicts instead of false confirmation

### DIFF
--- a/components/online/checkout/StepConfirm.vue
+++ b/components/online/checkout/StepConfirm.vue
@@ -508,12 +508,6 @@ const submitOrder = async () => {
     notifyOrderConfirmed('Tu pedido fue confirmado')
   }
   catch (error: any) {
-    if (error.status === 409) {
-      // Order already placed — treat as success
-      showSuccessModal.value = true
-      notifyOrderConfirmed('Tu pedido fue confirmado')
-      return
-    }
     checkoutError.value = checkoutErrorMessage(error)
   }
   finally {


### PR DESCRIPTION
## Summary
- stop treating every checkout 409 as a successful order confirmation
- show the backend conflict message instead of rendering Pedido confirmado without an order number

## Validation
- git diff --check