### PR TITLE
Front: enriquecer ticket FE y envío desde POS/ventas

### DIFF
--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -40,6 +40,13 @@ interface PromoLine {
   savings: number
 }
 
+interface InvoiceTaxLine {
+  label?: string | null
+  base?: number | string | null
+  rate?: number | string | null
+  amount?: number | string | null
+}
+
 const props = defineProps<{
   fiscalData?: {
     business_name?: string | null
@@ -84,6 +91,13 @@ const props = defineProps<{
     cufe?: string | null
     status?: string | null
     qrDataUrl?: string | null
+    issuedAt?: string | null
+    dianUrl?: string | null
+    resolutionText?: string | null
+    issuerLabel?: string | null
+    acquirerLabel?: string | null
+    paymentLabel?: string | null
+    taxLines?: InvoiceTaxLine[] | null
   } | null
 }>()
 
@@ -124,6 +138,64 @@ const hasSettlementBreakdown = computed(() =>
 const finalTotal = computed(() =>
   props.chargedTotal != null ? Number(props.chargedTotal) : Number(props.orderTotal) || 0,
 )
+
+const formatRate = (value: number | string | null | undefined) => {
+  if (value == null || value === '') return null
+  const numeric = Number(value)
+  if (Number.isFinite(numeric)) return `${numeric}%`
+  return String(value)
+}
+
+const invoiceNumberLabel = computed(() => {
+  const invoice = props.invoice
+  if (!invoice) return null
+  return [invoice.prefix, invoice.invoice_number].filter(Boolean).join('-') || null
+})
+
+const invoiceDianUrl = computed(() => {
+  const invoice = props.invoice
+  if (!invoice) return null
+  if (invoice.dianUrl) return invoice.dianUrl
+  return invoice.cufe
+    ? `https://catalogo-vpfe.dian.gov.co/document/searchqr?documentkey=${invoice.cufe}`
+    : null
+})
+
+const fallbackIssuerLabel = computed(() => {
+  const name = props.fiscalData?.business_name || props.displayName
+  const nit = props.fiscalData?.nit
+  if (name && nit) return `${name} - NIT ${nit}`
+  return name || (nit ? `NIT ${nit}` : null)
+})
+
+const fallbackAcquirerLabel = computed(() => {
+  if (props.customerName && props.customerFiscalLabel) return `${props.customerName} - ${props.customerFiscalLabel}`
+  return props.customerName || props.customerFiscalLabel || null
+})
+
+const invoicePaymentLabel = computed(() => {
+  if (props.invoice?.paymentLabel) return props.invoice.paymentLabel
+  if ((props.payments?.length ?? 0) > 0) {
+    return props.payments!.map(payment => payment.label).filter(Boolean).join(' + ') || null
+  }
+  return props.singlePaymentLabel || null
+})
+
+const invoiceTaxLines = computed(() => {
+  const explicit = (props.invoice?.taxLines ?? []).filter(line =>
+    line?.label || Number(line?.base) > 0 || Number(line?.amount) > 0,
+  )
+  if (explicit.length > 0) return explicit
+
+  const lines: InvoiceTaxLine[] = []
+  if (Number(props.standardTax) > 0) {
+    lines.push({ label: props.standardTaxLabel || 'Impuesto', amount: props.standardTax })
+  }
+  if (Number(props.liquorTax) > 0) {
+    lines.push({ label: 'IVA licores', rate: 5, amount: props.liquorTax })
+  }
+  return lines
+})
 
 const printableItems = computed(() =>
   consolidateReceiptPrintLines(props.items, {
@@ -293,10 +365,31 @@ const printableItems = computed(() =>
 
     <template v-if="invoice">
       <div class="receipt-divider">================================</div>
-      <div class="receipt-row" style="font-weight:bold;">FACTURA ELECTRONICA</div>
-      <div v-if="invoice.prefix || invoice.invoice_number" class="receipt-row">
-        {{ [invoice.prefix, invoice.invoice_number].filter(Boolean).join('-') }}
+      <div class="receipt-row" style="font-weight:bold;">FACTURA ELECTRONICA DE VENTA</div>
+      <div class="receipt-row receipt-small">Representacion impresa de factura electronica de venta</div>
+      <div v-if="invoiceNumberLabel" class="receipt-row" style="font-weight:bold;">{{ invoiceNumberLabel }}</div>
+      <div v-if="invoice.issuedAt" class="receipt-row receipt-small">Fecha emision DIAN: {{ invoice.issuedAt }}</div>
+      <div v-if="invoice.issuerLabel || fallbackIssuerLabel" class="receipt-row receipt-small">
+        Emisor: {{ invoice.issuerLabel || fallbackIssuerLabel }}
       </div>
+      <div v-if="invoice.acquirerLabel || fallbackAcquirerLabel" class="receipt-row receipt-small">
+        Adquirente: {{ invoice.acquirerLabel || fallbackAcquirerLabel }}
+      </div>
+      <div v-if="invoice.resolutionText" class="receipt-row receipt-small">{{ invoice.resolutionText }}</div>
+      <div v-if="invoicePaymentLabel" class="receipt-row receipt-small">Forma/medio de pago: {{ invoicePaymentLabel }}</div>
+      <template v-if="invoiceTaxLines.length > 0">
+        <div class="receipt-divider receipt-small">--------------------------------</div>
+        <div class="receipt-row receipt-small" style="font-weight:bold;">Detalle tributario</div>
+        <div
+          v-for="(line, idx) in invoiceTaxLines"
+          :key="`${line.label ?? 'tax'}-${idx}`"
+          class="receipt-tax-line receipt-small"
+        >
+          <span>{{ line.label || 'Impuesto' }}<template v-if="formatRate(line.rate)"> {{ formatRate(line.rate) }}</template></span>
+          <span v-if="Number(line.base) > 0">Base {{ money(line.base) }}</span>
+          <span>{{ money(line.amount) }}</span>
+        </div>
+      </template>
       <div v-if="invoice.cufe" class="receipt-row receipt-small receipt-cufe">
         CUFE: {{ invoice.cufe }}
       </div>
@@ -306,7 +399,7 @@ const printableItems = computed(() =>
         alt="QR verificacion DIAN"
         class="receipt-qr"
       >
-      <div v-if="invoice.cufe" class="receipt-row receipt-small">Verificar en DIAN</div>
+      <div v-if="invoiceDianUrl" class="receipt-row receipt-small">Verificar en DIAN</div>
       <div class="receipt-divider">================================</div>
     </template>
   </div>
@@ -350,6 +443,23 @@ const printableItems = computed(() =>
 .receipt-print-ticket .receipt-item span:last-child {
   white-space: nowrap;
   flex-shrink: 0;
+}
+
+.receipt-print-ticket .receipt-tax-line {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 3px;
+  margin: 2px 0;
+}
+
+.receipt-print-ticket .receipt-tax-line span:first-child {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.receipt-print-ticket .receipt-tax-line span:not(:first-child) {
+  white-space: nowrap;
+  text-align: right;
 }
 
 .receipt-print-ticket .receipt-total {
@@ -416,6 +526,7 @@ const printableItems = computed(() =>
 }
 
 @media print {
+  html,
   body.printing-receipt-ticket {
     margin: 0;
     padding: 0;
@@ -423,6 +534,14 @@ const printableItems = computed(() =>
 
   body.printing-receipt-ticket * {
     visibility: hidden;
+  }
+
+  body.printing-receipt-ticket #pos-receipt,
+  body.printing-receipt-ticket #pos-receipt *,
+  body.printing-receipt-ticket #pos-prefactura,
+  body.printing-receipt-ticket #pos-prefactura * {
+    display: none !important;
+    visibility: hidden !important;
   }
 
   body.printing-receipt-ticket .receipt-print-ticket,
@@ -441,9 +560,10 @@ const printableItems = computed(() =>
     background: #fff;
     box-sizing: border-box;
     padding: 0 1.5mm 14mm;
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
+    margin: 0 !important;
   }
 
   body.printing-receipt-ticket .receipt-print-ticket .receipt-logo {

--- a/components/ventas/InvoiceEmailModal.vue
+++ b/components/ventas/InvoiceEmailModal.vue
@@ -34,7 +34,7 @@ const emit = defineEmits<{
   (e: 'sent', email: string): void
 }>()
 
-const title = 'Enviar factura por correo'
+const title = 'Enviar factura electronica'
 
 // warocol.com#603 — A profile is "generic" (no useful email to prefill)
 // when either the phone is '0000000000' (per-tenant default Genérico) OR
@@ -138,7 +138,7 @@ const contentTemplate = () =>
                 h(
                   'p',
                   { class: 'text-xs text-green-800 dark:text-green-300 mt-0.5 leading-snug break-all' },
-                  `Se envió ${props.invoiceLabel} a ${sentToEmail.value}.`,
+                  `Se envio ${props.invoiceLabel} a ${sentToEmail.value}. Si el PDF/XML esta disponible, ira adjunto para soporte contable.`,
                 ),
               ]),
             ],
@@ -167,6 +167,19 @@ const contentTemplate = () =>
     // ─── Form (idle / sending / error) ──────────────────────────────────────
     state.value !== 'sent'
       ? h('div', { class: 'space-y-4' }, [
+          h(
+            'div',
+            { class: 'rounded-xl border border-border bg-surface-secondary/60 p-3' },
+            [
+              h('p', { class: 'text-sm font-semibold text-text-primary' }, `Factura ${props.invoiceLabel}`),
+              h(
+                'p',
+                { class: 'text-xs text-text-secondary mt-1 leading-snug' },
+                'Envia una copia fiscal al cliente o al contador. La factura aceptada puede incluir PDF y XML cuando esten disponibles.',
+              ),
+            ],
+          ),
+
           // Generic-customer hint banner
           isGenericCustomer.value
             ? h(
@@ -177,7 +190,7 @@ const contentTemplate = () =>
                   h(
                     'p',
                     { class: 'text-xs text-amber-800 dark:text-amber-300 leading-snug' },
-                    'Cliente genérico — sin correo en archivo. Indicá un destinatario.',
+                    'Cliente generico - sin correo en archivo. Indica un destinatario para enviar la factura.',
                   ),
                 ],
               )
@@ -250,11 +263,11 @@ const contentTemplate = () =>
                     },
                   ),
                   h('div', { class: 'min-w-0 flex-1' }, [
-                    h('p', { class: 'text-sm font-semibold text-text-primary' }, 'Otro correo'),
+                    h('p', { class: 'text-sm font-semibold text-text-primary' }, 'Correo contable u otro'),
                     h(
                       'p',
                       { class: 'text-xs text-text-secondary mt-0.5' },
-                      'Enviar a una dirección distinta',
+                      'Enviar a contador, administracion o una direccion distinta',
                     ),
                   ]),
                 ],

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -56,6 +56,13 @@ function formatTenantDateTime(date = new Date()) {
   })
 }
 
+function formatOptionalTenantDateTime(value?: string | Date | null) {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  return formatTenantDateTime(date)
+}
+
 function invalidateCheckoutPromoPreview() {
   cache.invalidateQueries({ key: ['pos', 'cart', posStore.cartId ?? null, 'tax-preview'] })
   if (isKitchenServiceMode.value && posStore.activeTableSession?.tableId) {
@@ -180,11 +187,12 @@ const isReadinessLoading = computed(() => !settingsData.value)
 
 // Invoice state
 const invoiceLoading = ref(false)
-const invoiceResult = ref<{ cufe: string; invoice_number: number; prefix: string; pdf_presigned_url: string | null; status: string } | null>(null)
+const invoiceResult = ref<{ cufe: string; invoice_number: number; prefix: string; pdf_presigned_url: string | null; status: string; emitted_at?: string | null; created_at?: string | null } | null>(null)
 const invoiceError = ref('')
 const invoiceQrDataUrl = ref('')
 const invoiceProgress = ref('')
 const invoiceResults = ref<{ order_id: string; prefix: string; invoice_number: number; cufe: string; status: string; error?: string }[]>([])
+const showInvoiceEmailModal = ref(false)
 
 const extractInvoiceFetchError = (e: any) =>
   e?.data?.detail || e?.data?.message || e?.message || 'Error al generar factura'
@@ -2330,6 +2338,8 @@ const generateInvoice = async () => {
             prefix: result.prefix,
             pdf_presigned_url: result.pdf_presigned_url || null,
             status: result.status,
+            emitted_at: result.emitted_at || null,
+            created_at: result.created_at || null,
           }
           if (result.cufe) {
             invoiceQrDataUrl.value = await buildInvoiceQrDataUrl(result.cufe)
@@ -2382,7 +2392,14 @@ const printReceipt = async () => {
     invoiceQrDataUrl.value = await buildInvoiceQrDataUrl(invoiceResult.value.cufe)
   }
   await nextTick()
+  document.body.classList.add('printing-receipt-ticket')
+  const cleanup = () => {
+    document.body.classList.remove('printing-receipt-ticket')
+    window.removeEventListener('afterprint', cleanup)
+  }
+  window.addEventListener('afterprint', cleanup)
   window.print()
+  setTimeout(cleanup, 1500)
 }
 
 // Issue #535 — tenant fiscal data for the prefactura header.
@@ -2522,6 +2539,105 @@ const receiptPromoBreakdown = computed(() => {
   if (savings <= 0) return []
   return [{ promotion_name: 'Promoción', promo_type: '', savings }]
 })
+
+const receiptPaymentLines = computed(() =>
+  splitPaymentsSnapshot.value.map(payment => ({
+    id: payment.id,
+    label: payment.payment_method_name,
+    amount: Number(payment.amount) || 0,
+    change: Number(payment.change) || null,
+  })),
+)
+
+const receiptSinglePaymentLabel = computed(() => {
+  const result = orderResult.value
+  if (!result?.payment_method) return null
+  return result.payment_method_name
+    ? `${getPaymentMethodLabel(result.payment_method)} · ${result.payment_method_name}`
+    : getPaymentMethodLabel(result.payment_method)
+})
+
+const receiptLocationLabel = computed(() => {
+  const context = receiptPrintContext.value
+  if (!context) return null
+  if (context.wasMesa && context.tableName) return `${tableSingular.value} ${context.tableCode} - ${context.tableName}`
+  if (context.isBar) return 'Barra'
+  return 'Mostrador'
+})
+
+const receiptCustomerFiscalLabel = computed(() => {
+  const context = receiptPrintContext.value
+  if (!context?.customerFiscalId) return null
+  return [context.customerFiscalIdType, context.customerFiscalId].filter(Boolean).join(': ')
+})
+
+const receiptInvoiceIssuedAt = computed(() =>
+  formatOptionalTenantDateTime(invoiceResult.value?.emitted_at || invoiceResult.value?.created_at) || receiptPrintContext.value?.soldAt || null,
+)
+
+const receiptInvoiceTaxLines = computed(() => {
+  const result = orderResult.value
+  if (!result) return []
+  return [
+    {
+      label: result.standard_tax_label || 'Impuesto',
+      amount: Number(result.standard_tax) || 0,
+    },
+    {
+      label: 'IVA licores',
+      rate: 5,
+      amount: Number(result.liquor_tax) || 0,
+    },
+  ].filter(line => Number(line.amount) > 0)
+})
+
+const receiptInvoice = computed(() => {
+  const invoice = invoiceResult.value
+  if (!invoice) return null
+  return {
+    prefix: invoice.prefix,
+    invoice_number: invoice.invoice_number,
+    cufe: invoice.cufe,
+    status: invoice.status,
+    qrDataUrl: invoiceQrDataUrl.value,
+    issuedAt: receiptInvoiceIssuedAt.value,
+    paymentLabel: receiptSinglePaymentLabel.value,
+    taxLines: receiptInvoiceTaxLines.value,
+  }
+})
+
+const singleAcceptedInvoiceOrderId = computed(() => {
+  if (invoiceResult.value?.status !== 'accepted') return null
+  const ids = orderResult.value?.order_id
+    ? [orderResult.value.order_id]
+    : (orderResult.value?.order_ids ?? [])
+  if (ids.length !== 1) return null
+  if (invoiceResults.value.length > 0) {
+    const current = invoiceResults.value.find(result => result.order_id === ids[0])
+    if (!current || current.status !== 'accepted') return null
+  }
+  return ids[0]
+})
+
+const posInvoiceEmailCustomer = computed(() => {
+  const customer = selectedCustomer.value
+  if (!customer) return null
+  return {
+    name: customer.fiscal_business_name || customer.name || null,
+    phone: customer.phone_number,
+    email: customer.fiscal_email || customer.email,
+  }
+})
+
+const posInvoiceLabel = computed(() =>
+  invoiceResult.value
+    ? [invoiceResult.value.prefix, invoiceResult.value.invoice_number].filter(Boolean).join('-')
+    : '',
+)
+
+const onPosInvoiceEmailSent = (email: string) => {
+  toast.success(`Factura enviada a ${email}`, { title: 'Enviado' })
+}
 
 function capturePrefacturaPrintSnapshot() {
   prefacturaPrintSnapshot.value = {
@@ -4787,12 +4903,20 @@ onUnmounted(() => {
             <!-- Success — show ONLY invoice number -->
             <div
               v-else-if="invoiceResult?.prefix && invoiceResult?.invoice_number"
-              class="rounded-lg border border-state-success-border bg-state-success-bg p-3 text-center"
+              class="rounded-lg border border-state-success-border bg-state-success-bg p-3 text-center space-y-2"
             >
               <p class="text-xs font-semibold text-state-success-text">Factura generada</p>
               <p class="text-sm font-semibold text-state-success-text mt-1">
                 {{ invoiceResult.prefix }}-{{ invoiceResult.invoice_number }}
               </p>
+              <button
+                v-if="singleAcceptedInvoiceOrderId"
+                type="button"
+                @click="showInvoiceEmailModal = true"
+                class="mx-auto min-h-[36px] px-3 py-1.5 rounded-lg text-xs font-semibold border border-state-success-border bg-surface text-state-success-text hover:bg-state-success-bg transition-colors"
+              >
+                Enviar factura por correo
+              </button>
             </div>
 
             <!-- Error -->
@@ -4897,6 +5021,49 @@ onUnmounted(() => {
         </div>
       </div>
     </Teleport>
+
+    <VentasInvoiceEmailModal
+      v-if="singleAcceptedInvoiceOrderId"
+      v-model:open="showInvoiceEmailModal"
+      :order-id="singleAcceptedInvoiceOrderId"
+      :invoice-label="posInvoiceLabel"
+      :customer="posInvoiceEmailCustomer"
+      @sent="onPosInvoiceEmailSent"
+    />
+
+    <PosReceiptPrintTicket
+      v-if="orderResult"
+      :fiscal-data="fiscalData"
+      :display-name="businessProfile?.display_name"
+      :address="businessProfile?.address"
+      :city="businessProfile?.city"
+      :phone="businessProfile?.phone_number"
+      :logo-url="receiptLogoUrl"
+      :document-label="receiptDocumentLabel"
+      :order-number="orderResult.order_number"
+      :sold-at="receiptPrintContext?.soldAt"
+      :location-label="receiptLocationLabel"
+      :waiter-name="receiptPrintContext?.waiterName"
+      :customer-name="receiptPrintContext?.customerName"
+      :customer-fiscal-label="receiptCustomerFiscalLabel"
+      :items="printableReceiptItems"
+      :subtotal="orderResult.subtotal"
+      :promo-breakdown="receiptPromoBreakdown"
+      :discount-amount="Number(orderResult.discount_amount) || 0"
+      :waro-discount-label="orderResultWaroLineLabel"
+      :waro-discount-amount="orderResultWaroDiscountCop"
+      :standard-tax-label="orderResult.standard_tax_label"
+      :standard-tax="Number(orderResult.standard_tax) || 0"
+      :liquor-tax="Number(orderResult.liquor_tax) || 0"
+      :order-total="Number(orderResult.total_amount) || 0"
+      :tip-label="receiptTipLabel"
+      :tip-amount="Number(orderResult.tip_amount) || 0"
+      :advance-applied="Number(orderResult.advance_applied) || 0"
+      :charged-total="orderResultChargedAmount"
+      :payments="receiptPaymentLines"
+      :single-payment-label="receiptSinglePaymentLabel"
+      :invoice="receiptInvoice"
+    />
 
   <!-- Issue #535 — Hidden prefactura for printing.
        Only visible via @media print + body class .printing-prefactura.

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -527,6 +527,22 @@ const saleReceiptSinglePaymentLabel = computed(() => {
   return resolveLabel(o.payment_method, o.payment_method_id)
 })
 
+const saleReceiptInvoiceTaxLines = computed(() => {
+  const o = order.value
+  if (!o) return []
+  return [
+    {
+      label: o.standard_tax_label || 'Impuesto',
+      amount: Number(o.standard_tax) || 0,
+    },
+    {
+      label: 'IVA licores',
+      rate: 5,
+      amount: Number(o.liquor_tax) || 0,
+    },
+  ].filter(line => Number(line.amount) > 0)
+})
+
 const saleReceiptInvoice = computed(() => {
   if (!invoiceData.value) return null
   return {
@@ -535,6 +551,9 @@ const saleReceiptInvoice = computed(() => {
     cufe: invoiceData.value.cufe,
     status: invoiceData.value.status,
     qrDataUrl: invoiceQrDataUrl.value,
+    issuedAt: invoiceData.value.emitted_at ? formatDate(invoiceData.value.emitted_at) : null,
+    paymentLabel: saleReceiptSinglePaymentLabel.value,
+    taxLines: saleReceiptInvoiceTaxLines.value,
   }
 })
 


### PR DESCRIPTION
## Summary
- Enrich the shared printed electronic invoice block with representation text, issuer/acquirer, issue date, payment and tax details when available.
- Use the shared receipt ticket for POS printing and expose FE email from POS only for a single accepted invoice.
- Update invoice email modal copy for accountant/PDF/XML use.

## Tests
- npx nuxi prepare
- npm run build (stopped after user asked to stop build-only validation; first run reached SSR and failed because local node_modules was missing destr, then npm install restored dependencies)

Closes #1587