### PR TITLE
Point POS catalog to POS products endpoint

### DIFF
--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -1224,7 +1224,7 @@ const selectedCategory = ref('all')
 // Load products from API
 const { data: productsData, status: productsStatus, asyncStatus: productsAsyncStatus, error: productsError, refetch } = useQuery({
   key: () => ['pos', 'products', currentTenant.value?.id],
-  query: () => $fetch('/api/menu/products', {
+  query: () => $fetch('/api/pos/products', {
     params: {
       is_available: true,
       limit: 250,


### PR DESCRIPTION
## Summary
- Update POS product catalog fetch to use `/api/pos/products`.
- Keep existing POS catalog params and cache key unchanged.

## Tests
- `rg -n "/api/menu/products" pages/pos || true`
- `rg -n "/api/pos/products" pages/pos/index.vue`

Closes #1535