### PR TITLE
Normalize fiscal document input in POS

### DIFF
--- a/components/pos/CustomerIdentificationModal.vue
+++ b/components/pos/CustomerIdentificationModal.vue
@@ -275,6 +275,7 @@
                       id="new-fiscal-id"
                       v-model="createForm.fiscal_id"
                       type="text"
+                      @input="createForm.fiscal_id = normalizeFiscalDocumentId(createForm.fiscal_id)"
                       :placeholder="createForm.fiscal_id_type === 'NIT' ? '900123456 (sin DV)' : '1063279307'"
                       :disabled="isCreating"
                       class="w-full px-4 py-3 border-2 border-border rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary text-text-primary bg-background text-base disabled:opacity-50"
@@ -371,6 +372,7 @@
                   id="edit-fiscal-id"
                   v-model="fiscalForm.fiscal_id"
                   type="text"
+                  @input="fiscalForm.fiscal_id = normalizeFiscalDocumentId(fiscalForm.fiscal_id)"
                   :placeholder="fiscalForm.fiscal_id_type === 'NIT' ? '900123456 (sin DV)' : '1063279307'"
                   :disabled="isCreating"
                   class="w-full px-4 py-3 border-2 border-border rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary text-text-primary bg-background text-base disabled:opacity-50"
@@ -436,6 +438,7 @@
 import { ref, computed, watch, nextTick } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
 import { $fetch } from 'ofetch'
+import { normalizeFiscalDocumentId } from '~/utils/fiscalDocument'
 import { posDebugLog, posDebugSerializeError } from '~/utils/posDebugLog'
 
 type FiscalIdType = 'CC' | 'NIT' | 'CE' | 'PA' | 'TI' | ''
@@ -709,7 +712,7 @@ const handleCreate = async () => {
   try {
     const fiscalPayload = wantsInvoice.value ? {
       fiscal_id_type: createForm.value.fiscal_id_type || null,
-      fiscal_id: createForm.value.fiscal_id?.trim() || null,
+      fiscal_id: normalizeFiscalDocumentId(createForm.value.fiscal_id) || null,
       fiscal_business_name: createForm.value.fiscal_business_name?.trim() || null,
       fiscal_email: createForm.value.email?.trim() || null,
     } : {}
@@ -755,7 +758,7 @@ const handleSaveFiscal = async () => {
         method: 'PATCH',
         body: {
           fiscal_id_type: fiscalForm.value.fiscal_id_type || null,
-          fiscal_id: fiscalForm.value.fiscal_id?.trim() || null,
+          fiscal_id: normalizeFiscalDocumentId(fiscalForm.value.fiscal_id) || null,
           fiscal_business_name: fiscalForm.value.fiscal_business_name?.trim() || null,
         },
       },

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -15,6 +15,7 @@ import DeliveryAddressForm from '~/components/pos/checkout/DeliveryAddressForm.v
 import { displayTableCode } from '~/composables/useTableDisplayCode'
 import { formatPromoTypeLabel } from '~/utils/promotionPreview'
 import { computePromoEligibleSubtotal, linePromoSavingsForProduct } from '~/utils/promoProductMatch'
+import { normalizeFiscalDocumentId } from '~/utils/fiscalDocument'
 import { posDebugLog, posDebugSerializeError } from '~/utils/posDebugLog'
 import { consolidateReceiptPrintLines } from '~/utils/receiptPrintLines'
 
@@ -219,7 +220,7 @@ const fiscalWizardForm = ref({
 })
 const fiscalWizardCanSubmit = computed(() => Boolean(
   fiscalWizardForm.value.fiscal_id_type
-    && fiscalWizardForm.value.fiscal_id.trim()
+    && normalizeFiscalDocumentId(fiscalWizardForm.value.fiscal_id)
     && fiscalWizardForm.value.fiscal_business_name.trim(),
 ))
 
@@ -2669,7 +2670,7 @@ const submitFiscalAndInvoice = async () => {
         method: 'PATCH',
         body: {
           fiscal_id_type: fiscalWizardForm.value.fiscal_id_type || null,
-          fiscal_id: fiscalWizardForm.value.fiscal_id.trim() || null,
+          fiscal_id: normalizeFiscalDocumentId(fiscalWizardForm.value.fiscal_id) || null,
           fiscal_business_name: fiscalWizardForm.value.fiscal_business_name.trim() || null,
         },
       },
@@ -4730,6 +4731,7 @@ onUnmounted(() => {
                 <input
                   v-model="fiscalWizardForm.fiscal_id"
                   type="text"
+                  @input="fiscalWizardForm.fiscal_id = normalizeFiscalDocumentId(fiscalWizardForm.fiscal_id)"
                   :placeholder="fiscalWizardForm.fiscal_id_type === 'NIT' ? '900123456 (sin DV)' : '1063279307'"
                   :disabled="fiscalWizardSaving"
                   class="w-full min-h-[44px] px-3 py-2 border-2 border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary text-text-primary bg-background text-sm disabled:opacity-50"

--- a/utils/fiscalDocument.ts
+++ b/utils/fiscalDocument.ts
@@ -1,0 +1,6 @@
+export function normalizeFiscalDocumentId(value: string | null | undefined): string {
+  return String(value ?? '')
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, '')
+}


### PR DESCRIPTION
## Summary
- Add a shared fiscal document normalization helper
- Clean customer fiscal document values while typing and before POST/PATCH from POS flows

## Tests
- NODE_OPTIONS=--max-old-space-size=8192 npm exec nuxi -- typecheck (fails on existing project-wide type errors; no new fiscal-document helper errors surfaced)