### PR TITLE
feat(gastos): progressive loading on create/edit like productos

### DIFF
--- a/pages/finanzas.vue
+++ b/pages/finanzas.vue
@@ -1,17 +1,31 @@
 <template>
   <div class="flex flex-col gap-3 md:gap-4">
     <UiModuleNavigation :navigation-items="navigationItems" />
-    <NuxtPage :key="route.fullPath" />
+    <!-- Key by section (/finanzas/gastos, /finanzas/pagos, …) so create/edit
+         within a section does not force a full remount of the shell. -->
+    <NuxtPage :key="sectionKey" />
   </div>
 </template>
 
 <script setup lang="ts">
 const route = useRoute()
+const lastFinanzasPath = useState<string | null>('finanzas-last-path', () => null)
 
 definePageMeta({
   layout: 'dashboard',
   module: 'finanzas',
 })
+
+// Same pattern as menu.vue: first 3 path segments = section root
+// e.g. /finanzas/gastos/crear and /finanzas/gastos/:id share /finanzas/gastos
+const sectionKey = computed(() => route.path.split('/').slice(0, 3).join('/'))
+
+watch(
+  () => route.fullPath,
+  (_currentPath, previousPath) => {
+    lastFinanzasPath.value = previousPath ?? null
+  }
+)
 
 const navigationItems = [
   { to: '/finanzas/arqueo',           label: 'Arqueo de caja' },

--- a/pages/finanzas/gastos/[id]/editar.vue
+++ b/pages/finanzas/gastos/[id]/editar.vue
@@ -156,6 +156,7 @@
 </template>
 
 <script setup lang="ts">
+import { useQuery, useQueryCache } from '@pinia/colada'
 import { usePaymentMethods } from '~/composables/usePaymentMethods'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
@@ -164,6 +165,7 @@ const route = useRoute()
 const expenseId = route.params.id as string
 
 const { currentTenant } = useTenantReactive()
+const cache = useQueryCache()
 
 // Payment methods
 const { paymentGroups, fetchPaymentMethods } = usePaymentMethods()
@@ -172,32 +174,30 @@ fetchPaymentMethods()
 // State
 const isSubmitting = ref(false)
 
-// Load categories
-const { data: categoriesData } = await useAsyncData(
-  `expense-categories-${currentTenant.value?.id || 'default'}`,
-  () => $fetch('/api/finance/expenses/categories'),
-  {
-    server: false,
-    default: () => ({ data: [] })
-  }
-)
+// Shared Colada key with list → cache hit when navigating from index
+const { data: categoriesData } = useQuery({
+  key: () => ['finance', 'expense-categories', currentTenant.value?.id],
+  query: () => $fetch('/api/finance/expenses/categories'),
+  enabled: () => !!currentTenant.value,
+  staleTime: 30_000,
+})
 
 const categories = computed(() => {
-  const data = categoriesData.value
+  const data = categoriesData.value as any
   if (!data) return []
   return Array.isArray(data) ? data : (data.data || [])
 })
 
-// Fetch expense data
-const { data: expenseData, pending: isLoading, error: fetchError } = await useAsyncData(
-  `expense-edit-${expenseId}`,
-  () => $fetch(`/api/finance/expenses/${expenseId}`),
-  {
-    server: false
-  }
-)
+// Shared key with detail page → open edit with cached expense (optimistic)
+const { data: expenseData, error: fetchError } = useQuery({
+  key: () => ['expense', expenseId],
+  query: () => $fetch(`/api/finance/expenses/${expenseId}`),
+  staleTime: 30_000,
+})
 
-const expense = computed(() => expenseData.value?.data)
+const expense = computed(() => (expenseData.value as any)?.data)
+// Full-page loader only when no cache yet
+const isLoading = computed(() => !expenseData.value && !fetchError.value)
 
 // Form state
 const form = reactive({
@@ -267,8 +267,10 @@ const handleSubmit = async () => {
       body: payload
     })
 
-    // Success - redirect to detail
-    navigateTo(`/finanzas/gastos/${expenseId}`)
+    // Invalidate list + detail so return path progressive-refreshes (like productos)
+    cache.invalidateQueries({ key: ['finance', 'expenses'] })
+    cache.invalidateQueries({ key: ['expense', expenseId] })
+    await navigateTo(`/finanzas/gastos/${expenseId}`)
   } catch (error: any) {
     console.error('Error updating expense:', error)
 

--- a/pages/finanzas/gastos/[id]/index.vue
+++ b/pages/finanzas/gastos/[id]/index.vue
@@ -670,7 +670,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useQuery } from '@pinia/colada'
+import { useQuery, useQueryCache } from '@pinia/colada'
 import { usePaymentMethods } from '~/composables/usePaymentMethods'
 import { usePaymentLabel } from '~/composables/usePaymentLabel'
 import { useFormatters } from '~/composables/useFormatters'
@@ -681,6 +681,7 @@ const route = useRoute()
 const expenseId = route.params.id as string
 
 const { currentTenant } = useTenantReactive()
+const cache = useQueryCache()
 
 // Payment methods
 const { paymentGroups, isLoading: pmGroupsLoading, fetchPaymentMethods } = usePaymentMethods()
@@ -701,18 +702,16 @@ const attachmentsToRemove = ref<string[]>([])
 const fileInput = ref<HTMLInputElement | null>(null)
 const selectedFiles = ref<File[]>([])
 
-// Load categories
-const { data: categoriesData } = useAsyncData(
-  `expense-categories-${currentTenant.value?.id || 'default'}`,
-  () => $fetch('/api/finance/expenses/categories'),
-  {
-    server: false,
-    default: () => ({ data: [] })
-  }
-)
+// Shared Colada key with list/create
+const { data: categoriesData } = useQuery({
+  key: () => ['finance', 'expense-categories', currentTenant.value?.id],
+  query: () => $fetch('/api/finance/expenses/categories'),
+  enabled: () => !!currentTenant.value,
+  staleTime: 30_000,
+})
 
 const categories = computed(() => {
-  const data = categoriesData.value
+  const data = categoriesData.value as any
   if (!data) return []
   return Array.isArray(data) ? data : (data.data || [])
 })
@@ -861,7 +860,9 @@ const handleSubmit = async () => {
       }
     }
 
-    // Success - refresh data and exit edit mode
+    // Invalidate list + this detail; progressive refresh via isRefreshing/header matrix
+    cache.invalidateQueries({ key: ['finance', 'expenses'] })
+    cache.invalidateQueries({ key: ['expense', expenseId] })
     await refetch()
     isEditing.value = false
     attachmentsToRemove.value = []
@@ -996,7 +997,9 @@ const deleteExpense = async () => {
       method: 'DELETE'
     })
 
-    navigateTo('/finanzas/gastos')
+    cache.invalidateQueries({ key: ['finance', 'expenses'] })
+    cache.invalidateQueries({ key: ['expense', expenseId] })
+    await navigateTo('/finanzas/gastos')
   } catch (error: any) {
     console.error('Error deleting expense:', error)
     alert(error?.data?.detail || 'Error al eliminar el gasto')

--- a/pages/finanzas/gastos/crear.vue
+++ b/pages/finanzas/gastos/crear.vue
@@ -295,6 +295,7 @@
 </template>
 
 <script setup lang="ts">
+import { useQuery, useQueryCache } from '@pinia/colada'
 import { usePaymentMethods } from '~/composables/usePaymentMethods'
 import { useFormatters } from '~/composables/useFormatters'
 
@@ -305,6 +306,7 @@ useHead({ title: 'Registrar Gasto' })
 const { currentTenant } = useTenantReactive()
 const { todayISO } = useTenantTimezone()
 const { formatCalendarDate } = useFormatters()
+const cache = useQueryCache()
 
 const { paymentGroups, fetchPaymentMethods } = usePaymentMethods()
 fetchPaymentMethods()
@@ -312,29 +314,26 @@ fetchPaymentMethods()
 const isSubmitting = ref(false)
 const submitError = ref<string | null>(null)
 
-const { data: categoriesData, pending: isLoadingCategories } = useAsyncData(
-  `expense-categories-${currentTenant.value?.id || 'default'}`,
-  () => $fetch('/api/finance/expenses/categories'),
-  {
-    server: false,
-    default: () => ({ data: [] })
-  }
-)
+// Shared Colada key with list → cache hit when coming from /finanzas/gastos (optimistic form)
+const { data: categoriesData, refetch: refetchCategories } = useQuery({
+  key: () => ['finance', 'expense-categories', currentTenant.value?.id],
+  query: () => $fetch('/api/finance/expenses/categories'),
+  enabled: () => !!currentTenant.value,
+  staleTime: 30_000,
+})
 
 const categories = computed(() => {
-  const data = categoriesData.value
+  const data = categoriesData.value as any
   if (!data) return []
   return Array.isArray(data) ? data : (data.data || [])
 })
 
-const { setRefreshHandler } = useLayoutActions()
-const refreshCategories = async () => {
-  await refreshNuxtData(`expense-categories-${currentTenant.value?.id || 'default'}`)
-}
+// Full-page loader only when there is no cache yet (mirrors productos create)
+const isLoadingCategories = computed(() => !categoriesData.value)
 
-onMounted(() => {
-  setRefreshHandler(refreshCategories)
-})
+const { setRefreshHandler, clearRefreshHandler } = useLayoutActions()
+onMounted(() => { setRefreshHandler(refetchCategories) })
+onUnmounted(() => { clearRefreshHandler(refetchCategories) })
 
 const form = reactive({
   transactionDate: todayISO(),
@@ -494,11 +493,15 @@ const handleSubmit = async () => {
         })
       } catch (fileError) {
         console.error('Error uploading files:', fileError)
+        // Still invalidate list so the created expense appears on return
+        cache.invalidateQueries({ key: ['finance', 'expenses'] })
         submitError.value = 'Gasto creado, pero hubo un error al subir los archivos.'
         return
       }
     }
 
+    // Invalidate list cache so return to index shows progressive refresh (like productos)
+    cache.invalidateQueries({ key: ['finance', 'expenses'] })
     await navigateTo('/finanzas/gastos')
   } catch (error: any) {
     console.error('Error creating expense:', error)

--- a/pages/finanzas/gastos/index.vue
+++ b/pages/finanzas/gastos/index.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useQueryCache } from '@pinia/colada'
 import { useFormatters } from '~/composables/useFormatters'
 import { filterSelectClass } from '~/composables/useFilterSelectClass'
+import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import MetricCard from '~/components/shared/MetricCard.vue'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
@@ -11,6 +13,7 @@ useHead({ title: 'Gastos' })
 // Tenant reactivity
 const { currentTenant } = useTenantReactive()
 const { todayISO } = useTenantTimezone()
+const cache = useQueryCache()
 
 const defaultMonth = () => todayISO().slice(0, 7)
 const currentMonth = ref(defaultMonth())
@@ -122,7 +125,9 @@ const deleteExpense = async (expenseId: string) => {
       method: 'DELETE'
     })
 
-    // Refresh the list after deletion
+    // Invalidate list + detail so UI updates optimistically (progressive refresh)
+    cache.invalidateQueries({ key: ['finance', 'expenses'] })
+    cache.invalidateQueries({ key: ['expense', expenseId] })
     await refetch()
   } catch (error: any) {
     console.error('Error deleting expense:', error)
@@ -132,10 +137,12 @@ const deleteExpense = async (expenseId: string) => {
 
 // Set refresh handler for layout
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
+// Progressive: full-page loader only on first fetch; refetches use header matrix
 registerProgressiveLoading(isRefreshing)
+// When returning from crear/editar/detalle, force a background refresh
+useMenuReturnRefresh('/finanzas/gastos', refetch, 'finanzas-last-path')
 onMounted(() => { setRefreshHandler(refetch) })
-onUnmounted(() => { clearRefreshHandler(refetch)
-})
+onUnmounted(() => { clearRefreshHandler(refetch) })
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- Align `/finanzas/gastos` create/edit/list UX with `/menu/productos` progressive loading: stable section shell, Colada cache, invalidate on mutations, return refresh with header matrix (no full-page loader when cache exists).
- `finanzas.vue` uses section key + `finanzas-last-path`; list uses `useMenuReturnRefresh`; create/edit/detail share query keys and invalidate `finance/expenses` + `expense/:id` after saves/deletes.

## Test plan
- [ ] Open `/finanzas/gastos`, then Create → form should appear without cold full-page load when categories are cached
- [ ] Save a new expense → return to list with existing rows visible and progressive refresh in header
- [ ] Open detail/edit with cached expense → no full-page loader when possible
- [ ] Delete from list or detail → list updates after invalidation
- [ ] Confirm other finanzas sections still navigate correctly (section key only remounts on section change)