### PR TITLE
Improve expense error messages

### DIFF
--- a/pages/finanzas/gastos/[id]/editar.vue
+++ b/pages/finanzas/gastos/[id]/editar.vue
@@ -278,9 +278,13 @@ const handleSubmit = async () => {
       if (typeof error.data.detail === 'string') {
         errorMessage = error.data.detail
       } else if (Array.isArray(error.data.detail)) {
-        errorMessage = error.data.detail.map((e: any) => e.msg || JSON.stringify(e)).join(', ')
+        errorMessage = error.data.detail.map((e: any) => e.msg || e.message || 'Revisa los datos del gasto.').join(', ')
       } else {
-        errorMessage = JSON.stringify(error.data.detail)
+        errorMessage = error.data.detail.message
+          || error.data.detail.msg
+          || error.data.detail.error
+          || error.data.detail.detail
+          || 'No se pudo actualizar el gasto. Revisa los datos e intenta nuevamente.'
       }
     } else if (error?.message) {
       errorMessage = error.message

--- a/pages/finanzas/gastos/[id]/index.vue
+++ b/pages/finanzas/gastos/[id]/index.vue
@@ -875,9 +875,13 @@ const handleSubmit = async () => {
       if (typeof error.data.detail === 'string') {
         errorMessage = error.data.detail
       } else if (Array.isArray(error.data.detail)) {
-        errorMessage = error.data.detail.map((e: any) => e.msg || JSON.stringify(e)).join(', ')
+        errorMessage = error.data.detail.map((e: any) => e.msg || e.message || 'Revisa los datos del gasto.').join(', ')
       } else {
-        errorMessage = JSON.stringify(error.data.detail)
+        errorMessage = error.data.detail.message
+          || error.data.detail.msg
+          || error.data.detail.error
+          || error.data.detail.detail
+          || 'No se pudo actualizar el gasto. Revisa los datos e intenta nuevamente.'
       }
     } else if (error?.message) {
       errorMessage = error.message

--- a/pages/finanzas/gastos/crear.vue
+++ b/pages/finanzas/gastos/crear.vue
@@ -444,9 +444,13 @@ const extractErrorMessage = (error: any) => {
   if (error?.data?.detail) {
     if (typeof error.data.detail === 'string') return error.data.detail
     if (Array.isArray(error.data.detail)) {
-      return error.data.detail.map((e: any) => e.msg || JSON.stringify(e)).join(', ')
+      return error.data.detail.map((e: any) => e.msg || e.message || 'Revisa los datos del gasto.').join(', ')
     }
-    return JSON.stringify(error.data.detail)
+    return error.data.detail.message
+      || error.data.detail.msg
+      || error.data.detail.error
+      || error.data.detail.detail
+      || 'No se pudo guardar el gasto. Revisa los datos e intenta nuevamente.'
   }
   return error?.message || 'Error al guardar el gasto. Por favor intenta nuevamente.'
 }


### PR DESCRIPTION
## Summary
- avoid rendering raw object/JSON details in expense create and edit errors
- prefer readable message/msg/error/detail fields with a clear fallback

## Tests
- Not run: no lint script is defined and build was skipped by request

Refs uno0uno/api-warolabs#602