### PR TITLE
Block public checkout when online order quota is exhausted

### DIFF
--- a/components/directory/DirectoryView.vue
+++ b/components/directory/DirectoryView.vue
@@ -40,6 +40,11 @@ const error = computed(() => (fetchError.value as { message?: string } | null)?.
 const hasRestaurants = computed(() => restaurants.value.length > 0)
 const isEmptyDirectory = computed(() => !pending.value && !error.value && !hasRestaurants.value)
 
+const isOrderable = (restaurant: unknown) => {
+  const row = restaurant as Record<string, unknown>
+  return row.is_currently_open === true && row.online_orders_available !== false
+}
+
 useSeoMeta({
   title: () => `Restaurantes en ${cityName.value} - Waro Colombia`,
   description: () => `Descubre los mejores restaurantes en ${cityName.value}. Explora menús, precios y haz tus pedidos en línea.`,
@@ -157,7 +162,7 @@ useHead(() => ({
             </span>
 
             <span
-              v-if="(restaurant as any).is_currently_open"
+              v-if="isOrderable(restaurant)"
               class="absolute top-3 right-3 inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-semibold bg-success/90 text-success-foreground rounded-xl backdrop-blur-sm"
             >
               <span class="w-1.5 h-1.5 bg-success-foreground rounded-full animate-pulse" aria-hidden="true" />

--- a/components/online/CartBottomBar.vue
+++ b/components/online/CartBottomBar.vue
@@ -1,7 +1,7 @@
 <template>
   <Teleport to="body">
     <Transition name="bar-slide">
-      <div v-if="cartStore.itemCount > 0 && acceptsOnlineOrders" class="cart-bottom-bar bg-surface border-t border-border shadow-2xl">
+      <div v-if="cartStore.itemCount > 0 && acceptsOnlineOrders && onlineOrdersAvailable" class="cart-bottom-bar bg-surface border-t border-border shadow-2xl">
         <!-- Inner container — aligned with body content
              (max-w-7xl mx-auto px-4 — same shape PublicMenu and
              RestaurantHeader use). Previous `md:px-16 2xl:px-[30rem]`
@@ -78,8 +78,10 @@ import { useOnlineCartStore } from '~/stores/online_cart'
 
 withDefaults(defineProps<{
   acceptsOnlineOrders?: boolean
+  onlineOrdersAvailable?: boolean
 }>(), {
   acceptsOnlineOrders: true,
+  onlineOrdersAvailable: true,
 })
 
 defineEmits<{

--- a/components/online/CartDrawer.vue
+++ b/components/online/CartDrawer.vue
@@ -114,6 +114,8 @@
                 :minimum-order="minimumOrder"
                 :restaurant-open="props.restaurantOpen"
                 :accepts-online-orders="props.acceptsOnlineOrders"
+                :online-orders-available="props.onlineOrdersAvailable"
+                :online-orders-unavailable-message="props.onlineOrdersUnavailableMessage"
                 @checkout="handleCheckout"
               />
             </div>
@@ -165,6 +167,8 @@ const props = defineProps<{
   modelValue: boolean
   restaurantOpen?: boolean
   acceptsOnlineOrders?: boolean
+  onlineOrdersAvailable?: boolean
+  onlineOrdersUnavailableMessage?: string
   // Real minimum from tenant_public_profiles.min_order_amount, forwarded
   // by the parent page (warocol.com#632). Decimal-string-safe — the
   // CartSummary boundary normalizes via Number().

--- a/components/online/CartSummary.vue
+++ b/components/online/CartSummary.vue
@@ -56,6 +56,14 @@
       Este restaurante no recibe pedidos en línea actualmente
     </div>
 
+    <!-- Online orders unavailable notice -->
+    <div v-else-if="showCheckoutButton && !onlineOrdersAvailable" class="flex items-center gap-2 p-3 mb-2 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-sm">
+      <svg class="w-4 h-4 flex-shrink-0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.586a1 1 0 0 1 .707.293l5.414 5.414a1 1 0 0 1 .293.707V19a2 2 0 0 1-2 2Z" />
+      </svg>
+      {{ onlineOrdersUnavailableMessage || 'Este restaurante no puede recibir pedidos en línea actualmente' }}
+    </div>
+
     <!-- Restaurant closed notice -->
     <div v-else-if="showCheckoutButton && !restaurantOpen" class="flex items-center gap-2 p-3 mb-2 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-sm">
       <svg class="w-4 h-4 flex-shrink-0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
@@ -76,6 +84,7 @@
       @click="$emit('checkout')"
     >
       <span v-if="!acceptsOnlineOrders">Pedidos en línea no disponibles</span>
+      <span v-else-if="!onlineOrdersAvailable">Pedidos en línea no disponibles</span>
       <span v-else-if="!restaurantOpen">Restaurante cerrado</span>
       <span v-else-if="normalizedMinimumOrder > subtotal">Pedido mínimo no alcanzado</span>
       <span v-else>Continuar a Checkout</span>
@@ -101,6 +110,8 @@ const props = withDefaults(
     showCheckoutButton?: boolean
     restaurantOpen?: boolean
     acceptsOnlineOrders?: boolean
+    onlineOrdersAvailable?: boolean
+    onlineOrdersUnavailableMessage?: string
   }>(),
   {
     orderType: 'delivery',
@@ -110,6 +121,8 @@ const props = withDefaults(
     showCheckoutButton: true,
     restaurantOpen: true,
     acceptsOnlineOrders: true,
+    onlineOrdersAvailable: true,
+    onlineOrdersUnavailableMessage: '',
   }
 )
 
@@ -129,6 +142,7 @@ const total = computed(() => {
 
 const isCheckoutDisabled = computed(() => {
   if (!props.acceptsOnlineOrders) return true
+  if (!props.onlineOrdersAvailable) return true
   if (!props.restaurantOpen) return true
   return normalizedMinimumOrder.value > 0 && props.subtotal < normalizedMinimumOrder.value
 })

--- a/components/online/checkout/StepConfirm.vue
+++ b/components/online/checkout/StepConfirm.vue
@@ -276,7 +276,7 @@ const addressStore = useAddressStore()
 // navigates from the menu page (warocol.com#632). Falls back to one
 // fresh fetch when the user arrives directly at /checkout (bookmark).
 const restaurantSlug = computed(() => String(route.params.tenant ?? ''))
-const { data: tenantProfile } = useQuery({
+const { data: tenantProfile, refetch: refetchTenantProfile } = useQuery({
   key: () => ['restaurant', 'public', restaurantSlug.value],
   query: () => $fetch(`/api/public/restaurant/${restaurantSlug.value}`),
   enabled: () => !!restaurantSlug.value,
@@ -294,6 +294,10 @@ type TipProfile = {
   tip_default_percentages?: number[]
   tip_preselect_index?: number | null
 }
+type OnlineOrderAvailabilityProfile = {
+  online_orders_available?: boolean
+  online_orders_unavailable_message?: string | null
+}
 const tipEnabled = computed(
   () => (tenantProfile.value as { data?: TipProfile } | null)?.data?.tip_enabled === true,
 )
@@ -307,6 +311,14 @@ const tipModel = ref<{ amount: number; source: 'preset' | 'custom' | 'none' }>({
   amount: 0,
   source: 'none',
 })
+const onlineOrdersAvailable = computed(
+  () => (tenantProfile.value as { data?: OnlineOrderAvailabilityProfile } | null)
+    ?.data?.online_orders_available !== false,
+)
+const onlineOrdersUnavailableMessage = computed(
+  () => (tenantProfile.value as { data?: OnlineOrderAvailabilityProfile } | null)
+    ?.data?.online_orders_unavailable_message || 'Este restaurante no puede recibir pedidos en línea actualmente.',
+)
 
 // ── Display helpers ───────────────────────────────────────────────────────
 
@@ -439,6 +451,12 @@ const checkoutErrorMessage = (error: any) => {
 const submitOrder = async () => {
   if (!cartStore.cartId) return
 
+  await refetchTenantProfile()
+  if (!onlineOrdersAvailable.value) {
+    checkoutError.value = onlineOrdersUnavailableMessage.value
+    return
+  }
+
   paymentError.value = ''
   if (!paymentSelection.value.slug) {
     paymentError.value = 'Selecciona un método de pago.'
@@ -528,6 +546,7 @@ const goToOrder = () => {
 
 const isValid = computed(() => {
   if (cartStore.isEmpty || !otpAuthStore.isAuthenticated) return false
+  if (!onlineOrdersAvailable.value) return false
   if (!paymentSelection.value.slug) return false
   const grp = paymentGroups.value.find((g) => g.slug === paymentSelection.value.slug)
   if (grp?.methods?.length && !paymentSelection.value.id) return false

--- a/components/public/PublicMenu.vue
+++ b/components/public/PublicMenu.vue
@@ -42,6 +42,14 @@
       </div>
     </div>
 
+    <!-- Online ordering unavailable by quota or another public-safe backend reason -->
+    <div v-else-if="!onlineOrdersAvailable" class="max-w-7xl mx-auto px-4 pt-6">
+      <div class="flex items-center gap-3 px-4 py-3 rounded-xl bg-destructive/10 border border-destructive/20 text-destructive text-sm font-medium">
+        <span>📋</span>
+        <span>{{ onlineOrdersUnavailableMessage || 'Este restaurante no puede recibir pedidos en línea actualmente.' }}</span>
+      </div>
+    </div>
+
     <!-- Closed Banner — only shown when accepting orders but currently closed -->
     <div v-else-if="!restaurantOpen" class="max-w-7xl mx-auto px-4 pt-6">
       <div class="flex items-center gap-3 px-4 py-3 rounded-xl bg-destructive/10 border border-destructive/20 text-destructive text-sm font-medium">
@@ -123,6 +131,14 @@ const props = defineProps({
     type: Boolean,
     default: true
   },
+  onlineOrdersAvailable: {
+    type: Boolean,
+    default: true
+  },
+  onlineOrdersUnavailableMessage: {
+    type: String,
+    default: ''
+  },
   /** When set, overrides acceptsOnlineOrders for add-to-cart gating (Table QR #713). */
   orderingEnabled: {
     type: Boolean,
@@ -143,7 +159,7 @@ const ordersAvailable = computed(() => {
   if (props.orderingEnabled !== undefined) {
     return props.restaurantOpen && props.orderingEnabled
   }
-  return props.restaurantOpen && props.acceptsOnlineOrders
+  return props.restaurantOpen && props.acceptsOnlineOrders && props.onlineOrdersAvailable
 })
 
 // All categories including "Todos"

--- a/components/public/RestaurantHeader.vue
+++ b/components/public/RestaurantHeader.vue
@@ -46,7 +46,7 @@
 
               <!-- Open/Closed Badge -->
               <span
-                v-if="restaurant.is_currently_open"
+                v-if="isOrderable"
                 class="inline-flex items-center px-3 py-1 rounded-md text-sm font-medium bg-success/10 text-success"
               >
                 <span class="w-2 h-2 bg-success rounded-full mr-2 animate-pulse" />
@@ -197,6 +197,11 @@ const props = defineProps({
 
 const showHours = ref(false)
 const showContact = ref(false)
+
+const isOrderable = computed(() =>
+  props.restaurant.is_currently_open === true &&
+  props.restaurant.online_orders_available !== false
+)
 
 const hasSocialMedia = computed(() => {
   const social = props.restaurant.social_media

--- a/pages/[tenant]/index.vue
+++ b/pages/[tenant]/index.vue
@@ -69,6 +69,9 @@ const restaurant = computed(() => (profileData.value as any)?.data || null)
 const onlineOrdersAvailable = computed(() =>
   restaurant.value?.online_orders_available ?? (restaurant.value?.accepts_online_orders ?? false),
 )
+const customerOrderingOpen = computed(() =>
+  (restaurant.value?.is_currently_open ?? true) && onlineOrdersAvailable.value
+)
 const onlineOrdersUnavailableMessage = computed(() =>
   restaurant.value?.online_orders_unavailable_message || 'Este restaurante no puede recibir pedidos en línea actualmente.',
 )
@@ -254,7 +257,7 @@ const handleCheckout = async () => {
     toast.error(onlineOrdersUnavailableMessage.value)
     return
   }
-  if (!(restaurant.value?.is_currently_open ?? true)) return
+  if (!customerOrderingOpen.value) return
 
   // Purge items that are no longer available online (same logic as handleCartOpen)
   const onlineIds = new Set(products.value.map((p: any) => p.id))
@@ -370,7 +373,7 @@ const cancelSwitch = () => {
           :categories="categories"
           :products="products"
           :is-loading="menuStatus === 'pending'"
-          :restaurant-open="restaurant.is_currently_open ?? true"
+          :restaurant-open="customerOrderingOpen"
           :accepts-online-orders="restaurant.accepts_online_orders ?? false"
           :online-orders-available="onlineOrdersAvailable"
           :online-orders-unavailable-message="onlineOrdersUnavailableMessage"
@@ -388,7 +391,7 @@ const cancelSwitch = () => {
       <!-- Cart Drawer -->
       <CartDrawer
         v-model="isCartOpen"
-        :restaurant-open="restaurant.is_currently_open ?? true"
+        :restaurant-open="customerOrderingOpen"
         :accepts-online-orders="restaurant.accepts_online_orders ?? false"
         :online-orders-available="onlineOrdersAvailable"
         :online-orders-unavailable-message="onlineOrdersUnavailableMessage"

--- a/pages/[tenant]/index.vue
+++ b/pages/[tenant]/index.vue
@@ -66,6 +66,12 @@ const { data: menuData, status: menuStatus, asyncStatus: menuAsyncStatus, error:
 })
 
 const restaurant = computed(() => (profileData.value as any)?.data || null)
+const onlineOrdersAvailable = computed(() =>
+  restaurant.value?.online_orders_available ?? (restaurant.value?.accepts_online_orders ?? false),
+)
+const onlineOrdersUnavailableMessage = computed(() =>
+  restaurant.value?.online_orders_unavailable_message || 'Este restaurante no puede recibir pedidos en línea actualmente.',
+)
 
 // Declared at setup scope so $fetch Nuxt auto-import is in context.
 const recoverCartSession = async (tenantId: string) => {
@@ -244,6 +250,10 @@ const handleCheckout = async () => {
     toast.error('Este restaurante no recibe pedidos en línea actualmente.')
     return
   }
+  if (!onlineOrdersAvailable.value) {
+    toast.error(onlineOrdersUnavailableMessage.value)
+    return
+  }
   if (!(restaurant.value?.is_currently_open ?? true)) return
 
   // Purge items that are no longer available online (same logic as handleCartOpen)
@@ -362,6 +372,8 @@ const cancelSwitch = () => {
           :is-loading="menuStatus === 'pending'"
           :restaurant-open="restaurant.is_currently_open ?? true"
           :accepts-online-orders="restaurant.accepts_online_orders ?? false"
+          :online-orders-available="onlineOrdersAvailable"
+          :online-orders-unavailable-message="onlineOrdersUnavailableMessage"
           @product-click="handleProductClick"
         />
       </div>
@@ -369,6 +381,7 @@ const cancelSwitch = () => {
       <!-- Cart Bottom Bar -->
       <CartBottomBar
         :accepts-online-orders="restaurant.accepts_online_orders ?? false"
+        :online-orders-available="onlineOrdersAvailable"
         @open-cart="handleCartOpen"
       />
 
@@ -377,6 +390,8 @@ const cancelSwitch = () => {
         v-model="isCartOpen"
         :restaurant-open="restaurant.is_currently_open ?? true"
         :accepts-online-orders="restaurant.accepts_online_orders ?? false"
+        :online-orders-available="onlineOrdersAvailable"
+        :online-orders-unavailable-message="onlineOrdersUnavailableMessage"
         :min-order-amount="restaurant.min_order_amount ?? 0"
         @checkout="handleCheckout"
         @open-product="handleOpenProductFromCart"

--- a/pages/equipo/miembros/index.vue
+++ b/pages/equipo/miembros/index.vue
@@ -659,7 +659,7 @@ useHead({ title: 'Miembros - Equipo' })
 const { currentTenant } = useTenantReactive()
 const toast = useToast()
 const authStore = useAuthStore()
-const { operationalQuotas } = useBilling()
+const { operationalQuotas, fetchBillingOverview } = useBilling()
 
 const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
 const roleFilter = ref('')
@@ -964,7 +964,7 @@ const sendInvitation = async () => {
         title: 'Invitacion enviada'
       })
       closeInviteModal()
-      refresh()
+      await Promise.all([refresh(), fetchBillingOverview()])
     } else {
       inviteError.value = response.message || 'Error al enviar la invitacion'
     }
@@ -1140,7 +1140,7 @@ const cancelInvitation = async () => {
     if (response.success) {
       toast.success(`Invitacion para ${invitationToCancel.value.email} cancelada`)
       closeCancelInvitationModal()
-      refresh()
+      await Promise.all([refresh(), fetchBillingOverview()])
     } else {
       toast.error(response.message || 'Error al cancelar invitacion')
     }

--- a/pages/gestion/billing/index.vue
+++ b/pages/gestion/billing/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useBilling, type BillingPlan, type BillingQuotaKey, type BillingUsageMetric } from '~/composables/useBilling'
+import { useBilling, type BillingPlan, type BillingQuotaKey } from '~/composables/useBilling'
 import { useFormatters } from '~/composables/useFormatters'
 
 interface Column {
@@ -14,7 +14,7 @@ definePageMeta({})
 useHead({ title: 'Historial de pagos — WaRo Admin' })
 
 const {
-  plans, subscription, accessStatus, remainingUsage, events, eventsTotal, loading, isRefreshing, error,
+  plans, subscription, accessStatus, events, eventsTotal, loading, isRefreshing, error,
   fetchPlans, fetchMyEvents, fetchBillingOverview, subscribeOrThrow,
 } = useBilling()
 
@@ -30,8 +30,7 @@ const isInitialLoading = computed(() =>
   (
     plans.value === undefined ||
     subscription.value === undefined ||
-    accessStatus.value === undefined ||
-    (subscription.value !== null && remainingUsage.value === undefined)
+    accessStatus.value === undefined
   )
 )
 
@@ -62,98 +61,6 @@ const goToPage = async (page: number) => {
   currentPage.value = p
   await fetchMyEvents(PAGE_SIZE, (p - 1) * PAGE_SIZE)
 }
-
-// ── Usage bars ───────────────────────────────────────────────────
-const fallbackUsageMetric = (used = 0, limit = 0): BillingUsageMetric => ({
-  used,
-  limit,
-  remaining: Math.max(limit - used, 0),
-  period_start: subscription.value?.current_period_start ?? '',
-  period_end: subscription.value?.current_period_end ?? '',
-})
-
-const scanUsage = computed<BillingUsageMetric>(() =>
-  remainingUsage.value?.scan_usage ??
-  fallbackUsageMetric(subscription.value?.scans_used ?? 0, subscription.value?.scan_limit ?? 0)
-)
-const electronicInvoiceUsage = computed<BillingUsageMetric>(() =>
-  remainingUsage.value?.electronic_invoice_usage ?? fallbackUsageMetric()
-)
-
-type UsageMetricValue = Pick<BillingUsageMetric, 'used' | 'limit' | 'remaining'>
-
-const hasLimitedQuota = (metric: UsageMetricValue) =>
-  typeof metric.limit === 'number' && metric.limit > 0
-
-const usagePercentage = (metric: UsageMetricValue) =>
-  hasLimitedQuota(metric) ? (metric.used / metric.limit!) * 100 : 0
-
-const metricLimitLabel = (metric: UsageMetricValue, zeroLabel = 'No incluido') => {
-  if (metric.limit === null) return 'Sin límite'
-  if (typeof metric.limit !== 'number') return zeroLabel
-  if (metric.limit <= 0) return zeroLabel
-  return metric.limit.toLocaleString('es-CO')
-}
-
-const metricRemainingLabel = (metric: UsageMetricValue, zeroLabel = 'No incluido') => {
-  if (metric.limit === null) return 'Sin límite'
-  if (typeof metric.limit !== 'number') return zeroLabel
-  if (metric.limit <= 0) return zeroLabel
-  return (metric.remaining ?? 0).toLocaleString('es-CO')
-}
-
-const metricUsageLabel = (metric: UsageMetricValue, unit: string, zeroLabel = 'No incluido') => {
-  const used = metric.used ?? 0
-  if (metric.limit === null) {
-    return `${used.toLocaleString('es-CO')} ${unit} usados - sin límite`
-  }
-  return `${used.toLocaleString('es-CO')} de ${metricLimitLabel(metric, zeroLabel)} ${unit} usados`
-}
-
-const scanPercentage = computed(() => usagePercentage(scanUsage.value))
-const electronicInvoicePercentage = computed(() => usagePercentage(electronicInvoiceUsage.value))
-
-const usageBarColorClass = (percentage: number) => {
-  const p = percentage
-  if (p >= 100) return 'bg-status-critical-text'
-  if (p >= 80)  return 'bg-status-warning-text'
-  if (p >= 50)  return 'bg-status-info-text'
-  return 'bg-status-success-text'
-}
-const usageLabelClass = (percentage: number) => {
-  const p = percentage
-  if (p >= 100) return 'text-status-critical-text'
-  if (p >= 80)  return 'text-status-warning-text'
-  if (p >= 50)  return 'text-status-info-text'
-  return 'text-text-secondary'
-}
-
-const scanBarColorClass = computed(() => usageBarColorClass(scanPercentage.value))
-const scanLabelClass = computed(() => usageLabelClass(scanPercentage.value))
-const electronicInvoiceBarColorClass = computed(() => usageBarColorClass(electronicInvoicePercentage.value))
-const electronicInvoiceLabelClass = computed(() => usageLabelClass(electronicInvoicePercentage.value))
-
-const quotaUsageRows = computed(() =>
-  quotaDisplayConfig
-    .map((config) => {
-      const metric = remainingUsage.value?.quota_usage?.[config.key]
-      if (!metric) return null
-      const percentage = usagePercentage(metric)
-      return {
-        ...config,
-        metric,
-        percentage,
-        labelClass: usageLabelClass(percentage),
-        barClass: usageBarColorClass(percentage),
-      }
-    })
-    .filter((row): row is QuotaDisplayConfig & {
-      metric: BillingUsageMetric
-      percentage: number
-      labelClass: string
-      barClass: string
-    } => row !== null)
-)
 
 // ── Subscribe modal (2-step wizard) ─────────────────────────────
 const showModal       = ref(false)
@@ -485,7 +392,6 @@ const eventReference = (item: any): string => {
 const eventAmount = (item: any): string | null => {
   const val = item?.amount ?? item?.metadata?.amount
   if (val) return formatCOP(Number(val))
-  if (item?.event_type === 'gift_granted') return 'Cortesía'
   return null
 }
 
@@ -676,117 +582,6 @@ watch(() => currentTenant.value?.id, async () => {
             <p class="text-base font-semibold text-text-primary">
               {{ subscription.current_period_end ? formatDate(subscription.current_period_end) : '—' }}
             </p>
-          </div>
-        </div>
-
-        <!-- Usage bars (only when subscription exists) -->
-        <div v-if="subscription" class="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-border border-b border-border">
-          <div class="px-6 py-5">
-            <div class="flex items-center justify-between gap-3 mb-2">
-              <p class="text-xs font-medium text-text-secondary uppercase tracking-widest">Escaneos — período actual</p>
-              <p :class="['text-xs font-semibold', scanLabelClass]">{{ scanPercentage.toFixed(0) }}%</p>
-            </div>
-            <div
-              class="w-full h-3 bg-surface-secondary rounded-full overflow-hidden"
-              role="progressbar"
-              :aria-valuenow="scanUsage.used"
-              aria-valuemin="0"
-              :aria-valuemax="scanUsage.limit ?? scanUsage.used"
-              :aria-label="metricUsageLabel(scanUsage, 'escaneos')"
-            >
-              <div
-                :class="['h-full rounded-full transition-all duration-500', scanBarColorClass]"
-                :style="{ width: `${Math.min(scanPercentage, 100)}%` }"
-              />
-            </div>
-            <p class="mt-2 text-sm text-text-secondary">
-              <span class="font-semibold text-text-primary">{{ scanUsage.used.toLocaleString('es-CO') }}</span>
-              de
-              <span class="font-semibold text-text-primary">{{ metricLimitLabel(scanUsage) }}</span>
-              escaneos usados
-            </p>
-            <p class="mt-1 text-xs text-text-secondary">
-              {{ metricRemainingLabel(scanUsage) }} restantes
-            </p>
-          </div>
-
-          <div class="px-6 py-5">
-            <div class="flex items-center justify-between gap-3 mb-2">
-              <p class="text-xs font-medium text-text-secondary uppercase tracking-widest">Facturación electrónica</p>
-              <p :class="['text-xs font-semibold', electronicInvoiceLabelClass]">{{ electronicInvoicePercentage.toFixed(0) }}%</p>
-            </div>
-            <div
-              class="w-full h-3 bg-surface-secondary rounded-full overflow-hidden"
-              role="progressbar"
-              :aria-valuenow="electronicInvoiceUsage.used"
-              aria-valuemin="0"
-              :aria-valuemax="electronicInvoiceUsage.limit ?? electronicInvoiceUsage.used"
-              :aria-label="metricUsageLabel(electronicInvoiceUsage, 'facturas electrónicas', 'Sin cupo pagado')"
-            >
-              <div
-                :class="['h-full rounded-full transition-all duration-500', electronicInvoiceBarColorClass]"
-                :style="{ width: `${Math.min(electronicInvoicePercentage, 100)}%` }"
-              />
-            </div>
-            <p class="mt-2 text-sm text-text-secondary">
-              <span class="font-semibold text-text-primary">{{ electronicInvoiceUsage.used.toLocaleString('es-CO') }}</span>
-              de
-              <span class="font-semibold text-text-primary">{{ metricLimitLabel(electronicInvoiceUsage, 'Sin cupo pagado') }}</span>
-              facturas usadas
-            </p>
-            <p class="mt-1 text-xs text-text-secondary">
-              <template v-if="hasLimitedQuota(electronicInvoiceUsage)">
-                {{ metricRemainingLabel(electronicInvoiceUsage) }} restantes
-              </template>
-              <template v-else>
-                Sin cupo pagado - 0 restantes
-              </template>
-            </p>
-          </div>
-        </div>
-
-        <div v-if="subscription && quotaUsageRows.length > 0" class="border-b border-border">
-          <div class="px-6 py-4 border-b border-border">
-            <p class="text-xs font-medium text-text-secondary uppercase tracking-widest">Uso operativo del plan</p>
-          </div>
-          <div class="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-border">
-            <div
-              v-for="row in quotaUsageRows"
-              :key="row.key"
-              class="px-6 py-5 border-b border-border last:border-b-0 md:[&:nth-last-child(-n+2)]:border-b-0"
-            >
-              <div class="flex items-center justify-between gap-3 mb-2">
-                <p class="text-xs font-medium text-text-secondary uppercase tracking-widest">{{ row.label }}</p>
-                <p :class="['text-xs font-semibold', row.labelClass]">{{ row.percentage.toFixed(0) }}%</p>
-              </div>
-              <div
-                class="w-full h-3 bg-surface-secondary rounded-full overflow-hidden"
-                role="progressbar"
-                :aria-valuenow="row.metric.used"
-                aria-valuemin="0"
-                :aria-valuemax="row.metric.limit ?? row.metric.used"
-                :aria-label="metricUsageLabel(row.metric, row.unit, row.zeroLabel)"
-              >
-                <div
-                  :class="['h-full rounded-full transition-all duration-500', row.barClass]"
-                  :style="{ width: `${Math.min(row.percentage, 100)}%` }"
-                />
-              </div>
-              <p class="mt-2 text-sm text-text-secondary">
-                {{ metricUsageLabel(row.metric, row.unit, row.zeroLabel) }}
-              </p>
-              <p class="mt-1 text-xs text-text-secondary">
-                <template v-if="hasLimitedQuota(row.metric)">
-                  {{ metricRemainingLabel(row.metric) }} restantes
-                </template>
-                <template v-else-if="row.metric.limit === null">
-                  Sin límite por override
-                </template>
-                <template v-else>
-                  {{ row.zeroLabel ?? 'No incluido' }}
-                </template>
-              </p>
-            </div>
           </div>
         </div>
 

--- a/pages/gestion/billing/uso.vue
+++ b/pages/gestion/billing/uso.vue
@@ -206,7 +206,6 @@ const periodLabel = computed(() => {
             >
               <div class="flex-1 min-w-0">
                 <p class="text-sm font-semibold text-text-primary leading-tight truncate">{{ item.resource }}</p>
-                <p class="text-xs text-text-secondary mt-0.5 truncate">{{ item.description }}</p>
               </div>
               <div class="grid grid-cols-4 gap-3 text-right flex-shrink-0">
                 <div>
@@ -232,7 +231,6 @@ const periodLabel = computed(() => {
           <template #cell-resource="{ item }">
             <div>
               <p class="text-sm font-semibold text-text-primary">{{ item.resource }}</p>
-              <p class="text-xs text-text-secondary mt-0.5">{{ item.description }}</p>
             </div>
           </template>
 

--- a/pages/gestion/billing/uso.vue
+++ b/pages/gestion/billing/uso.vue
@@ -181,96 +181,85 @@ const periodLabel = computed(() => {
 <template>
   <div class="flex flex-col gap-3 md:gap-4">
     <div v-if="isInitialLoading" class="flex items-center justify-center min-h-[300px]">
-      <div class="flex items-center gap-3 text-sm text-text-secondary">
-        <UiLoadingMatrix size="5.5px" color="currentColor" />
-        Cargando uso
-      </div>
+      <CommonsTheCustomLoader size="large" />
     </div>
 
     <template v-else>
-      <UiResponsiveDataView
-        title="Uso restante"
-        row-size="sm"
-        :columns="columns"
-        :data="tableData"
-        empty-message="No hay cupos disponibles"
-        empty-sub-message="Los cupos aparecerán cuando tengas una suscripción activa"
-        variant="default"
-      >
-        <template #header>
-          <div class="flex flex-col gap-1">
-            <p class="text-xs font-semibold text-data-table-header-text uppercase tracking-wider">Uso restante</p>
-            <p class="text-sm text-data-table-cell-muted">{{ periodLabel }}</p>
-          </div>
-        </template>
+      <div class="border border-border bg-surface">
+        <div class="px-4 py-3 md:px-6 md:py-4 border-b border-border">
+          <p class="text-xs font-medium text-text-secondary uppercase tracking-widest">Uso restante</p>
+          <p class="mt-1 text-sm text-text-secondary">{{ periodLabel }}</p>
+        </div>
 
-        <template #mobileHeader>
-          <div class="flex flex-col gap-1">
-            <p class="text-xs font-semibold text-data-table-header-text uppercase tracking-wider">Uso restante</p>
-            <p class="text-sm text-data-table-cell-muted">{{ periodLabel }}</p>
-          </div>
-        </template>
-
-        <template #card="{ item, index }">
-          <div
-            class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-data-table-row-hover-bg"
-            :class="index % 2 === 0 ? 'bg-data-table-row-bg' : 'bg-data-table-row-alt-bg'"
-          >
-            <div class="flex-1 min-w-0">
-              <p class="text-sm font-semibold text-text-primary leading-tight truncate">{{ item.resource }}</p>
-              <p class="text-xs text-text-secondary mt-0.5 truncate">{{ item.description }}</p>
-            </div>
-            <div class="grid grid-cols-4 gap-3 text-right flex-shrink-0">
-              <div>
-                <p class="text-xs text-text-secondary">Usado</p>
-                <p class="text-sm font-semibold text-text-primary tabular-nums">{{ item.used.toLocaleString('es-CO') }}</p>
+        <UiResponsiveDataView
+          row-size="sm"
+          :columns="columns"
+          :data="tableData"
+          empty-message="No hay cupos disponibles"
+          empty-sub-message="Los cupos aparecerán cuando tengas una suscripción activa"
+          variant="default"
+        >
+          <template #card="{ item, index }">
+            <div
+              class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-data-table-row-hover-bg"
+              :class="index % 2 === 0 ? 'bg-data-table-row-bg' : 'bg-data-table-row-alt-bg'"
+            >
+              <div class="flex-1 min-w-0">
+                <p class="text-sm font-semibold text-text-primary leading-tight truncate">{{ item.resource }}</p>
+                <p class="text-xs text-text-secondary mt-0.5 truncate">{{ item.description }}</p>
               </div>
-              <div>
-                <p class="text-xs text-text-secondary">Disp.</p>
-                <p class="text-sm text-text-secondary tabular-nums">{{ metricLimitLabel(item, item.zeroLabel) }}</p>
-              </div>
-              <div>
-                <p class="text-xs text-text-secondary">Rest.</p>
-                <p class="text-sm font-semibold text-text-primary tabular-nums">{{ metricRemainingLabel(item, item.zeroLabel) }}</p>
-              </div>
-              <div>
-                <p class="text-xs text-text-secondary">%</p>
-                <p class="text-sm text-text-secondary tabular-nums">{{ item.percentage }}%</p>
+              <div class="grid grid-cols-4 gap-3 text-right flex-shrink-0">
+                <div>
+                  <p class="text-xs text-text-secondary">Usado</p>
+                  <p class="text-sm font-semibold text-text-primary tabular-nums">{{ item.used.toLocaleString('es-CO') }}</p>
+                </div>
+                <div>
+                  <p class="text-xs text-text-secondary">Disp.</p>
+                  <p class="text-sm text-text-secondary tabular-nums">{{ metricLimitLabel(item, item.zeroLabel) }}</p>
+                </div>
+                <div>
+                  <p class="text-xs text-text-secondary">Rest.</p>
+                  <p class="text-sm font-semibold text-text-primary tabular-nums">{{ metricRemainingLabel(item, item.zeroLabel) }}</p>
+                </div>
+                <div>
+                  <p class="text-xs text-text-secondary">%</p>
+                  <p class="text-sm text-text-secondary tabular-nums">{{ item.percentage }}%</p>
+                </div>
               </div>
             </div>
-          </div>
-        </template>
+          </template>
 
-        <template #cell-resource="{ item }">
-          <div>
-            <p class="text-sm font-semibold text-text-primary">{{ item.resource }}</p>
-            <p class="text-xs text-text-secondary mt-0.5">{{ item.description }}</p>
-          </div>
-        </template>
+          <template #cell-resource="{ item }">
+            <div>
+              <p class="text-sm font-semibold text-text-primary">{{ item.resource }}</p>
+              <p class="text-xs text-text-secondary mt-0.5">{{ item.description }}</p>
+            </div>
+          </template>
 
-        <template #cell-used="{ item }">
-          <span class="text-sm font-semibold text-text-primary tabular-nums">
-            {{ item.used.toLocaleString('es-CO') }}
-          </span>
-        </template>
+          <template #cell-used="{ item }">
+            <span class="text-sm font-semibold text-text-primary tabular-nums">
+              {{ item.used.toLocaleString('es-CO') }}
+            </span>
+          </template>
 
-        <template #cell-limit="{ item }">
-          <span class="text-sm text-text-secondary tabular-nums">
-            {{ metricLimitLabel(item, item.zeroLabel) }}
-          </span>
-          <span v-if="item.emptyMessage" class="block text-xs text-text-secondary">{{ item.emptyMessage }}</span>
-        </template>
+          <template #cell-limit="{ item }">
+            <span class="text-sm text-text-secondary tabular-nums">
+              {{ metricLimitLabel(item, item.zeroLabel) }}
+            </span>
+            <span v-if="item.emptyMessage" class="block text-xs text-text-secondary">{{ item.emptyMessage }}</span>
+          </template>
 
-        <template #cell-remaining="{ item }">
-          <span class="text-sm font-semibold text-text-primary tabular-nums">
-            {{ metricRemainingLabel(item, item.zeroLabel) }}
-          </span>
-        </template>
+          <template #cell-remaining="{ item }">
+            <span class="text-sm font-semibold text-text-primary tabular-nums">
+              {{ metricRemainingLabel(item, item.zeroLabel) }}
+            </span>
+          </template>
 
-        <template #cell-percentage="{ item }">
-          <span class="text-sm text-text-secondary tabular-nums">{{ item.percentage }}%</span>
-        </template>
-      </UiResponsiveDataView>
+          <template #cell-percentage="{ item }">
+            <span class="text-sm text-text-secondary tabular-nums">{{ item.percentage }}%</span>
+          </template>
+        </UiResponsiveDataView>
+      </div>
     </template>
   </div>
 </template>

--- a/pages/gestion/billing/uso.vue
+++ b/pages/gestion/billing/uso.vue
@@ -185,12 +185,12 @@ const periodLabel = computed(() => {
     </div>
 
     <template v-else>
-      <div class="border border-border bg-surface">
-        <div class="px-4 py-3 md:px-6 md:py-4 border-b border-border">
-          <p class="text-xs font-medium text-text-secondary uppercase tracking-widest">Uso restante</p>
-          <p class="mt-1 text-sm text-text-secondary">{{ periodLabel }}</p>
-        </div>
+      <div class="border border-border bg-surface px-4 py-3 md:px-6 md:py-4">
+        <p class="text-xs font-semibold text-text-secondary uppercase tracking-widest">Uso restante</p>
+        <p class="mt-1 text-base font-medium leading-6 text-text-primary">{{ periodLabel }}</p>
+      </div>
 
+      <div>
         <UiResponsiveDataView
           row-size="sm"
           :columns="columns"

--- a/pages/gestion/billing/uso.vue
+++ b/pages/gestion/billing/uso.vue
@@ -185,7 +185,7 @@ const periodLabel = computed(() => {
     </div>
 
     <template v-else>
-      <div class="border border-border bg-surface px-4 py-3 md:px-6 md:py-4">
+      <div class="rounded-xl border border-border bg-surface px-4 py-3 md:px-6 md:py-4">
         <p class="text-xs font-semibold text-text-secondary uppercase tracking-widest">Uso restante</p>
         <p class="mt-1 text-base font-medium leading-6 text-text-primary">{{ periodLabel }}</p>
       </div>

--- a/pages/gestion/billing/uso.vue
+++ b/pages/gestion/billing/uso.vue
@@ -84,14 +84,6 @@ const metricRemainingLabel = (metric: UsageMetricValue, zeroLabel = 'No incluido
   return (metric.remaining ?? 0).toLocaleString('es-CO')
 }
 
-const metricUsageLabel = (metric: UsageMetricValue, unit: string, zeroLabel = 'No incluido') => {
-  const used = metric.used ?? 0
-  if (metric.limit === null) {
-    return `${used.toLocaleString('es-CO')} ${unit} usados - sin límite`
-  }
-  return `${used.toLocaleString('es-CO')} de ${metricLimitLabel(metric, zeroLabel)} ${unit} usados`
-}
-
 const scanUsage = computed<BillingUsageMetric>(() =>
   remainingUsage.value?.scan_usage ??
   fallbackUsageMetric(subscription.value?.scans_used ?? 0, subscription.value?.scan_limit ?? 0)
@@ -143,6 +135,7 @@ const columns: Column[] = [
   { key: 'used', title: 'Usado', sortable: false, align: 'right' },
   { key: 'limit', title: 'Disponible', sortable: false, align: 'right' },
   { key: 'remaining', title: 'Restante', sortable: false, align: 'right' },
+  { key: 'percentage', title: '% usado', sortable: false, align: 'right' },
 ]
 
 const tableData = computed(() => {
@@ -195,70 +188,89 @@ const periodLabel = computed(() => {
     </div>
 
     <template v-else>
-      <div class="border border-border bg-surface">
-        <div class="px-4 py-3 md:px-6 md:py-4 border-b border-border">
-          <p class="text-xs font-medium text-text-secondary uppercase tracking-widest">Uso restante</p>
-          <p class="mt-1 text-sm text-text-secondary">{{ periodLabel }}</p>
-        </div>
+      <UiResponsiveDataView
+        title="Uso restante"
+        row-size="sm"
+        :columns="columns"
+        :data="tableData"
+        empty-message="No hay cupos disponibles"
+        empty-sub-message="Los cupos aparecerán cuando tengas una suscripción activa"
+        variant="default"
+      >
+        <template #header>
+          <div class="flex flex-col gap-1">
+            <p class="text-xs font-semibold text-data-table-header-text uppercase tracking-wider">Uso restante</p>
+            <p class="text-sm text-data-table-cell-muted">{{ periodLabel }}</p>
+          </div>
+        </template>
 
-        <UiResponsiveDataView
-          row-size="sm"
-          :columns="columns"
-          :data="tableData"
-          empty-message="No hay cupos disponibles"
-          empty-sub-message="Los cupos aparecerán cuando tengas una suscripción activa"
-          variant="default"
-        >
-          <template #card="{ item, index }">
-            <div
-              class="flex items-start gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-surface-secondary"
-              :class="index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'"
-            >
-              <div class="flex-1 min-w-0">
-                <p class="text-sm font-semibold text-text-primary leading-tight">{{ item.resource }}</p>
-                <p class="text-xs text-text-secondary mt-0.5">{{ item.description }}</p>
-                <p class="text-xs text-text-secondary mt-2">
-                  {{ metricUsageLabel(item, item.unit, item.zeroLabel) }}
-                </p>
+        <template #mobileHeader>
+          <div class="flex flex-col gap-1">
+            <p class="text-xs font-semibold text-data-table-header-text uppercase tracking-wider">Uso restante</p>
+            <p class="text-sm text-data-table-cell-muted">{{ periodLabel }}</p>
+          </div>
+        </template>
+
+        <template #card="{ item, index }">
+          <div
+            class="flex items-center gap-3 py-3 px-3 border-b border-border transition-colors hover:bg-data-table-row-hover-bg"
+            :class="index % 2 === 0 ? 'bg-data-table-row-bg' : 'bg-data-table-row-alt-bg'"
+          >
+            <div class="flex-1 min-w-0">
+              <p class="text-sm font-semibold text-text-primary leading-tight truncate">{{ item.resource }}</p>
+              <p class="text-xs text-text-secondary mt-0.5 truncate">{{ item.description }}</p>
+            </div>
+            <div class="grid grid-cols-4 gap-3 text-right flex-shrink-0">
+              <div>
+                <p class="text-xs text-text-secondary">Usado</p>
+                <p class="text-sm font-semibold text-text-primary tabular-nums">{{ item.used.toLocaleString('es-CO') }}</p>
               </div>
-              <div class="text-right flex-shrink-0">
-                <p class="text-sm font-bold text-text-primary">{{ metricRemainingLabel(item, item.zeroLabel) }}</p>
-                <p class="text-xs text-text-secondary">
-                  {{ item.remaining === null ? 'sin tope' : 'restantes' }}
-                </p>
+              <div>
+                <p class="text-xs text-text-secondary">Disp.</p>
+                <p class="text-sm text-text-secondary tabular-nums">{{ metricLimitLabel(item, item.zeroLabel) }}</p>
+              </div>
+              <div>
+                <p class="text-xs text-text-secondary">Rest.</p>
+                <p class="text-sm font-semibold text-text-primary tabular-nums">{{ metricRemainingLabel(item, item.zeroLabel) }}</p>
+              </div>
+              <div>
+                <p class="text-xs text-text-secondary">%</p>
+                <p class="text-sm text-text-secondary tabular-nums">{{ item.percentage }}%</p>
               </div>
             </div>
-          </template>
+          </div>
+        </template>
 
-          <template #cell-resource="{ item }">
-            <div>
-              <p class="text-sm font-semibold text-text-primary">{{ item.resource }}</p>
-              <p class="text-xs text-text-secondary mt-0.5">{{ item.description }}</p>
-            </div>
-          </template>
+        <template #cell-resource="{ item }">
+          <div>
+            <p class="text-sm font-semibold text-text-primary">{{ item.resource }}</p>
+            <p class="text-xs text-text-secondary mt-0.5">{{ item.description }}</p>
+          </div>
+        </template>
 
-          <template #cell-used="{ item }">
-            <span class="text-sm font-semibold text-text-primary">
-              {{ item.used.toLocaleString('es-CO') }}
-            </span>
-            <span class="text-xs text-text-secondary"> {{ item.unit }}</span>
-          </template>
+        <template #cell-used="{ item }">
+          <span class="text-sm font-semibold text-text-primary tabular-nums">
+            {{ item.used.toLocaleString('es-CO') }}
+          </span>
+        </template>
 
-          <template #cell-limit="{ item }">
-            <span class="text-sm text-text-secondary">
-              {{ metricLimitLabel(item, item.zeroLabel) }}
-            </span>
-            <span v-if="item.emptyMessage" class="block text-xs text-text-secondary">{{ item.emptyMessage }}</span>
-          </template>
+        <template #cell-limit="{ item }">
+          <span class="text-sm text-text-secondary tabular-nums">
+            {{ metricLimitLabel(item, item.zeroLabel) }}
+          </span>
+          <span v-if="item.emptyMessage" class="block text-xs text-text-secondary">{{ item.emptyMessage }}</span>
+        </template>
 
-          <template #cell-remaining="{ item }">
-            <span class="text-sm font-semibold text-text-primary">
-              {{ metricRemainingLabel(item, item.zeroLabel) }}
-            </span>
-            <span class="block text-xs text-text-secondary">{{ item.percentage }}% usado</span>
-          </template>
-        </UiResponsiveDataView>
-      </div>
+        <template #cell-remaining="{ item }">
+          <span class="text-sm font-semibold text-text-primary tabular-nums">
+            {{ metricRemainingLabel(item, item.zeroLabel) }}
+          </span>
+        </template>
+
+        <template #cell-percentage="{ item }">
+          <span class="text-sm text-text-secondary tabular-nums">{{ item.percentage }}%</span>
+        </template>
+      </UiResponsiveDataView>
     </template>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- consume public online order availability on the storefront
- block cart checkout and direct checkout confirmation when quota is exhausted
- show the customer-safe unavailable message before final checkout

## Tests
- pytest tests/test_quota_enforcement.py
- Not run: npm run build (skipped per request)

Depends on uno0uno/api-warolabs#586.

Closes #1512