### PR TITLE
Clarify analytics navigation for ingredient usage

### DIFF
--- a/composables/useDashboardPageConfig.ts
+++ b/composables/useDashboardPageConfig.ts
@@ -351,7 +351,7 @@ export const useDashboardPageConfig = () => {
       }
     } else if (path.includes('/analytics') || path.includes('/analitica')) {
       return {
-        pageTitle: 'Mis Ventas',
+        pageTitle: 'Analítica',
         pageSubtitle: undefined,
         searchPlaceholder: 'Buscar métricas...',
         activePage: 'analytics' as const,

--- a/constants/dashboardNavigation.ts
+++ b/constants/dashboardNavigation.ts
@@ -45,7 +45,7 @@ export const dashboardPrimaryItems: DashboardNavItem[] = [
 ]
 
 export const dashboardSecondaryItems: DashboardNavItem[] = [
-  { to: '/analitica', page: 'analytics', label: 'Analítica Ventas', icon: ChartBarIcon, module: 'analitica' },
+  { to: '/analitica', page: 'analytics', label: 'Analítica', icon: ChartBarIcon, module: 'analitica' },
   { to: '/asistente/kali', page: 'asistente', label: 'Kali', icon: SparklesIcon, module: 'analitica', feature: 'kali_enabled' },
   { to: '/finanzas/arqueo', page: 'finanzas', label: 'Finanzas', icon: BanknotesIcon, module: 'finanzas' },
   { to: '/facturacion', page: 'facturacion', label: 'Facturación', icon: DocumentTextIcon, module: 'facturacion' },

--- a/pages/analitica/ingredientes.vue
+++ b/pages/analitica/ingredientes.vue
@@ -33,9 +33,9 @@
           <select
             v-model="categoryFilter"
             :class="filterSelectClassFor(categoryFilter)"
-            aria-label="Filtrar por categoria"
+            aria-label="Filtrar por categoría"
           >
-            <option value="">Categoria</option>
+            <option value="">Categoría</option>
             <option v-for="category in categories" :key="category" :value="category">
               {{ category }}
             </option>
@@ -79,13 +79,13 @@
           :subtitle="`${summary.coveragePct}% con movimientos`"
         />
         <MetricCard
-          title="Variacion costo"
+          title="Variación costo"
           :value="summary.avgCostVariationPct"
           format="percentage"
           :precision="1"
           :variant="summary.avgCostVariationPct > 10 ? 'warning' : 'info'"
           size="sm"
-          subtitle="Ultimo vs promedio base"
+          subtitle="Último vs promedio base"
         />
       </section>
 
@@ -115,7 +115,7 @@
                 />
               </div>
               <p class="text-xs text-text-secondary mt-1">
-                {{ item.category || 'Sin categoria' }} · {{ formatQuantity(item.consumed_quantity) }} {{ item.unit || 'und' }}
+                {{ item.category || 'Sin categoría' }} · {{ formatQuantity(item.consumed_quantity) }} {{ item.unit || 'und' }}
               </p>
             </div>
             <div class="flex flex-col items-end gap-1 flex-shrink-0">
@@ -128,7 +128,7 @@
         <template #cell-ingredient_name="{ item }">
           <div class="min-w-0">
             <span class="text-sm font-bold text-text-primary">{{ item.ingredient_name }}</span>
-            <p class="text-xs text-text-secondary">{{ item.category || 'Sin categoria' }}</p>
+            <p class="text-xs text-text-secondary">{{ item.category || 'Sin categoría' }}</p>
           </div>
         </template>
 
@@ -215,7 +215,7 @@ const { formatCurrency } = useFormatters()
 const { localSearchTerm, appliedSearch, performSearch: applySearch, clearSearch } = useAppliedSearch()
 const { dateRangeDates, presetDates, formatDateRange, dateRange, clearDateRange } = useDateRangePresets()
 
-useHead({ title: 'Analitica de Ingredientes' })
+useHead({ title: 'Analítica de Ingredientes' })
 
 const ingredientFilter = ref('')
 const categoryFilter = ref('')
@@ -317,7 +317,7 @@ const summary = computed(() => {
 
   const periodLabel = period.value?.from && period.value?.to
     ? `${period.value.from} a ${period.value.to}`
-    : 'Periodo actual'
+    : 'Período actual'
 
   return {
     totalIngredients,
@@ -368,7 +368,7 @@ const ingredientTableColumns = [
   { key: 'consumed_quantity', title: 'Consumo', sortable: false, format: 'text', align: 'right' },
   { key: 'estimated_consumed_cost', title: 'Costo estimado', sortable: false, format: 'text', align: 'right' },
   { key: 'weighted_avg_cost_per_unit', title: 'Costo prom.', sortable: false, format: 'text', align: 'right' },
-  { key: 'latest_cost_per_unit', title: 'Ultimo costo', sortable: false, format: 'text', align: 'right' },
+  { key: 'latest_cost_per_unit', title: 'Último costo', sortable: false, format: 'text', align: 'right' },
   { key: 'cost_trend', title: 'Tendencia', sortable: false, format: 'text', align: 'right' },
   { key: 'movement_count', title: 'Mov.', sortable: false, format: 'text', align: 'right' },
   { key: 'data_coverage', title: 'Cobertura', sortable: false, format: 'text', align: 'center' },

--- a/pages/ventas/productos.vue
+++ b/pages/ventas/productos.vue
@@ -4,7 +4,7 @@ import { formatDistanceToNow } from 'date-fns'
 import { es } from 'date-fns/locale'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
-useHead({ title: 'Productos - Ventas' })
+useHead({ title: 'Productos vendidos - Ventas' })
 
 const { setRefreshHandler, clearRefreshHandler, setLastUpdateText, registerProgressiveLoading } = useLayoutActions()
 const { currentTenant } = useTenantReactive()
@@ -130,6 +130,12 @@ const API_SORT_TO_TABLE: Record<'qty_desc' | 'revenue_desc' | 'name_asc', { fiel
 
 const tableSortField = computed(() => API_SORT_TO_TABLE[sortFilter.value].field)
 const tableSortDirection = computed(() => API_SORT_TO_TABLE[sortFilter.value].direction)
+const ingredientAnalyticsLink = computed(() => ({
+  path: '/analitica/ingredientes',
+  query: dateRange.value.from && dateRange.value.to
+    ? { date_from: dateRange.value.from, date_to: dateRange.value.to }
+    : {},
+}))
 
 function handleTableSort(field: string) {
   const nextSort = TABLE_SORT_TO_API[field]
@@ -198,6 +204,18 @@ onUnmounted(() => {
           variant="primary"
         />
       </div>
+
+      <NuxtLink
+        :to="ingredientAnalyticsLink"
+        class="flex flex-col gap-2 rounded-lg border border-border bg-surface px-4 py-3 text-sm transition-colors hover:border-primary hover:bg-surface-secondary sm:flex-row sm:items-center sm:justify-between"
+        aria-label="Ver consumo y costo por ingrediente"
+      >
+        <span>
+          <span class="font-semibold text-text-primary">Productos vendidos</span>
+          <span class="text-text-secondary"> muestran mix e ingresos; ingredientes muestra consumo y costo.</span>
+        </span>
+        <span class="font-semibold text-primary whitespace-nowrap">Ver ingredientes</span>
+      </NuxtLink>
 
       <!-- Filters bar -->
       <UiAdvancedFiltersBar


### PR DESCRIPTION
## Summary
- Rename the desktop analytics nav entry so Analítica is not presented as only sales.
- Add a lightweight bridge from products sold to ingredient consumption/cost analytics.
- Polish ingredient analytics copy with clear Spanish labels and accents.

## Tests
- git diff --check
- Skipped npm run build by request (sin build)

Closes #1567