### PR TITLE
Fix FE receipt print layout

### DIFF
--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -560,9 +560,11 @@ const printableItems = computed(() =>
     background: #fff;
     box-sizing: border-box;
     padding: 0 1.5mm 14mm;
-    position: fixed;
-    top: 0;
+    position: absolute;
+    top: 4mm;
     left: 0;
+    max-height: none !important;
+    overflow: visible !important;
     margin: 0 !important;
   }
 

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -5434,10 +5434,19 @@ onUnmounted(() => {
     padding: 0;
   }
 
-  /* Hide everything, then reveal only the receipt (default — post-payment). */
+  /* Hide everything, then reveal only the legacy receipt unless the shared
+     receipt component is driving this print job. */
   body * { visibility: hidden; }
-  #pos-receipt,
-  #pos-receipt * { visibility: visible; }
+  body:not(.printing-receipt-ticket) #pos-receipt,
+  body:not(.printing-receipt-ticket) #pos-receipt * { visibility: visible; }
+
+  body.printing-receipt-ticket #pos-receipt,
+  body.printing-receipt-ticket #pos-receipt *,
+  body.printing-receipt-ticket #pos-prefactura,
+  body.printing-receipt-ticket #pos-prefactura * {
+    display: none !important;
+    visibility: hidden !important;
+  }
 
   /* Issue #535 — when body has .printing-prefactura class, swap which
      printable div is visible. The receipt path stays the default. */
@@ -5465,6 +5474,8 @@ onUnmounted(() => {
 
   /* Hide each by default; the body class toggles which is shown. */
   #pos-prefactura { display: none !important; }
+  body.printing-receipt-ticket #pos-receipt,
+  body.printing-receipt-ticket #pos-prefactura { display: none !important; }
   body.printing-prefactura #pos-receipt { display: none !important; }
   body.printing-prefactura #pos-prefactura { display: block !important; }
 

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -606,10 +606,13 @@ const printReceipt = async () => {
 
   document.body.classList.add('printing-receipt-ticket')
   await nextTick()
-  window.print()
-  window.setTimeout(() => {
+  const cleanup = () => {
     document.body.classList.remove('printing-receipt-ticket')
-  }, 250)
+    window.removeEventListener('afterprint', cleanup)
+  }
+  window.addEventListener('afterprint', cleanup)
+  window.print()
+  window.setTimeout(cleanup, 1500)
 }
 
 // Edit mode functions


### PR DESCRIPTION
## Summary
- Add top offset and visible overflow to the shared FE receipt print container
- Prevent POS legacy #pos-receipt print CSS from competing with the shared receipt print mode
- Align ventas print cleanup timing with POS afterprint/fallback behavior

## Tests
- git diff --check
- Not run: npm run build (requested sin build)
- Manual pending: print preview in /pos/checkout and /ventas/dbdcda32-286f-4450-8333-582446c9cc96

Closes #1590