### PR TITLE
Keep ingredient analytics filters on one line

### DIFF
--- a/pages/analitica/clientes/index.vue
+++ b/pages/analitica/clientes/index.vue
@@ -196,54 +196,6 @@ onUnmounted(() => {
 <template>
   <div class="flex flex-col gap-3 md:gap-4">
 
-    <!-- Filters Bar — always visible -->
-    <ClientOnly>
-      <div class="flex items-center gap-2 w-full overflow-x-auto scrollbar-hide">
-        <div class="flex-1 min-w-0">
-          <VueDatePicker
-            v-model="dateRangeDates"
-            range
-            :preset-dates="presetDates"
-            :enable-time-picker="false"
-            :locale="es"
-            placeholder="Rango de fechas"
-            auto-apply
-            :teleport="true"
-            :timezone="timezone"
-            :max-date="maxDate"
-            :format="formatDateRange"
-            input-class-name="dp-custom-input"
-            menu-class-name="dp-custom-menu"
-            calendar-cell-class-name="dp-custom-cell"
-          />
-        </div>
-        <input
-          v-model="searchQuery"
-          type="text"
-          placeholder="Buscar cliente..."
-          aria-label="Buscar cliente por nombre o teléfono"
-          class="flex-1 min-w-0 h-10 px-3 text-sm border-2 border-border rounded-lg bg-background text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-colors"
-        />
-        <button
-          v-if="hasFilters"
-          @click="clearFilters"
-          class="h-10 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-secondary hover:text-text-primary hover:border-primary transition-colors flex-shrink-0"
-          title="Limpiar filtros"
-          aria-label="Limpiar filtros"
-        >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
-        </button>
-        <button
-          type="button"
-          @click="showCreateModal = true"
-          class="h-10 px-4 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 transition-colors flex-shrink-0 whitespace-nowrap"
-          aria-label="Crear nuevo cliente"
-        >
-          + Nuevo cliente
-        </button>
-      </div>
-    </ClientOnly>
-
     <AnaliticaCreateCustomerModal
       v-model="showCreateModal"
       @created="onCustomerCreated"
@@ -265,6 +217,54 @@ onUnmounted(() => {
         <MetricCard title="Total comprado" :value="totalRevenue" format="currency" variant="primary" />
         <MetricCard title="Ticket promedio" :value="totalCustomers > 0 ? totalRevenue / totalCustomers : 0" format="currency" variant="primary" class="col-span-2 md:col-span-1" />
       </div>
+
+      <!-- Filters Bar -->
+      <ClientOnly>
+        <div class="flex items-center gap-2 w-full overflow-x-auto scrollbar-hide">
+          <div class="flex-1 min-w-0">
+            <VueDatePicker
+              v-model="dateRangeDates"
+              range
+              :preset-dates="presetDates"
+              :enable-time-picker="false"
+              :locale="es"
+              placeholder="Rango de fechas"
+              auto-apply
+              :teleport="true"
+              :timezone="timezone"
+              :max-date="maxDate"
+              :format="formatDateRange"
+              input-class-name="dp-custom-input"
+              menu-class-name="dp-custom-menu"
+              calendar-cell-class-name="dp-custom-cell"
+            />
+          </div>
+          <input
+            v-model="searchQuery"
+            type="text"
+            placeholder="Buscar cliente..."
+            aria-label="Buscar cliente por nombre o teléfono"
+            class="flex-1 min-w-0 h-10 px-3 text-sm border-2 border-border rounded-lg bg-background text-text-primary placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-colors"
+          />
+          <button
+            v-if="hasFilters"
+            @click="clearFilters"
+            class="h-10 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-secondary hover:text-text-primary hover:border-primary transition-colors flex-shrink-0"
+            title="Limpiar filtros"
+            aria-label="Limpiar filtros"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
+          </button>
+          <button
+            type="button"
+            @click="showCreateModal = true"
+            class="h-10 px-4 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 transition-colors flex-shrink-0 whitespace-nowrap"
+            aria-label="Crear nuevo cliente"
+          >
+            + Nuevo cliente
+          </button>
+        </div>
+      </ClientOnly>
 
       <!-- Table loading (filter change, no cached data yet) -->
       <div v-if="isRefreshing && customers.length === 0" class="flex items-center justify-center min-h-[200px]">

--- a/pages/analitica/cocina.vue
+++ b/pages/analitica/cocina.vue
@@ -11,29 +11,6 @@
           Métricas de desempeño y eficiencia de las estaciones de preparación.
         </p>
       </div>
-
-      <div class="flex items-center gap-3">
-        <VueDatePicker
-          v-model="dateRangeDates"
-          range
-          :enable-time-picker="false"
-          :preset-dates="presetDates"
-          auto-apply
-          :timezone="timezone"
-          :max-date="maxDate"
-          :format="formatDateRange"
-          placeholder="Seleccionar periodo"
-          class="min-w-[280px]"
-          @update:model-value="fetchMetrics"
-        />
-        <button 
-          @click="fetchMetrics" 
-          class="p-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
-          :class="{ 'animate-spin': loading }"
-        >
-          <Icon name="lucide:refresh-cw" class="w-5 h-5 text-gray-600 dark:text-gray-400" />
-        </button>
-      </div>
     </div>
 
     <div v-if="loading && !metrics" class="flex items-center justify-center py-20">
@@ -78,6 +55,29 @@
           <div class="text-3xl font-bold text-green-500">{{ 100 - metrics.summary.late_pct }}%</div>
           <div class="text-xs text-gray-500 mt-1">Basado en umbrales de alerta</div>
         </div>
+      </div>
+
+      <div class="flex items-center gap-3 w-full overflow-x-auto">
+        <VueDatePicker
+          v-model="dateRangeDates"
+          range
+          :enable-time-picker="false"
+          :preset-dates="presetDates"
+          auto-apply
+          :timezone="timezone"
+          :max-date="maxDate"
+          :format="formatDateRange"
+          placeholder="Seleccionar periodo"
+          class="min-w-[280px]"
+          @update:model-value="fetchMetrics"
+        />
+        <button
+          @click="fetchMetrics"
+          class="p-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors flex-shrink-0"
+          :class="{ 'animate-spin': loading }"
+        >
+          <Icon name="lucide:refresh-cw" class="w-5 h-5 text-gray-600 dark:text-gray-400" />
+        </button>
       </div>
 
       <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/pages/analitica/ingredientes.vue
+++ b/pages/analitica/ingredientes.vue
@@ -7,6 +7,38 @@
     <CommonsTheErrorState v-else-if="fetchError" />
 
     <template v-else>
+      <section class="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4 mb-6">
+        <MetricCard
+          title="Ingredientes"
+          :value="summary.totalIngredients"
+          format="number"
+          variant="primary"
+          :subtitle="summary.periodLabel"
+        />
+        <MetricCard
+          title="Costo estimado"
+          :value="summary.estimatedCostLabel"
+          format="text"
+          variant="primary"
+          :subtitle="`${summary.movementCount} movimientos`"
+        />
+        <MetricCard
+          title="Con consumo"
+          :value="summary.recordedRows"
+          format="number"
+          variant="primary"
+          :subtitle="`${summary.coveragePct}% con movimientos`"
+        />
+        <MetricCard
+          title="Variación costo"
+          :value="summary.avgCostVariationPct"
+          format="percentage"
+          :precision="1"
+          variant="primary"
+          subtitle="Último vs promedio base"
+        />
+      </section>
+
       <UiAdvancedFiltersBar
         v-model:search="localSearchTerm"
         v-model:date-range="dateRangeDates"
@@ -21,7 +53,7 @@
         <template #additional-filters>
           <select
             v-model="ingredientFilter"
-            :class="filterSelectClassFor(ingredientFilter)"
+            :class="[filterSelectClass, 'w-full sm:w-52 md:hidden']"
             aria-label="Filtrar por ingrediente"
           >
             <option value="">Ingrediente</option>
@@ -32,7 +64,7 @@
 
           <select
             v-model="categoryFilter"
-            :class="filterSelectClassFor(categoryFilter)"
+            :class="[filterSelectClass, 'w-full sm:w-40 md:hidden']"
             aria-label="Filtrar por categoría"
           >
             <option value="">Categoría</option>
@@ -43,7 +75,7 @@
 
           <select
             v-model="sortOption"
-            :class="filterSelectClassFor(sortOption, { active: true })"
+            :class="[filterSelectClass, 'w-full sm:w-56 md:hidden']"
             aria-label="Ordenar ingredientes"
           >
             <option v-for="option in sortOptions" :key="option.value" :value="option.value">
@@ -53,42 +85,6 @@
         </template>
       </UiAdvancedFiltersBar>
 
-      <section class="grid grid-cols-2 gap-3 md:grid-cols-4 md:gap-4">
-        <MetricCard
-          title="Ingredientes"
-          :value="summary.totalIngredients"
-          format="number"
-          variant="primary"
-          size="sm"
-          :subtitle="summary.periodLabel"
-        />
-        <MetricCard
-          title="Costo estimado"
-          :value="summary.estimatedCostLabel"
-          format="text"
-          variant="warning"
-          size="sm"
-          :subtitle="`${summary.movementCount} movimientos`"
-        />
-        <MetricCard
-          title="Con consumo"
-          :value="summary.recordedRows"
-          format="number"
-          variant="success"
-          size="sm"
-          :subtitle="`${summary.coveragePct}% con movimientos`"
-        />
-        <MetricCard
-          title="Variación costo"
-          :value="summary.avgCostVariationPct"
-          format="percentage"
-          :precision="1"
-          :variant="summary.avgCostVariationPct > 10 ? 'warning' : 'info'"
-          size="sm"
-          subtitle="Último vs promedio base"
-        />
-      </section>
-
       <UiResponsiveDataView
         row-size="sm"
         :columns="ingredientTableColumns"
@@ -96,7 +92,11 @@
         item-key="ingredient_id"
         empty-message="No hay consumo de ingredientes"
         empty-sub-message="No se encontraron movimientos de consumo o compras para el periodo seleccionado"
+        :sort-field="tableSortField"
+        :sort-direction="tableSortDirection"
         variant="default"
+        @sort="handleTableSort"
+        @row-click="openIngredientMovements"
       >
         <template #card="{ item, index }">
           <div
@@ -121,15 +121,78 @@
             <div class="flex flex-col items-end gap-1 flex-shrink-0">
               <span class="text-sm font-bold text-text-primary">{{ formatCurrency(item.estimated_consumed_cost) }}</span>
               <span class="text-xs text-text-secondary">{{ formatUnitCost(item.weighted_avg_cost_per_unit, item.unit) }}</span>
+              <NuxtLink
+                :to="ingredientMovementsPath(item.ingredient_id)"
+                class="mt-1 text-xs font-semibold text-primary hover:text-primary/80 transition-colors"
+                aria-label="Ver movimientos del ingrediente"
+              >
+                Ver movimientos
+              </NuxtLink>
             </div>
           </div>
+        </template>
+
+        <template #header-ingredient_name>
+          <UiTableHeaderFilter
+            v-model="ingredientFilter"
+            title="Ingrediente"
+            column-key="ingredient_name"
+            sortable
+            :sort-field="tableSortField"
+            :sort-direction="tableSortDirection"
+            filter-type="select"
+            :options="ingredientHeaderOptions"
+            all-label="Ingrediente"
+            align="left"
+            @sort="handleTableSort"
+          />
+        </template>
+
+        <template #header-category>
+          <UiTableHeaderFilter
+            v-model="categoryFilter"
+            title="Categoría"
+            filter-type="select"
+            :options="categoryHeaderOptions"
+            all-label="Categoría"
+            align="left"
+          />
+        </template>
+
+        <template #header-consumed_quantity>
+          <UiTableHeaderFilter
+            title="Consumo"
+            column-key="consumed_quantity"
+            sortable
+            :sort-field="tableSortField"
+            :sort-direction="tableSortDirection"
+            filter-type="none"
+            align="right"
+            @sort="handleTableSort"
+          />
+        </template>
+
+        <template #header-estimated_consumed_cost>
+          <UiTableHeaderFilter
+            title="Costo estimado"
+            column-key="estimated_consumed_cost"
+            sortable
+            :sort-field="tableSortField"
+            :sort-direction="tableSortDirection"
+            filter-type="none"
+            align="right"
+            @sort="handleTableSort"
+          />
         </template>
 
         <template #cell-ingredient_name="{ item }">
           <div class="min-w-0">
             <span class="text-sm font-bold text-text-primary">{{ item.ingredient_name }}</span>
-            <p class="text-xs text-text-secondary">{{ item.category || 'Sin categoría' }}</p>
           </div>
+        </template>
+
+        <template #cell-category="{ value }">
+          <span class="text-sm text-text-secondary">{{ value || 'Sin categoría' }}</span>
         </template>
 
         <template #cell-consumed_quantity="{ item }">
@@ -175,6 +238,22 @@
             size="sm"
           />
         </template>
+
+        <template #cell-actions="{ row }">
+          <div class="flex justify-center">
+            <NuxtLink
+              :to="ingredientMovementsPath(row.ingredient_id)"
+              class="inline-flex h-8 w-8 items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-surface-secondary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary"
+              title="Ver movimientos"
+              aria-label="Ver movimientos del ingrediente"
+              @click.stop
+            >
+              <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5h6M9 9h6M9 13h6m-8 6h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+            </NuxtLink>
+          </div>
+        </template>
       </UiResponsiveDataView>
     </template>
   </div>
@@ -186,7 +265,7 @@ import { es } from 'date-fns/locale'
 import { formatDistanceToNow } from 'date-fns'
 import MetricCard from '~/components/shared/MetricCard.vue'
 import { INGREDIENTS_FETCH_LIMIT } from '@/composables/useMenuIngredients'
-import { filterSelectClassFor } from '~/composables/useFilterSelectClass'
+import { filterSelectClass } from '~/composables/useFilterSelectClass'
 import { useFormatters } from '~/composables/useFormatters'
 import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 
@@ -230,6 +309,23 @@ const sortOptions = [
   { value: 'ingredient_name_asc', label: 'Ingrediente A-Z' },
 ]
 
+const SORT_TO_TABLE: Record<string, { field: string; direction: 'asc' | 'desc' }> = {
+  estimated_consumed_cost_desc: { field: 'estimated_consumed_cost', direction: 'desc' },
+  estimated_consumed_cost_asc: { field: 'estimated_consumed_cost', direction: 'asc' },
+  consumed_quantity_desc: { field: 'consumed_quantity', direction: 'desc' },
+  consumed_quantity_asc: { field: 'consumed_quantity', direction: 'asc' },
+  ingredient_name_asc: { field: 'ingredient_name', direction: 'asc' },
+  ingredient_name_desc: { field: 'ingredient_name', direction: 'desc' },
+  latest_cost_per_unit_desc: { field: 'latest_cost_per_unit', direction: 'desc' },
+  weighted_avg_cost_per_unit_desc: { field: 'weighted_avg_cost_per_unit', direction: 'desc' },
+}
+
+const TABLE_SORT_TO_API: Record<string, { asc: string; desc: string }> = {
+  ingredient_name: { asc: 'ingredient_name_asc', desc: 'ingredient_name_desc' },
+  consumed_quantity: { asc: 'consumed_quantity_asc', desc: 'consumed_quantity_desc' },
+  estimated_consumed_cost: { asc: 'estimated_consumed_cost_asc', desc: 'estimated_consumed_cost_desc' },
+}
+
 const hasActiveFilters = computed(
   () =>
     !!localSearchTerm.value
@@ -241,6 +337,21 @@ const hasActiveFilters = computed(
 )
 
 const performSearch = () => applySearch()
+
+function handleTableSort(event: string | { field: string; direction?: 'asc' | 'desc' }) {
+  const field = typeof event === 'string' ? event : event.field
+  const supportedSort = TABLE_SORT_TO_API[field]
+  if (!supportedSort) return
+
+  const direction =
+    typeof event === 'object' && event.direction
+      ? event.direction
+      : tableSortField.value === field && tableSortDirection.value === 'asc'
+        ? 'desc'
+        : 'asc'
+
+  sortOption.value = supportedSort[direction]
+}
 
 const { data: ingredientsData } = useQuery({
   key: () => ['analytics', 'ingredients-lookup', currentTenant.value?.id],
@@ -266,6 +377,12 @@ const categories = computed(() => {
   })
   return Array.from(values).sort()
 })
+const ingredientHeaderOptions = computed(() =>
+  ingredients.value.map((ingredient: any) => ({ label: ingredient.name, value: ingredient.id })),
+)
+const categoryHeaderOptions = computed(() =>
+  categories.value.map((category) => ({ label: category, value: category })),
+)
 
 const { data: analyticsData, error: fetchError, status: queryStatus, asyncStatus: queryAsyncStatus, refetch } = useQuery({
   key: () => ['analytics', 'ingredients-summary', currentTenant.value?.id, {
@@ -294,6 +411,9 @@ const period = computed(() => (analyticsData.value as any)?.data?.period ?? null
 const isLoading = computed(() => queryStatus.value === 'pending' && !analyticsData.value)
 const isRefreshing = computed(() => queryAsyncStatus.value === 'loading' && analyticsData.value != null)
 const lastUpdateText = computed(() => formatDistanceToNow(lastUpdate.value, { addSuffix: true, locale: es }))
+const tableSortState = computed(() => SORT_TO_TABLE[sortOption.value] ?? SORT_TO_TABLE.consumed_quantity_desc)
+const tableSortField = computed(() => tableSortState.value.field)
+const tableSortDirection = computed(() => tableSortState.value.direction)
 
 const displayRows = computed<DisplayRow[]>(() => {
   const q = appliedSearch.value.trim().toLowerCase()
@@ -365,6 +485,7 @@ const clearFilters = () => {
 
 const ingredientTableColumns = [
   { key: 'ingredient_name', title: 'Ingrediente', sortable: false, format: 'text', align: 'left' },
+  { key: 'category', title: 'Categoría', sortable: false, format: 'text', align: 'left' },
   { key: 'consumed_quantity', title: 'Consumo', sortable: false, format: 'text', align: 'right' },
   { key: 'estimated_consumed_cost', title: 'Costo estimado', sortable: false, format: 'text', align: 'right' },
   { key: 'weighted_avg_cost_per_unit', title: 'Costo prom.', sortable: false, format: 'text', align: 'right' },
@@ -372,7 +493,16 @@ const ingredientTableColumns = [
   { key: 'cost_trend', title: 'Tendencia', sortable: false, format: 'text', align: 'right' },
   { key: 'movement_count', title: 'Mov.', sortable: false, format: 'text', align: 'right' },
   { key: 'data_coverage', title: 'Cobertura', sortable: false, format: 'text', align: 'center' },
+  { key: 'actions', title: '', sortable: false, format: 'text', align: 'center' },
 ] as const
+
+function ingredientMovementsPath(ingredientId: string): string {
+  return `/abastecimiento/movimientos?ingredient_id=${encodeURIComponent(ingredientId)}`
+}
+
+function openIngredientMovements(row: DisplayRow): void {
+  navigateTo(ingredientMovementsPath(row.ingredient_id))
+}
 
 function costTrendPct(item: IngredientAnalyticsRow): number | null {
   const latest = Number(item.latest_cost_per_unit)

--- a/pages/analitica/rentabilidad.vue
+++ b/pages/analitica/rentabilidad.vue
@@ -147,38 +147,6 @@ onUnmounted(() => {
 
     <!-- Content -->
     <template v-else>
-      <!-- Date Filter -->
-      <ClientOnly>
-      <div class="flex items-center gap-2 w-full overflow-x-auto scrollbar-hide">
-        <VueDatePicker
-          v-model="dateRangeDates"
-          range
-          :preset-dates="presetDates"
-          :enable-time-picker="false"
-          :locale="es"
-          placeholder="Rango de fechas"
-          auto-apply
-          :teleport="true"
-          :timezone="timezone"
-          :max-date="maxDate"
-          :format="formatDateRange"
-          input-class-name="dp-custom-input"
-          menu-class-name="dp-custom-menu"
-          calendar-cell-class-name="dp-custom-cell"
-        />
-        <button
-          v-if="dateRangeDates"
-          @click="dateRangeDates = null"
-          class="h-10 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-secondary hover:text-text-primary hover:border-primary transition-colors flex-shrink-0"
-          title="Limpiar filtro"
-        >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
-      </div>
-      </ClientOnly>
-
       <section>
         <div :class="['grid grid-cols-2 gap-3 md:gap-4 mb-6', hasOperativeFoodCost ? 'md:grid-cols-5' : 'md:grid-cols-4']">
           <MetricCard
@@ -221,6 +189,38 @@ onUnmounted(() => {
             :subtitle="dogsSubtitle"
           />
         </div>
+
+        <!-- Date Filter -->
+        <ClientOnly>
+          <div class="flex items-center gap-2 w-full overflow-x-auto scrollbar-hide mb-6">
+            <VueDatePicker
+              v-model="dateRangeDates"
+              range
+              :preset-dates="presetDates"
+              :enable-time-picker="false"
+              :locale="es"
+              placeholder="Rango de fechas"
+              auto-apply
+              :teleport="true"
+              :timezone="timezone"
+              :max-date="maxDate"
+              :format="formatDateRange"
+              input-class-name="dp-custom-input"
+              menu-class-name="dp-custom-menu"
+              calendar-cell-class-name="dp-custom-cell"
+            />
+            <button
+              v-if="dateRangeDates"
+              @click="dateRangeDates = null"
+              class="h-10 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-secondary hover:text-text-primary hover:border-primary transition-colors flex-shrink-0"
+              title="Limpiar filtro"
+            >
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </ClientOnly>
 
         <!-- Rentabilidad Real -->
         <HealthSemaphore

--- a/pages/analitica/ventas.vue
+++ b/pages/analitica/ventas.vue
@@ -288,40 +288,6 @@ const formatCurrency = (value: number) =>
 
     <!-- Main Content -->
     <div v-else class="space-y-8 pb-20">
-      <!-- Filters Bar -->
-      <ClientOnly>
-      <div class="flex items-center gap-2 w-full overflow-x-auto scrollbar-hide">
-        <VueDatePicker
-          v-model="dateRangeDates"
-          range
-          :preset-dates="presetDates"
-          :enable-time-picker="false"
-          :locale="es"
-          placeholder="Rango de fechas"
-          auto-apply
-          :teleport="true"
-          :timezone="timezone"
-          :max-date="maxDate"
-          :format="formatDateRange"
-          input-class-name="dp-custom-input"
-          menu-class-name="dp-custom-menu"
-          calendar-cell-class-name="dp-custom-cell"
-        />
-        <select v-model="paymentMethodFilter" aria-label="Filtrar por método de pago" class="h-10 pl-3 pr-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer min-w-[130px] flex-shrink-0">
-          <option :value="null">Método pago</option>
-          <option v-for="group in paymentGroups" :key="group.slug" :value="group.slug">{{ group.name }}</option>
-        </select>
-        <select v-model="statusFilter" aria-label="Filtrar por estado" class="h-10 pl-3 pr-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer min-w-[120px] flex-shrink-0">
-          <option :value="null">Estado</option>
-          <option value="completed">Completadas</option>
-          <option value="cancelled">Canceladas</option>
-          <option value="pending">Pendientes</option>
-        </select>
-        <button v-if="dateRangeDates || paymentMethodFilter || statusFilter" @click="clearFilters" class="h-10 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-secondary hover:text-text-primary hover:border-primary transition-colors flex-shrink-0" title="Limpiar filtros" aria-label="Limpiar filtros">
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
-        </button>
-      </div>
-      </ClientOnly>
       <section>
         <div :class="['grid grid-cols-2 gap-3 md:gap-4 mb-6', tipEnabled ? 'md:grid-cols-5' : 'md:grid-cols-4']">
           <MetricCard title="Ventas Brutas" :value="metrics.total_sales" format="currency" variant="primary" />
@@ -347,6 +313,41 @@ const formatCurrency = (value: number) =>
           <MetricCard :title="metrics.standard_tax_label || 'INC 8%'" :value="metrics.total_standard_tax" format="currency" variant="primary" />
           <MetricCard :title="forecastLabel" :value="forecast" format="currency" variant="primary" :subtitle="forecastSubtitle" class="col-span-2 md:col-span-1" />
         </div>
+
+        <!-- Filters Bar -->
+        <ClientOnly>
+        <div class="flex items-center gap-2 w-full overflow-x-auto scrollbar-hide mb-6">
+          <VueDatePicker
+            v-model="dateRangeDates"
+            range
+            :preset-dates="presetDates"
+            :enable-time-picker="false"
+            :locale="es"
+            placeholder="Rango de fechas"
+            auto-apply
+            :teleport="true"
+            :timezone="timezone"
+            :max-date="maxDate"
+            :format="formatDateRange"
+            input-class-name="dp-custom-input"
+            menu-class-name="dp-custom-menu"
+            calendar-cell-class-name="dp-custom-cell"
+          />
+          <select v-model="paymentMethodFilter" aria-label="Filtrar por método de pago" class="h-10 pl-3 pr-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer min-w-[130px] flex-shrink-0">
+            <option :value="null">Método pago</option>
+            <option v-for="group in paymentGroups" :key="group.slug" :value="group.slug">{{ group.name }}</option>
+          </select>
+          <select v-model="statusFilter" aria-label="Filtrar por estado" class="h-10 pl-3 pr-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer min-w-[120px] flex-shrink-0">
+            <option :value="null">Estado</option>
+            <option value="completed">Completadas</option>
+            <option value="cancelled">Canceladas</option>
+            <option value="pending">Pendientes</option>
+          </select>
+          <button v-if="dateRangeDates || paymentMethodFilter || statusFilter" @click="clearFilters" class="h-10 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-secondary hover:text-text-primary hover:border-primary transition-colors flex-shrink-0" title="Limpiar filtros" aria-label="Limpiar filtros">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
+          </button>
+        </div>
+        </ClientOnly>
 
         <!-- Rentabilidad Teaser Banner -->
         <NuxtLink


### PR DESCRIPTION
## Summary
- Constrain the ingredient, category, and sort filter widths in Analítica > Ingredientes.
- Keeps the filter row aligned on desktop while still allowing mobile wrapping.

## Tests
- git diff --check
- Build not run; CSS-only follow-up from visual review.