### PR TITLE
Bloquear invitaciones al alcanzar cuota de usuarios administrativos

### DIFF
--- a/composables/useBilling.ts
+++ b/composables/useBilling.ts
@@ -112,6 +112,185 @@ export interface BillingRemainingUsage {
   quota_usage?: BillingQuotaUsage
 }
 
+export type OperationalQuotaKey =
+  | 'admin_users'
+  | 'active_kitchens'
+  | 'active_tables_including_bar'
+  | 'active_qr_tables'
+  | 'completed_online_orders_per_month'
+
+export type OperationalQuotaStatus = 'allowed' | 'blocked' | 'unlimited' | 'loading' | 'error' | 'unknown'
+
+export interface BillingQuotaResourceConfig {
+  key: BillingQuotaKey
+  label: string
+  description: string
+  unit: string
+  blockedMessage: string
+  unlimitedMessage: string
+  zeroLabel?: string
+}
+
+export interface OperationalQuotaResult {
+  resource: OperationalQuotaKey
+  status: OperationalQuotaStatus
+  allowed: boolean
+  blocked: boolean
+  unlimited: boolean
+  loading: boolean
+  label: string
+  unit: string
+  message: string
+  metric: BillingUsageMetric | null
+}
+
+export const BILLING_QUOTA_RESOURCE_CONFIG: Record<BillingQuotaKey, BillingQuotaResourceConfig> = {
+  admin_users: {
+    key: 'admin_users',
+    label: 'Usuarios administrativos',
+    description: 'Miembros internos activos del establecimiento',
+    unit: 'usuarios administrativos',
+    blockedMessage: 'Alcanzaste el límite de usuarios administrativos de tu plan.',
+    unlimitedMessage: 'Puedes invitar usuarios administrativos sin límite por override.',
+  },
+  active_sessions_per_admin_user: {
+    key: 'active_sessions_per_admin_user',
+    label: 'Sesiones activas por usuario administrativo',
+    description: 'Máximo de sesiones simultáneas por usuario interno',
+    unit: 'sesiones',
+    blockedMessage: 'Alcanzaste el límite de sesiones activas por usuario administrativo.',
+    unlimitedMessage: 'Las sesiones activas no tienen límite por override.',
+  },
+  active_kitchens: {
+    key: 'active_kitchens',
+    label: 'Cocinas activas',
+    description: 'Puntos de preparación activos',
+    unit: 'cocinas',
+    blockedMessage: 'Alcanzaste el límite de cocinas activas de tu plan.',
+    unlimitedMessage: 'Puedes activar cocinas sin límite por override.',
+  },
+  active_tables_including_bar: {
+    key: 'active_tables_including_bar',
+    label: 'Mesas activas, incluida barra',
+    description: 'Mesas operativas del establecimiento',
+    unit: 'mesas',
+    blockedMessage: 'Alcanzaste el límite de mesas activas de tu plan.',
+    unlimitedMessage: 'Puedes activar mesas sin límite por override.',
+  },
+  active_qr_tables: {
+    key: 'active_qr_tables',
+    label: 'Mesas con QR activo',
+    description: 'Mesas activas con venta por QR',
+    unit: 'mesas QR',
+    blockedMessage: 'Alcanzaste el límite de mesas con QR activo de tu plan.',
+    unlimitedMessage: 'Puedes activar QR en mesas sin límite por override.',
+  },
+  completed_online_orders_per_month: {
+    key: 'completed_online_orders_per_month',
+    label: 'Pedidos en línea completados/mes',
+    description: 'Pedidos públicos completados en el período actual',
+    unit: 'pedidos',
+    blockedMessage: 'Alcanzaste el límite de pedidos en línea completados de tu plan.',
+    unlimitedMessage: 'Puedes recibir pedidos en línea sin límite por override.',
+  },
+  electronic_invoices_per_period: {
+    key: 'electronic_invoices_per_period',
+    label: 'Facturación electrónica',
+    description: 'Facturas incluidas en el período actual',
+    unit: 'facturas',
+    blockedMessage: 'No tienes cupo disponible de facturación electrónica.',
+    unlimitedMessage: 'La facturación electrónica no tiene límite por override.',
+    zeroLabel: 'No incluido',
+  },
+}
+
+export const OPERATIONAL_QUOTA_KEYS: OperationalQuotaKey[] = [
+  'admin_users',
+  'active_kitchens',
+  'active_tables_including_bar',
+  'active_qr_tables',
+  'completed_online_orders_per_month',
+]
+
+const operationalQuotaFallbackMessage = 'No pudimos verificar esta cuota ahora. El sistema validará la acción al guardar.'
+
+export const resolveOperationalQuota = (
+  resource: OperationalQuotaKey,
+  metric?: BillingUsageMetric | null,
+  state: { loading?: boolean; error?: boolean } = {}
+): OperationalQuotaResult => {
+  const config = BILLING_QUOTA_RESOURCE_CONFIG[resource]
+  const base = {
+    resource,
+    label: config.label,
+    unit: config.unit,
+    metric: metric ?? null,
+  }
+
+  if (state.loading) {
+    return {
+      ...base,
+      status: 'loading',
+      allowed: true,
+      blocked: false,
+      unlimited: false,
+      loading: true,
+      message: 'Estamos verificando tu cuota. Si continúas, el sistema validará la acción al guardar.',
+    }
+  }
+
+  if (state.error) {
+    return {
+      ...base,
+      status: 'error',
+      allowed: true,
+      blocked: false,
+      unlimited: false,
+      loading: false,
+      message: operationalQuotaFallbackMessage,
+    }
+  }
+
+  if (!metric) {
+    return {
+      ...base,
+      status: 'unknown',
+      allowed: true,
+      blocked: false,
+      unlimited: false,
+      loading: false,
+      message: operationalQuotaFallbackMessage,
+    }
+  }
+
+  if (metric.limit === null) {
+    return {
+      ...base,
+      status: 'unlimited',
+      allowed: true,
+      blocked: false,
+      unlimited: true,
+      loading: false,
+      message: config.unlimitedMessage,
+    }
+  }
+
+  const remaining = metric.remaining ?? Math.max(metric.limit - metric.used, 0)
+  const isBlocked = metric.limit <= 0 || remaining <= 0
+
+  return {
+    ...base,
+    status: isBlocked ? 'blocked' : 'allowed',
+    allowed: !isBlocked,
+    blocked: isBlocked,
+    unlimited: false,
+    loading: false,
+    message: isBlocked
+      ? config.blockedMessage
+      : `Tienes ${remaining.toLocaleString('es-CO')} ${config.unit} disponibles.`,
+  }
+}
+
 export const useBilling = () => {
   const cache = useQueryCache()
   const { currentTenant } = useTenantReactive()
@@ -193,6 +372,27 @@ export const useBilling = () => {
   const usageHistory = computed<ScanMonthlyEntry[]>(() => usageHistoryData.value ?? [])
   const events = computed<BillingEvent[]>(() => eventsData.value?.events ?? [])
   const eventsTotal = computed<number>(() => eventsData.value?.total ?? 0)
+  const operationalQuotaLoading = computed(() =>
+    remainingUsageAsyncStatus.value === 'loading' && remainingUsage.value == null
+  )
+  const operationalQuotaError = computed(() => remainingUsageStatus.value === 'error')
+  const getOperationalQuota = (resource: OperationalQuotaKey) =>
+    resolveOperationalQuota(
+      resource,
+      remainingUsage.value?.quota_usage?.[resource] ?? null,
+      {
+        loading: operationalQuotaLoading.value,
+        error: operationalQuotaError.value,
+      }
+    )
+  const operationalQuotas = computed<Record<OperationalQuotaKey, OperationalQuotaResult>>(() =>
+    OPERATIONAL_QUOTA_KEYS.reduce((acc, resource) => {
+      acc[resource] = getOperationalQuota(resource)
+      return acc
+    }, {} as Record<OperationalQuotaKey, OperationalQuotaResult>)
+  )
+  const canGrowOperationalResource = (resource: OperationalQuotaKey) =>
+    getOperationalQuota(resource).allowed
 
   const loading = computed(() =>
     subscribeMutation.isLoading.value ||
@@ -279,9 +479,12 @@ export const useBilling = () => {
     usageHistory,
     events,
     eventsTotal,
+    operationalQuotas,
     loading,
     isRefreshing,
     error,
+    getOperationalQuota,
+    canGrowOperationalResource,
     fetchPlans,
     fetchSubscription,
     fetchAccessStatus,

--- a/composables/useBillingOperationalQuota.test.ts
+++ b/composables/useBillingOperationalQuota.test.ts
@@ -1,0 +1,87 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  BILLING_QUOTA_RESOURCE_CONFIG,
+  OPERATIONAL_QUOTA_KEYS,
+  resolveOperationalQuota,
+} from './useBilling.ts'
+
+const metric = (overrides = {}) => ({
+  used: 1,
+  limit: 3,
+  remaining: 2,
+  period_start: '2026-07-01',
+  period_end: '2026-07-31',
+  ...overrides,
+})
+
+describe('resolveOperationalQuota', () => {
+  it('allows finite quotas with remaining usage', () => {
+    const result = resolveOperationalQuota('admin_users', metric({ used: 2, limit: 5, remaining: 3 }))
+
+    assert.equal(result.status, 'allowed')
+    assert.equal(result.allowed, true)
+    assert.equal(result.blocked, false)
+    assert.match(result.message, /3 usuarios administrativos disponibles/)
+  })
+
+  it('blocks finite quotas with no remaining usage', () => {
+    const result = resolveOperationalQuota('active_kitchens', metric({ used: 2, limit: 2, remaining: 0 }))
+
+    assert.equal(result.status, 'blocked')
+    assert.equal(result.allowed, false)
+    assert.equal(result.blocked, true)
+    assert.equal(result.message, BILLING_QUOTA_RESOURCE_CONFIG.active_kitchens.blockedMessage)
+  })
+
+  it('treats null limits as unlimited and allowed', () => {
+    const result = resolveOperationalQuota('active_tables_including_bar', metric({ limit: null, remaining: null }))
+
+    assert.equal(result.status, 'unlimited')
+    assert.equal(result.allowed, true)
+    assert.equal(result.blocked, false)
+    assert.equal(result.unlimited, true)
+  })
+
+  it('blocks finite quotas with zero or negative limits', () => {
+    const zeroLimit = resolveOperationalQuota('active_qr_tables', metric({ used: 0, limit: 0, remaining: 0 }))
+    const negativeLimit = resolveOperationalQuota('active_qr_tables', metric({ used: 0, limit: -1, remaining: 0 }))
+
+    assert.equal(zeroLimit.status, 'blocked')
+    assert.equal(zeroLimit.blocked, true)
+    assert.equal(negativeLimit.status, 'blocked')
+    assert.equal(negativeLimit.blocked, true)
+  })
+
+  it('does not block while loading or when a query errored', () => {
+    const loading = resolveOperationalQuota('completed_online_orders_per_month', null, { loading: true })
+    const error = resolveOperationalQuota('completed_online_orders_per_month', null, { error: true })
+
+    assert.equal(loading.status, 'loading')
+    assert.equal(loading.allowed, true)
+    assert.equal(loading.blocked, false)
+    assert.equal(loading.loading, true)
+    assert.equal(error.status, 'error')
+    assert.equal(error.allowed, true)
+    assert.equal(error.blocked, false)
+  })
+
+  it('does not block when the metric is missing', () => {
+    const result = resolveOperationalQuota('admin_users')
+
+    assert.equal(result.status, 'unknown')
+    assert.equal(result.allowed, true)
+    assert.equal(result.blocked, false)
+  })
+
+  it('defines reusable messages for every operational resource', () => {
+    for (const resource of OPERATIONAL_QUOTA_KEYS) {
+      const config = BILLING_QUOTA_RESOURCE_CONFIG[resource]
+
+      assert.equal(typeof config.blockedMessage, 'string')
+      assert.equal(typeof config.unlimitedMessage, 'string')
+      assert.ok(config.blockedMessage.length > 0)
+      assert.ok(config.unlimitedMessage.length > 0)
+    }
+  })
+})

--- a/pages/equipo/miembros/index.vue
+++ b/pages/equipo/miembros/index.vue
@@ -33,7 +33,12 @@
         </template>
 
         <template #trailing>
-          <button @click="openInviteModal" class="btn-primary px-4 py-2 rounded-lg flex items-center gap-2 text-sm font-medium whitespace-nowrap">
+          <button
+            :disabled="isAdminUsersQuotaBlocked"
+            :title="isAdminUsersQuotaBlocked ? adminUsersQuotaMessage : 'Invitar miembro'"
+            @click="openInviteModal"
+            class="btn-primary px-4 py-2 rounded-lg flex items-center gap-2 text-sm font-medium whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed"
+          >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
             </svg>
@@ -41,6 +46,18 @@
           </button>
         </template>
       </UiAdvancedFiltersBar>
+
+      <div
+        v-if="isAdminUsersQuotaBlocked"
+        class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+      >
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <p>{{ adminUsersQuotaMessage }}</p>
+          <NuxtLink to="/gestion/billing/uso" class="font-semibold text-amber-950 underline underline-offset-2">
+            Ver Mi Plan
+          </NuxtLink>
+        </div>
+      </div>
 
       <!-- Responsive Data View -->
       <UiResponsiveDataView
@@ -418,7 +435,7 @@
               </button>
               <button
                 type="submit"
-                :disabled="inviteSending"
+                :disabled="inviteSending || isAdminUsersQuotaBlocked"
                 class="flex-1 btn-primary px-4 py-2 rounded-lg disabled:opacity-50"
               >
                 {{ inviteSending ? 'Enviando...' : 'Enviar invitacion' }}
@@ -642,6 +659,7 @@ useHead({ title: 'Miembros - Equipo' })
 const { currentTenant } = useTenantReactive()
 const toast = useToast()
 const authStore = useAuthStore()
+const { operationalQuotas } = useBilling()
 
 const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
 const roleFilter = ref('')
@@ -857,12 +875,58 @@ const inviteForm = reactive({
   role: 'admin'
 })
 
+const adminUsersQuota = computed(() => operationalQuotas.value.admin_users)
+const isAdminUsersQuotaBlocked = computed(() => adminUsersQuota.value.blocked)
+const adminUsersQuotaMessage = computed(() => {
+  const quota = adminUsersQuota.value
+  const metric = quota.metric
+
+  if (!metric || metric.limit === null) return quota.message
+
+  const used = metric.used.toLocaleString('es-CO')
+  const limit = metric.limit.toLocaleString('es-CO')
+  return `${quota.message} Uso actual: ${used} de ${limit} ${quota.unit}. Revisa Mi Plan para ampliar tu cupo.`
+})
+
+const showAdminUsersQuotaBlocked = () => {
+  const message = adminUsersQuotaMessage.value
+  inviteError.value = message
+  toast.warning(message, { title: 'Cupo de usuarios agotado' })
+}
+
+const quotaExceededMessageFromError = (err: any) => {
+  const detail = err?.data?.detail ?? err?.data ?? {}
+  const used = typeof detail.used === 'number' ? detail.used : null
+  const limit = typeof detail.limit === 'number' ? detail.limit : null
+
+  if (used !== null && limit !== null) {
+    return `Alcanzaste el límite de usuarios administrativos de tu plan. Uso actual: ${used.toLocaleString('es-CO')} de ${limit.toLocaleString('es-CO')} usuarios administrativos. Revisa Mi Plan para ampliar tu cupo.`
+  }
+
+  return adminUsersQuotaMessage.value
+}
+
+const isQuotaExceededError = (err: any) => {
+  const detail = err?.data?.detail
+  return err?.status === 429 ||
+    err?.statusCode === 429 ||
+    err?.data?.code === 'quota_exceeded' ||
+    err?.data?.error === 'quota_exceeded' ||
+    detail?.code === 'quota_exceeded' ||
+    detail?.error === 'quota_exceeded'
+}
+
 // Delete Modal State
 const showDeleteModal = ref(false)
 const memberToDelete = ref(null)
 const deleting = ref(false)
 
 const openInviteModal = () => {
+  if (isAdminUsersQuotaBlocked.value) {
+    showAdminUsersQuotaBlocked()
+    return
+  }
+
   inviteForm.name = ''
   inviteForm.email = ''
   inviteForm.phone = ''
@@ -876,6 +940,11 @@ const closeInviteModal = () => {
 }
 
 const sendInvitation = async () => {
+  if (isAdminUsersQuotaBlocked.value) {
+    showAdminUsersQuotaBlocked()
+    return
+  }
+
   inviteSending.value = true
   inviteError.value = ''
 
@@ -901,7 +970,9 @@ const sendInvitation = async () => {
     }
   } catch (err) {
     console.error('Error sending invitation:', err)
-    inviteError.value = err.data?.message || err.message || 'Error al enviar la invitacion'
+    inviteError.value = isQuotaExceededError(err)
+      ? quotaExceededMessageFromError(err)
+      : err?.data?.message || err?.message || 'Error al enviar la invitacion'
   } finally {
     inviteSending.value = false
   }

--- a/pages/gestion/billing/uso.vue
+++ b/pages/gestion/billing/uso.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
-import { useBilling, type BillingQuotaKey, type BillingUsageMetric } from '~/composables/useBilling'
+import {
+  BILLING_QUOTA_RESOURCE_CONFIG,
+  useBilling,
+  type BillingUsageMetric,
+} from '~/composables/useBilling'
 
 interface Column {
   key: string
@@ -96,22 +100,14 @@ const electronicInvoiceUsage = computed<BillingUsageMetric>(() =>
   remainingUsage.value?.electronic_invoice_usage ?? fallbackUsageMetric()
 )
 
-interface QuotaDisplayConfig {
-  key: BillingQuotaKey
-  label: string
-  description: string
-  unit: string
-  zeroLabel?: string
-}
-
-const quotaDisplayConfig: QuotaDisplayConfig[] = [
-  { key: 'admin_users', label: 'Usuarios administrativos', description: 'Miembros internos activos del establecimiento', unit: 'usuarios administrativos' },
-  { key: 'active_sessions_per_admin_user', label: 'Sesiones activas por usuario administrativo', description: 'Máximo de sesiones simultáneas por usuario interno', unit: 'sesiones' },
-  { key: 'active_kitchens', label: 'Cocinas activas', description: 'Puntos de preparación activos', unit: 'cocinas' },
-  { key: 'active_tables_including_bar', label: 'Mesas activas, incluida barra', description: 'Mesas operativas del establecimiento', unit: 'mesas' },
-  { key: 'active_qr_tables', label: 'Mesas con QR activo', description: 'Mesas activas con venta por QR', unit: 'mesas QR' },
-  { key: 'completed_online_orders_per_month', label: 'Pedidos en línea completados/mes', description: 'Pedidos públicos completados en el período actual', unit: 'pedidos' },
-  { key: 'electronic_invoices_per_period', label: 'Facturación electrónica', description: 'Facturas incluidas en el período actual', unit: 'facturas', zeroLabel: 'No incluido' },
+const quotaDisplayConfig = [
+  BILLING_QUOTA_RESOURCE_CONFIG.admin_users,
+  BILLING_QUOTA_RESOURCE_CONFIG.active_sessions_per_admin_user,
+  BILLING_QUOTA_RESOURCE_CONFIG.active_kitchens,
+  BILLING_QUOTA_RESOURCE_CONFIG.active_tables_including_bar,
+  BILLING_QUOTA_RESOURCE_CONFIG.active_qr_tables,
+  BILLING_QUOTA_RESOURCE_CONFIG.completed_online_orders_per_month,
+  BILLING_QUOTA_RESOURCE_CONFIG.electronic_invoices_per_period,
 ]
 
 const quotaUsageRows = computed(() =>


### PR DESCRIPTION
## Summary
- Use the operational admin users quota helper on /equipo/miembros.
- Disable and guard member invitations when admin_users quota is exhausted.
- Show current usage with a Mi Plan link and preserve 429 fallback messaging.

## Validation
- git diff --check -- pages/equipo/miembros/index.vue
- Build skipped per request: sin build.

Closes #1508