### PR TITLE
Add frontend module gates

### DIFF
--- a/pages/analitica/clientes/[id].vue
+++ b/pages/analitica/clientes/[id].vue
@@ -11,7 +11,7 @@ import {
   type ApiPaymentGroup,
 } from '~/utils/paymentDefaults';
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'analitica' })
 
 const route = useRoute()
 const router = useRouter()

--- a/pages/analitica/clientes/index.vue
+++ b/pages/analitica/clientes/index.vue
@@ -6,7 +6,7 @@ import { es } from 'date-fns/locale';
 import { formatDistanceToNow } from 'date-fns';
 import MetricCard from '~/components/shared/MetricCard.vue';
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'analitica' })
 
 const { setRefreshHandler, clearRefreshHandler, setLastUpdateText, registerProgressiveLoading } = useLayoutActions()
 

--- a/pages/analitica/cocina.vue
+++ b/pages/analitica/cocina.vue
@@ -206,9 +206,7 @@
 import { VueDatePicker } from '@vuepic/vue-datepicker'
 import '@vuepic/vue-datepicker/dist/main.css'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'analitica' })
 
 useHead({
   title: 'Analítica de Cocina | WARO'

--- a/pages/billing/confirmacion.vue
+++ b/pages/billing/confirmacion.vue
@@ -80,6 +80,8 @@
 </template>
 
 <script setup lang="ts">
+// Billing confirmation must stay ungated so payment return/callback flows
+// can complete even before module access is available.
 definePageMeta({ layout: 'dashboard' })
 
 const route = useRoute()

--- a/pages/despacho/comandas.vue
+++ b/pages/despacho/comandas.vue
@@ -4,7 +4,7 @@ import { useTenantReactive } from '@/composables/useTenantReactive'
 import { useActiveStationsQuery } from '@/composables/queries/useActiveStations'
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'despacho' })
 
 useHead({ title: 'Comandas — WARO' })
 

--- a/pages/despacho/domicilios/[id].vue
+++ b/pages/despacho/domicilios/[id].vue
@@ -4,7 +4,7 @@ import { Printer } from 'lucide-vue-next'
 import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
 import { printComandaTickets } from '~/composables/useComandaPrint'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'despacho' })
 useHead({ title: 'Detalle Pedido — WARO' })
 
 const route = useRoute()

--- a/pages/despacho/domicilios/index.vue
+++ b/pages/despacho/domicilios/index.vue
@@ -3,7 +3,7 @@ import { onMounted, onUnmounted, watch } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'despacho' })
 
 useHead({ title: 'Domicilios — WARO' })
 

--- a/pages/despacho/en-mesa/[id].vue
+++ b/pages/despacho/en-mesa/[id].vue
@@ -8,7 +8,7 @@ import { notifyTableSessionUpdated, storeTableQrPaymentIntent } from '~/composab
 import { useNotifications } from '~/composables/useNotifications'
 import { normalizeTimezone } from '~/utils/bogotaDate'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'despacho' })
 
 useHead({ title: 'Pedido en mesa — WARO' })
 

--- a/pages/despacho/en-mesa/index.vue
+++ b/pages/despacho/en-mesa/index.vue
@@ -5,7 +5,7 @@ import type { Column } from '~/components/ui/ResponsiveDataView.vue'
 import { formatTableQrPayment } from '~/composables/formatTableQrPayment'
 import { normalizeTimezone } from '~/utils/bogotaDate'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'despacho' })
 
 useHead({ title: 'Pedidos en mesa (QR) — WARO' })
 

--- a/pages/equipo/miembros/[id].vue
+++ b/pages/equipo/miembros/[id].vue
@@ -7,6 +7,8 @@ import type { Column } from '~/components/ui/ResponsiveDataView.vue'
 
 definePageMeta({
   layout: 'dashboard',
+
+  module: 'equipo',
 })
 
 useHead({ title: 'Perfil de mesero — Equipo' })

--- a/pages/equipo/salarios/[id]/configurar.vue
+++ b/pages/equipo/salarios/[id]/configurar.vue
@@ -543,6 +543,8 @@
 </template>
 
 <script setup lang="ts">
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
+
 import { computed, reactive, ref, watch } from 'vue'
 const route = useRoute()
 const toast = useToast()

--- a/pages/equipo/salarios/[id]/index.vue
+++ b/pages/equipo/salarios/[id]/index.vue
@@ -2,9 +2,7 @@
 import { ref, reactive, computed, watch, inject, onMounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const route = useRoute()
 const router = useRouter()

--- a/pages/equipo/salarios/[id]/pago.vue
+++ b/pages/equipo/salarios/[id]/pago.vue
@@ -396,6 +396,8 @@
 </template>
 
 <script setup lang="ts">
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
+
 import { computed, reactive, ref, watch } from 'vue'
 const route = useRoute()
 const toast = useToast()

--- a/pages/equipo/salarios/[id]/prestaciones/cesantias.vue
+++ b/pages/equipo/salarios/[id]/prestaciones/cesantias.vue
@@ -383,9 +383,7 @@ import { usePaymentMethods } from '~/composables/usePaymentMethods'
 import { useFormatters } from '~/composables/useFormatters'
 import { SLUG_ICON_MAP, SLUG_ICON_FALLBACK } from '~/utils/paymentDefaults'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const route = useRoute()
 const toast = useToast()

--- a/pages/equipo/salarios/[id]/prestaciones/dotacion.vue
+++ b/pages/equipo/salarios/[id]/prestaciones/dotacion.vue
@@ -363,9 +363,7 @@ import { usePaymentMethods } from '~/composables/usePaymentMethods'
 import { useFormatters } from '~/composables/useFormatters'
 import { SLUG_ICON_MAP, SLUG_ICON_FALLBACK } from '~/utils/paymentDefaults'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const route = useRoute()
 const toast = useToast()

--- a/pages/equipo/salarios/[id]/prestaciones/horas-extras.vue
+++ b/pages/equipo/salarios/[id]/prestaciones/horas-extras.vue
@@ -374,9 +374,7 @@ import { useFormatters } from '~/composables/useFormatters'
 // @ts-ignore
 import { usePaymentMethods } from '~/composables/usePaymentMethods'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const route = useRoute()
 const toast = useToast()

--- a/pages/equipo/salarios/[id]/prestaciones/int-cesantias.vue
+++ b/pages/equipo/salarios/[id]/prestaciones/int-cesantias.vue
@@ -353,9 +353,7 @@ import { usePaymentMethods } from '~/composables/usePaymentMethods'
 import { useFormatters } from '~/composables/useFormatters'
 import { SLUG_ICON_MAP, SLUG_ICON_FALLBACK } from '~/utils/paymentDefaults'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const route = useRoute()
 const toast = useToast()

--- a/pages/equipo/salarios/[id]/prestaciones/liquidacion.vue
+++ b/pages/equipo/salarios/[id]/prestaciones/liquidacion.vue
@@ -1,5 +1,5 @@
 <script setup>
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const route = useRoute()
 const employeeId = route.params.id

--- a/pages/equipo/salarios/[id]/prestaciones/prima.vue
+++ b/pages/equipo/salarios/[id]/prestaciones/prima.vue
@@ -365,9 +365,7 @@ import { usePaymentMethods } from '~/composables/usePaymentMethods'
 import { useFormatters } from '~/composables/useFormatters'
 import { SLUG_ICON_MAP, SLUG_ICON_FALLBACK } from '~/utils/paymentDefaults'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const route = useRoute()
 const toast = useToast()

--- a/pages/equipo/salarios/[id]/prestaciones/vacaciones.vue
+++ b/pages/equipo/salarios/[id]/prestaciones/vacaciones.vue
@@ -360,9 +360,7 @@ import { usePaymentMethods } from '~/composables/usePaymentMethods'
 import { useFormatters } from '~/composables/useFormatters'
 import { SLUG_ICON_MAP, SLUG_ICON_FALLBACK } from '~/utils/paymentDefaults'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const route = useRoute()
 const toast = useToast()

--- a/pages/equipo/salarios/index.vue
+++ b/pages/equipo/salarios/index.vue
@@ -2,9 +2,7 @@
 import { computed, onMounted, onUnmounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 useHead({ title: 'Salarios' })
 

--- a/pages/equipo/salarios/pagos/[id].vue
+++ b/pages/equipo/salarios/pagos/[id].vue
@@ -2,9 +2,7 @@
 import { ref, computed, inject, onMounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const route = useRoute()
 const router = useRouter()

--- a/pages/finanzas/cierre-contable/index.vue
+++ b/pages/finanzas/cierre-contable/index.vue
@@ -157,7 +157,7 @@
 import { ref, computed, watch } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Cierre contable - Warocol' })
 
 const { formatDateTime } = useFormatters()

--- a/pages/finanzas/contabilidad/asientos/crear.vue
+++ b/pages/finanzas/contabilidad/asientos/crear.vue
@@ -2,7 +2,7 @@
 import { ref, computed } from 'vue'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Nuevo asiento contable - Warocol' })
 
 const { currentTenant } = useTenantReactive()

--- a/pages/finanzas/contabilidad/asientos/index.vue
+++ b/pages/finanzas/contabilidad/asientos/index.vue
@@ -3,7 +3,7 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { filterSelectClass } from '~/composables/useFilterSelectClass'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Asientos contables - Warocol' })
 
 const { currentTenant } = useTenantReactive()

--- a/pages/finanzas/contabilidad/balance-comprobacion.vue
+++ b/pages/finanzas/contabilidad/balance-comprobacion.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Balance de comprobación - Warocol' })
 
 const { currentTenant } = useTenantReactive()

--- a/pages/finanzas/contabilidad/cuentas/[id].vue
+++ b/pages/finanzas/contabilidad/cuentas/[id].vue
@@ -3,7 +3,7 @@ import { ref, computed, nextTick, onMounted, onUnmounted } from 'vue'
 import { es } from 'date-fns/locale'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const route = useRoute()
 const accountId = computed(() => route.params.id as string)

--- a/pages/finanzas/contabilidad/cuentas/index.vue
+++ b/pages/finanzas/contabilidad/cuentas/index.vue
@@ -3,7 +3,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { es } from 'date-fns/locale'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Cuentas contables' })
 
 const { currentTenant } = useTenantReactive()

--- a/pages/finanzas/gastos/[id]/editar.vue
+++ b/pages/finanzas/gastos/[id]/editar.vue
@@ -158,9 +158,7 @@
 <script setup lang="ts">
 import { usePaymentMethods } from '~/composables/usePaymentMethods'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const route = useRoute()
 const expenseId = route.params.id as string

--- a/pages/finanzas/gastos/[id]/index.vue
+++ b/pages/finanzas/gastos/[id]/index.vue
@@ -675,9 +675,7 @@ import { usePaymentMethods } from '~/composables/usePaymentMethods'
 import { usePaymentLabel } from '~/composables/usePaymentLabel'
 import { useFormatters } from '~/composables/useFormatters'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const route = useRoute()
 const expenseId = route.params.id as string

--- a/pages/finanzas/gastos/[id]/instancia.vue
+++ b/pages/finanzas/gastos/[id]/instancia.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import { ref, reactive, computed, watch } from 'vue'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const route = useRoute()
 const router = useRouter()

--- a/pages/finanzas/gastos/crear.vue
+++ b/pages/finanzas/gastos/crear.vue
@@ -298,9 +298,7 @@
 import { usePaymentMethods } from '~/composables/usePaymentMethods'
 import { useFormatters } from '~/composables/useFormatters'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 useHead({ title: 'Registrar Gasto' })
 

--- a/pages/finanzas/gastos/index.vue
+++ b/pages/finanzas/gastos/index.vue
@@ -4,9 +4,7 @@ import { useFormatters } from '~/composables/useFormatters'
 import { filterSelectClass } from '~/composables/useFilterSelectClass'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 useHead({ title: 'Gastos' })
 

--- a/pages/finanzas/gastos/instancias/[id].vue
+++ b/pages/finanzas/gastos/instancias/[id].vue
@@ -258,9 +258,7 @@
 
 <script setup lang="ts">
 import { useFormatters } from '~/composables/useFormatters'
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const route = useRoute()
 const router = useRouter()

--- a/pages/finanzas/metodos-pago/[groupId].vue
+++ b/pages/finanzas/metodos-pago/[groupId].vue
@@ -353,7 +353,7 @@
 import { ref, computed, nextTick } from 'vue'
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const { currentTenant } = useTenantReactive()
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()

--- a/pages/finanzas/metodos-pago/index.vue
+++ b/pages/finanzas/metodos-pago/index.vue
@@ -115,7 +115,7 @@
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Métodos de pago - Warocol' })
 
 const { currentTenant } = useTenantReactive()

--- a/pages/finanzas/pagos/index.vue
+++ b/pages/finanzas/pagos/index.vue
@@ -216,7 +216,8 @@ import { useFormatters } from '~/composables/useFormatters'
 
 definePageMeta({
   layout: 'dashboard',
-  title: 'Gestión de Pagos'
+  title: 'Gestión de Pagos',
+  module: 'finanzas',
 })
 
 useHead({

--- a/pages/finanzas/pagos/registrar.vue
+++ b/pages/finanzas/pagos/registrar.vue
@@ -22,7 +22,8 @@ import { useRoute, navigateTo } from '#app'
 
 definePageMeta({
   layout: 'dashboard',
-  title: 'Registrar Pago'
+  title: 'Registrar Pago',
+  module: 'finanzas',
 })
 
 useHead({ title: 'Registrar Pago' })

--- a/pages/finanzas/reportes/pl-mensual.vue
+++ b/pages/finanzas/reportes/pl-mensual.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 
-definePageMeta({ middleware: 'auth' })
+definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: 'Estado de Resultados mensual - Warocol' })
 
 // ── Query params (initial values from URL or current date) ────────────────────

--- a/pages/gestion/ingredientes/index.vue
+++ b/pages/gestion/ingredientes/index.vue
@@ -458,6 +458,8 @@ import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 
 definePageMeta({
   layout: 'dashboard',
+
+  module: 'abastecimiento',
 })
 
 useHead({ title: WAREHOUSE_COPY.waroTemplatesSubPageTitle })

--- a/pages/menu/categorias/index.vue
+++ b/pages/menu/categorias/index.vue
@@ -179,6 +179,7 @@ import { PencilSquareIcon, TrashIcon } from '@heroicons/vue/24/outline'
 definePageMeta({
   // layout: 'dashboard' — inherited from parent menu.vue
   // module gating: inherited as 'menu' from parent menu.vue
+  module: 'menu',
 })
 
 useHead({ title: 'Categorías' })

--- a/pages/menu/index.vue
+++ b/pages/menu/index.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'menu' })
 
 useHead({ title: 'Menú' })
 

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -244,6 +244,7 @@ import {
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
+  module: 'menu',
 })
 
 useHead({ title: 'Editar Modificador' })

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -257,6 +257,7 @@ import {
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
+  module: 'menu',
 })
 
 useHead({ title: 'Crear Modificador' })

--- a/pages/menu/modificadores/index.vue
+++ b/pages/menu/modificadores/index.vue
@@ -288,6 +288,7 @@ import { useTenantReactive } from '@/composables/useTenantReactive'
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
+  module: 'menu',
 })
 
 useHead({ title: 'Modificadores' })

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -873,7 +873,8 @@ definePageMeta({
       label: 'Volver a Productos',
       action: () => navigateTo('/menu/productos')
     }
-  })
+  }),
+  module: 'menu',
 })
 
 const route = useRoute()

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -709,6 +709,7 @@ import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
+  module: 'menu',
 })
 
 useHead({ title: 'Crear Producto' })

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -891,6 +891,7 @@ import { useToast } from '@/composables/useToast'
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
+  module: 'menu',
 })
 
 const route = useRoute()

--- a/pages/menu/recetas/[id].vue
+++ b/pages/menu/recetas/[id].vue
@@ -254,7 +254,8 @@ definePageMeta({
     backButton.value = {
       label: 'Volver a Recetas'
     }
-  })
+  }),
+  module: 'menu',
 })
 
 useHead({ title: 'Editar Receta' })

--- a/pages/menu/recetas/crear.vue
+++ b/pages/menu/recetas/crear.vue
@@ -262,6 +262,7 @@ import { useTenantReactive } from '@/composables/useTenantReactive'
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
+  module: 'menu',
 })
 
 useHead({ title: 'Crear Receta' })

--- a/pages/menu/recetas/index.vue
+++ b/pages/menu/recetas/index.vue
@@ -262,6 +262,7 @@ import { formatDomainQuantity, normalizeDomainNumber } from '~/utils/domainNumbe
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
+  module: 'menu',
 })
 
 useHead({ title: 'Recetas' })

--- a/pages/operaciones/comandas.vue
+++ b/pages/operaciones/comandas.vue
@@ -535,7 +535,7 @@ import {
 } from '@heroicons/vue/24/outline'
 import QRCode from 'qrcode'
 
-definePageMeta({ layout: 'dashboard' })
+definePageMeta({ layout: 'dashboard', module: 'operaciones' })
 useHead({ title: 'Comandas & Cocina | Operaciones' })
 
 const { currentTenant } = useTenantReactive()

--- a/pages/operaciones/mesas.vue
+++ b/pages/operaciones/mesas.vue
@@ -2,9 +2,7 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { displayTableCode } from '~/composables/useTableDisplayCode'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'operaciones' })
 
 const { singular, plural } = useTableLabel()
 const singularLower = computed(() => singular.value.toLowerCase())

--- a/pages/operaciones/personalizar.vue
+++ b/pages/operaciones/personalizar.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'operaciones' })
 
 useHead({ title: 'Personalizar | Operaciones' })
 

--- a/pages/operaciones/propinas.vue
+++ b/pages/operaciones/propinas.vue
@@ -3,6 +3,8 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 
 definePageMeta({
   layout: 'dashboard',
+
+  module: 'finanzas',
 })
 
 useHead({ title: 'Propinas | Ventas' })

--- a/pages/terminos-y-condiciones.vue
+++ b/pages/terminos-y-condiciones.vue
@@ -135,6 +135,8 @@ import {
 import { extractApiError } from '~/composables/useQueryError'
 import type { LegalTermsDocument } from '~/composables/useLegalTerms'
 
+// Global-auth legal exception: users must be able to review and accept terms
+// before module-gated dashboard workflows are available.
 definePageMeta({ layout: 'dashboard' })
 
 const route = useRoute()

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -5,9 +5,7 @@ import { useFormatters } from '~/composables/useFormatters'
 import { formatPromoTypeLabel } from '~/utils/promotionPreview'
 import { mergePosPaymentGroupsFromApi, type ApiPaymentGroup } from '~/utils/paymentDefaults'
 
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'ventas' })
 
 useHead({ title: 'Detalle de Venta' })
 

--- a/pages/ventas/crear.vue
+++ b/pages/ventas/crear.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-definePageMeta({
-  layout: 'dashboard'
-})
+definePageMeta({ layout: 'dashboard', module: 'ventas' })
 
 useHead({ title: 'Nueva Venta' })
 

--- a/pages/ventas/propinas/index.vue
+++ b/pages/ventas/propinas/index.vue
@@ -6,6 +6,8 @@ import type { Column } from '~/components/ui/ResponsiveDataView.vue'
 
 definePageMeta({
   layout: 'dashboard',
+
+  module: 'finanzas',
 })
 
 useHead({ title: 'Historial de propinas — Ventas' })


### PR DESCRIPTION
## Summary
- Add explicit frontend module metadata to private dashboard routes from the #1520 RBAC audit
- Gate payroll and tips surfaces under finanzas, menu children under menu, dispatch under despacho, analytics under analitica, and team detail under equipo
- Preserve audited exceptions such as /403, billing confirmation, public/auth/token/content flows, and legal terms

## Tests
- rg scoped target pages for missing module metadata
- rg dashboard no-module scan excluding documented exceptions
- git diff --check on scoped files
- Not run: npm run build (requested sin build)

Closes #1521