### PR TITLE
POS: add persisted comanda reprint selector

### DIFF
--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -88,18 +88,6 @@
         :key="item.orderItemId"
         class="relative"
       >
-        <label
-          v-if="showPrintItemSelection && printableOrderItemIds.includes(item.orderItemId)"
-          class="absolute top-2 left-2 z-10 flex items-center"
-        >
-          <input
-            type="checkbox"
-            class="h-4 w-4 rounded border-border text-primary focus:ring-action-primary-focus-ring/30"
-            :checked="selectedTabItemIds.includes(item.orderItemId)"
-            :aria-label="`Seleccionar ${item.productName} para reimprimir comanda`"
-            @change="$emit('toggle-tab-selection', item.orderItemId)"
-          />
-        </label>
         <PosCartItem
           :item="{
             product: { id: item.productId, name: item.productName, price: item.unitPrice, image: '🍽️', category: '' },
@@ -120,9 +108,6 @@
           :lock-increment="isTabLineFired(item)"
           :hide-line-controls="isTabLineTerminal(item)"
           @edit="$emit('edit-tab-item', item.orderItemId, item.productId)"
-          :class="[
-            showPrintItemSelection && printableOrderItemIds.includes(item.orderItemId) ? 'pl-8' : '',
-          ]"
           @increment="$emit('increment-tab-item', item.orderItemId)"
           @decrement="$emit('decrement-tab-item', item.orderItemId)"
           @remove="$emit('remove-tab-item', item.orderItemId)"
@@ -171,8 +156,48 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" />
         </svg>
         <p class="text-text-secondary">{{ mesaMode ? `${tableSingular} sin pedidos` : 'Carrito vacío' }}</p>
-        <p class="text-sm text-text-tertiary mt-1">Selecciona productos para agregar</p>
-      </div>
+          <p class="text-sm text-text-tertiary mt-1">Selecciona productos para agregar</p>
+        </div>
+
+        <section
+          v-if="showSentComandas"
+          class="mt-3 rounded-xl border border-border bg-surface-secondary/45 p-3 space-y-2"
+        >
+          <div class="flex items-center justify-between gap-2">
+            <h3 class="text-[11px] font-bold uppercase tracking-widest text-text-tertiary">Comandas enviadas</h3>
+            <span class="text-[11px] font-semibold text-text-secondary">{{ selectedComandaCount }}/{{ sentComandas.length }}</span>
+          </div>
+          <div class="space-y-1.5">
+            <label
+              v-for="comanda in sentComandas"
+              :key="comanda.id"
+              class="flex items-start gap-2 rounded-lg border border-border bg-surface px-2.5 py-2 cursor-pointer hover:bg-surface-secondary transition-colors"
+            >
+              <input
+                type="checkbox"
+                class="mt-0.5 h-4 w-4 rounded border-border text-primary focus:ring-action-primary-focus-ring/30"
+                :checked="selectedComandaIds.includes(comanda.id)"
+                :aria-label="`Seleccionar comanda ${comanda.comandaNumber}`"
+                @change="$emit('toggle-comanda-selection', comanda.id)"
+              />
+              <span class="min-w-0 flex-1">
+                <span class="flex items-center justify-between gap-2">
+                  <span class="text-xs font-bold text-text-primary truncate">
+                    #{{ comanda.comandaNumber }} · {{ comanda.stationName }}
+                  </span>
+                  <span class="text-[10px] font-semibold text-text-tertiary whitespace-nowrap">
+                    {{ formatComandaTime(comanda.firedAt) }}
+                  </span>
+                </span>
+                <span class="mt-0.5 flex items-center gap-1.5 text-[11px] text-text-secondary min-w-0">
+                  <span class="font-medium">{{ comanda.itemCount }} {{ comanda.itemCount === 1 ? 'ítem' : 'ítems' }}</span>
+                  <span v-if="statusLabel(comanda.status)" class="text-text-tertiary">· {{ statusLabel(comanda.status) }}</span>
+                  <span v-if="comanda.itemPreview" class="truncate">· {{ comanda.itemPreview }}</span>
+                </span>
+              </span>
+            </label>
+          </div>
+        </section>
       </template>
     </div>
 
@@ -347,7 +372,9 @@
         <button
           v-if="comandasEnabled && canPrintComandas"
           type="button"
+          :disabled="selectedComandaCount === 0"
           class="w-full min-h-[44px] rounded-xl border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
+          :class="selectedComandaCount === 0 ? 'opacity-40 cursor-not-allowed' : ''"
           :aria-label="printComandaLabel"
           @click="$emit('print-comandas')"
         >
@@ -421,6 +448,16 @@ interface TabItem {
   sentAt?: string | null
 }
 
+interface SentComanda {
+  id: string
+  comandaNumber: string
+  stationName: string
+  status?: string
+  firedAt?: string | null
+  itemCount: number
+  itemPreview?: string
+}
+
 interface Props {
   items: CartItem[]
   total: number
@@ -433,10 +470,9 @@ interface Props {
   tabItemsLoading?: Set<string>
   comandasEnabled?: boolean
   unfiredCount?: number
-  showPrintItemSelection?: boolean
-  printableOrderItemIds?: string[]
+  sentComandas?: SentComanda[]
   canPrintComandas?: boolean
-  selectedTabItemIds?: string[]
+  selectedComandaIds?: string[]
   pendingRemoveItemId?: string | null
   // Issue #575 — per-order waiter attribution (bar + counter)
   showServedByChip?: boolean
@@ -467,7 +503,7 @@ interface Emits {
   (e: 'increment-tab-item', orderItemId: string): void
   (e: 'decrement-tab-item', orderItemId: string): void
   (e: 'print-comandas'): void
-  (e: 'toggle-tab-selection', orderItemId: string): void
+  (e: 'toggle-comanda-selection', comandaId: string): void
   // Issue #575
   (e: 'update:served-by', memberId: string | null): void
 }
@@ -482,10 +518,9 @@ const props = withDefaults(defineProps<Props>(), {
   tabItemsLoading: () => new Set(),
   comandasEnabled: false,
   unfiredCount: 0,
-  showPrintItemSelection: false,
-  printableOrderItemIds: () => [],
+  sentComandas: () => [],
   canPrintComandas: false,
-  selectedTabItemIds: () => [],
+  selectedComandaIds: () => [],
   pendingRemoveItemId: null,
   showServedByChip: false,
   servedByMemberId: null,
@@ -510,9 +545,9 @@ const openSaleButtonClass = computed(() => [
 ])
 
 const printComandaLabel = computed(() => {
-  const n = props.selectedTabItemIds?.length ?? 0
-  if (n > 0) return `Reimprimir seleccionados (${n})`
-  return 'Reimprimir última comanda'
+  const n = selectedComandaCount.value
+  if (n > 0 && n < props.sentComandas.length) return `Reimprimir seleccionadas (${n})`
+  return 'Reimprimir comandas'
 })
 const emit = defineEmits<Emits>()
 
@@ -578,6 +613,37 @@ function cartLinePromoTitle(item: CartItem): string | null {
 const displayItemCount = computed(() =>
   props.mesaMode ? props.tabItems.length + props.items.length : props.items.length
 )
+
+const showSentComandas = computed(() =>
+  props.mesaMode
+  && props.comandasEnabled
+  && !props.isLoadingTabItems
+  && !props.isAddingToTab
+  && !props.isClearingTab
+  && props.sentComandas.length > 0
+)
+
+const selectedComandaCount = computed(() => props.selectedComandaIds.length)
+
+function formatComandaTime(value?: string | null): string {
+  if (!value) return ''
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return ''
+  return new Intl.DateTimeFormat('es-CO', {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(d)
+}
+
+function statusLabel(status?: string): string | null {
+  const labels: Record<string, string> = {
+    pending: 'Pendiente',
+    preparing: 'Preparando',
+    ready: 'Lista',
+    delivered: 'Entregada',
+  }
+  return status ? labels[status] ?? status : null
+}
 
 // Issue #575 — handler for the served_by select
 const onServedByChange = (event: Event) => {

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -353,9 +353,10 @@ const tabError = ref<string | null>(null)
 const tabSuccess = ref<string | null>(null)
 
 // #753 — kitchen ticket print after fire
-const lastFiredComandasRaw = ref<unknown[]>([])
+const persistedComandasRaw = ref<unknown[]>([])
 const comandasForPrint = ref<ComandaPrintPayload[]>([])
-const selectedTabItemIds = ref<string[]>([])
+const selectedComandaIds = ref<string[]>([])
+const comandaSelectionInitialized = ref(false)
 const comandaPrintSessionKey = ref<string | null>(null)
 const posBusinessName = computed(
   () => settingsData.value?.data?.business_name
@@ -369,9 +370,10 @@ const currentComandaPrintSessionKey = () => {
 }
 
 function resetComandaPrintState() {
-  lastFiredComandasRaw.value = []
+  persistedComandasRaw.value = []
   comandasForPrint.value = []
-  selectedTabItemIds.value = []
+  selectedComandaIds.value = []
+  comandaSelectionInitialized.value = false
   comandaPrintSessionKey.value = null
 }
 
@@ -381,52 +383,87 @@ const canPrintComandas = computed(
     && comandaPrintSessionKey.value === currentComandaPrintSessionKey(),
 )
 
-/** Tab lines from the last fire batch — checkboxes select tickets to re-print (#812). */
-const printableOrderItemIds = computed(
-  () => orderItemIdsFromComandas(lastFiredComandasRaw.value),
-)
-
-const showPrintItemSelection = computed(
-  () =>
-    comandasEnabled.value
-    && isKitchenServiceMode.value
-    && canPrintComandas.value
-    && printableOrderItemIds.value.size > 0,
-)
+function rawComandaId(raw: unknown, index: number): string {
+  const c = raw as Record<string, unknown>
+  return String(c.id ?? `${c.comanda_number ?? index}:${c.station_name ?? ''}:${c.fired_at ?? ''}`)
+}
 
 const comandasForPrintDisplay = computed(() => {
   if (!canPrintComandas.value) return []
-  const sel = selectedTabItemIds.value
-  const raw = lastFiredComandasRaw.value
-  if (!Array.isArray(raw) || sel.length === 0) {
-    return comandasForPrint.value
-  }
+  const sel = selectedComandaIds.value
+  if (sel.length === 0) return []
+  const raw = persistedComandasRaw.value
   const selSet = new Set(sel)
   const filteredRaw = (raw as Record<string, unknown>[])
-    .map((c) => {
-      const items = ((c.items as Record<string, unknown>[]) ?? []).filter(
-        (i) => i.order_item_id != null && selSet.has(String(i.order_item_id)),
-      )
-      return { ...c, items }
-    })
-    .filter((c) => ((c.items as unknown[]) ?? []).length > 0)
+    .filter((c, index) => selSet.has(rawComandaId(c, index)))
   return mapComandasForPrint(filteredRaw)
 })
 
-function toggleTabItemSelection(orderItemId: string) {
-  const idx = selectedTabItemIds.value.indexOf(orderItemId)
-  if (idx >= 0) {
-    selectedTabItemIds.value = selectedTabItemIds.value.filter(id => id !== orderItemId)
+const sentComandasForPanel = computed(() => (
+  (persistedComandasRaw.value as Record<string, unknown>[]).map((c, index) => {
+    const items = ((c.items as Record<string, unknown>[]) ?? [])
+    return {
+      id: rawComandaId(c, index),
+      comandaNumber: String(c.comanda_number ?? '—'),
+      stationName: (c.station_name as string) ?? 'Sin cocina asignada',
+      status: String(c.status ?? ''),
+      firedAt: c.fired_at != null ? String(c.fired_at) : null,
+      itemCount: items.length,
+      itemPreview: items
+        .slice(0, 2)
+        .map(i => `${Number(i.quantity ?? 1)}x ${String(i.kitchen_name ?? '')}`.trim())
+        .filter(Boolean)
+        .join(', '),
+    }
+  })
+))
+
+function applyPersistedComandas(rawComandas: unknown[], preserveSelection = true) {
+  const printableRaw = (rawComandas as Record<string, unknown>[])
+    .filter(c => (((c.items as unknown[]) ?? []).length > 0))
+  const ids = printableRaw.map((c, index) => rawComandaId(c, index))
+  const hadComandas = persistedComandasRaw.value.length > 0
+  persistedComandasRaw.value = printableRaw
+  comandasForPrint.value = mapComandasForPrint(printableRaw)
+  comandaPrintSessionKey.value = currentComandaPrintSessionKey()
+
+  if (preserveSelection && comandaSelectionInitialized.value && hadComandas) {
+    const available = new Set(ids)
+    selectedComandaIds.value = selectedComandaIds.value.filter(id => available.has(id))
   } else {
-    selectedTabItemIds.value = [...selectedTabItemIds.value, orderItemId]
+    selectedComandaIds.value = ids
+    comandaSelectionInitialized.value = true
+  }
+}
+
+async function refreshPersistedComandas(tableId?: string, fetchGen = tableSessionFetchGen, preserveSelection = true) {
+  const activeTableId = tableId ?? posStore.activeTableSession?.tableId
+  if (!activeTableId || !comandasEnabled.value || !isKitchenServiceMode.value) {
+    resetComandaPrintState()
+    return
+  }
+  try {
+    const res = await $fetch<{ success: boolean; data?: { comandas?: unknown[] } }>(`/api/tables/${activeTableId}/comandas`)
+    if (fetchGen !== tableSessionFetchGen) return
+    applyPersistedComandas(Array.isArray(res?.data?.comandas) ? res.data.comandas : [], preserveSelection)
+  } catch (e: unknown) {
+    if (isNoOpenSessionError(e)) resetComandaPrintState()
+  }
+}
+
+function toggleComandaSelection(comandaId: string) {
+  comandaSelectionInitialized.value = true
+  const idx = selectedComandaIds.value.indexOf(comandaId)
+  if (idx >= 0) {
+    selectedComandaIds.value = selectedComandaIds.value.filter(id => id !== comandaId)
+  } else {
+    selectedComandaIds.value = [...selectedComandaIds.value, comandaId]
   }
 }
 
 function applyFireResult(rawComandas: unknown[], firedCount: number) {
   if (rawComandas.length > 0) {
-    lastFiredComandasRaw.value = rawComandas
-    comandasForPrint.value = mapComandasForPrint(rawComandas)
-    comandaPrintSessionKey.value = currentComandaPrintSessionKey()
+    applyPersistedComandas(rawComandas, false)
   } else {
     resetComandaPrintState()
   }
@@ -442,7 +479,6 @@ function applyFireResult(rawComandas: unknown[], firedCount: number) {
           : item
       }),
     )
-    selectedTabItemIds.value = []
   }
 }
 
@@ -451,6 +487,7 @@ async function syncTabAfterAdd(addRes: unknown, addedCount: number) {
   if (!comandasEnabled.value || addedCount <= 0) return
   const { comandas, fired_items_count } = parseFireTableResponse(addRes as FireTableResponse)
   applyFireResult(comandas, fired_items_count)
+  await refreshPersistedComandas(undefined, tableSessionFetchGen, false)
   if (fired_items_count > 0) {
     tabSuccess.value = `${fired_items_count} ${fired_items_count === 1 ? 'ítem enviado' : 'ítems enviados'} a cocina`
     setTimeout(() => { tabSuccess.value = null }, 3000)
@@ -569,6 +606,7 @@ const loadCurrentTableSession = async (
     if (!session?.data?.session?.id) return false
     applyTableSessionFromApi(session.data, fetchGen, tableCtx)
     tableSessionBackendReady.value = true
+    await refreshPersistedComandas(tableId, fetchGen)
     return true
   } catch (e: unknown) {
     if (isNoOpenSessionError(e)) return false
@@ -1959,10 +1997,9 @@ onUnmounted(() => {
         :tab-items-loading="tabItemsLoading"
         :comandas-enabled="comandasEnabled"
         :unfired-count="unfiredCount"
-        :show-print-item-selection="showPrintItemSelection"
-        :printable-order-item-ids="[...printableOrderItemIds]"
+        :sent-comandas="sentComandasForPanel"
         :can-print-comandas="canPrintComandas"
-        :selected-tab-item-ids="selectedTabItemIds"
+        :selected-comanda-ids="selectedComandaIds"
         :pending-remove-item-id="pendingRemoveItemId"
         :show-served-by-chip="showServedByChip"
         :served-by-member-id="posStore.cartServedByMemberId"
@@ -1982,7 +2019,7 @@ onUnmounted(() => {
         @increment-tab-item="incrementTabItem"
         @decrement-tab-item="decrementTabItem"
         @print-comandas="handlePrintComandas"
-        @toggle-tab-selection="toggleTabItemSelection"
+        @toggle-comanda-selection="toggleComandaSelection"
         @update:served-by="(id) => posStore.setCartServedBy(id)"
       />
       </div>
@@ -2097,10 +2134,9 @@ onUnmounted(() => {
       :tab-items-loading="tabItemsLoading"
       :comandas-enabled="comandasEnabled"
       :unfired-count="unfiredCount"
-      :show-print-item-selection="showPrintItemSelection"
-      :printable-order-item-ids="[...printableOrderItemIds]"
+      :sent-comandas="sentComandasForPanel"
       :can-print-comandas="canPrintComandas"
-      :selected-tab-item-ids="selectedTabItemIds"
+      :selected-comanda-ids="selectedComandaIds"
       :pending-remove-item-id="pendingRemoveItemId"
       :show-served-by-chip="showServedByChip"
       :served-by-member-id="posStore.cartServedByMemberId"
@@ -2120,7 +2156,7 @@ onUnmounted(() => {
       @increment-tab-item="incrementTabItem"
       @decrement-tab-item="decrementTabItem"
       @print-comandas="handlePrintComandas"
-      @toggle-tab-selection="toggleTabItemSelection"
+      @toggle-comanda-selection="toggleComandaSelection"
       @update:served-by="(id) => posStore.setCartServedBy(id)"
     />
   </UiBottomSheetModal>


### PR DESCRIPTION
## Summary
- load persisted table-session comandas into the POS cart after session load/refresh
- replace order-item reprint checkboxes with a same-card Comandas enviadas selector by comanda
- reprint selected persisted comandas with clearer button copy

## Tests
- Not run: build skipped by request (sin build)
- Verified: git diff --check

## Manual validation
- Open a mesa, add/send items to cocina, and verify immediate kitchen print flow still has comandas available.
- Refresh or leave/re-enter the mesa and verify Comandas enviadas repopulates from persisted comandas.
- Deselect one comanda and reprint; only selected comandas should print.
- Send a later single item and verify older persisted comandas remain available for reprint.

Closes #1529