### PR TITLE
POS checkout accordions for order and comandas

### DIFF
--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -263,7 +263,10 @@
         <button
           type="button"
           :disabled="items.length === 0 || isDeleting || isAddingToTab"
-          class="w-full min-h-[44px] rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
+          class="w-full min-h-[44px] rounded-lg text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
+          :class="comandasEnabled
+            ? 'bg-action-success-bg text-action-success-text focus-visible:ring-action-success-focus-ring'
+            : 'bg-action-primary-bg text-action-primary-text focus-visible:ring-primary'"
           :aria-label="`Agregar items a la ${tableSingularLower}`"
           @click="$emit('add-to-tab')"
         >

--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -159,45 +159,6 @@
           <p class="text-sm text-text-tertiary mt-1">Selecciona productos para agregar</p>
         </div>
 
-        <section
-          v-if="showSentComandas"
-          class="mt-3 rounded-xl border border-border bg-surface-secondary/45 p-3 space-y-2"
-        >
-          <div class="flex items-center justify-between gap-2">
-            <h3 class="text-[11px] font-bold uppercase tracking-widest text-text-tertiary">Comandas enviadas</h3>
-            <span class="text-[11px] font-semibold text-text-secondary">{{ selectedComandaCount }}/{{ sentComandas.length }}</span>
-          </div>
-          <div class="space-y-1.5">
-            <label
-              v-for="comanda in sentComandas"
-              :key="comanda.id"
-              class="flex items-start gap-2 rounded-lg border border-border bg-surface px-2.5 py-2 cursor-pointer hover:bg-surface-secondary transition-colors"
-            >
-              <input
-                type="checkbox"
-                class="mt-0.5 h-4 w-4 rounded border-border text-primary focus:ring-action-primary-focus-ring/30"
-                :checked="selectedComandaIds.includes(comanda.id)"
-                :aria-label="`Seleccionar comanda ${comanda.comandaNumber}`"
-                @change="$emit('toggle-comanda-selection', comanda.id)"
-              />
-              <span class="min-w-0 flex-1">
-                <span class="flex items-center justify-between gap-2">
-                  <span class="text-xs font-bold text-text-primary truncate">
-                    #{{ comanda.comandaNumber }} · {{ comanda.stationName }}
-                  </span>
-                  <span class="text-[10px] font-semibold text-text-tertiary whitespace-nowrap">
-                    {{ formatComandaTime(comanda.firedAt) }}
-                  </span>
-                </span>
-                <span class="mt-0.5 flex items-center gap-1.5 text-[11px] text-text-secondary min-w-0">
-                  <span class="font-medium">{{ comanda.itemCount }} {{ comanda.itemCount === 1 ? 'ítem' : 'ítems' }}</span>
-                  <span v-if="statusLabel(comanda.status)" class="text-text-tertiary">· {{ statusLabel(comanda.status) }}</span>
-                  <span v-if="comanda.itemPreview" class="truncate">· {{ comanda.itemPreview }}</span>
-                </span>
-              </span>
-            </label>
-          </div>
-        </section>
       </template>
     </div>
 
@@ -368,21 +329,39 @@
         </div>
 
 
-        <!-- #753 / #812 — Re-print kitchen tickets (fire is via Agregar y enviar only) -->
-        <button
-          v-if="comandasEnabled && canPrintComandas"
-          type="button"
-          :disabled="selectedComandaCount === 0"
-          class="w-full min-h-[44px] rounded-xl border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
-          :class="selectedComandaCount === 0 ? 'opacity-40 cursor-not-allowed' : ''"
-          :aria-label="printComandaLabel"
-          @click="$emit('print-comandas')"
-        >
-          <svg class="h-4 w-4 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18M6.72 13.829 6.34 18m10.94-4.171L17.66 18M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.75A2.25 2.25 0 0 1 5.25 7.5h13.5A2.25 2.25 0 0 1 21 9.75v6A2.25 2.25 0 0 1 18.75 18h-1.09M6.34 18h11.32" />
-          </svg>
-          {{ printComandaLabel }}
-        </button>
+        <!-- #753 / #812 — Kitchen ticket reprint actions stay compact; history lives in a panel. -->
+        <div v-if="comandasEnabled" class="grid grid-cols-2 gap-2">
+          <button
+            type="button"
+            :disabled="!canPrintLatestComanda"
+            class="min-h-[44px] rounded-xl border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1.5 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+            aria-label="Reimprimir última comanda enviada"
+            @click="$emit('print-latest-comanda')"
+          >
+            <svg class="h-4 w-4 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.75A2.25 2.25 0 0 1 5.25 7.5h13.5A2.25 2.25 0 0 1 21 9.75v6A2.25 2.25 0 0 1 18.75 18h-1.09M6.34 18h11.32" />
+            </svg>
+            Reimprimir última
+          </button>
+          <button
+            type="button"
+            class="min-h-[44px] rounded-xl border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1.5 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
+            aria-label="Abrir comandas para reimprimir"
+            @click="$emit('open-comandas-reprint')"
+          >
+            <svg class="h-4 w-4 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3.75h10.5A2.25 2.25 0 0 1 19.5 6v14.25l-2.625-1.5-2.625 1.5-2.625-1.5-2.625 1.5-2.625-1.5-2.625 1.5V6a2.25 2.25 0 0 1 2.25-2.25Z" />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 8.25h7.5M8.25 12h7.5M8.25 15.75h4.5" />
+            </svg>
+            <span>Comandas</span>
+            <span
+              v-if="persistedComandasCount > 0"
+              class="ml-0.5 min-w-5 h-5 px-1.5 rounded-full bg-surface-secondary text-[10px] font-bold text-text-secondary tabular-nums inline-flex items-center justify-center"
+            >
+              {{ persistedComandasCount > 99 ? '99+' : persistedComandasCount }}
+            </span>
+          </button>
+        </div>
 
         <!-- Primary: Add to tab — full width -->
         <button
@@ -448,16 +427,6 @@ interface TabItem {
   sentAt?: string | null
 }
 
-interface SentComanda {
-  id: string
-  comandaNumber: string
-  stationName: string
-  status?: string
-  firedAt?: string | null
-  itemCount: number
-  itemPreview?: string
-}
-
 interface Props {
   items: CartItem[]
   total: number
@@ -470,9 +439,8 @@ interface Props {
   tabItemsLoading?: Set<string>
   comandasEnabled?: boolean
   unfiredCount?: number
-  sentComandas?: SentComanda[]
-  canPrintComandas?: boolean
-  selectedComandaIds?: string[]
+  canPrintLatestComanda?: boolean
+  persistedComandasCount?: number
   pendingRemoveItemId?: string | null
   // Issue #575 — per-order waiter attribution (bar + counter)
   showServedByChip?: boolean
@@ -502,8 +470,8 @@ interface Emits {
   (e: 'remove-tab-item', orderItemId: string): void
   (e: 'increment-tab-item', orderItemId: string): void
   (e: 'decrement-tab-item', orderItemId: string): void
-  (e: 'print-comandas'): void
-  (e: 'toggle-comanda-selection', comandaId: string): void
+  (e: 'print-latest-comanda'): void
+  (e: 'open-comandas-reprint'): void
   // Issue #575
   (e: 'update:served-by', memberId: string | null): void
 }
@@ -518,9 +486,8 @@ const props = withDefaults(defineProps<Props>(), {
   tabItemsLoading: () => new Set(),
   comandasEnabled: false,
   unfiredCount: 0,
-  sentComandas: () => [],
-  canPrintComandas: false,
-  selectedComandaIds: () => [],
+  canPrintLatestComanda: false,
+  persistedComandasCount: 0,
   pendingRemoveItemId: null,
   showServedByChip: false,
   servedByMemberId: null,
@@ -544,11 +511,6 @@ const openSaleButtonClass = computed(() => [
     : 'border-dashed border-border text-text-tertiary hover:bg-surface-secondary hover:text-text-secondary',
 ])
 
-const printComandaLabel = computed(() => {
-  const n = selectedComandaCount.value
-  if (n > 0 && n < props.sentComandas.length) return `Reimprimir seleccionadas (${n})`
-  return 'Reimprimir comandas'
-})
 const emit = defineEmits<Emits>()
 
 const posStore = usePOSStore()
@@ -613,37 +575,6 @@ function cartLinePromoTitle(item: CartItem): string | null {
 const displayItemCount = computed(() =>
   props.mesaMode ? props.tabItems.length + props.items.length : props.items.length
 )
-
-const showSentComandas = computed(() =>
-  props.mesaMode
-  && props.comandasEnabled
-  && !props.isLoadingTabItems
-  && !props.isAddingToTab
-  && !props.isClearingTab
-  && props.sentComandas.length > 0
-)
-
-const selectedComandaCount = computed(() => props.selectedComandaIds.length)
-
-function formatComandaTime(value?: string | null): string {
-  if (!value) return ''
-  const d = new Date(value)
-  if (Number.isNaN(d.getTime())) return ''
-  return new Intl.DateTimeFormat('es-CO', {
-    hour: '2-digit',
-    minute: '2-digit',
-  }).format(d)
-}
-
-function statusLabel(status?: string): string | null {
-  const labels: Record<string, string> = {
-    pending: 'Pendiente',
-    preparing: 'Preparando',
-    ready: 'Lista',
-    delivered: 'Entregada',
-  }
-  return status ? labels[status] ?? status : null
-}
 
 // Issue #575 — handler for the served_by select
 const onServedByChange = (event: Event) => {

--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -88,18 +88,6 @@
         :key="item.orderItemId"
         class="relative"
       >
-        <label
-          v-if="showPrintItemSelection && printableOrderItemIds.includes(item.orderItemId)"
-          class="absolute top-2 left-2 z-10 flex items-center"
-        >
-          <input
-            type="checkbox"
-            class="h-4 w-4 rounded border-border text-primary focus:ring-action-primary-focus-ring/30"
-            :checked="selectedTabItemIds.includes(item.orderItemId)"
-            :aria-label="`Seleccionar ${item.productName} para reimprimir comanda`"
-            @change="$emit('toggle-tab-selection', item.orderItemId)"
-          />
-        </label>
         <PosCartItem
           :item="{
             product: { id: item.productId, name: item.productName, price: item.unitPrice, image: '🍽️', category: '' },
@@ -120,9 +108,6 @@
           :lock-increment="isTabLineFired(item)"
           :hide-line-controls="isTabLineTerminal(item)"
           @edit="$emit('edit-tab-item', item.orderItemId, item.productId)"
-          :class="[
-            showPrintItemSelection && printableOrderItemIds.includes(item.orderItemId) ? 'pl-8' : '',
-          ]"
           @increment="$emit('increment-tab-item', item.orderItemId)"
           @decrement="$emit('decrement-tab-item', item.orderItemId)"
           @remove="$emit('remove-tab-item', item.orderItemId)"
@@ -171,8 +156,48 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" />
         </svg>
         <p class="text-text-secondary">{{ mesaMode ? `${tableSingular} sin pedidos` : 'Carrito vacío' }}</p>
-        <p class="text-sm text-text-tertiary mt-1">Selecciona productos para agregar</p>
-      </div>
+          <p class="text-sm text-text-tertiary mt-1">Selecciona productos para agregar</p>
+        </div>
+
+        <section
+          v-if="showSentComandas"
+          class="mt-3 rounded-xl border border-border bg-surface-secondary/45 p-3 space-y-2"
+        >
+          <div class="flex items-center justify-between gap-2">
+            <h3 class="text-[11px] font-bold uppercase tracking-widest text-text-tertiary">Comandas enviadas</h3>
+            <span class="text-[11px] font-semibold text-text-secondary">{{ selectedComandaCount }}/{{ sentComandas.length }}</span>
+          </div>
+          <div class="space-y-1.5">
+            <label
+              v-for="comanda in sentComandas"
+              :key="comanda.id"
+              class="flex items-start gap-2 rounded-lg border border-border bg-surface px-2.5 py-2 cursor-pointer hover:bg-surface-secondary transition-colors"
+            >
+              <input
+                type="checkbox"
+                class="mt-0.5 h-4 w-4 rounded border-border text-primary focus:ring-action-primary-focus-ring/30"
+                :checked="selectedComandaIds.includes(comanda.id)"
+                :aria-label="`Seleccionar comanda ${comanda.comandaNumber}`"
+                @change="$emit('toggle-comanda-selection', comanda.id)"
+              />
+              <span class="min-w-0 flex-1">
+                <span class="flex items-center justify-between gap-2">
+                  <span class="text-xs font-bold text-text-primary truncate">
+                    #{{ comanda.comandaNumber }} · {{ comanda.stationName }}
+                  </span>
+                  <span class="text-[10px] font-semibold text-text-tertiary whitespace-nowrap">
+                    {{ formatComandaTime(comanda.firedAt) }}
+                  </span>
+                </span>
+                <span class="mt-0.5 flex items-center gap-1.5 text-[11px] text-text-secondary min-w-0">
+                  <span class="font-medium">{{ comanda.itemCount }} {{ comanda.itemCount === 1 ? 'ítem' : 'ítems' }}</span>
+                  <span v-if="statusLabel(comanda.status)" class="text-text-tertiary">· {{ statusLabel(comanda.status) }}</span>
+                  <span v-if="comanda.itemPreview" class="truncate">· {{ comanda.itemPreview }}</span>
+                </span>
+              </span>
+            </label>
+          </div>
+        </section>
       </template>
     </div>
 
@@ -347,7 +372,9 @@
         <button
           v-if="comandasEnabled && canPrintComandas"
           type="button"
+          :disabled="selectedComandaCount === 0"
           class="w-full min-h-[44px] rounded-xl border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
+          :class="selectedComandaCount === 0 ? 'opacity-40 cursor-not-allowed' : ''"
           :aria-label="printComandaLabel"
           @click="$emit('print-comandas')"
         >
@@ -421,6 +448,16 @@ interface TabItem {
   sentAt?: string | null
 }
 
+interface SentComanda {
+  id: string
+  comandaNumber: string
+  stationName: string
+  status?: string
+  firedAt?: string | null
+  itemCount: number
+  itemPreview?: string
+}
+
 interface Props {
   items: CartItem[]
   total: number
@@ -433,10 +470,9 @@ interface Props {
   tabItemsLoading?: Set<string>
   comandasEnabled?: boolean
   unfiredCount?: number
-  showPrintItemSelection?: boolean
-  printableOrderItemIds?: string[]
+  sentComandas?: SentComanda[]
   canPrintComandas?: boolean
-  selectedTabItemIds?: string[]
+  selectedComandaIds?: string[]
   pendingRemoveItemId?: string | null
   // Issue #575 — per-order waiter attribution (bar + counter)
   showServedByChip?: boolean
@@ -467,7 +503,7 @@ interface Emits {
   (e: 'increment-tab-item', orderItemId: string): void
   (e: 'decrement-tab-item', orderItemId: string): void
   (e: 'print-comandas'): void
-  (e: 'toggle-tab-selection', orderItemId: string): void
+  (e: 'toggle-comanda-selection', comandaId: string): void
   // Issue #575
   (e: 'update:served-by', memberId: string | null): void
 }
@@ -482,10 +518,9 @@ const props = withDefaults(defineProps<Props>(), {
   tabItemsLoading: () => new Set(),
   comandasEnabled: false,
   unfiredCount: 0,
-  showPrintItemSelection: false,
-  printableOrderItemIds: () => [],
+  sentComandas: () => [],
   canPrintComandas: false,
-  selectedTabItemIds: () => [],
+  selectedComandaIds: () => [],
   pendingRemoveItemId: null,
   showServedByChip: false,
   servedByMemberId: null,
@@ -510,9 +545,9 @@ const openSaleButtonClass = computed(() => [
 ])
 
 const printComandaLabel = computed(() => {
-  const n = props.selectedTabItemIds?.length ?? 0
-  if (n > 0) return `Reimprimir seleccionados (${n})`
-  return 'Reimprimir última comanda'
+  const n = selectedComandaCount.value
+  if (n > 0 && n < props.sentComandas.length) return `Reimprimir seleccionadas (${n})`
+  return 'Reimprimir comandas'
 })
 const emit = defineEmits<Emits>()
 
@@ -578,6 +613,37 @@ function cartLinePromoTitle(item: CartItem): string | null {
 const displayItemCount = computed(() =>
   props.mesaMode ? props.tabItems.length + props.items.length : props.items.length
 )
+
+const showSentComandas = computed(() =>
+  props.mesaMode
+  && props.comandasEnabled
+  && !props.isLoadingTabItems
+  && !props.isAddingToTab
+  && !props.isClearingTab
+  && props.sentComandas.length > 0
+)
+
+const selectedComandaCount = computed(() => props.selectedComandaIds.length)
+
+function formatComandaTime(value?: string | null): string {
+  if (!value) return ''
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return ''
+  return new Intl.DateTimeFormat('es-CO', {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(d)
+}
+
+function statusLabel(status?: string): string | null {
+  const labels: Record<string, string> = {
+    pending: 'Pendiente',
+    preparing: 'Preparando',
+    ready: 'Lista',
+    delivered: 'Entregada',
+  }
+  return status ? labels[status] ?? status : null
+}
 
 // Issue #575 — handler for the served_by select
 const onServedByChange = (event: Event) => {

--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -4,10 +4,10 @@
     :class="fitHeight ? 'h-fit lg:h-[calc(100dvh-7rem)] lg:max-h-[calc(100dvh-7rem)]' : 'h-full'"
   >
     <!-- Cart Header -->
-    <div class="px-4 py-3.5 border-b border-border bg-surface">
+    <div class="px-4 py-2.5 border-b border-border bg-surface">
       <div class="flex items-center justify-between gap-2">
         <h2 class="text-sm font-bold text-text-primary tracking-wide">Orden Actual</h2>
-        <span class="rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-semibold text-primary">
+        <span class="rounded-full bg-primary/10 px-2.5 py-0.5 text-[11px] font-semibold text-primary">
           {{ displayItemCount }} {{ displayItemCount === 1 ? 'ítem' : 'ítems' }}
         </span>
       </div>
@@ -22,18 +22,18 @@
          - Interactive picker when there are items in cart or tab. -->
     <div
       v-if="showServedByChip && isLoadingTabItems"
-      class="px-4 py-2 border-b border-border bg-surface-secondary/40"
+      class="px-3 py-1.5 border-b border-border bg-surface-secondary/40"
       aria-hidden="true"
     >
       <div class="flex items-center gap-2 animate-pulse">
         <div class="w-3.5 h-3.5 rounded-full bg-surface-secondary flex-shrink-0" />
         <div class="h-3 w-20 rounded bg-surface-secondary flex-shrink-0" />
-        <div class="flex-1 min-h-[36px] rounded-lg bg-surface-secondary" />
+        <div class="flex-1 min-h-[32px] rounded-lg bg-surface-secondary" />
       </div>
     </div>
     <div
       v-else-if="showServedByChip && (items.length > 0 || (tabItems && tabItems.length > 0))"
-      class="px-4 py-2 border-b border-border bg-surface-secondary/40"
+      class="px-3 py-1.5 border-b border-border bg-surface-secondary/40"
     >
       <div class="flex items-center gap-2">
         <svg class="w-3.5 h-3.5 text-text-tertiary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -42,7 +42,7 @@
         <span class="text-[10px] font-bold text-text-tertiary uppercase tracking-wider flex-shrink-0">Servido por</span>
         <select
           :value="servedByMemberId || ''"
-          class="flex-1 min-h-[36px] px-2.5 py-1 text-xs font-medium bg-surface border border-border rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary transition-colors outline-none text-text-primary cursor-pointer"
+          class="flex-1 min-h-[32px] px-2.5 py-1 text-xs font-medium bg-surface border border-border rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary transition-colors outline-none text-text-primary cursor-pointer"
           aria-label="Atribuir esta orden a un mesero"
           @change="onServedByChange"
         >
@@ -59,7 +59,7 @@
     </div>
 
     <!-- Cart summary/actions: sticky at the top of the order panel -->
-    <div class="flex-shrink-0 px-4 py-4 border-b border-border space-y-3 bg-surface-secondary/40">
+    <div class="flex-shrink-0 px-3 py-3 border-b border-border space-y-2 bg-surface-secondary/40">
       <!-- Total — net after line promos (#1022) -->
       <div
         v-if="orderPromoSavings > 0"
@@ -75,25 +75,25 @@
         <span class="font-medium text-text-tertiary">Anticipo mesa</span>
         <span class="font-semibold text-state-success-text tabular-nums">{{ formatCurrency(tableAdvanceAvailable) }}</span>
       </div>
-      <div class="flex items-center justify-between">
-        <span class="text-xs font-semibold text-text-tertiary uppercase tracking-widest">Total</span>
+      <div class="flex items-center justify-between gap-3">
+        <span class="text-[11px] font-semibold text-text-tertiary uppercase tracking-widest">Total</span>
         <div class="flex flex-col items-end">
           <span
             v-if="orderPromoSavings > 0"
-            class="text-sm text-text-tertiary line-through tabular-nums"
+            class="text-xs text-text-tertiary line-through tabular-nums"
           >{{ formatCurrency(grossOrderTotal) }}</span>
-          <span class="text-3xl font-black text-text-primary tabular-nums">{{ formatCurrency(netOrderTotal) }}</span>
+          <span class="text-2xl font-black text-text-primary tabular-nums leading-none">{{ formatCurrency(netOrderTotal) }}</span>
         </div>
       </div>
 
       <!-- Actions — Mostrador / barra sin comandas -->
-      <div v-if="!mesaMode" class="space-y-2">
+      <div v-if="!mesaMode" class="space-y-1.5">
         <template v-if="openSalePrimaryIdle && showOpenSale">
           <button
             type="button"
             :aria-disabled="!openSaleEnabled"
             :title="openSaleTooltip ?? undefined"
-            class="w-full h-12 rounded-xl bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 shadow-sm"
+            class="w-full h-10 rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 shadow-sm"
             @click="$emit('open-sale')"
           >
             <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
@@ -121,7 +121,7 @@
             v-if="hasCartItems && !hideProcessOrder"
             type="button"
             :disabled="isDeleting"
-            class="w-full h-12 rounded-xl bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
+            class="w-full h-10 rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
             @click="$emit('process-order')"
           >
             <svg v-if="isDeleting" class="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -137,7 +137,7 @@
             v-if="hasCartItems"
             type="button"
             :disabled="isDeleting"
-            class="w-full min-h-[44px] rounded-xl border border-border text-text-secondary text-sm font-medium flex items-center justify-center gap-2 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+            class="w-full min-h-9 rounded-lg border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1.5 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
             @click="$emit('clear-cart')"
           >
             <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
@@ -149,13 +149,13 @@
       </div>
 
       <!-- Actions — Mesa / barra con comandas -->
-      <div v-else class="space-y-2">
+      <div v-else class="space-y-1.5">
         <template v-if="openSalePrimaryIdle && showOpenSale">
           <button
             type="button"
             :aria-disabled="!openSaleEnabled"
             :title="openSaleTooltip ?? undefined"
-            class="w-full h-12 rounded-xl bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 shadow-sm"
+            class="w-full h-10 rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 shadow-sm"
             @click="$emit('open-sale')"
           >
             <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
@@ -184,7 +184,7 @@
           v-if="showBarProcessOrder"
           type="button"
           :disabled="items.length === 0 || isDeleting"
-          class="w-full h-12 rounded-xl bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
+          class="w-full h-10 rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
           @click="$emit('process-order')"
         >
           <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
@@ -193,12 +193,12 @@
           Procesar Orden
         </button>
         <!-- 2-col grid: secondary actions (Liberar moved to the active-mesa banner) -->
-        <div class="grid grid-cols-2 gap-2">
+        <div class="grid grid-cols-2 gap-1.5">
           <!-- Pedir cuenta -->
           <button
             type="button"
             :disabled="tabItems.length === 0"
-            class="min-h-[44px] rounded-xl border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+            class="min-h-9 rounded-lg border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
             aria-label="Pedir la cuenta"
             @click="$emit('request-bill')"
           >
@@ -211,7 +211,7 @@
           <button
             type="button"
             :disabled="(items.length === 0 && tabItems.length === 0) || isDeleting || isClearingTab"
-            class="min-h-[44px] rounded-xl border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+            class="min-h-9 rounded-lg border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
             @click="$emit('clear-cart')"
           >
             <UiLoadingDots v-if="isClearingTab" size="7px" />
@@ -226,11 +226,11 @@
 
 
         <!-- #753 / #812 — Kitchen ticket reprint actions stay compact; history lives in a panel. -->
-        <div v-if="comandasEnabled" class="grid grid-cols-2 gap-2">
+        <div v-if="comandasEnabled" class="grid grid-cols-2 gap-1.5">
           <button
             type="button"
             :disabled="!canPrintLatestComanda"
-            class="min-h-[44px] rounded-xl border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1.5 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+            class="min-h-9 rounded-lg border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1.5 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
             aria-label="Reimprimir última comanda enviada"
             @click="$emit('print-latest-comanda')"
           >
@@ -241,7 +241,7 @@
           </button>
           <button
             type="button"
-            class="min-h-[44px] rounded-xl border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1.5 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
+            class="min-h-9 rounded-lg border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1.5 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
             aria-label="Abrir comandas para reimprimir"
             @click="$emit('open-comandas-reprint')"
           >
@@ -263,7 +263,7 @@
         <button
           type="button"
           :disabled="items.length === 0 || isDeleting || isAddingToTab"
-          class="w-full h-12 rounded-xl bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
+          class="w-full h-10 rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
           :aria-label="`Agregar items a la ${tableSingularLower}`"
           @click="$emit('add-to-tab')"
         >
@@ -278,7 +278,7 @@
     </div>
 
     <!-- Items list: tab items (committed) + current cart items -->
-    <div class="flex-1 min-h-0 overflow-y-auto overscroll-y-contain p-4 space-y-2.5">
+    <div class="flex-1 min-h-0 overflow-y-auto overscroll-y-contain p-3 space-y-2">
 
       <!-- Skeleton while loading tab items, adding to tab, or clearing -->
       <template v-if="isLoadingTabItems || isAddingToTab || isClearingTab">
@@ -505,7 +505,7 @@ const hasCartItems = computed(() => props.items.length > 0)
 const hasTabItems = computed(() => (props.tabItems?.length ?? 0) > 0)
 
 const openSaleButtonClass = computed(() => [
-  'min-h-[44px] rounded-xl border text-sm font-semibold flex items-center justify-center gap-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 cursor-pointer',
+  'min-h-9 rounded-lg border text-xs font-semibold flex items-center justify-center gap-1.5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 cursor-pointer',
   props.openSaleEnabled
     ? 'border-dashed border-primary/50 text-primary hover:bg-primary/5'
     : 'border-dashed border-border text-text-tertiary hover:bg-surface-secondary hover:text-text-secondary',

--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -59,7 +59,7 @@
     </div>
 
     <!-- Cart summary/actions: sticky at the top of the order panel -->
-    <div class="flex-shrink-0 px-3 py-3 border-b border-border space-y-2 bg-surface-secondary/40">
+    <div class="flex-shrink-0 px-3.5 py-3 border-b border-border space-y-2.5 bg-surface-secondary/40">
       <!-- Total — net after line promos (#1022) -->
       <div
         v-if="orderPromoSavings > 0"
@@ -82,18 +82,18 @@
             v-if="orderPromoSavings > 0"
             class="text-xs text-text-tertiary line-through tabular-nums"
           >{{ formatCurrency(grossOrderTotal) }}</span>
-          <span class="text-2xl font-black text-text-primary tabular-nums leading-none">{{ formatCurrency(netOrderTotal) }}</span>
+          <span class="text-[1.75rem] font-black text-text-primary tabular-nums leading-none">{{ formatCurrency(netOrderTotal) }}</span>
         </div>
       </div>
 
       <!-- Actions — Mostrador / barra sin comandas -->
-      <div v-if="!mesaMode" class="space-y-1.5">
+      <div v-if="!mesaMode" class="space-y-2">
         <template v-if="openSalePrimaryIdle && showOpenSale">
           <button
             type="button"
             :aria-disabled="!openSaleEnabled"
             :title="openSaleTooltip ?? undefined"
-            class="w-full h-10 rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 shadow-sm"
+            class="w-full min-h-[44px] rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 shadow-sm"
             @click="$emit('open-sale')"
           >
             <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
@@ -121,7 +121,7 @@
             v-if="hasCartItems && !hideProcessOrder"
             type="button"
             :disabled="isDeleting"
-            class="w-full h-10 rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
+            class="w-full min-h-[44px] rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
             @click="$emit('process-order')"
           >
             <svg v-if="isDeleting" class="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -137,7 +137,7 @@
             v-if="hasCartItems"
             type="button"
             :disabled="isDeleting"
-            class="w-full min-h-9 rounded-lg border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1.5 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+            class="w-full min-h-[44px] rounded-lg border border-border text-text-secondary text-sm font-medium flex items-center justify-center gap-1.5 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
             @click="$emit('clear-cart')"
           >
             <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
@@ -149,13 +149,13 @@
       </div>
 
       <!-- Actions — Mesa / barra con comandas -->
-      <div v-else class="space-y-1.5">
+      <div v-else class="space-y-2">
         <template v-if="openSalePrimaryIdle && showOpenSale">
           <button
             type="button"
             :aria-disabled="!openSaleEnabled"
             :title="openSaleTooltip ?? undefined"
-            class="w-full h-10 rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 shadow-sm"
+            class="w-full min-h-[44px] rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 shadow-sm"
             @click="$emit('open-sale')"
           >
             <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
@@ -184,7 +184,7 @@
           v-if="showBarProcessOrder"
           type="button"
           :disabled="items.length === 0 || isDeleting"
-          class="w-full h-10 rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
+          class="w-full min-h-[44px] rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
           @click="$emit('process-order')"
         >
           <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
@@ -193,25 +193,25 @@
           Procesar Orden
         </button>
         <!-- 2-col grid: secondary actions (Liberar moved to the active-mesa banner) -->
-        <div class="grid grid-cols-2 gap-1.5">
+        <div class="grid grid-cols-2 gap-2">
           <!-- Pedir cuenta -->
           <button
             type="button"
             :disabled="tabItems.length === 0"
-            class="min-h-9 rounded-lg border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+            class="min-h-[44px] rounded-lg border border-border text-text-secondary text-sm font-medium flex items-center justify-center gap-1.5 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
             aria-label="Pedir la cuenta"
             @click="$emit('request-bill')"
           >
             <svg class="h-4 w-4 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 14.25l6-6m4.5-3.493V21.75l-3.75-1.5-3.75 1.5-3.75-1.5-3.75 1.5V4.757c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0c1.1.128 1.907 1.077 1.907 2.185Z" />
             </svg>
-            Pedir cuenta
+            Cuenta
           </button>
           <!-- Limpiar -->
           <button
             type="button"
             :disabled="(items.length === 0 && tabItems.length === 0) || isDeleting || isClearingTab"
-            class="min-h-9 rounded-lg border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+            class="min-h-[44px] rounded-lg border border-border text-text-secondary text-sm font-medium flex items-center justify-center gap-1.5 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
             @click="$emit('clear-cart')"
           >
             <UiLoadingDots v-if="isClearingTab" size="7px" />
@@ -226,22 +226,22 @@
 
 
         <!-- #753 / #812 — Kitchen ticket reprint actions stay compact; history lives in a panel. -->
-        <div v-if="comandasEnabled" class="grid grid-cols-2 gap-1.5">
+        <div v-if="comandasEnabled" class="grid grid-cols-2 gap-2">
           <button
             type="button"
             :disabled="!canPrintLatestComanda"
-            class="min-h-9 rounded-lg border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1.5 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+            class="min-h-[44px] rounded-lg border border-border text-text-secondary text-sm font-medium flex items-center justify-center gap-1.5 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
             aria-label="Reimprimir última comanda enviada"
             @click="$emit('print-latest-comanda')"
           >
             <svg class="h-4 w-4 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.75A2.25 2.25 0 0 1 5.25 7.5h13.5A2.25 2.25 0 0 1 21 9.75v6A2.25 2.25 0 0 1 18.75 18h-1.09M6.34 18h11.32" />
             </svg>
-            Reimprimir última
+            Última
           </button>
           <button
             type="button"
-            class="min-h-9 rounded-lg border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1.5 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
+            class="min-h-[44px] rounded-lg border border-border text-text-secondary text-sm font-medium flex items-center justify-center gap-1.5 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
             aria-label="Abrir comandas para reimprimir"
             @click="$emit('open-comandas-reprint')"
           >
@@ -263,7 +263,7 @@
         <button
           type="button"
           :disabled="items.length === 0 || isDeleting || isAddingToTab"
-          class="w-full h-10 rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
+          class="w-full min-h-[44px] rounded-lg bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed shadow-sm"
           :aria-label="`Agregar items a la ${tableSingularLower}`"
           @click="$emit('add-to-tab')"
         >
@@ -271,7 +271,7 @@
           <svg v-else class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>
-          {{ isAddingToTab ? 'Enviando...' : (comandasEnabled ? 'Agregar y enviar a cocina' : `Agregar a la ${tableSingularLower}`) }}
+          {{ isAddingToTab ? 'Enviando...' : (comandasEnabled ? 'Enviar a cocina' : `Agregar a la ${tableSingularLower}`) }}
         </button>
         </template>
       </div>
@@ -505,7 +505,7 @@ const hasCartItems = computed(() => props.items.length > 0)
 const hasTabItems = computed(() => (props.tabItems?.length ?? 0) > 0)
 
 const openSaleButtonClass = computed(() => [
-  'min-h-9 rounded-lg border text-xs font-semibold flex items-center justify-center gap-1.5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 cursor-pointer',
+  'min-h-[44px] rounded-lg border text-sm font-semibold flex items-center justify-center gap-1.5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 cursor-pointer',
   props.openSaleEnabled
     ? 'border-dashed border-primary/50 text-primary hover:bg-primary/5'
     : 'border-dashed border-border text-text-tertiary hover:bg-surface-secondary hover:text-text-secondary',

--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="flex flex-col min-h-0 lg:w-96 border border-border rounded-2xl bg-surface overflow-hidden shadow-sm"
-    :class="fitHeight ? 'h-fit' : 'h-full'"
+    :class="fitHeight ? 'h-fit lg:h-[calc(100dvh-7rem)] lg:max-h-[calc(100dvh-7rem)]' : 'h-full'"
   >
     <!-- Cart Header -->
     <div class="px-4 py-3.5 border-b border-border bg-surface">
@@ -58,112 +58,8 @@
       </div>
     </div>
 
-    <!-- Items list: tab items (committed) + current cart items -->
-    <div class="flex-1 min-h-0 overflow-y-auto overscroll-y-contain p-4 space-y-2.5">
-
-      <!-- Skeleton while loading tab items, adding to tab, or clearing -->
-      <template v-if="isLoadingTabItems || isAddingToTab || isClearingTab">
-        <div v-for="n in 3" :key="n" class="rounded-xl border border-border bg-surface-secondary/40 p-3 animate-pulse">
-          <div class="flex items-start gap-2">
-            <div class="h-7 w-7 shrink-0 rounded-full bg-surface-secondary" />
-            <div class="flex-1 space-y-1.5">
-              <div class="h-3.5 bg-surface-secondary rounded w-3/4" />
-              <div class="h-2.5 bg-surface-secondary rounded w-1/3" />
-            </div>
-            <div class="h-3.5 bg-surface-secondary rounded w-12 shrink-0" />
-          </div>
-          <div class="mt-2.5 pl-9 flex items-center gap-1.5">
-            <div class="h-9 w-20 bg-surface-secondary rounded-lg" />
-            <div class="flex-1" />
-            <div class="h-11 w-11 bg-surface-secondary rounded-lg" />
-            <div class="h-11 w-11 bg-surface-secondary rounded-lg" />
-          </div>
-        </div>
-      </template>
-
-      <!-- Tab items already on the mesa (only when not loading/adding/clearing) -->
-      <template v-else-if="!isLoadingTabItems && !isAddingToTab && !isClearingTab">
-      <div
-        v-for="(item, idx) in tabItems"
-        :key="item.orderItemId"
-        class="relative"
-      >
-        <PosCartItem
-          :item="{
-            product: { id: item.productId, name: item.productName, price: item.unitPrice, image: '🍽️', category: '' },
-            modifiers: item.modifiers ?? [],
-            quantity: item.quantity,
-            notes: item.notes ?? undefined,
-            fulfillmentStatus: item.fulfillmentStatus,
-            sentAt: item.sentAt
-          }"
-          :order-number="idx + 1"
-          :show-fulfillment-status="comandasEnabled"
-          :promo-label="tabLinePromoLabel(item)"
-          :promo-title="tabLinePromoTitle(item)"
-          :promo-savings="tabLinePromoSavings(item)"
-          :gross-total="item.subtotal"
-          :hide-duplicate="true"
-          :hide-edit="isTabLineFired(item)"
-          :lock-increment="isTabLineFired(item)"
-          :hide-line-controls="isTabLineTerminal(item)"
-          @edit="$emit('edit-tab-item', item.orderItemId, item.productId)"
-          @increment="$emit('increment-tab-item', item.orderItemId)"
-          @decrement="$emit('decrement-tab-item', item.orderItemId)"
-          @remove="$emit('remove-tab-item', item.orderItemId)"
-          @duplicate="() => {}"
-        />
-
-        <!-- Loading overlay — only while that line is mutating -->
-        <div
-          v-if="tabItemsLoading.has(item.orderItemId)"
-          class="absolute inset-0 z-20 rounded-xl bg-surface/70 flex items-center justify-center backdrop-blur-[1px] pointer-events-auto"
-          aria-hidden="true"
-        >
-          <UiLoadingDots size="9px" />
-        </div>
-      </div>
-
-      <!-- Divider when there are both tab items and new cart items -->
-      <div v-if="mesaMode && tabItems.length > 0 && items.length > 0" class="flex items-center gap-2 py-1">
-        <div class="flex-1 h-px bg-border" />
-        <span class="text-[10px] font-bold text-text-tertiary uppercase tracking-widest flex-shrink-0">Por agregar</span>
-        <div class="flex-1 h-px bg-border" />
-      </div>
-
-      <!-- Current cart items -->
-      <PosCartItem
-        v-for="(item, index) in items"
-        :key="index"
-        :item="item"
-        :order-number="tabItems.length + index + 1"
-        :promo-label="cartLinePromoLabel(item)"
-        :promo-title="cartLinePromoTitle(item)"
-        :promo-savings="cartLinePromoSavings(item)"
-        @edit="$emit('edit-item', index, item.product.id)"
-        @remove="$emit('remove-item', index)"
-        @increment="$emit('increment-item', index)"
-        @decrement="$emit('decrement-item', index)"
-        @duplicate="$emit('duplicate-item', index)"
-      />
-
-      <!-- Empty state: nothing at all -->
-      <div
-        v-if="tabItems.length === 0 && items.length === 0 && !isLoadingTabItems"
-        class="text-center py-12"
-      >
-        <svg class="h-16 w-16 mx-auto text-text-secondary mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" />
-        </svg>
-        <p class="text-text-secondary">{{ mesaMode ? `${tableSingular} sin pedidos` : 'Carrito vacío' }}</p>
-          <p class="text-sm text-text-tertiary mt-1">Selecciona productos para agregar</p>
-        </div>
-
-      </template>
-    </div>
-
-    <!-- Cart Footer -->
-    <div class="flex-shrink-0 px-4 py-4 border-t border-border space-y-3 bg-surface-secondary/40">
+    <!-- Cart summary/actions: sticky at the top of the order panel -->
+    <div class="flex-shrink-0 px-4 py-4 border-b border-border space-y-3 bg-surface-secondary/40">
       <!-- Total — net after line promos (#1022) -->
       <div
         v-if="orderPromoSavings > 0"
@@ -379,6 +275,110 @@
         </button>
         </template>
       </div>
+    </div>
+
+    <!-- Items list: tab items (committed) + current cart items -->
+    <div class="flex-1 min-h-0 overflow-y-auto overscroll-y-contain p-4 space-y-2.5">
+
+      <!-- Skeleton while loading tab items, adding to tab, or clearing -->
+      <template v-if="isLoadingTabItems || isAddingToTab || isClearingTab">
+        <div v-for="n in 3" :key="n" class="rounded-xl border border-border bg-surface-secondary/40 p-3 animate-pulse">
+          <div class="flex items-start gap-2">
+            <div class="h-7 w-7 shrink-0 rounded-full bg-surface-secondary" />
+            <div class="flex-1 space-y-1.5">
+              <div class="h-3.5 bg-surface-secondary rounded w-3/4" />
+              <div class="h-2.5 bg-surface-secondary rounded w-1/3" />
+            </div>
+            <div class="h-3.5 bg-surface-secondary rounded w-12 shrink-0" />
+          </div>
+          <div class="mt-2.5 pl-9 flex items-center gap-1.5">
+            <div class="h-9 w-20 bg-surface-secondary rounded-lg" />
+            <div class="flex-1" />
+            <div class="h-11 w-11 bg-surface-secondary rounded-lg" />
+            <div class="h-11 w-11 bg-surface-secondary rounded-lg" />
+          </div>
+        </div>
+      </template>
+
+      <!-- Tab items already on the mesa (only when not loading/adding/clearing) -->
+      <template v-else-if="!isLoadingTabItems && !isAddingToTab && !isClearingTab">
+      <div
+        v-for="(item, idx) in tabItems"
+        :key="item.orderItemId"
+        class="relative"
+      >
+        <PosCartItem
+          :item="{
+            product: { id: item.productId, name: item.productName, price: item.unitPrice, image: '🍽️', category: '' },
+            modifiers: item.modifiers ?? [],
+            quantity: item.quantity,
+            notes: item.notes ?? undefined,
+            fulfillmentStatus: item.fulfillmentStatus,
+            sentAt: item.sentAt
+          }"
+          :order-number="idx + 1"
+          :show-fulfillment-status="comandasEnabled"
+          :promo-label="tabLinePromoLabel(item)"
+          :promo-title="tabLinePromoTitle(item)"
+          :promo-savings="tabLinePromoSavings(item)"
+          :gross-total="item.subtotal"
+          :hide-duplicate="true"
+          :hide-edit="isTabLineFired(item)"
+          :lock-increment="isTabLineFired(item)"
+          :hide-line-controls="isTabLineTerminal(item)"
+          @edit="$emit('edit-tab-item', item.orderItemId, item.productId)"
+          @increment="$emit('increment-tab-item', item.orderItemId)"
+          @decrement="$emit('decrement-tab-item', item.orderItemId)"
+          @remove="$emit('remove-tab-item', item.orderItemId)"
+          @duplicate="() => {}"
+        />
+
+        <!-- Loading overlay — only while that line is mutating -->
+        <div
+          v-if="tabItemsLoading.has(item.orderItemId)"
+          class="absolute inset-0 z-20 rounded-xl bg-surface/70 flex items-center justify-center backdrop-blur-[1px] pointer-events-auto"
+          aria-hidden="true"
+        >
+          <UiLoadingDots size="9px" />
+        </div>
+      </div>
+
+      <!-- Divider when there are both tab items and new cart items -->
+      <div v-if="mesaMode && tabItems.length > 0 && items.length > 0" class="flex items-center gap-2 py-1">
+        <div class="flex-1 h-px bg-border" />
+        <span class="text-[10px] font-bold text-text-tertiary uppercase tracking-widest flex-shrink-0">Por agregar</span>
+        <div class="flex-1 h-px bg-border" />
+      </div>
+
+      <!-- Current cart items -->
+      <PosCartItem
+        v-for="(item, index) in items"
+        :key="index"
+        :item="item"
+        :order-number="tabItems.length + index + 1"
+        :promo-label="cartLinePromoLabel(item)"
+        :promo-title="cartLinePromoTitle(item)"
+        :promo-savings="cartLinePromoSavings(item)"
+        @edit="$emit('edit-item', index, item.product.id)"
+        @remove="$emit('remove-item', index)"
+        @increment="$emit('increment-item', index)"
+        @decrement="$emit('decrement-item', index)"
+        @duplicate="$emit('duplicate-item', index)"
+      />
+
+      <!-- Empty state: nothing at all -->
+      <div
+        v-if="tabItems.length === 0 && items.length === 0 && !isLoadingTabItems"
+        class="text-center py-12"
+      >
+        <svg class="h-16 w-16 mx-auto text-text-secondary mb-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" />
+        </svg>
+        <p class="text-text-secondary">{{ mesaMode ? `${tableSingular} sin pedidos` : 'Carrito vacío' }}</p>
+          <p class="text-sm text-text-tertiary mt-1">Selecciona productos para agregar</p>
+        </div>
+
+      </template>
     </div>
   </div>
 </template>

--- a/components/pos/ComandasReprintPanel.vue
+++ b/components/pos/ComandasReprintPanel.vue
@@ -1,0 +1,228 @@
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-200"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div v-if="modelValue" class="fixed inset-0 z-40 bg-overlay-backdrop/40" aria-hidden="true" @click="close" />
+    </Transition>
+
+    <Transition name="panel">
+      <div
+        v-if="modelValue"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Reimprimir comandas"
+        class="fixed z-50 flex flex-col bg-surface shadow-2xl
+               inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh]
+               md:inset-y-0 md:right-0 md:bottom-auto md:left-auto md:inset-x-auto md:rounded-none md:w-full md:max-w-lg md:max-h-none md:h-full"
+      >
+        <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
+          <div class="w-10 h-1 rounded-full bg-sheet-border" aria-hidden="true" />
+        </div>
+
+        <div class="flex-shrink-0 bg-surface-secondary/40 border-b border-border px-5 py-4">
+          <div class="flex items-start justify-between gap-3">
+            <div class="flex items-center gap-3 min-w-0 flex-1">
+              <div class="flex-shrink-0 w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
+                <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.7" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3.75h10.5A2.25 2.25 0 0 1 19.5 6v14.25l-2.625-1.5-2.625 1.5-2.625-1.5-2.625 1.5-2.625-1.5-2.625 1.5V6a2.25 2.25 0 0 1 2.25-2.25Z" />
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 8.25h7.5M8.25 12h7.5M8.25 15.75h4.5" />
+                </svg>
+              </div>
+              <div class="min-w-0">
+                <h2 class="text-base font-bold text-text-primary leading-tight">Reimprimir comandas</h2>
+                <p class="text-xs text-text-secondary leading-snug mt-0.5 truncate">
+                  {{ tableDisplayName || 'Sesión actual' }} · {{ comandas.length }} {{ comandas.length === 1 ? 'comanda' : 'comandas' }}
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              aria-label="Cerrar panel"
+              class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+              @click="close"
+            >
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18 18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div class="flex-1 overflow-y-auto px-5 py-4">
+          <div v-if="loading" class="space-y-2.5">
+            <div v-for="i in 4" :key="i" class="h-20 rounded-xl bg-surface-secondary animate-pulse" />
+          </div>
+
+          <div
+            v-else-if="comandas.length === 0"
+            class="rounded-xl border border-border bg-surface-secondary/50 px-4 py-6 text-center"
+          >
+            <p class="text-sm font-semibold text-text-primary">No hay comandas enviadas</p>
+            <p class="text-xs text-text-secondary mt-1">Esta sesión todavía no tiene comandas para reimprimir.</p>
+          </div>
+
+          <div v-else class="space-y-2.5">
+            <label
+              v-for="comanda in comandas"
+              :key="comanda.id"
+              class="flex items-start gap-3 rounded-xl border bg-surface px-3 py-3 cursor-pointer transition-colors"
+              :class="isSelected(comanda.id) ? 'border-primary bg-primary/5' : 'border-border hover:bg-surface-secondary/60'"
+            >
+              <input
+                type="checkbox"
+                class="mt-0.5 h-4 w-4 rounded border-border text-primary focus:ring-action-primary-focus-ring/30 flex-shrink-0"
+                :checked="isSelected(comanda.id)"
+                :aria-label="`Seleccionar comanda ${comanda.comandaNumber}`"
+                @change="$emit('toggle-comanda', comanda.id)"
+              />
+              <span class="min-w-0 flex-1">
+                <span class="flex items-start justify-between gap-2">
+                  <span class="min-w-0">
+                    <span class="block text-sm font-bold text-text-primary truncate">
+                      #{{ comanda.comandaNumber }} · {{ comanda.stationName }}
+                    </span>
+                    <span class="mt-1 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-text-secondary">
+                      <span class="font-medium">{{ comanda.itemCount }} {{ comanda.itemCount === 1 ? 'ítem' : 'ítems' }}</span>
+                      <span v-if="statusLabel(comanda.status)" class="text-text-tertiary">· {{ statusLabel(comanda.status) }}</span>
+                      <span v-if="comanda.itemPreview" class="truncate max-w-full">· {{ comanda.itemPreview }}</span>
+                    </span>
+                  </span>
+                  <span class="text-[10px] font-semibold text-text-tertiary whitespace-nowrap pt-0.5">
+                    {{ formatComandaTime(comanda.firedAt) }}
+                  </span>
+                </span>
+              </span>
+            </label>
+          </div>
+        </div>
+
+        <div class="flex-shrink-0 border-t border-border bg-surface-secondary/40 px-5 py-4 space-y-3">
+          <div class="flex items-center justify-between gap-2">
+            <div class="flex items-center gap-2">
+              <button
+                type="button"
+                :disabled="loading || comandas.length === 0"
+                class="min-h-[36px] px-3 rounded-lg border border-border text-[11px] font-semibold text-text-secondary hover:bg-surface hover:text-text-primary transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                @click="$emit('select-all')"
+              >
+                Seleccionar todas
+              </button>
+              <button
+                type="button"
+                :disabled="loading || selectedIds.length === 0"
+                class="min-h-[36px] px-3 rounded-lg border border-border text-[11px] font-semibold text-text-secondary hover:bg-surface hover:text-text-primary transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                @click="$emit('clear-selection')"
+              >
+                Limpiar
+              </button>
+            </div>
+            <button
+              type="button"
+              :disabled="loading"
+              class="min-h-[36px] px-3 rounded-lg text-[11px] font-semibold text-text-secondary hover:bg-surface hover:text-text-primary transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              @click="$emit('refresh')"
+            >
+              Actualizar
+            </button>
+          </div>
+          <button
+            type="button"
+            :disabled="loading || selectedIds.length === 0"
+            class="w-full min-h-[46px] rounded-xl bg-action-primary-bg text-action-primary-text text-sm font-semibold flex items-center justify-center gap-2 hover:opacity-90 active:scale-[0.98] transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+            @click="$emit('print-selected')"
+          >
+            <svg class="h-4 w-4 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.75A2.25 2.25 0 0 1 5.25 7.5h13.5A2.25 2.25 0 0 1 21 9.75v6A2.25 2.25 0 0 1 18.75 18h-1.09M6.34 18h11.32" />
+            </svg>
+            {{ selectedIds.length > 0 ? `Reimprimir seleccionadas (${selectedIds.length})` : 'Reimprimir seleccionadas' }}
+          </button>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+interface ReprintComanda {
+  id: string
+  comandaNumber: string
+  stationName: string
+  status?: string
+  firedAt?: string | null
+  itemCount: number
+  itemPreview?: string
+}
+
+const props = withDefaults(defineProps<{
+  modelValue: boolean
+  comandas: ReprintComanda[]
+  selectedIds: string[]
+  loading?: boolean
+  tableDisplayName?: string | null
+}>(), {
+  comandas: () => [],
+  selectedIds: () => [],
+  loading: false,
+  tableDisplayName: null,
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+  'toggle-comanda': [id: string]
+  'select-all': []
+  'clear-selection': []
+  'print-selected': []
+  'refresh': []
+}>()
+
+const selectedSet = computed(() => new Set(props.selectedIds))
+const close = () => emit('update:modelValue', false)
+const isSelected = (id: string) => selectedSet.value.has(id)
+
+function formatComandaTime(value?: string | null): string {
+  if (!value) return ''
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return ''
+  return new Intl.DateTimeFormat('es-CO', {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(d)
+}
+
+function statusLabel(status?: string): string | null {
+  const labels: Record<string, string> = {
+    pending: 'Pendiente',
+    preparing: 'Preparando',
+    ready: 'Lista',
+    delivered: 'Entregada',
+    cancelled: 'Cancelada',
+  }
+  return status ? labels[status] ?? status : null
+}
+</script>
+
+<style scoped>
+.panel-enter-active,
+.panel-leave-active {
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.panel-enter-from,
+.panel-leave-to {
+  opacity: 0;
+  transform: translateY(100%);
+}
+
+@media (min-width: 768px) {
+  .panel-enter-from,
+  .panel-leave-to {
+    transform: translateX(100%);
+  }
+}
+</style>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -16,6 +16,8 @@ import { displayTableCode } from '~/composables/useTableDisplayCode'
 import { formatPromoTypeLabel } from '~/utils/promotionPreview'
 import { computePromoEligibleSubtotal, linePromoSavingsForProduct } from '~/utils/promoProductMatch'
 import { posDebugLog, posDebugSerializeError } from '~/utils/posDebugLog'
+import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
+import { mapComandasForPrint, printComandaTickets } from '~/composables/useComandaPrint'
 
 interface TopProduct {
   name: string
@@ -227,7 +229,7 @@ const customerInsights = ref<CustomerInsights | null>(null)
 const insightsLoading = ref(false)
 // Accordions start closed; the user opens them on demand. Previous behavior
 // auto-opened "summary" / "insights" on customer change — too noisy.
-const activeAccordion = ref<'insights' | 'summary' | 'waros' | null>(null)
+const activeAccordion = ref<'order' | 'comandas' | 'insights' | 'summary' | 'waros' | null>(null)
 
 const { tabItems: storeTabItems } = storeToRefs(posStore)
 
@@ -729,6 +731,167 @@ const {
   enabled: () => isKitchenServiceMode.value && !!posStore.activeTableSession?.tableId,
   staleTime: 5_000,  // short — running_total changes when items are added
 })
+
+const {
+  data: checkoutComandasData,
+  asyncStatus: checkoutComandasAsyncStatus,
+} = useQuery({
+  key: () => ['tables', posStore.activeTableSession?.tableId ?? null, posStore.activeTableSession?.sessionId ?? null, 'comandas'],
+  query: () => $fetch<{ success: boolean; data?: { comandas?: unknown[] } }>(
+    `/api/tables/${posStore.activeTableSession!.tableId}/comandas`
+  ),
+  enabled: () => comandasEnabled.value && isKitchenServiceMode.value && !!posStore.activeTableSession?.tableId,
+  staleTime: 5_000,
+})
+
+const persistedComandasRaw = ref<unknown[]>([])
+const comandasForPrint = ref<ComandaPrintPayload[]>([])
+const selectedComandaIds = ref<string[]>([])
+const comandaSelectionInitialized = ref(false)
+const comandaPrintSessionKey = ref<string | null>(null)
+const posBusinessName = computed(
+  () => settingsData.value?.data?.business_name
+    ?? settingsData.value?.data?.display_name
+    ?? 'WARO',
+)
+
+const currentComandaPrintSessionKey = () => {
+  const session = posStore.activeTableSession
+  return session ? `${session.tableId}:${session.sessionId ?? ''}` : null
+}
+
+function resetComandaPrintState() {
+  persistedComandasRaw.value = []
+  comandasForPrint.value = []
+  selectedComandaIds.value = []
+  comandaSelectionInitialized.value = false
+  comandaPrintSessionKey.value = null
+}
+
+const canPrintComandas = computed(
+  () =>
+    comandasForPrint.value.length > 0
+    && comandaPrintSessionKey.value === currentComandaPrintSessionKey(),
+)
+
+function rawComandaId(raw: unknown, index: number): string {
+  const c = raw as Record<string, unknown>
+  return String(c.id ?? `${c.comanda_number ?? index}:${c.station_name ?? ''}:${c.fired_at ?? ''}`)
+}
+
+const comandasForPrintDisplay = computed(() => {
+  if (!canPrintComandas.value) return []
+  const sel = selectedComandaIds.value
+  if (sel.length === 0) return []
+  const selSet = new Set(sel)
+  const filteredRaw = (persistedComandasRaw.value as Record<string, unknown>[])
+    .filter((c, index) => selSet.has(rawComandaId(c, index)))
+  return mapComandasForPrint(filteredRaw)
+})
+
+const sentComandasForCheckout = computed(() => (
+  (persistedComandasRaw.value as Record<string, unknown>[]).map((c, index) => {
+    const items = ((c.items as Record<string, unknown>[]) ?? [])
+    return {
+      id: rawComandaId(c, index),
+      comandaNumber: String(c.comanda_number ?? '—'),
+      stationName: (c.station_name as string) ?? 'Sin cocina asignada',
+      status: String(c.status ?? ''),
+      firedAt: c.fired_at != null ? String(c.fired_at) : null,
+      itemCount: items.length,
+      itemPreview: items
+        .slice(0, 2)
+        .map(i => `${Number(i.quantity ?? 1)}x ${String(i.kitchen_name ?? '')}`.trim())
+        .filter(Boolean)
+        .join(', '),
+    }
+  })
+))
+
+const selectedComandaCount = computed(() => selectedComandaIds.value.length)
+const checkoutComandasLoading = computed(() =>
+  checkoutComandasAsyncStatus.value === 'loading' && !checkoutComandasData.value
+)
+const showCheckoutComandas = computed(() => comandasEnabled.value && isKitchenServiceMode.value)
+const checkoutComandasPrintLabel = computed(() => {
+  const n = selectedComandaCount.value
+  if (n > 0 && n < sentComandasForCheckout.value.length) return `Reimprimir seleccionadas (${n})`
+  return 'Reimprimir comandas'
+})
+
+function applyPersistedComandas(rawComandas: unknown[], preserveSelection = true) {
+  const printableRaw = (rawComandas as Record<string, unknown>[])
+    .filter(c => (((c.items as unknown[]) ?? []).length > 0))
+  const ids = printableRaw.map((c, index) => rawComandaId(c, index))
+  const hadComandas = persistedComandasRaw.value.length > 0
+  persistedComandasRaw.value = printableRaw
+  comandasForPrint.value = mapComandasForPrint(printableRaw)
+  comandaPrintSessionKey.value = currentComandaPrintSessionKey()
+
+  if (preserveSelection && comandaSelectionInitialized.value && hadComandas) {
+    const available = new Set(ids)
+    selectedComandaIds.value = selectedComandaIds.value.filter(id => available.has(id))
+  } else {
+    selectedComandaIds.value = ids
+    comandaSelectionInitialized.value = ids.length > 0
+  }
+}
+
+watch(
+  () => checkoutComandasData.value?.data?.comandas,
+  (rows) => applyPersistedComandas(Array.isArray(rows) ? rows : []),
+  { immediate: true },
+)
+
+watch(
+  [showCheckoutComandas, () => posStore.activeTableSession?.tableId, () => posStore.activeTableSession?.sessionId],
+  ([enabled, tableId, sessionId], previous) => {
+    if (!enabled) {
+      resetComandaPrintState()
+      return
+    }
+    if (!previous) return
+    const [, previousTableId, previousSessionId] = previous
+    if (tableId !== previousTableId || sessionId !== previousSessionId) {
+      resetComandaPrintState()
+    }
+  },
+)
+
+function toggleComandaSelection(comandaId: string) {
+  comandaSelectionInitialized.value = true
+  const idx = selectedComandaIds.value.indexOf(comandaId)
+  if (idx >= 0) {
+    selectedComandaIds.value = selectedComandaIds.value.filter(id => id !== comandaId)
+  } else {
+    selectedComandaIds.value = [...selectedComandaIds.value, comandaId]
+  }
+}
+
+function formatComandaTime(value?: string | null): string {
+  if (!value) return ''
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return ''
+  return new Intl.DateTimeFormat('es-CO', {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(d)
+}
+
+function statusLabel(status?: string): string | null {
+  const labels: Record<string, string> = {
+    pending: 'Pendiente',
+    preparing: 'Preparando',
+    ready: 'Lista',
+    delivered: 'Entregada',
+  }
+  return status ? labels[status] ?? status : null
+}
+
+function handlePrintComandas() {
+  if (!comandasForPrintDisplay.value.length) return
+  printComandaTickets()
+}
 
 // POS tax preview — manual + WaRo discounts are folded into discount_amount (#1063).
 const { data: posTaxPreviewData } = useQuery({
@@ -2786,6 +2949,9 @@ const refreshAll = async () => {
     isKitchenServiceMode.value
       ? cache.invalidateQueries({ key: ['tables', posStore.activeTableSession?.tableId ?? null, 'current'] })
       : cache.invalidateQueries({ key: ['pos', 'cart', posStore.cartId ?? null, 'tax-preview'] }),
+    showCheckoutComandas.value
+      ? cache.invalidateQueries({ key: ['tables', posStore.activeTableSession?.tableId ?? null, posStore.activeTableSession?.sessionId ?? null, 'comandas'] })
+      : Promise.resolve(),
   ])
 }
 registerProgressiveLoading(isRefreshing, 'Actualizando pagos')
@@ -2976,19 +3142,31 @@ onUnmounted(() => {
       <!-- LEFT COLUMN: Order Items & Payment Method -->
       <div class="lg:col-span-8 space-y-6">
 
-        <!-- Section: Order Items -->
+        <!-- ACCORDION: Orden -->
         <div class="bg-surface rounded-2xl shadow-sm border border-border overflow-hidden">
-          <div class="px-4 py-3 border-b border-border flex justify-between items-center bg-surface-secondary/50">
-            <h2 class="font-bold text-text-primary flex items-center gap-2 text-sm md:text-base">
-              <svg class="h-4 w-4 md:h-5 md:w-5 text-primary" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 10.5V6a3.75 3.75 0 1 0-7.5 0v4.5m11.356-1.993 1.263 12c.07.665-.45 1.243-1.119 1.243H4.25a1.125 1.125 0 0 1-1.12-1.243l1.264-12A1.125 1.125 0 0 1 5.513 7.5h12.974c.576 0 1.059.435 1.119 1.007ZM8.625 10.5a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm7.5 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
-            </svg>
-              Items de la Orden
+          <button
+            type="button"
+            @click="activeAccordion = activeAccordion === 'order' ? null : 'order'"
+            class="w-full px-4 py-3 flex justify-between items-center bg-surface-secondary/50 text-left hover:bg-surface-secondary/70 transition-colors"
+          >
+            <span class="font-bold text-text-primary flex items-center gap-2 text-sm md:text-base">
+                <svg class="h-4 w-4 md:h-5 md:w-5 text-primary" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 10.5V6a3.75 3.75 0 1 0-7.5 0v4.5m11.356-1.993 1.263 12c.07.665-.45 1.243-1.119 1.243H4.25a1.125 1.125 0 0 1-1.12-1.243l1.264-12A1.125 1.125 0 0 1 5.513 7.5h12.974c.576 0 1.059.435 1.119 1.007ZM8.625 10.5a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm7.5 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+              </svg>
+              Orden
               <span class="text-text-tertiary font-normal text-xs ml-1">({{ cartItems.length }})</span>
-            </h2>
-          </div>
+            </span>
+            <svg
+              class="h-4 w-4 text-text-tertiary flex-shrink-0 transition-transform duration-200"
+              :class="activeAccordion === 'order' ? 'rotate-0' : 'rotate-180'"
+              xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" />
+            </svg>
+          </button>
 
-          <div class="divide-y divide-border">
+          <div v-show="activeAccordion === 'order'" class="divide-y divide-border border-t border-border">
             <!-- Cart Items -->
             <div
               v-for="(item, index) in cartItems"
@@ -3777,6 +3955,91 @@ onUnmounted(() => {
           </div>
         </div>
 
+        <!-- ACCORDION: Comandas -->
+        <div
+          v-if="showCheckoutComandas"
+          class="bg-surface rounded-2xl border border-border overflow-hidden shadow-sm"
+        >
+          <button
+            type="button"
+            @click="activeAccordion = activeAccordion === 'comandas' ? null : 'comandas'"
+            class="w-full px-5 py-4 flex items-center justify-between gap-3 text-left hover:bg-surface-secondary/40 transition-colors"
+          >
+            <span class="font-bold text-text-primary flex items-center gap-2">
+              <svg class="h-4 w-4 text-primary" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.7" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3.75h10.5A2.25 2.25 0 0 1 19.5 6v14.25l-2.625-1.5-2.625 1.5-2.625-1.5-2.625 1.5-2.625-1.5-2.625 1.5V6a2.25 2.25 0 0 1 2.25-2.25Z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 8.25h7.5M8.25 12h7.5M8.25 15.75h4.5" />
+              </svg>
+              Comandas
+            </span>
+            <span class="ml-auto text-xs font-semibold text-text-secondary">
+              {{ selectedComandaCount }}/{{ sentComandasForCheckout.length }}
+            </span>
+            <svg
+              class="h-4 w-4 text-text-tertiary flex-shrink-0 transition-transform duration-200"
+              :class="activeAccordion === 'comandas' ? 'rotate-0' : 'rotate-180'"
+              xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" />
+            </svg>
+          </button>
+
+          <div v-show="activeAccordion === 'comandas'" class="border-t border-border px-5 py-4 space-y-3">
+            <div v-if="checkoutComandasLoading" class="space-y-2">
+              <div v-for="i in 2" :key="i" class="h-14 rounded-lg bg-surface-secondary animate-pulse" />
+            </div>
+            <div
+              v-else-if="sentComandasForCheckout.length === 0"
+              class="rounded-lg border border-border bg-surface-secondary/50 px-3 py-3 text-sm text-text-secondary"
+            >
+              No hay comandas enviadas para esta sesión.
+            </div>
+            <div v-else class="space-y-1.5">
+              <label
+                v-for="comanda in sentComandasForCheckout"
+                :key="comanda.id"
+                class="flex items-start gap-2 rounded-lg border border-border bg-surface px-2.5 py-2 cursor-pointer hover:bg-surface-secondary transition-colors"
+              >
+                <input
+                  type="checkbox"
+                  class="mt-0.5 h-4 w-4 rounded border-border text-primary focus:ring-action-primary-focus-ring/30"
+                  :checked="selectedComandaIds.includes(comanda.id)"
+                  :aria-label="`Seleccionar comanda ${comanda.comandaNumber}`"
+                  @change="toggleComandaSelection(comanda.id)"
+                />
+                <span class="min-w-0 flex-1">
+                  <span class="flex items-center justify-between gap-2">
+                    <span class="text-xs font-bold text-text-primary truncate">
+                      #{{ comanda.comandaNumber }} · {{ comanda.stationName }}
+                    </span>
+                    <span class="text-[10px] font-semibold text-text-tertiary whitespace-nowrap">
+                      {{ formatComandaTime(comanda.firedAt) }}
+                    </span>
+                  </span>
+                  <span class="mt-0.5 flex items-center gap-1.5 text-[11px] text-text-secondary min-w-0">
+                    <span class="font-medium">{{ comanda.itemCount }} {{ comanda.itemCount === 1 ? 'ítem' : 'ítems' }}</span>
+                    <span v-if="statusLabel(comanda.status)" class="text-text-tertiary">· {{ statusLabel(comanda.status) }}</span>
+                    <span v-if="comanda.itemPreview" class="truncate">· {{ comanda.itemPreview }}</span>
+                  </span>
+                </span>
+              </label>
+            </div>
+            <button
+              type="button"
+              :disabled="!canPrintComandas || selectedComandaCount === 0"
+              class="w-full min-h-[44px] rounded-xl border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+              :aria-label="checkoutComandasPrintLabel"
+              @click="handlePrintComandas"
+            >
+              <svg class="h-4 w-4 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18M6.72 13.829 6.34 18m10.94-4.171L17.66 18M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.75A2.25 2.25 0 0 1 5.25 7.5h13.5A2.25 2.25 0 0 1 21 9.75v6A2.25 2.25 0 0 1 18.75 18h-1.09M6.34 18h11.32" />
+              </svg>
+              {{ checkoutComandasPrintLabel }}
+            </button>
+          </div>
+        </div>
+
         <!-- WAROS CARD (desktop) — accordion -->
         <div
           v-if="warosPanelVisible"
@@ -4289,6 +4552,91 @@ onUnmounted(() => {
             </div>
             <p class="text-right text-xs text-text-tertiary">COP</p>
           </div>
+        </div>
+      </div>
+
+      <!-- ACCORDION: Comandas -->
+      <div
+        v-if="showCheckoutComandas"
+        class="bg-surface rounded-2xl border border-border overflow-hidden shadow-sm"
+      >
+        <button
+          type="button"
+          @click="activeAccordion = activeAccordion === 'comandas' ? null : 'comandas'"
+          class="w-full px-5 py-4 flex items-center justify-between gap-3 text-left hover:bg-surface-secondary/40 transition-colors"
+        >
+          <span class="font-bold text-text-primary flex items-center gap-2">
+            <svg class="h-4 w-4 text-primary" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.7" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3.75h10.5A2.25 2.25 0 0 1 19.5 6v14.25l-2.625-1.5-2.625 1.5-2.625-1.5-2.625 1.5-2.625-1.5-2.625 1.5V6a2.25 2.25 0 0 1 2.25-2.25Z" />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 8.25h7.5M8.25 12h7.5M8.25 15.75h4.5" />
+            </svg>
+            Comandas
+          </span>
+          <span class="ml-auto text-xs font-semibold text-text-secondary">
+            {{ selectedComandaCount }}/{{ sentComandasForCheckout.length }}
+          </span>
+          <svg
+            class="h-4 w-4 text-text-tertiary flex-shrink-0 transition-transform duration-200"
+            :class="activeAccordion === 'comandas' ? 'rotate-0' : 'rotate-180'"
+            xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" />
+          </svg>
+        </button>
+
+        <div v-show="activeAccordion === 'comandas'" class="border-t border-border px-5 py-4 space-y-3">
+          <div v-if="checkoutComandasLoading" class="space-y-2">
+            <div v-for="i in 2" :key="i" class="h-14 rounded-lg bg-surface-secondary animate-pulse" />
+          </div>
+          <div
+            v-else-if="sentComandasForCheckout.length === 0"
+            class="rounded-lg border border-border bg-surface-secondary/50 px-3 py-3 text-sm text-text-secondary"
+          >
+            No hay comandas enviadas para esta sesión.
+          </div>
+          <div v-else class="space-y-1.5">
+            <label
+              v-for="comanda in sentComandasForCheckout"
+              :key="comanda.id"
+              class="flex items-start gap-2 rounded-lg border border-border bg-surface px-2.5 py-2 cursor-pointer hover:bg-surface-secondary transition-colors"
+            >
+              <input
+                type="checkbox"
+                class="mt-0.5 h-4 w-4 rounded border-border text-primary focus:ring-action-primary-focus-ring/30"
+                :checked="selectedComandaIds.includes(comanda.id)"
+                :aria-label="`Seleccionar comanda ${comanda.comandaNumber}`"
+                @change="toggleComandaSelection(comanda.id)"
+              />
+              <span class="min-w-0 flex-1">
+                <span class="flex items-center justify-between gap-2">
+                  <span class="text-xs font-bold text-text-primary truncate">
+                    #{{ comanda.comandaNumber }} · {{ comanda.stationName }}
+                  </span>
+                  <span class="text-[10px] font-semibold text-text-tertiary whitespace-nowrap">
+                    {{ formatComandaTime(comanda.firedAt) }}
+                  </span>
+                </span>
+                <span class="mt-0.5 flex items-center gap-1.5 text-[11px] text-text-secondary min-w-0">
+                  <span class="font-medium">{{ comanda.itemCount }} {{ comanda.itemCount === 1 ? 'ítem' : 'ítems' }}</span>
+                  <span v-if="statusLabel(comanda.status)" class="text-text-tertiary">· {{ statusLabel(comanda.status) }}</span>
+                  <span v-if="comanda.itemPreview" class="truncate">· {{ comanda.itemPreview }}</span>
+                </span>
+              </span>
+            </label>
+          </div>
+          <button
+            type="button"
+            :disabled="!canPrintComandas || selectedComandaCount === 0"
+            class="w-full min-h-[44px] rounded-xl border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
+            :aria-label="checkoutComandasPrintLabel"
+            @click="handlePrintComandas"
+          >
+            <svg class="h-4 w-4 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18M6.72 13.829 6.34 18m10.94-4.171L17.66 18M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.75A2.25 2.25 0 0 1 5.25 7.5h13.5A2.25 2.25 0 0 1 21 9.75v6A2.25 2.25 0 0 1 18.75 18h-1.09M6.34 18h11.32" />
+            </svg>
+            {{ checkoutComandasPrintLabel }}
+          </button>
         </div>
       </div>
 
@@ -5188,6 +5536,12 @@ onUnmounted(() => {
     v-model="showExpediterPanel"
     :table-session-id="posStore.activeTableSession?.tableId ?? null"
     :table-display-name="posStore.activeTableSession?.tableName ?? null"
+  />
+
+  <PosComandaPrintTickets
+    v-if="comandasEnabled"
+    :comandas="comandasForPrintDisplay"
+    :business-name="posBusinessName"
   />
   </div>
 </template>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -16,8 +16,6 @@ import { displayTableCode } from '~/composables/useTableDisplayCode'
 import { formatPromoTypeLabel } from '~/utils/promotionPreview'
 import { computePromoEligibleSubtotal, linePromoSavingsForProduct } from '~/utils/promoProductMatch'
 import { posDebugLog, posDebugSerializeError } from '~/utils/posDebugLog'
-import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
-import { mapComandasForPrint, printComandaTickets } from '~/composables/useComandaPrint'
 
 interface TopProduct {
   name: string
@@ -229,7 +227,7 @@ const customerInsights = ref<CustomerInsights | null>(null)
 const insightsLoading = ref(false)
 // Accordions start closed; the user opens them on demand. Previous behavior
 // auto-opened "summary" / "insights" on customer change — too noisy.
-const activeAccordion = ref<'order' | 'comandas' | 'insights' | 'summary' | 'waros' | null>(null)
+const activeAccordion = ref<'order' | 'insights' | 'summary' | 'waros' | null>(null)
 
 const { tabItems: storeTabItems } = storeToRefs(posStore)
 
@@ -311,9 +309,6 @@ const isMesaMode = computed(
   () => !!posStore.activeTableSession && !posStore.activeTableSession?.isBar,
 )
 
-// Issue #537 — expediter mode (waiter advances comanda state from POS)
-const expediterEnabled = computed(() => settingsData.value?.data?.expediter_enabled === true)
-const showExpediterPanel = ref(false)
 const acceptsOnlineOrders = computed(() => settingsData.value?.data?.accepts_online_orders === true)
 
 // warocol.com#639 — tipping config (gated by tenant; defaults keep selector hidden)
@@ -731,167 +726,6 @@ const {
   enabled: () => isKitchenServiceMode.value && !!posStore.activeTableSession?.tableId,
   staleTime: 5_000,  // short — running_total changes when items are added
 })
-
-const {
-  data: checkoutComandasData,
-  asyncStatus: checkoutComandasAsyncStatus,
-} = useQuery({
-  key: () => ['tables', posStore.activeTableSession?.tableId ?? null, posStore.activeTableSession?.sessionId ?? null, 'comandas'],
-  query: () => $fetch<{ success: boolean; data?: { comandas?: unknown[] } }>(
-    `/api/tables/${posStore.activeTableSession!.tableId}/comandas`
-  ),
-  enabled: () => comandasEnabled.value && isKitchenServiceMode.value && !!posStore.activeTableSession?.tableId,
-  staleTime: 5_000,
-})
-
-const persistedComandasRaw = ref<unknown[]>([])
-const comandasForPrint = ref<ComandaPrintPayload[]>([])
-const selectedComandaIds = ref<string[]>([])
-const comandaSelectionInitialized = ref(false)
-const comandaPrintSessionKey = ref<string | null>(null)
-const posBusinessName = computed(
-  () => settingsData.value?.data?.business_name
-    ?? settingsData.value?.data?.display_name
-    ?? 'WARO',
-)
-
-const currentComandaPrintSessionKey = () => {
-  const session = posStore.activeTableSession
-  return session ? `${session.tableId}:${session.sessionId ?? ''}` : null
-}
-
-function resetComandaPrintState() {
-  persistedComandasRaw.value = []
-  comandasForPrint.value = []
-  selectedComandaIds.value = []
-  comandaSelectionInitialized.value = false
-  comandaPrintSessionKey.value = null
-}
-
-const canPrintComandas = computed(
-  () =>
-    comandasForPrint.value.length > 0
-    && comandaPrintSessionKey.value === currentComandaPrintSessionKey(),
-)
-
-function rawComandaId(raw: unknown, index: number): string {
-  const c = raw as Record<string, unknown>
-  return String(c.id ?? `${c.comanda_number ?? index}:${c.station_name ?? ''}:${c.fired_at ?? ''}`)
-}
-
-const comandasForPrintDisplay = computed(() => {
-  if (!canPrintComandas.value) return []
-  const sel = selectedComandaIds.value
-  if (sel.length === 0) return []
-  const selSet = new Set(sel)
-  const filteredRaw = (persistedComandasRaw.value as Record<string, unknown>[])
-    .filter((c, index) => selSet.has(rawComandaId(c, index)))
-  return mapComandasForPrint(filteredRaw)
-})
-
-const sentComandasForCheckout = computed(() => (
-  (persistedComandasRaw.value as Record<string, unknown>[]).map((c, index) => {
-    const items = ((c.items as Record<string, unknown>[]) ?? [])
-    return {
-      id: rawComandaId(c, index),
-      comandaNumber: String(c.comanda_number ?? '—'),
-      stationName: (c.station_name as string) ?? 'Sin cocina asignada',
-      status: String(c.status ?? ''),
-      firedAt: c.fired_at != null ? String(c.fired_at) : null,
-      itemCount: items.length,
-      itemPreview: items
-        .slice(0, 2)
-        .map(i => `${Number(i.quantity ?? 1)}x ${String(i.kitchen_name ?? '')}`.trim())
-        .filter(Boolean)
-        .join(', '),
-    }
-  })
-))
-
-const selectedComandaCount = computed(() => selectedComandaIds.value.length)
-const checkoutComandasLoading = computed(() =>
-  checkoutComandasAsyncStatus.value === 'loading' && !checkoutComandasData.value
-)
-const showCheckoutComandas = computed(() => comandasEnabled.value && isKitchenServiceMode.value)
-const checkoutComandasPrintLabel = computed(() => {
-  const n = selectedComandaCount.value
-  if (n > 0 && n < sentComandasForCheckout.value.length) return `Reimprimir seleccionadas (${n})`
-  return 'Reimprimir comandas'
-})
-
-function applyPersistedComandas(rawComandas: unknown[], preserveSelection = true) {
-  const printableRaw = (rawComandas as Record<string, unknown>[])
-    .filter(c => (((c.items as unknown[]) ?? []).length > 0))
-  const ids = printableRaw.map((c, index) => rawComandaId(c, index))
-  const hadComandas = persistedComandasRaw.value.length > 0
-  persistedComandasRaw.value = printableRaw
-  comandasForPrint.value = mapComandasForPrint(printableRaw)
-  comandaPrintSessionKey.value = currentComandaPrintSessionKey()
-
-  if (preserveSelection && comandaSelectionInitialized.value && hadComandas) {
-    const available = new Set(ids)
-    selectedComandaIds.value = selectedComandaIds.value.filter(id => available.has(id))
-  } else {
-    selectedComandaIds.value = ids
-    comandaSelectionInitialized.value = ids.length > 0
-  }
-}
-
-watch(
-  () => checkoutComandasData.value?.data?.comandas,
-  (rows) => applyPersistedComandas(Array.isArray(rows) ? rows : []),
-  { immediate: true },
-)
-
-watch(
-  [showCheckoutComandas, () => posStore.activeTableSession?.tableId, () => posStore.activeTableSession?.sessionId],
-  ([enabled, tableId, sessionId], previous) => {
-    if (!enabled) {
-      resetComandaPrintState()
-      return
-    }
-    if (!previous) return
-    const [, previousTableId, previousSessionId] = previous
-    if (tableId !== previousTableId || sessionId !== previousSessionId) {
-      resetComandaPrintState()
-    }
-  },
-)
-
-function toggleComandaSelection(comandaId: string) {
-  comandaSelectionInitialized.value = true
-  const idx = selectedComandaIds.value.indexOf(comandaId)
-  if (idx >= 0) {
-    selectedComandaIds.value = selectedComandaIds.value.filter(id => id !== comandaId)
-  } else {
-    selectedComandaIds.value = [...selectedComandaIds.value, comandaId]
-  }
-}
-
-function formatComandaTime(value?: string | null): string {
-  if (!value) return ''
-  const d = new Date(value)
-  if (Number.isNaN(d.getTime())) return ''
-  return new Intl.DateTimeFormat('es-CO', {
-    hour: '2-digit',
-    minute: '2-digit',
-  }).format(d)
-}
-
-function statusLabel(status?: string): string | null {
-  const labels: Record<string, string> = {
-    pending: 'Pendiente',
-    preparing: 'Preparando',
-    ready: 'Lista',
-    delivered: 'Entregada',
-  }
-  return status ? labels[status] ?? status : null
-}
-
-function handlePrintComandas() {
-  if (!comandasForPrintDisplay.value.length) return
-  printComandaTickets()
-}
 
 // POS tax preview — manual + WaRo discounts are folded into discount_amount (#1063).
 const { data: posTaxPreviewData } = useQuery({
@@ -2949,9 +2783,6 @@ const refreshAll = async () => {
     isKitchenServiceMode.value
       ? cache.invalidateQueries({ key: ['tables', posStore.activeTableSession?.tableId ?? null, 'current'] })
       : cache.invalidateQueries({ key: ['pos', 'cart', posStore.cartId ?? null, 'tax-preview'] }),
-    showCheckoutComandas.value
-      ? cache.invalidateQueries({ key: ['tables', posStore.activeTableSession?.tableId ?? null, posStore.activeTableSession?.sessionId ?? null, 'comandas'] })
-      : Promise.resolve(),
   ])
 }
 registerProgressiveLoading(isRefreshing, 'Actualizando pagos')
@@ -3024,13 +2855,13 @@ watch(showEmptyCheckout, (empty, wasEmpty) => {
 
 watch(
   () => [isKitchenServiceMode.value, comandasEnabled.value, storeTabItems.value.length] as const,
-  ([kitchen, comandas, tabCount], prev) => {
+  ([kitchen, kitchenFlag, tabCount], prev) => {
     if (!prev) return
-    const [prevKitchen, prevComandas, prevTabCount] = prev
-    if (kitchen === prevKitchen && comandas === prevComandas && tabCount === prevTabCount) return
+    const [prevKitchen, prevKitchenFlag, prevTabCount] = prev
+    if (kitchen === prevKitchen && kitchenFlag === prevKitchenFlag && tabCount === prevTabCount) return
     posDebugLog('checkout', 'mode:changed', {
-      from: { kitchen: prevKitchen, comandas: prevComandas, tabCount: prevTabCount },
-      to: { kitchen, comandas, tabCount },
+      from: { kitchen: prevKitchen, kitchenFlag: prevKitchenFlag, tabCount: prevTabCount },
+      to: { kitchen, kitchenFlag, tabCount },
       ...checkoutDebugSnapshot(),
     })
   },
@@ -3955,91 +3786,6 @@ onUnmounted(() => {
           </div>
         </div>
 
-        <!-- ACCORDION: Comandas -->
-        <div
-          v-if="showCheckoutComandas"
-          class="bg-surface rounded-2xl border border-border overflow-hidden shadow-sm"
-        >
-          <button
-            type="button"
-            @click="activeAccordion = activeAccordion === 'comandas' ? null : 'comandas'"
-            class="w-full px-5 py-4 flex items-center justify-between gap-3 text-left hover:bg-surface-secondary/40 transition-colors"
-          >
-            <span class="font-bold text-text-primary flex items-center gap-2">
-              <svg class="h-4 w-4 text-primary" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.7" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3.75h10.5A2.25 2.25 0 0 1 19.5 6v14.25l-2.625-1.5-2.625 1.5-2.625-1.5-2.625 1.5-2.625-1.5-2.625 1.5V6a2.25 2.25 0 0 1 2.25-2.25Z" />
-                <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 8.25h7.5M8.25 12h7.5M8.25 15.75h4.5" />
-              </svg>
-              Comandas
-            </span>
-            <span class="ml-auto text-xs font-semibold text-text-secondary">
-              {{ selectedComandaCount }}/{{ sentComandasForCheckout.length }}
-            </span>
-            <svg
-              class="h-4 w-4 text-text-tertiary flex-shrink-0 transition-transform duration-200"
-              :class="activeAccordion === 'comandas' ? 'rotate-0' : 'rotate-180'"
-              xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" />
-            </svg>
-          </button>
-
-          <div v-show="activeAccordion === 'comandas'" class="border-t border-border px-5 py-4 space-y-3">
-            <div v-if="checkoutComandasLoading" class="space-y-2">
-              <div v-for="i in 2" :key="i" class="h-14 rounded-lg bg-surface-secondary animate-pulse" />
-            </div>
-            <div
-              v-else-if="sentComandasForCheckout.length === 0"
-              class="rounded-lg border border-border bg-surface-secondary/50 px-3 py-3 text-sm text-text-secondary"
-            >
-              No hay comandas enviadas para esta sesión.
-            </div>
-            <div v-else class="space-y-1.5">
-              <label
-                v-for="comanda in sentComandasForCheckout"
-                :key="comanda.id"
-                class="flex items-start gap-2 rounded-lg border border-border bg-surface px-2.5 py-2 cursor-pointer hover:bg-surface-secondary transition-colors"
-              >
-                <input
-                  type="checkbox"
-                  class="mt-0.5 h-4 w-4 rounded border-border text-primary focus:ring-action-primary-focus-ring/30"
-                  :checked="selectedComandaIds.includes(comanda.id)"
-                  :aria-label="`Seleccionar comanda ${comanda.comandaNumber}`"
-                  @change="toggleComandaSelection(comanda.id)"
-                />
-                <span class="min-w-0 flex-1">
-                  <span class="flex items-center justify-between gap-2">
-                    <span class="text-xs font-bold text-text-primary truncate">
-                      #{{ comanda.comandaNumber }} · {{ comanda.stationName }}
-                    </span>
-                    <span class="text-[10px] font-semibold text-text-tertiary whitespace-nowrap">
-                      {{ formatComandaTime(comanda.firedAt) }}
-                    </span>
-                  </span>
-                  <span class="mt-0.5 flex items-center gap-1.5 text-[11px] text-text-secondary min-w-0">
-                    <span class="font-medium">{{ comanda.itemCount }} {{ comanda.itemCount === 1 ? 'ítem' : 'ítems' }}</span>
-                    <span v-if="statusLabel(comanda.status)" class="text-text-tertiary">· {{ statusLabel(comanda.status) }}</span>
-                    <span v-if="comanda.itemPreview" class="truncate">· {{ comanda.itemPreview }}</span>
-                  </span>
-                </span>
-              </label>
-            </div>
-            <button
-              type="button"
-              :disabled="!canPrintComandas || selectedComandaCount === 0"
-              class="w-full min-h-[44px] rounded-xl border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
-              :aria-label="checkoutComandasPrintLabel"
-              @click="handlePrintComandas"
-            >
-              <svg class="h-4 w-4 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18M6.72 13.829 6.34 18m10.94-4.171L17.66 18M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.75A2.25 2.25 0 0 1 5.25 7.5h13.5A2.25 2.25 0 0 1 21 9.75v6A2.25 2.25 0 0 1 18.75 18h-1.09M6.34 18h11.32" />
-              </svg>
-              {{ checkoutComandasPrintLabel }}
-            </button>
-          </div>
-        </div>
-
         <!-- WAROS CARD (desktop) — accordion -->
         <div
           v-if="warosPanelVisible"
@@ -4368,20 +4114,6 @@ onUnmounted(() => {
             <span>Imprimir prefactura</span>
           </button>
 
-          <!-- Issue #537 — Estado de comandas (expediter) -->
-          <button
-            v-if="expediterEnabled && comandasEnabled && (isMesaMode || posStore.activeTableSession)"
-            type="button"
-            class="w-full bg-surface border-2 border-border hover:border-primary hover:text-primary text-text-secondary font-semibold py-3 px-6 rounded-xl transition-all flex items-center justify-center gap-2 active:scale-95 focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30"
-            aria-label="Ver estado de comandas"
-            @click="showExpediterPanel = true"
-          >
-            <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.8" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            <span>Estado de comandas</span>
-          </button>
-
           <button
             @click="cancelOrder"
             class="w-full bg-surface border border-border hover:bg-destructive/10 hover:text-destructive hover:border-destructive/20 text-text-secondary font-semibold py-3 px-6 rounded-xl transition-all flex items-center justify-center gap-2"
@@ -4552,91 +4284,6 @@ onUnmounted(() => {
             </div>
             <p class="text-right text-xs text-text-tertiary">COP</p>
           </div>
-        </div>
-      </div>
-
-      <!-- ACCORDION: Comandas -->
-      <div
-        v-if="showCheckoutComandas"
-        class="bg-surface rounded-2xl border border-border overflow-hidden shadow-sm"
-      >
-        <button
-          type="button"
-          @click="activeAccordion = activeAccordion === 'comandas' ? null : 'comandas'"
-          class="w-full px-5 py-4 flex items-center justify-between gap-3 text-left hover:bg-surface-secondary/40 transition-colors"
-        >
-          <span class="font-bold text-text-primary flex items-center gap-2">
-            <svg class="h-4 w-4 text-primary" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.7" stroke="currentColor" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3.75h10.5A2.25 2.25 0 0 1 19.5 6v14.25l-2.625-1.5-2.625 1.5-2.625-1.5-2.625 1.5-2.625-1.5-2.625 1.5V6a2.25 2.25 0 0 1 2.25-2.25Z" />
-              <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 8.25h7.5M8.25 12h7.5M8.25 15.75h4.5" />
-            </svg>
-            Comandas
-          </span>
-          <span class="ml-auto text-xs font-semibold text-text-secondary">
-            {{ selectedComandaCount }}/{{ sentComandasForCheckout.length }}
-          </span>
-          <svg
-            class="h-4 w-4 text-text-tertiary flex-shrink-0 transition-transform duration-200"
-            :class="activeAccordion === 'comandas' ? 'rotate-0' : 'rotate-180'"
-            xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
-            aria-hidden="true"
-          >
-            <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" />
-          </svg>
-        </button>
-
-        <div v-show="activeAccordion === 'comandas'" class="border-t border-border px-5 py-4 space-y-3">
-          <div v-if="checkoutComandasLoading" class="space-y-2">
-            <div v-for="i in 2" :key="i" class="h-14 rounded-lg bg-surface-secondary animate-pulse" />
-          </div>
-          <div
-            v-else-if="sentComandasForCheckout.length === 0"
-            class="rounded-lg border border-border bg-surface-secondary/50 px-3 py-3 text-sm text-text-secondary"
-          >
-            No hay comandas enviadas para esta sesión.
-          </div>
-          <div v-else class="space-y-1.5">
-            <label
-              v-for="comanda in sentComandasForCheckout"
-              :key="comanda.id"
-              class="flex items-start gap-2 rounded-lg border border-border bg-surface px-2.5 py-2 cursor-pointer hover:bg-surface-secondary transition-colors"
-            >
-              <input
-                type="checkbox"
-                class="mt-0.5 h-4 w-4 rounded border-border text-primary focus:ring-action-primary-focus-ring/30"
-                :checked="selectedComandaIds.includes(comanda.id)"
-                :aria-label="`Seleccionar comanda ${comanda.comandaNumber}`"
-                @change="toggleComandaSelection(comanda.id)"
-              />
-              <span class="min-w-0 flex-1">
-                <span class="flex items-center justify-between gap-2">
-                  <span class="text-xs font-bold text-text-primary truncate">
-                    #{{ comanda.comandaNumber }} · {{ comanda.stationName }}
-                  </span>
-                  <span class="text-[10px] font-semibold text-text-tertiary whitespace-nowrap">
-                    {{ formatComandaTime(comanda.firedAt) }}
-                  </span>
-                </span>
-                <span class="mt-0.5 flex items-center gap-1.5 text-[11px] text-text-secondary min-w-0">
-                  <span class="font-medium">{{ comanda.itemCount }} {{ comanda.itemCount === 1 ? 'ítem' : 'ítems' }}</span>
-                  <span v-if="statusLabel(comanda.status)" class="text-text-tertiary">· {{ statusLabel(comanda.status) }}</span>
-                  <span v-if="comanda.itemPreview" class="truncate">· {{ comanda.itemPreview }}</span>
-                </span>
-              </span>
-            </label>
-          </div>
-          <button
-            type="button"
-            :disabled="!canPrintComandas || selectedComandaCount === 0"
-            class="w-full min-h-[44px] rounded-xl border border-border text-text-secondary text-xs font-medium flex items-center justify-center gap-1 hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
-            :aria-label="checkoutComandasPrintLabel"
-            @click="handlePrintComandas"
-          >
-            <svg class="h-4 w-4 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18M6.72 13.829 6.34 18m10.94-4.171L17.66 18M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.75A2.25 2.25 0 0 1 5.25 7.5h13.5A2.25 2.25 0 0 1 21 9.75v6A2.25 2.25 0 0 1 18.75 18h-1.09M6.34 18h11.32" />
-            </svg>
-            {{ checkoutComandasPrintLabel }}
-          </button>
         </div>
       </div>
 
@@ -5530,19 +5177,6 @@ onUnmounted(() => {
     </template>
   </div>
 
-  <!-- Issue #537 — Estado de comandas (expediter) slide-over -->
-  <PosComandasEstadoPanel
-    v-if="expediterEnabled && comandasEnabled"
-    v-model="showExpediterPanel"
-    :table-session-id="posStore.activeTableSession?.tableId ?? null"
-    :table-display-name="posStore.activeTableSession?.tableName ?? null"
-  />
-
-  <PosComandaPrintTickets
-    v-if="comandasEnabled"
-    :comandas="comandasForPrintDisplay"
-    :business-name="posBusinessName"
-  />
   </div>
 </template>
 

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -1748,22 +1748,22 @@ onUnmounted(() => {
       </div>
 
       <!-- Mesa Banner skeleton while loading tab items -->
-      <div v-if="isLoadingTabItems || isAddingToTab" class="bg-surface border border-border rounded-2xl p-3.5 shadow-sm animate-pulse">
-        <div class="flex items-center gap-3">
-          <div class="w-9 h-9 rounded-xl bg-surface-secondary flex-shrink-0" />
-          <div class="flex-1 flex items-center gap-3">
+      <div v-if="isLoadingTabItems || isAddingToTab" class="bg-surface border border-border rounded-xl p-2.5 shadow-sm animate-pulse">
+        <div class="flex items-center gap-2.5">
+          <div class="w-8 h-8 rounded-lg bg-surface-secondary flex-shrink-0" />
+          <div class="flex-1 flex items-center gap-2.5">
             <div class="h-2.5 w-20 bg-surface-secondary rounded" />
             <div class="h-2.5 w-16 bg-surface-secondary rounded" />
             <div class="h-2.5 w-32 bg-surface-secondary rounded" />
           </div>
-          <div class="h-7 w-16 bg-surface-secondary rounded-lg flex-shrink-0" />
+          <div class="h-7 w-14 bg-surface-secondary rounded-lg flex-shrink-0" />
         </div>
       </div>
 
       <!-- Barra Banner (bar session — behaves as normal POS) -->
-      <div v-else-if="posStore.activeTableSession?.isBar" class="bg-surface border border-state-warning-border/40 rounded-2xl p-3.5 shadow-sm">
-        <div class="flex items-center gap-3">
-          <div class="bg-state-warning-bg p-2.5 rounded-xl flex-shrink-0">
+      <div v-else-if="posStore.activeTableSession?.isBar" class="bg-surface border border-state-warning-border/40 rounded-xl p-2.5 shadow-sm">
+        <div class="flex items-center gap-2.5">
+          <div class="bg-state-warning-bg p-2 rounded-lg flex-shrink-0">
             <svg class="w-4 h-4 text-state-warning-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9.75 3.104v5.714a2.25 2.25 0 0 1-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 0 1 4.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0 1 12 15a9.065 9.065 0 0 0-6.23-.693L5 14.5m14.8.8 1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0 1 12 21a48.25 48.25 0 0 1-8.135-.687c-1.718-.293-2.3-2.379-1.067-3.61L5 14.5" />
             </svg>
@@ -1792,10 +1792,10 @@ onUnmounted(() => {
       </div>
 
       <!-- Mesa Banner (when arriving from a table session) -->
-      <div v-else-if="posStore.activeTableSession" class="bg-surface border border-border rounded-2xl p-3.5 shadow-sm">
-        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-3">
-          <div class="flex items-start gap-3 min-w-0 flex-1">
-            <div class="bg-status-success-bg p-2.5 rounded-xl flex-shrink-0">
+      <div v-else-if="posStore.activeTableSession" class="bg-surface border border-border rounded-xl p-2.5 shadow-sm">
+        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-2.5">
+          <div class="flex items-center gap-2.5 min-w-0 flex-1">
+            <div class="bg-status-success-bg p-2 rounded-lg flex-shrink-0">
               <svg class="w-4 h-4 text-status-success-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M3 10h18M3 14h18M10 10V6m4 4V6m-9 8v4m14-4v4M5 6h14a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2z" />
               </svg>
@@ -1806,12 +1806,12 @@ onUnmounted(() => {
                 <span class="hidden sm:inline w-px h-3 bg-border flex-shrink-0" aria-hidden="true" />
                 <span class="text-sm font-bold text-text-primary">{{ posStore.activeTableSession.tableName }}</span>
               </div>
-              <p class="text-xs text-text-secondary tabular-nums mt-1">
+              <p class="text-[11px] text-text-secondary tabular-nums mt-0.5 leading-snug">
                 {{ formatCurrencyPOS(posStore.activeTableSession.runningTotal) }} acumulado · {{ formatDuration(posStore.activeTableSession.openedAt) }}
               </p>
               <p
                 v-if="showActiveMinimumConsumption && activeMinimumConsumption"
-                class="text-xs text-text-secondary tabular-nums mt-1"
+                class="text-[11px] text-text-secondary tabular-nums mt-0.5 leading-snug"
               >
                 Mínimo {{ formatCurrencyPOS(activeMinimumConsumption.amount) }} ·
                 Consumido {{ formatCurrencyPOS(activeMinimumConsumption.consumed) }} ·
@@ -1820,13 +1820,13 @@ onUnmounted(() => {
             </div>
           </div>
           <!-- Mesero + actions — stacked on mobile/tablet; inline on desktop -->
-          <div class="flex flex-wrap items-center gap-2 lg:flex-shrink-0 lg:justify-end">
+          <div class="flex flex-wrap items-center gap-1.5 lg:flex-shrink-0 lg:justify-end">
             <!-- Issue #574 — Waiter loading chip — width adapts to the rotating
                  phrase so it doesn't overflow the original chip. Same pattern
                  as the dashboard header progressive-load indicator. -->
             <div
               v-if="waiterAttributionEnabled && isChangingSessionWaiter"
-              class="h-9 inline-flex items-center gap-2 px-3 rounded-lg border border-border bg-surface-secondary text-text-secondary text-[10px] font-bold uppercase tracking-wider whitespace-nowrap"
+              class="h-8 inline-flex items-center gap-1.5 px-2.5 rounded-lg border border-border bg-surface-secondary text-text-secondary text-[10px] font-bold uppercase tracking-wider whitespace-nowrap"
               aria-live="polite"
             >
               <UiLoadingDots size="7px" color="currentColor" />
@@ -1837,7 +1837,7 @@ onUnmounted(() => {
               <select
                 :value="bannerEffectiveWaiterId || ''"
                 aria-label="Cambiar mesero de la sesión activa"
-                class="h-9 inline-flex items-center leading-none pl-7 pr-7 rounded-lg border border-border bg-surface-secondary text-[10px] font-bold uppercase tracking-wider transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/35 focus-visible:ring-offset-1 appearance-none bg-none cursor-pointer [&::-ms-expand]:hidden"
+                class="h-8 inline-flex items-center leading-none pl-7 pr-7 rounded-lg border border-border bg-surface-secondary text-[10px] font-bold uppercase tracking-wider transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/35 focus-visible:ring-offset-1 appearance-none bg-none cursor-pointer [&::-ms-expand]:hidden"
                 style="background-image: none; -webkit-appearance: none; -moz-appearance: none; text-align-last: center;"
                 :class="bannerEffectiveWaiterId ? 'text-text-primary' : 'text-text-secondary italic'"
                 @change="handleChangeSessionWaiter"
@@ -1873,7 +1873,7 @@ onUnmounted(() => {
               v-if="canPayTableAdvance"
               type="button"
               :disabled="isBannerClosing || posStore.isCancellingMesa"
-              class="h-9 inline-flex items-center gap-1.5 text-[10px] font-bold text-primary uppercase tracking-wider px-2.5 rounded-lg border border-primary/30 hover:bg-primary/10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed"
+              class="h-8 inline-flex items-center gap-1.5 text-[10px] font-bold text-primary uppercase tracking-wider px-2.5 rounded-lg border border-primary/30 hover:bg-primary/10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed"
               :aria-label="`Pagar anticipo de la ${tableSingularLower}`"
               @click="showTableAdvancePanel = true"
             >
@@ -1886,7 +1886,7 @@ onUnmounted(() => {
             <button
               type="button"
               :disabled="isBannerClosing || posStore.isCancellingMesa"
-              class="h-9 inline-flex items-center gap-1.5 text-[10px] font-bold text-text-secondary uppercase tracking-wider px-2.5 rounded-lg border border-border hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed"
+              class="h-8 inline-flex items-center gap-1.5 text-[10px] font-bold text-text-secondary uppercase tracking-wider px-2.5 rounded-lg border border-border hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed"
               :aria-label="`Volver al plano de ${tablePluralLower} (la ${tableSingularLower} sigue abierta)`"
               @click="leaveActiveTableSession"
             >
@@ -1899,7 +1899,7 @@ onUnmounted(() => {
             <button
               type="button"
               :disabled="isBannerClosing || posStore.isCancellingMesa"
-              class="h-9 inline-flex items-center gap-1.5 text-[10px] font-bold text-status-error-text uppercase tracking-wider px-2.5 rounded-lg border border-status-error-text/30 hover:bg-status-error-bg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-status-error-text focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed"
+              class="h-8 inline-flex items-center gap-1.5 text-[10px] font-bold text-status-error-text uppercase tracking-wider px-2.5 rounded-lg border border-status-error-text/30 hover:bg-status-error-bg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-status-error-text focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed"
               :aria-label="`Liberar la ${tableSingularLower}`"
               @click="handleReleaseMesa"
             >
@@ -1915,11 +1915,11 @@ onUnmounted(() => {
         </div>
 
         <!-- Tab error -->
-        <p v-if="tabError" class="mt-2 text-xs text-destructive bg-destructive/10 rounded-lg px-3 py-1.5">
+        <p v-if="tabError" class="mt-1.5 text-xs text-destructive bg-destructive/10 rounded-lg px-2.5 py-1">
           {{ tabError }}
         </p>
         <!-- Tab success (fire to kitchen) -->
-        <p v-if="tabSuccess" class="mt-2 text-xs text-state-success-text bg-state-success-bg rounded-lg px-3 py-1.5 border border-state-success-border">
+        <p v-if="tabSuccess" class="mt-1.5 text-xs text-state-success-text bg-state-success-bg rounded-lg px-2.5 py-1 border border-state-success-border">
           {{ tabSuccess }}
         </p>
       </div>

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, watch, watchEffect } from 'vue'
+import { ref, computed, nextTick, onMounted, onUnmounted, watch, watchEffect } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useQueryCache } from '@pinia/colada'
 import { $fetch } from 'ofetch'
@@ -353,11 +353,14 @@ const tabError = ref<string | null>(null)
 const tabSuccess = ref<string | null>(null)
 
 // #753 — kitchen ticket print after fire
+const LAST_FIRED_COMANDAS_TTL_MS = 12 * 60 * 60 * 1000
 const persistedComandasRaw = ref<unknown[]>([])
-const comandasForPrint = ref<ComandaPrintPayload[]>([])
+const lastFiredComandasRaw = ref<unknown[]>([])
+const printQueueComandas = ref<ComandaPrintPayload[]>([])
 const selectedComandaIds = ref<string[]>([])
-const comandaSelectionInitialized = ref(false)
-const comandaPrintSessionKey = ref<string | null>(null)
+const lastFiredComandaSessionKey = ref<string | null>(null)
+const persistedComandasLoading = ref(false)
+const showComandasReprintPanel = ref(false)
 const posBusinessName = computed(
   () => settingsData.value?.data?.business_name
     ?? settingsData.value?.data?.display_name
@@ -371,25 +374,34 @@ const currentComandaPrintSessionKey = () => {
 
 function resetComandaPrintState() {
   persistedComandasRaw.value = []
-  comandasForPrint.value = []
   selectedComandaIds.value = []
-  comandaSelectionInitialized.value = false
-  comandaPrintSessionKey.value = null
+  printQueueComandas.value = []
 }
 
-const canPrintComandas = computed(
+function clearLastFiredComandasState() {
+  lastFiredComandasRaw.value = []
+  lastFiredComandaSessionKey.value = null
+}
+
+const canPrintLatestComanda = computed(
   () =>
-    comandasForPrint.value.length > 0
-    && comandaPrintSessionKey.value === currentComandaPrintSessionKey(),
+    mapComandasForPrint(lastFiredComandasRaw.value).length > 0
+    && lastFiredComandaSessionKey.value === currentComandaPrintSessionKey(),
 )
+
+const lastFiredComandasStorageKey = () => {
+  const tenantId = currentTenant.value?.id
+  const session = posStore.activeTableSession
+  if (!tenantId || !session?.tableId || !session?.sessionId) return null
+  return `waro:pos:last-fired-comandas:${tenantId}:${session.tableId}:${session.sessionId}`
+}
 
 function rawComandaId(raw: unknown, index: number): string {
   const c = raw as Record<string, unknown>
   return String(c.id ?? `${c.comanda_number ?? index}:${c.station_name ?? ''}:${c.fired_at ?? ''}`)
 }
 
-const comandasForPrintDisplay = computed(() => {
-  if (!canPrintComandas.value) return []
+const persistedComandasForPrintDisplay = computed(() => {
   const sel = selectedComandaIds.value
   if (sel.length === 0) return []
   const raw = persistedComandasRaw.value
@@ -422,17 +434,13 @@ function applyPersistedComandas(rawComandas: unknown[], preserveSelection = true
   const printableRaw = (rawComandas as Record<string, unknown>[])
     .filter(c => (((c.items as unknown[]) ?? []).length > 0))
   const ids = printableRaw.map((c, index) => rawComandaId(c, index))
-  const hadComandas = persistedComandasRaw.value.length > 0
   persistedComandasRaw.value = printableRaw
-  comandasForPrint.value = mapComandasForPrint(printableRaw)
-  comandaPrintSessionKey.value = currentComandaPrintSessionKey()
 
-  if (preserveSelection && comandaSelectionInitialized.value && hadComandas) {
+  if (preserveSelection) {
     const available = new Set(ids)
     selectedComandaIds.value = selectedComandaIds.value.filter(id => available.has(id))
   } else {
-    selectedComandaIds.value = ids
-    comandaSelectionInitialized.value = true
+    selectedComandaIds.value = []
   }
 }
 
@@ -442,17 +450,19 @@ async function refreshPersistedComandas(tableId?: string, fetchGen = tableSessio
     resetComandaPrintState()
     return
   }
+  persistedComandasLoading.value = true
   try {
     const res = await $fetch<{ success: boolean; data?: { comandas?: unknown[] } }>(`/api/tables/${activeTableId}/comandas`)
     if (fetchGen !== tableSessionFetchGen) return
     applyPersistedComandas(Array.isArray(res?.data?.comandas) ? res.data.comandas : [], preserveSelection)
   } catch (e: unknown) {
     if (isNoOpenSessionError(e)) resetComandaPrintState()
+  } finally {
+    if (fetchGen === tableSessionFetchGen) persistedComandasLoading.value = false
   }
 }
 
 function toggleComandaSelection(comandaId: string) {
-  comandaSelectionInitialized.value = true
   const idx = selectedComandaIds.value.indexOf(comandaId)
   if (idx >= 0) {
     selectedComandaIds.value = selectedComandaIds.value.filter(id => id !== comandaId)
@@ -461,11 +471,46 @@ function toggleComandaSelection(comandaId: string) {
   }
 }
 
+function selectAllPersistedComandas() {
+  selectedComandaIds.value = sentComandasForPanel.value.map(c => c.id)
+}
+
+function clearPersistedComandaSelection() {
+  selectedComandaIds.value = []
+}
+
+function persistLastFiredComandas(rawComandas: unknown[]) {
+  if (typeof window === 'undefined') return
+  const key = lastFiredComandasStorageKey()
+  if (!key) return
+  localStorage.setItem(key, JSON.stringify({ savedAt: Date.now(), comandas: rawComandas }))
+}
+
+function hydrateLastFiredComandas() {
+  if (typeof window === 'undefined') return
+  const key = lastFiredComandasStorageKey()
+  clearLastFiredComandasState()
+  if (!key) return
+  try {
+    const parsed = JSON.parse(localStorage.getItem(key) ?? 'null') as { savedAt?: number; comandas?: unknown[] } | null
+    if (!parsed || !Array.isArray(parsed.comandas) || !parsed.savedAt) return
+    if (Date.now() - parsed.savedAt > LAST_FIRED_COMANDAS_TTL_MS) {
+      localStorage.removeItem(key)
+      return
+    }
+    if (mapComandasForPrint(parsed.comandas).length === 0) return
+    lastFiredComandasRaw.value = parsed.comandas
+    lastFiredComandaSessionKey.value = currentComandaPrintSessionKey()
+  } catch {
+    localStorage.removeItem(key)
+  }
+}
+
 function applyFireResult(rawComandas: unknown[], firedCount: number) {
   if (rawComandas.length > 0) {
-    applyPersistedComandas(rawComandas, false)
-  } else {
-    resetComandaPrintState()
+    lastFiredComandasRaw.value = rawComandas
+    lastFiredComandaSessionKey.value = currentComandaPrintSessionKey()
+    persistLastFiredComandas(rawComandas)
   }
   const firedIds = orderItemIdsFromComandas(rawComandas)
   if (firedCount > 0 && posStore.activeTableSession) {
@@ -497,8 +542,25 @@ async function syncTabAfterAdd(addRes: unknown, addedCount: number) {
   }
 }
 
-function handlePrintComandas() {
-  if (!comandasForPrintDisplay.value.length) return
+async function openComandasReprintPanel() {
+  selectedComandaIds.value = []
+  showComandasReprintPanel.value = true
+  await refreshPersistedComandas(undefined, tableSessionFetchGen, false)
+}
+
+async function printLatestComanda() {
+  if (!canPrintLatestComanda.value) return
+  const queue = mapComandasForPrint(lastFiredComandasRaw.value)
+  if (!queue.length) return
+  printQueueComandas.value = queue
+  await nextTick()
+  printComandaTickets()
+}
+
+async function printSelectedPersistedComandas() {
+  if (!persistedComandasForPrintDisplay.value.length) return
+  printQueueComandas.value = persistedComandasForPrintDisplay.value
+  await nextTick()
   printComandaTickets()
 }
 
@@ -575,6 +637,7 @@ const applyTableSessionFromApi = (
     minimumConsumption: mapMinimumConsumptionFromApi(s.minimum_consumption),
   })
   posStore.setTabItems(mapTabItemsFromApi(data.tab_items ?? []))
+  hydrateLastFiredComandas()
 }
 
 const httpStatus = (e: unknown) => {
@@ -619,6 +682,7 @@ const handleEnterTable = async (ctx: { tableId: string; sessionId: string; table
   isEnteringTable.value = true
   tableSessionBackendReady.value = false
   resetComandaPrintState()
+  clearLastFiredComandasState()
   posStore.clearAll()
   bumpTableSessionFetchGen()
   isLoadingTabItems.value = true
@@ -1413,11 +1477,13 @@ const duplicateCartItem = async (index: number) => {
 
 const leaveActiveTableSession = () => {
   resetComandaPrintState()
+  clearLastFiredComandasState()
   posStore.clearAll()
 }
 
 const exitActiveTableSession = () => {
   resetComandaPrintState()
+  clearLastFiredComandasState()
   posStore.exitSession()
 }
 
@@ -1437,6 +1503,7 @@ const executeClearCart = async (reason: string) => {
         body: { reason: reason.trim() || null },
       })
       resetComandaPrintState()
+      clearLastFiredComandasState()
       posStore.setTabItems([])
       if (posStore.activeTableSession) {
         posStore.setTableSession({
@@ -1511,7 +1578,11 @@ watch(
   (session, previousSession) => {
     const nextKey = session ? `${session.tableId}:${session.sessionId}` : null
     const previousKey = previousSession ? `${previousSession.tableId}:${previousSession.sessionId}` : null
-    if (nextKey !== previousKey) resetComandaPrintState()
+    if (nextKey !== previousKey) {
+      resetComandaPrintState()
+      clearLastFiredComandasState()
+      if (session) hydrateLastFiredComandas()
+    }
     if (!session) tableSessionBackendReady.value = false
   },
 )
@@ -1997,9 +2068,8 @@ onUnmounted(() => {
         :tab-items-loading="tabItemsLoading"
         :comandas-enabled="comandasEnabled"
         :unfired-count="unfiredCount"
-        :sent-comandas="sentComandasForPanel"
-        :can-print-comandas="canPrintComandas"
-        :selected-comanda-ids="selectedComandaIds"
+        :can-print-latest-comanda="canPrintLatestComanda"
+        :persisted-comandas-count="sentComandasForPanel.length"
         :pending-remove-item-id="pendingRemoveItemId"
         :show-served-by-chip="showServedByChip"
         :served-by-member-id="posStore.cartServedByMemberId"
@@ -2018,8 +2088,8 @@ onUnmounted(() => {
         @remove-tab-item="removeTabItem"
         @increment-tab-item="incrementTabItem"
         @decrement-tab-item="decrementTabItem"
-        @print-comandas="handlePrintComandas"
-        @toggle-comanda-selection="toggleComandaSelection"
+        @print-latest-comanda="printLatestComanda"
+        @open-comandas-reprint="openComandasReprintPanel"
         @update:served-by="(id) => posStore.setCartServedBy(id)"
       />
       </div>
@@ -2110,8 +2180,22 @@ onUnmounted(() => {
 
   <PosComandaPrintTickets
     v-if="comandasEnabled"
-    :comandas="comandasForPrintDisplay"
+    :comandas="printQueueComandas"
     :business-name="posBusinessName"
+  />
+
+  <PosComandasReprintPanel
+    v-if="comandasEnabled"
+    v-model="showComandasReprintPanel"
+    :comandas="sentComandasForPanel"
+    :selected-ids="selectedComandaIds"
+    :loading="persistedComandasLoading"
+    :table-display-name="posStore.activeTableSession?.tableName ?? null"
+    @toggle-comanda="toggleComandaSelection"
+    @select-all="selectAllPersistedComandas"
+    @clear-selection="clearPersistedComandaSelection"
+    @print-selected="printSelectedPersistedComandas"
+    @refresh="refreshPersistedComandas(undefined, tableSessionFetchGen, true)"
   />
 
   <!-- warocol.com#1032 — mobile/tablet cart sheet (bar lives in dashboard layout) -->
@@ -2134,9 +2218,8 @@ onUnmounted(() => {
       :tab-items-loading="tabItemsLoading"
       :comandas-enabled="comandasEnabled"
       :unfired-count="unfiredCount"
-      :sent-comandas="sentComandasForPanel"
-      :can-print-comandas="canPrintComandas"
-      :selected-comanda-ids="selectedComandaIds"
+      :can-print-latest-comanda="canPrintLatestComanda"
+      :persisted-comandas-count="sentComandasForPanel.length"
       :pending-remove-item-id="pendingRemoveItemId"
       :show-served-by-chip="showServedByChip"
       :served-by-member-id="posStore.cartServedByMemberId"
@@ -2155,8 +2238,8 @@ onUnmounted(() => {
       @remove-tab-item="removeTabItem"
       @increment-tab-item="incrementTabItem"
       @decrement-tab-item="decrementTabItem"
-      @print-comandas="handlePrintComandas"
-      @toggle-comanda-selection="toggleComandaSelection"
+      @print-latest-comanda="printLatestComanda"
+      @open-comandas-reprint="openComandasReprintPanel"
       @update:served-by="(id) => posStore.setCartServedBy(id)"
     />
   </UiBottomSheetModal>

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -353,9 +353,10 @@ const tabError = ref<string | null>(null)
 const tabSuccess = ref<string | null>(null)
 
 // #753 — kitchen ticket print after fire
-const lastFiredComandasRaw = ref<unknown[]>([])
+const persistedComandasRaw = ref<unknown[]>([])
 const comandasForPrint = ref<ComandaPrintPayload[]>([])
-const selectedTabItemIds = ref<string[]>([])
+const selectedComandaIds = ref<string[]>([])
+const comandaSelectionInitialized = ref(false)
 const comandaPrintSessionKey = ref<string | null>(null)
 const posBusinessName = computed(
   () => settingsData.value?.data?.business_name
@@ -369,9 +370,10 @@ const currentComandaPrintSessionKey = () => {
 }
 
 function resetComandaPrintState() {
-  lastFiredComandasRaw.value = []
+  persistedComandasRaw.value = []
   comandasForPrint.value = []
-  selectedTabItemIds.value = []
+  selectedComandaIds.value = []
+  comandaSelectionInitialized.value = false
   comandaPrintSessionKey.value = null
 }
 
@@ -381,52 +383,87 @@ const canPrintComandas = computed(
     && comandaPrintSessionKey.value === currentComandaPrintSessionKey(),
 )
 
-/** Tab lines from the last fire batch — checkboxes select tickets to re-print (#812). */
-const printableOrderItemIds = computed(
-  () => orderItemIdsFromComandas(lastFiredComandasRaw.value),
-)
-
-const showPrintItemSelection = computed(
-  () =>
-    comandasEnabled.value
-    && isKitchenServiceMode.value
-    && canPrintComandas.value
-    && printableOrderItemIds.value.size > 0,
-)
+function rawComandaId(raw: unknown, index: number): string {
+  const c = raw as Record<string, unknown>
+  return String(c.id ?? `${c.comanda_number ?? index}:${c.station_name ?? ''}:${c.fired_at ?? ''}`)
+}
 
 const comandasForPrintDisplay = computed(() => {
   if (!canPrintComandas.value) return []
-  const sel = selectedTabItemIds.value
-  const raw = lastFiredComandasRaw.value
-  if (!Array.isArray(raw) || sel.length === 0) {
-    return comandasForPrint.value
-  }
+  const sel = selectedComandaIds.value
+  if (sel.length === 0) return []
+  const raw = persistedComandasRaw.value
   const selSet = new Set(sel)
   const filteredRaw = (raw as Record<string, unknown>[])
-    .map((c) => {
-      const items = ((c.items as Record<string, unknown>[]) ?? []).filter(
-        (i) => i.order_item_id != null && selSet.has(String(i.order_item_id)),
-      )
-      return { ...c, items }
-    })
-    .filter((c) => ((c.items as unknown[]) ?? []).length > 0)
+    .filter((c, index) => selSet.has(rawComandaId(c, index)))
   return mapComandasForPrint(filteredRaw)
 })
 
-function toggleTabItemSelection(orderItemId: string) {
-  const idx = selectedTabItemIds.value.indexOf(orderItemId)
-  if (idx >= 0) {
-    selectedTabItemIds.value = selectedTabItemIds.value.filter(id => id !== orderItemId)
+const sentComandasForPanel = computed(() => (
+  (persistedComandasRaw.value as Record<string, unknown>[]).map((c, index) => {
+    const items = ((c.items as Record<string, unknown>[]) ?? [])
+    return {
+      id: rawComandaId(c, index),
+      comandaNumber: String(c.comanda_number ?? '—'),
+      stationName: (c.station_name as string) ?? 'Sin cocina asignada',
+      status: String(c.status ?? ''),
+      firedAt: c.fired_at != null ? String(c.fired_at) : null,
+      itemCount: items.length,
+      itemPreview: items
+        .slice(0, 2)
+        .map(i => `${Number(i.quantity ?? 1)}x ${String(i.kitchen_name ?? '')}`.trim())
+        .filter(Boolean)
+        .join(', '),
+    }
+  })
+))
+
+function applyPersistedComandas(rawComandas: unknown[], preserveSelection = true) {
+  const printableRaw = (rawComandas as Record<string, unknown>[])
+    .filter(c => (((c.items as unknown[]) ?? []).length > 0))
+  const ids = printableRaw.map((c, index) => rawComandaId(c, index))
+  const hadComandas = persistedComandasRaw.value.length > 0
+  persistedComandasRaw.value = printableRaw
+  comandasForPrint.value = mapComandasForPrint(printableRaw)
+  comandaPrintSessionKey.value = currentComandaPrintSessionKey()
+
+  if (preserveSelection && comandaSelectionInitialized.value && hadComandas) {
+    const available = new Set(ids)
+    selectedComandaIds.value = selectedComandaIds.value.filter(id => available.has(id))
   } else {
-    selectedTabItemIds.value = [...selectedTabItemIds.value, orderItemId]
+    selectedComandaIds.value = ids
+    comandaSelectionInitialized.value = true
+  }
+}
+
+async function refreshPersistedComandas(tableId?: string, fetchGen = tableSessionFetchGen, preserveSelection = true) {
+  const activeTableId = tableId ?? posStore.activeTableSession?.tableId
+  if (!activeTableId || !comandasEnabled.value || !isKitchenServiceMode.value) {
+    resetComandaPrintState()
+    return
+  }
+  try {
+    const res = await $fetch<{ success: boolean; data?: { comandas?: unknown[] } }>(`/api/tables/${activeTableId}/comandas`)
+    if (fetchGen !== tableSessionFetchGen) return
+    applyPersistedComandas(Array.isArray(res?.data?.comandas) ? res.data.comandas : [], preserveSelection)
+  } catch (e: unknown) {
+    if (isNoOpenSessionError(e)) resetComandaPrintState()
+  }
+}
+
+function toggleComandaSelection(comandaId: string) {
+  comandaSelectionInitialized.value = true
+  const idx = selectedComandaIds.value.indexOf(comandaId)
+  if (idx >= 0) {
+    selectedComandaIds.value = selectedComandaIds.value.filter(id => id !== comandaId)
+  } else {
+    selectedComandaIds.value = [...selectedComandaIds.value, comandaId]
   }
 }
 
 function applyFireResult(rawComandas: unknown[], firedCount: number) {
   if (rawComandas.length > 0) {
-    lastFiredComandasRaw.value = rawComandas
-    comandasForPrint.value = mapComandasForPrint(rawComandas)
-    comandaPrintSessionKey.value = currentComandaPrintSessionKey()
+    applyPersistedComandas(rawComandas, false)
   } else {
     resetComandaPrintState()
   }
@@ -442,7 +479,6 @@ function applyFireResult(rawComandas: unknown[], firedCount: number) {
           : item
       }),
     )
-    selectedTabItemIds.value = []
   }
 }
 
@@ -451,6 +487,7 @@ async function syncTabAfterAdd(addRes: unknown, addedCount: number) {
   if (!comandasEnabled.value || addedCount <= 0) return
   const { comandas, fired_items_count } = parseFireTableResponse(addRes as FireTableResponse)
   applyFireResult(comandas, fired_items_count)
+  await refreshPersistedComandas(undefined, tableSessionFetchGen, false)
   if (fired_items_count > 0) {
     tabSuccess.value = `${fired_items_count} ${fired_items_count === 1 ? 'ítem enviado' : 'ítems enviados'} a cocina`
     setTimeout(() => { tabSuccess.value = null }, 3000)
@@ -569,6 +606,7 @@ const loadCurrentTableSession = async (
     if (!session?.data?.session?.id) return false
     applyTableSessionFromApi(session.data, fetchGen, tableCtx)
     tableSessionBackendReady.value = true
+    await refreshPersistedComandas(tableId, fetchGen)
     return true
   } catch (e: unknown) {
     if (isNoOpenSessionError(e)) return false
@@ -1959,10 +1997,9 @@ onUnmounted(() => {
         :tab-items-loading="tabItemsLoading"
         :comandas-enabled="comandasEnabled"
         :unfired-count="unfiredCount"
-        :show-print-item-selection="showPrintItemSelection"
-        :printable-order-item-ids="[...printableOrderItemIds]"
+        :sent-comandas="sentComandasForPanel"
         :can-print-comandas="canPrintComandas"
-        :selected-tab-item-ids="selectedTabItemIds"
+        :selected-comanda-ids="selectedComandaIds"
         :pending-remove-item-id="pendingRemoveItemId"
         :show-served-by-chip="showServedByChip"
         :served-by-member-id="posStore.cartServedByMemberId"
@@ -1982,7 +2019,7 @@ onUnmounted(() => {
         @increment-tab-item="incrementTabItem"
         @decrement-tab-item="decrementTabItem"
         @print-comandas="handlePrintComandas"
-        @toggle-tab-selection="toggleTabItemSelection"
+        @toggle-comanda-selection="toggleComandaSelection"
         @update:served-by="(id) => posStore.setCartServedBy(id)"
       />
       </div>
@@ -2097,10 +2134,9 @@ onUnmounted(() => {
       :tab-items-loading="tabItemsLoading"
       :comandas-enabled="comandasEnabled"
       :unfired-count="unfiredCount"
-      :show-print-item-selection="showPrintItemSelection"
-      :printable-order-item-ids="[...printableOrderItemIds]"
+      :sent-comandas="sentComandasForPanel"
       :can-print-comandas="canPrintComandas"
-      :selected-tab-item-ids="selectedTabItemIds"
+      :selected-comanda-ids="selectedComandaIds"
       :pending-remove-item-id="pendingRemoveItemId"
       :show-served-by-chip="showServedByChip"
       :served-by-member-id="posStore.cartServedByMemberId"
@@ -2120,7 +2156,7 @@ onUnmounted(() => {
       @increment-tab-item="incrementTabItem"
       @decrement-tab-item="decrementTabItem"
       @print-comandas="handlePrintComandas"
-      @toggle-tab-selection="toggleTabItemSelection"
+      @toggle-comanda-selection="toggleComandaSelection"
       @update:served-by="(id) => posStore.setCartServedBy(id)"
     />
   </UiBottomSheetModal>

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -1726,11 +1726,16 @@ onUnmounted(() => {
 
     <!-- POS Content (shown always after loading) -->
     <div v-else>
+      <!-- Main POS Container -->
+      <div class="grid w-full grid-cols-1 items-start gap-4 md:gap-6 lg:grid-cols-[minmax(0,1fr)_24rem]">
+        <!-- Products Panel (Left) -->
+        <div class="min-w-0 flex flex-col space-y-4">
+          <div class="lg:sticky lg:top-0 lg:z-20 flex flex-col gap-3 bg-background pt-2 pb-2">
       <!-- Live promotion hint (warocol.com#983) -->
       <div
         v-if="hasActivePromos"
         role="status"
-        class="flex items-center gap-3 min-h-[44px] px-4 py-3 mb-4 bg-status-success-bg border border-status-success-text/25 rounded-xl"
+        class="flex items-center gap-3 min-h-[44px] px-4 py-3 bg-status-success-bg border border-status-success-text/25 rounded-xl"
       >
         <div class="flex-shrink-0 bg-status-success-text/15 p-1.5 rounded-lg">
           <svg class="w-4 h-4 text-status-success-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -1743,7 +1748,7 @@ onUnmounted(() => {
       </div>
 
       <!-- Mesa Banner skeleton while loading tab items -->
-      <div v-if="isLoadingTabItems || isAddingToTab" class="bg-surface border border-border rounded-2xl mb-4 p-3.5 shadow-sm animate-pulse">
+      <div v-if="isLoadingTabItems || isAddingToTab" class="bg-surface border border-border rounded-2xl p-3.5 shadow-sm animate-pulse">
         <div class="flex items-center gap-3">
           <div class="w-9 h-9 rounded-xl bg-surface-secondary flex-shrink-0" />
           <div class="flex-1 flex items-center gap-3">
@@ -1756,7 +1761,7 @@ onUnmounted(() => {
       </div>
 
       <!-- Barra Banner (bar session — behaves as normal POS) -->
-      <div v-else-if="posStore.activeTableSession?.isBar" class="bg-surface border border-state-warning-border/40 rounded-2xl mb-4 p-3.5 shadow-sm">
+      <div v-else-if="posStore.activeTableSession?.isBar" class="bg-surface border border-state-warning-border/40 rounded-2xl p-3.5 shadow-sm">
         <div class="flex items-center gap-3">
           <div class="bg-state-warning-bg p-2.5 rounded-xl flex-shrink-0">
             <svg class="w-4 h-4 text-state-warning-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -1787,7 +1792,7 @@ onUnmounted(() => {
       </div>
 
       <!-- Mesa Banner (when arriving from a table session) -->
-      <div v-else-if="posStore.activeTableSession" class="bg-surface border border-border rounded-2xl mb-4 p-3.5 shadow-sm">
+      <div v-else-if="posStore.activeTableSession" class="bg-surface border border-border rounded-2xl p-3.5 shadow-sm">
         <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-3">
           <div class="flex items-start gap-3 min-w-0 flex-1">
             <div class="bg-status-success-bg p-2.5 rounded-xl flex-shrink-0">
@@ -1920,7 +1925,7 @@ onUnmounted(() => {
       </div>
 
       <!-- Customer Header (when customer is identified and no mesa mode) -->
-      <div v-else-if="posStore.currentCustomer" class="bg-badge-primary-bg border border-badge-primary-border rounded-xl mb-4 p-4">
+      <div v-else-if="posStore.currentCustomer" class="bg-badge-primary-bg border border-badge-primary-border rounded-xl p-4">
         <div class="flex items-start justify-between gap-3">
           <div class="flex items-center gap-3 min-w-0">
             <div class="bg-badge-primary-bg p-3 rounded-xl border border-badge-primary-border flex-shrink-0">
@@ -1979,7 +1984,7 @@ onUnmounted(() => {
       </div>
 
       <!-- Identify customer CTA (counter/bar, no table session) -->
-      <div v-else class="mb-4">
+      <div v-else>
         <button
           type="button"
           class="w-full flex items-center justify-center gap-2 min-h-[44px] px-4 py-3 rounded-xl border-2 border-dashed border-badge-primary-border text-badge-primary-text font-semibold text-sm hover:bg-badge-primary-bg transition-colors"
@@ -1992,12 +1997,6 @@ onUnmounted(() => {
         </button>
       </div>
 
-
-      <!-- Main POS Container -->
-    <div class="grid w-full grid-cols-1 items-start gap-4 md:gap-6 lg:grid-cols-[minmax(0,1fr)_24rem]">
-      <!-- Products Panel (Left) -->
-      <div class="min-w-0 flex flex-col space-y-4">
-        <div class="lg:sticky lg:top-0 lg:z-20 flex flex-col gap-3 bg-background pt-2 pb-1">
           <!-- Search and Filters -->
           <div class="flex flex-col sm:flex-row gap-3">
             <div class="flex-1">
@@ -2050,7 +2049,7 @@ onUnmounted(() => {
 
       <!-- Cart Panel — desktop sidebar only; mobile uses bottom bar + sheet (#1032) -->
       <PosCartPanel
-        class="hidden lg:flex"
+        class="hidden lg:flex lg:sticky lg:top-0"
         fit-height
         :items="posStore.cart"
         :total="cartTotal"

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -1799,7 +1799,7 @@ onUnmounted(() => {
 
       <!-- Mesa Banner (when arriving from a table session) -->
       <div v-else-if="posStore.activeTableSession" class="bg-surface border border-border rounded-xl p-2.5 shadow-sm">
-        <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-2.5">
+        <div class="flex flex-col xl:flex-row xl:items-center xl:justify-between gap-2.5">
           <div class="flex items-center gap-2.5 min-w-0 flex-1">
             <div class="bg-status-success-bg p-2 rounded-lg flex-shrink-0">
               <svg class="w-4 h-4 text-status-success-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -1831,24 +1831,24 @@ onUnmounted(() => {
             </div>
           </div>
           <!-- Mesero + actions — stacked on mobile/tablet; inline on desktop -->
-          <div class="flex flex-wrap items-center gap-1.5 lg:flex-shrink-0 lg:justify-end">
+          <div class="grid w-full grid-cols-2 gap-1.5 sm:flex sm:flex-wrap sm:items-center xl:w-auto xl:flex-shrink-0 xl:justify-end">
             <!-- Issue #574 — Waiter loading chip — width adapts to the rotating
                  phrase so it doesn't overflow the original chip. Same pattern
                  as the dashboard header progressive-load indicator. -->
             <div
               v-if="waiterAttributionEnabled && isChangingSessionWaiter"
-              class="h-8 inline-flex items-center gap-1.5 px-2.5 rounded-lg border border-border bg-surface-secondary text-text-secondary text-[10px] font-bold uppercase tracking-wider whitespace-nowrap"
+              class="h-8 min-w-0 inline-flex items-center justify-center gap-1.5 px-2.5 rounded-lg border border-border bg-surface-secondary text-text-secondary text-[10px] font-bold uppercase tracking-wider whitespace-nowrap"
               aria-live="polite"
             >
               <UiLoadingDots size="7px" color="currentColor" />
               <span>{{ waiterChipLoadingPhrase }}</span>
             </div>
             <!-- Issue #574 — Idle waiter chip with auto-handoff dropdown -->
-            <div v-else-if="waiterAttributionEnabled" class="relative">
+            <div v-else-if="waiterAttributionEnabled" class="relative min-w-0 sm:min-w-[11rem]">
               <select
                 :value="bannerEffectiveWaiterId || ''"
                 aria-label="Cambiar mesero de la sesión activa"
-                class="h-8 inline-flex items-center leading-none pl-7 pr-7 rounded-lg border border-border bg-surface-secondary text-[10px] font-bold uppercase tracking-wider transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/35 focus-visible:ring-offset-1 appearance-none bg-none cursor-pointer [&::-ms-expand]:hidden"
+                class="h-8 w-full inline-flex items-center leading-none pl-7 pr-7 rounded-lg border border-border bg-surface-secondary text-[10px] font-bold uppercase tracking-wider transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/35 focus-visible:ring-offset-1 appearance-none bg-none cursor-pointer truncate [&::-ms-expand]:hidden"
                 style="background-image: none; -webkit-appearance: none; -moz-appearance: none; text-align-last: center;"
                 :class="bannerEffectiveWaiterId ? 'text-text-primary' : 'text-text-secondary italic'"
                 @change="handleChangeSessionWaiter"
@@ -1884,7 +1884,7 @@ onUnmounted(() => {
               v-if="canPayTableAdvance"
               type="button"
               :disabled="isBannerClosing || posStore.isCancellingMesa"
-              class="h-8 inline-flex items-center gap-1.5 text-[10px] font-bold text-primary uppercase tracking-wider px-2.5 rounded-lg border border-primary/30 hover:bg-primary/10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed"
+              class="h-8 min-w-0 inline-flex items-center justify-center gap-1.5 text-[10px] font-bold text-primary uppercase tracking-wider px-2.5 rounded-lg border border-primary/30 hover:bg-primary/10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed"
               :aria-label="`Pagar anticipo de la ${tableSingularLower}`"
               @click="showTableAdvancePanel = true"
             >
@@ -1897,7 +1897,7 @@ onUnmounted(() => {
             <button
               type="button"
               :disabled="isBannerClosing || posStore.isCancellingMesa"
-              class="h-8 inline-flex items-center gap-1.5 text-[10px] font-bold text-text-secondary uppercase tracking-wider px-2.5 rounded-lg border border-border hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed"
+              class="h-8 min-w-0 inline-flex items-center justify-center gap-1.5 text-[10px] font-bold text-text-secondary uppercase tracking-wider px-2.5 rounded-lg border border-border hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed"
               :aria-label="`Volver al plano de ${tablePluralLower} (la ${tableSingularLower} sigue abierta)`"
               @click="leaveActiveTableSession"
             >
@@ -1910,7 +1910,7 @@ onUnmounted(() => {
             <button
               type="button"
               :disabled="isBannerClosing || posStore.isCancellingMesa"
-              class="h-8 inline-flex items-center gap-1.5 text-[10px] font-bold text-status-error-text uppercase tracking-wider px-2.5 rounded-lg border border-status-error-text/30 hover:bg-status-error-bg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-status-error-text focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed"
+              class="h-8 min-w-0 inline-flex items-center justify-center gap-1.5 text-[10px] font-bold text-status-error-text uppercase tracking-wider px-2.5 rounded-lg border border-status-error-text/30 hover:bg-status-error-bg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-status-error-text focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed"
               :aria-label="`Liberar la ${tableSingularLower}`"
               @click="handleReleaseMesa"
             >

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -808,11 +808,17 @@ const showTableAdvancePanel = ref(false)
 const canPayTableAdvance = computed(() =>
   !!posStore.activeTableSession && !posStore.activeTableSession.isBar && showActiveMinimumConsumption.value,
 )
-const activeMinimumRemainingLabel = computed(() => {
+const activeMinimumStatusLabel = computed(() => {
   const state = activeMinimumConsumption.value
-  if (!state) return ''
+  if (!state || !state.enabled || state.amount <= 0) return ''
   if (state.covered || state.remaining <= 0) return 'Mínimo cubierto'
   return `${formatCurrencyPOS(state.remaining)} faltante`
+})
+const activeMinimumStatusClass = computed(() => {
+  const state = activeMinimumConsumption.value
+  return state?.covered || (state?.remaining ?? 0) <= 0
+    ? 'bg-state-success-bg text-state-success-text border-state-success-border'
+    : 'bg-state-warning-bg text-state-warning-text border-state-warning-border'
 })
 
 // Issue #956 — unified destructive-action confirmation with required motivo
@@ -1802,21 +1808,26 @@ onUnmounted(() => {
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
-                <span class="text-[10px] font-bold text-status-success-text uppercase tracking-widest">{{ tableSingular }} Activa</span>
+                <span class="text-[10px] font-bold text-status-success-text uppercase tracking-widest">{{ tableSingular }} activa</span>
                 <span class="hidden sm:inline w-px h-3 bg-border flex-shrink-0" aria-hidden="true" />
                 <span class="text-sm font-bold text-text-primary">{{ posStore.activeTableSession.tableName }}</span>
+                <span
+                  v-if="activeMinimumStatusLabel"
+                  class="inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold leading-none whitespace-nowrap"
+                  :class="activeMinimumStatusClass"
+                >
+                  {{ activeMinimumStatusLabel }}
+                </span>
               </div>
-              <p class="text-[11px] text-text-secondary tabular-nums mt-0.5 leading-snug">
-                {{ formatCurrencyPOS(posStore.activeTableSession.runningTotal) }} acumulado · {{ formatDuration(posStore.activeTableSession.openedAt) }}
-              </p>
-              <p
-                v-if="showActiveMinimumConsumption && activeMinimumConsumption"
-                class="text-[11px] text-text-secondary tabular-nums mt-0.5 leading-snug"
-              >
-                Mínimo {{ formatCurrencyPOS(activeMinimumConsumption.amount) }} ·
-                Consumido {{ formatCurrencyPOS(activeMinimumConsumption.consumed) }} ·
-                {{ activeMinimumRemainingLabel }}
-              </p>
+              <div class="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-text-secondary tabular-nums leading-snug">
+                <span>{{ formatCurrencyPOS(posStore.activeTableSession.runningTotal) }} acumulado</span>
+                <span class="text-text-tertiary" aria-hidden="true">·</span>
+                <span>{{ formatDuration(posStore.activeTableSession.openedAt) }}</span>
+                <template v-if="showActiveMinimumConsumption && activeMinimumConsumption">
+                  <span class="text-text-tertiary" aria-hidden="true">·</span>
+                  <span>Mín. {{ formatCurrencyPOS(activeMinimumConsumption.amount) }}</span>
+                </template>
+              </div>
             </div>
           </div>
           <!-- Mesero + actions — stacked on mobile/tablet; inline on desktop -->


### PR DESCRIPTION
## Summary
- Collapse checkout order lines into an `Orden` accordion while keeping customer, payment, prefactura, split, Waros, tip, and primary close controls visible.
- Add `Comandas` accordions on desktop and mobile checkout using persisted `/api/tables/{tableId}/comandas` data.
- Allow selected comanda reprint from checkout through the existing comanda print component.

## Validation
- SFC parse check: passed.
- SFC template compile check: passed.
- `git diff --check`: passed.
- Build skipped per request: `sin build`.

## Manual checkout path for PR validation
- Mesa with comandas: open checkout, inspect `Orden` and `Comandas`, select/deselect, reprint selected.
- Print prefactura, close order, verify success modal, receipt action, and DIAN invoice gate.
- Check split payment, credit, tip, Waros, counter mode, and empty/no-comandas states.

Closes #1530