### PR TITLE
Consolidate duplicate receipt print lines

### DIFF
--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { consolidateReceiptPrintLines } from '~/utils/receiptPrintLines'
+
 interface ReceiptItemModifier {
   id?: string | number | null
   name: string
@@ -9,11 +11,20 @@ interface ReceiptItemModifier {
 
 interface ReceiptItem {
   id?: string | number | null
+  productId?: string | number | null
   name: string
   quantity: number | string
   unitPrice: number
   total: number
+  notes?: string | null
   modifiers?: ReceiptItemModifier[]
+  promotionName?: string | null
+  promoType?: string | null
+  promoSavings?: number | string | null
+  promoOptOut?: boolean | null
+  discountAllocated?: number | string | null
+  netTotal?: number | string | null
+  taxCategory?: string | null
 }
 
 interface ReceiptPaymentLine {
@@ -113,6 +124,32 @@ const hasSettlementBreakdown = computed(() =>
 const finalTotal = computed(() =>
   props.chargedTotal != null ? Number(props.chargedTotal) : Number(props.orderTotal) || 0,
 )
+
+const printableItems = computed(() =>
+  consolidateReceiptPrintLines(props.items, {
+    productKey: item => item.productId ?? item.name,
+    displayName: item => item.name,
+    quantity: item => item.quantity,
+    unitPrice: item => item.unitPrice,
+    total: item => item.total,
+    modifiers: item => item.modifiers,
+    notes: item => item.notes,
+    guards: item => [
+      item.promotionName,
+      item.promoType,
+      item.promoSavings,
+      item.promoOptOut,
+      item.discountAllocated,
+      item.netTotal,
+      item.taxCategory,
+    ],
+    merge: (item, aggregate) => ({
+      ...item,
+      quantity: aggregate.quantity,
+      total: aggregate.total,
+    }),
+  })
+)
 </script>
 
 <template>
@@ -149,7 +186,7 @@ const finalTotal = computed(() =>
       <span class="receipt-col-total">Total</span>
     </div>
 
-    <template v-for="item in items" :key="item.id ?? item.name">
+    <template v-for="item in printableItems" :key="item.id ?? item.name">
       <div class="receipt-grid-row receipt-small">
         <span class="receipt-col-desc">{{ item.name }}</span>
         <span class="receipt-col-qty">{{ item.quantity }}</span>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -16,6 +16,7 @@ import { displayTableCode } from '~/composables/useTableDisplayCode'
 import { formatPromoTypeLabel } from '~/utils/promotionPreview'
 import { computePromoEligibleSubtotal, linePromoSavingsForProduct } from '~/utils/promoProductMatch'
 import { posDebugLog, posDebugSerializeError } from '~/utils/posDebugLog'
+import { consolidateReceiptPrintLines } from '~/utils/receiptPrintLines'
 
 interface TopProduct {
   name: string
@@ -1682,6 +1683,42 @@ const formatModifierPrintDesc = (mod: PrintModifier) => {
   const qty = Number(mod.quantity) || 1
   return qty > 1 ? `+ ${mod.name} ×${qty}` : `+ ${mod.name}`
 }
+
+const receiptPrintLineGuards = (item: any) => [
+  item.promo_opt_out,
+  item.promoOptOut,
+  item.promotionName,
+  item.promoType,
+  item.promoSavings,
+  item.applied_promotion_id,
+  item.discount_allocated,
+  item.net_total,
+  item.tax_category,
+]
+
+const consolidateCheckoutPrintItems = (items: any[]) =>
+  consolidateReceiptPrintLines(items, {
+    productKey: item => item.product?.id ?? item.productId ?? item.product_id ?? item.id,
+    displayName: item => item.product?.name ?? item.productName ?? item.name,
+    quantity: item => item.quantity,
+    unitPrice: item => getItemUnitPrice(item),
+    total: item => getItemTotal(item),
+    modifiers: item => item.modifiers ?? [],
+    notes: item => item.notes,
+    guards: receiptPrintLineGuards,
+    merge: (item, aggregate) => ({
+      ...item,
+      quantity: aggregate.quantity,
+    }),
+  })
+
+const printablePrefacturaItems = computed(() =>
+  consolidateCheckoutPrintItems(cartItems.value)
+)
+
+const printableReceiptItems = computed(() =>
+  consolidateCheckoutPrintItems(cartItemsSnapshot.value)
+)
 
 function checkoutErrorMessage(error: any, fallback: string) {
   const detail = error?.data?.detail
@@ -4903,7 +4940,7 @@ onUnmounted(() => {
       <span class="receipt-col-price">Precio</span>
       <span class="receipt-col-total">Total</span>
     </div>
-    <template v-for="item in cartItems" :key="item.id ?? item.orderItemId">
+    <template v-for="item in printablePrefacturaItems" :key="item.id ?? item.orderItemId">
       <div class="receipt-grid-row receipt-small">
         <span class="receipt-col-desc">
           {{ item.product?.name || item.name }}<span v-if="isKitchenServiceMode && item.fired === false"> *</span>
@@ -5046,7 +5083,7 @@ onUnmounted(() => {
       <span class="receipt-col-price">Precio</span>
       <span class="receipt-col-total">Total</span>
     </div>
-    <template v-for="item in cartItemsSnapshot" :key="item.id ?? item.orderItemId">
+    <template v-for="item in printableReceiptItems" :key="item.id ?? item.orderItemId">
       <div class="receipt-grid-row receipt-small">
         <span class="receipt-col-desc">{{ item.product?.name || item.name }}</span>
         <span class="receipt-col-qty">{{ item.quantity }}</span>

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -385,10 +385,19 @@ const saleReceiptItems = computed(() =>
     const total = itemReceiptTotal(item)
     return {
       id: item.id,
+      productId: item.product?.id ?? item.product_id ?? null,
       name: item.product?.name || item.name || 'Producto',
       quantity,
       unitPrice: total / quantity,
       total,
+      notes: item.notes ?? null,
+      promotionName: item.promotion_name ?? item.promotionName ?? null,
+      promoType: item.promotion_type ?? item.promoType ?? null,
+      promoSavings: item.promo_savings_allocated ?? item.promoSavings ?? null,
+      promoOptOut: item.promo_opt_out ?? item.promoOptOut ?? null,
+      discountAllocated: item.discount_allocated ?? null,
+      netTotal: item.net_total ?? null,
+      taxCategory: item.tax_category ?? null,
       modifiers: (item.modifiers ?? []).map((modifier: any) => ({
         id: modifier.id,
         name: modifier.name || 'Adicion',

--- a/utils/receiptPrintLines.test.ts
+++ b/utils/receiptPrintLines.test.ts
@@ -1,0 +1,131 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { consolidateReceiptPrintLines } from './receiptPrintLines.ts'
+
+type TestLine = {
+  productId: string
+  name: string
+  quantity: number
+  unitPrice: number
+  total: number
+  notes?: string | null
+  modifiers?: Array<{ id?: string; name: string; price: number; quantity?: number }>
+}
+
+const group = (items: TestLine[]) =>
+  consolidateReceiptPrintLines(items, {
+    productKey: item => item.productId,
+    displayName: item => item.name,
+    quantity: item => item.quantity,
+    unitPrice: item => item.unitPrice,
+    total: item => item.total,
+    modifiers: item => item.modifiers,
+    notes: item => item.notes,
+    merge: (item, aggregate) => ({
+      ...item,
+      quantity: aggregate.quantity,
+      total: aggregate.total,
+    }),
+  })
+
+const groupWithPromoGuard = (items: Array<TestLine & { promo?: string | null }>) =>
+  consolidateReceiptPrintLines(items, {
+    productKey: item => item.productId,
+    displayName: item => item.name,
+    quantity: item => item.quantity,
+    unitPrice: item => item.unitPrice,
+    total: item => item.total,
+    modifiers: item => item.modifiers,
+    notes: item => item.notes,
+    guards: item => [item.promo],
+    merge: (item, aggregate) => ({
+      ...item,
+      quantity: aggregate.quantity,
+      total: aggregate.total,
+    }),
+  })
+
+describe('consolidateReceiptPrintLines', () => {
+  it('groups plain duplicate products for receipt printing', () => {
+    const lines = group([
+      { productId: 'burger', name: 'Burger', quantity: 1, unitPrice: 12000, total: 12000 },
+      { productId: 'burger', name: 'Burger', quantity: 2, unitPrice: 12000, total: 24000 },
+    ])
+
+    assert.equal(lines.length, 1)
+    assert.equal(lines[0].quantity, 3)
+    assert.equal(lines[0].total, 36000)
+  })
+
+  it('groups products with the same modifiers regardless of modifier order', () => {
+    const lines = group([
+      {
+        productId: 'pizza',
+        name: 'Pizza',
+        quantity: 1,
+        unitPrice: 20000,
+        total: 20000,
+        modifiers: [
+          { id: 'cheese', name: 'Queso', price: 2000, quantity: 1 },
+          { id: 'pepperoni', name: 'Pepperoni', price: 3000, quantity: 2 },
+        ],
+      },
+      {
+        productId: 'pizza',
+        name: 'Pizza',
+        quantity: 1,
+        unitPrice: 20000,
+        total: 20000,
+        modifiers: [
+          { id: 'pepperoni', name: 'Pepperoni', price: 3000, quantity: 2 },
+          { id: 'cheese', name: 'Queso', price: 2000, quantity: 1 },
+        ],
+      },
+    ])
+
+    assert.equal(lines.length, 1)
+    assert.equal(lines[0].quantity, 2)
+    assert.equal(lines[0].total, 40000)
+  })
+
+  it('keeps products with different modifiers separated', () => {
+    const lines = group([
+      {
+        productId: 'pizza',
+        name: 'Pizza',
+        quantity: 1,
+        unitPrice: 20000,
+        total: 20000,
+        modifiers: [{ id: 'cheese', name: 'Queso', price: 2000 }],
+      },
+      {
+        productId: 'pizza',
+        name: 'Pizza',
+        quantity: 1,
+        unitPrice: 20000,
+        total: 20000,
+        modifiers: [{ id: 'bacon', name: 'Tocineta', price: 4000 }],
+      },
+    ])
+
+    assert.equal(lines.length, 2)
+  })
+
+  it('keeps products with different notes separated', () => {
+    const lines = group([
+      { productId: 'juice', name: 'Jugo', quantity: 1, unitPrice: 8000, total: 8000, notes: 'sin hielo' },
+      { productId: 'juice', name: 'Jugo', quantity: 1, unitPrice: 8000, total: 8000, notes: 'con hielo' },
+    ])
+
+    assert.equal(lines.length, 2)
+  })
+
+  it('keeps products with different promo guards separated', () => {
+    const lines = groupWithPromoGuard([
+      { productId: 'burger', name: 'Burger', quantity: 1, unitPrice: 12000, total: 12000, promo: 'happy-hour' },
+      { productId: 'burger', name: 'Burger', quantity: 1, unitPrice: 12000, total: 12000, promo: null },
+    ])
+
+    assert.equal(lines.length, 2)
+  })
+})

--- a/utils/receiptPrintLines.ts
+++ b/utils/receiptPrintLines.ts
@@ -1,0 +1,86 @@
+export type ReceiptPrintLineModifier = {
+  id?: string | number | null
+  modifier_id?: string | number | null
+  name?: string | null
+  modifier_name?: string | null
+  price?: number | string | null
+  price_at_purchase?: number | string | null
+  quantity?: number | string | null
+}
+
+type ConsolidateOptions<T> = {
+  productKey: (item: T) => string | number | null | undefined
+  displayName: (item: T) => string | null | undefined
+  quantity: (item: T) => number | string | null | undefined
+  unitPrice: (item: T) => number | string | null | undefined
+  total: (item: T) => number | string | null | undefined
+  modifiers?: (item: T) => ReceiptPrintLineModifier[] | null | undefined
+  notes?: (item: T) => string | null | undefined
+  guards?: (item: T) => Array<string | number | boolean | null | undefined>
+  merge: (base: T, aggregate: { quantity: number; total: number }) => T
+}
+
+const numericKey = (value: number | string | null | undefined) => {
+  const n = Number(value)
+  return Number.isFinite(n) ? n.toFixed(6) : '0.000000'
+}
+
+const textKey = (value: string | number | boolean | null | undefined) =>
+  String(value ?? '').trim().toLowerCase()
+
+const modifierIdentity = (modifier: ReceiptPrintLineModifier) => {
+  const id = modifier.modifier_id ?? modifier.id ?? ''
+  const name = modifier.modifier_name ?? modifier.name ?? ''
+  const price = modifier.price_at_purchase ?? modifier.price
+  return {
+    id: textKey(id),
+    name: textKey(name),
+    price: numericKey(price),
+    quantity: numericKey(modifier.quantity ?? 1),
+  }
+}
+
+const modifiersKey = (modifiers: ReceiptPrintLineModifier[] = []) =>
+  JSON.stringify(
+    modifiers
+      .map(modifierIdentity)
+      .sort((a, b) =>
+        `${a.id}|${a.name}|${a.price}|${a.quantity}`.localeCompare(`${b.id}|${b.name}|${b.price}|${b.quantity}`)
+      )
+  )
+
+export function consolidateReceiptPrintLines<T>(
+  items: readonly T[],
+  options: ConsolidateOptions<T>,
+): T[] {
+  const grouped = new Map<string, { item: T; quantity: number; total: number }>()
+
+  for (const item of items) {
+    const key = JSON.stringify({
+      product: textKey(options.productKey(item)),
+      name: textKey(options.displayName(item)),
+      unitPrice: numericKey(options.unitPrice(item)),
+      notes: textKey(options.notes?.(item)),
+      modifiers: modifiersKey(options.modifiers?.(item) ?? []),
+      guards: (options.guards?.(item) ?? []).map(value => textKey(value)),
+    })
+
+    const quantity = Number(options.quantity(item)) || 0
+    const total = Number(options.total(item)) || 0
+    const existing = grouped.get(key)
+
+    if (existing) {
+      existing.quantity += quantity
+      existing.total += total
+    } else {
+      grouped.set(key, { item, quantity, total })
+    }
+  }
+
+  return Array.from(grouped.values()).map(group =>
+    options.merge(group.item, {
+      quantity: group.quantity,
+      total: group.total,
+    })
+  )
+}


### PR DESCRIPTION
## Summary

- Add a pure receipt print line consolidator that groups only visually identical printable items.
- Apply consolidation to POS prefactura, POS final receipt, and the reusable sale receipt print ticket.
- Preserve checkout/order persistence and existing receipt totals; only printed item rows are grouped.

## Tests

- `node --test utils/receiptPrintLines.test.ts`
- `npm run build`

Closes #1548

