### PR TITLE
feat(pos): platform legal footers from backend for FE print

### DIFF
--- a/components/pos/ReceiptPlatformFooter.vue
+++ b/components/pos/ReceiptPlatformFooter.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+/**
+ * Pie de documento: software WARO + (si FE) facturador Matias.
+ * Datos desde backend platform_legal (env). Nunca hardcode de NIT/PII.
+ * Emisor de la venta = tenant (cabecera), no este pie.
+ */
+import {
+  EMPTY_PLATFORM_LEGAL,
+  type PlatformLegalPrint,
+} from '~/constants/waroLegalEntity'
+
+const props = withDefaults(defineProps<{
+  documentKind?: 'prefactura' | 'sale' | 'fe'
+  platformLegal?: PlatformLegalPrint | null
+}>(), {
+  documentKind: 'sale',
+  platformLegal: null,
+})
+
+const legal = computed(() => props.platformLegal ?? EMPTY_PLATFORM_LEGAL)
+const software = computed(() => legal.value.software)
+const facturador = computed(() => legal.value.facturador)
+
+const hasSoftware = computed(() =>
+  !!(software.value.commercial_name || software.value.nit || software.value.legal_name),
+)
+
+const hasFacturador = computed(() =>
+  !!(facturador.value.brand_name || facturador.value.nit || facturador.value.legal_name),
+)
+
+const showFacturador = computed(() =>
+  props.documentKind === 'fe' && hasFacturador.value,
+)
+</script>
+
+<template>
+  <div v-if="hasSoftware || showFacturador" class="receipt-platform-footer">
+    <div class="receipt-divider">--------------------------------</div>
+
+    <template v-if="hasSoftware">
+      <div class="receipt-row receipt-small" style="font-weight:bold;">
+        {{ software.role_label }}
+      </div>
+      <div v-if="software.commercial_name" class="receipt-row receipt-small">
+        {{ software.commercial_name }}
+      </div>
+      <div v-if="software.nit" class="receipt-row receipt-small">
+        NIT {{ software.nit }}
+      </div>
+      <div v-if="software.legal_name" class="receipt-row receipt-small">
+        {{ software.legal_name }}
+      </div>
+      <div v-if="software.iva_responsibility_label" class="receipt-row receipt-small">
+        {{ software.iva_responsibility_label }}
+      </div>
+      <div class="receipt-row receipt-small" style="font-weight:bold;">
+        {{ software.not_issuer_disclaimer }}
+      </div>
+    </template>
+
+    <template v-if="showFacturador">
+      <div class="receipt-divider receipt-small">--------------------------------</div>
+      <div class="receipt-row receipt-small" style="font-weight:bold;">
+        {{ facturador.role_label }}
+      </div>
+      <div v-if="facturador.brand_name" class="receipt-row receipt-small">
+        {{ facturador.brand_name }}
+      </div>
+      <div v-if="facturador.nit" class="receipt-row receipt-small">
+        NIT {{ facturador.nit }}
+      </div>
+      <div v-if="facturador.legal_name" class="receipt-row receipt-small">
+        {{ facturador.legal_name }}
+      </div>
+      <div class="receipt-row receipt-small" style="font-weight:bold;">
+        {{ facturador.not_issuer_disclaimer }}
+      </div>
+      <div class="receipt-row receipt-small">
+        Emisor DIAN: establecimiento (tenant)
+      </div>
+    </template>
+
+    <div
+      v-if="documentKind === 'prefactura'"
+      class="receipt-row receipt-small"
+    >
+      Prefactura del establecimiento (no es documento fiscal DIAN)
+    </div>
+    <div
+      v-else-if="documentKind === 'sale'"
+      class="receipt-row receipt-small"
+    >
+      Comprobante de venta del establecimiento
+    </div>
+  </div>
+</template>

--- a/components/pos/ReceiptPrintHeader.vue
+++ b/components/pos/ReceiptPrintHeader.vue
@@ -17,8 +17,15 @@ const props = defineProps<{
   logoUrl?: string | null
 }>()
 
+/**
+ * Cabecera del establecimiento (tenant) — emisor comercial / vendedor.
+ * Según práctica Colombia: nombre o razón social + NIT del establecimiento.
+ * WARO no va aquí (ver ReceiptPlatformFooter).
+ */
 const headerName = computed(() =>
-  props.fiscalData?.business_name || props.displayName || 'WARO',
+  props.fiscalData?.business_name?.trim()
+  || props.displayName?.trim()
+  || '—',
 )
 
 const displayAddress = computed(() =>
@@ -33,6 +40,8 @@ const displayPhone = computed(() =>
   props.fiscalData?.phone || props.phone || null,
 )
 
+const sellerNit = computed(() => props.fiscalData?.nit?.trim() || null)
+
 const logoStyle = computed(() => buildReceiptLogoStyle())
 </script>
 
@@ -46,8 +55,11 @@ const logoStyle = computed(() => buildReceiptLogoStyle())
       :style="logoStyle"
     >
     <div class="receipt-header">{{ headerName }}</div>
-    <div v-if="fiscalData?.nit" class="receipt-row receipt-small">
-      NIT: {{ fiscalData.nit }}
+    <div class="receipt-row receipt-small" style="font-weight:bold;">
+      Establecimiento / vendedor
+    </div>
+    <div v-if="sellerNit" class="receipt-row receipt-small">
+      NIT: {{ sellerNit }}
     </div>
     <div v-if="displayAddress" class="receipt-row receipt-small">
       {{ displayAddress }}<span v-if="displayCity">, {{ displayCity }}</span>

--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -47,6 +47,8 @@ interface InvoiceTaxLine {
   amount?: number | string | null
 }
 
+import type { PlatformLegalPrint } from '~/constants/waroLegalEntity'
+
 const props = defineProps<{
   fiscalData?: {
     business_name?: string | null
@@ -56,6 +58,7 @@ const props = defineProps<{
     phone?: string | null
     email?: string | null
   } | null
+  platformLegal?: PlatformLegalPrint | null
   displayName?: string | null
   address?: string | null
   city?: string | null
@@ -161,9 +164,10 @@ const invoiceDianUrl = computed(() => {
     : null
 })
 
+/** Emisor FE = tenant fiscal only (never marketing displayName / WARO brand). */
 const fallbackIssuerLabel = computed(() => {
-  const name = props.fiscalData?.business_name || props.displayName
-  const nit = props.fiscalData?.nit
+  const name = props.fiscalData?.business_name?.trim() || null
+  const nit = props.fiscalData?.nit?.trim() || null
   if (name && nit) return `${name} - NIT ${nit}`
   return name || (nit ? `NIT ${nit}` : null)
 })
@@ -364,7 +368,25 @@ const printableItems = computed(() =>
     <div class="receipt-divider">================================</div>
     <div class="receipt-footer">Gracias por tu compra</div>
 
-    <template v-if="invoice">
+    <!-- Venta sin FE: comprobante del establecimiento (no factura DIAN) -->
+    <template v-if="!invoice">
+      <div class="receipt-divider receipt-small">--------------------------------</div>
+      <div class="receipt-row receipt-small" style="font-weight:bold;">
+        COMPROBANTE DE VENTA
+      </div>
+      <div class="receipt-row receipt-small">
+        No es factura electronica DIAN
+      </div>
+      <div
+        v-if="fallbackIssuerLabel"
+        class="receipt-row receipt-small"
+      >
+        Vendedor: {{ fallbackIssuerLabel }}
+      </div>
+      <PosReceiptPlatformFooter document-kind="sale" :platform-legal="platformLegal" />
+    </template>
+
+    <template v-else>
       <div class="receipt-divider">================================</div>
       <div class="receipt-row" style="font-weight:bold;">FACTURA ELECTRONICA DE VENTA</div>
       <div class="receipt-row receipt-small">Representacion impresa de factura electronica de venta</div>
@@ -402,6 +424,7 @@ const printableItems = computed(() =>
       >
       <div v-if="invoiceDianUrl" class="receipt-row receipt-small">Verificar en DIAN</div>
       <div class="receipt-divider">================================</div>
+      <PosReceiptPlatformFooter document-kind="fe" :platform-legal="platformLegal" />
     </template>
     </div>
   </Teleport>

--- a/constants/waroLegalEntity.ts
+++ b/constants/waroLegalEntity.ts
@@ -1,0 +1,48 @@
+/**
+ * Types + empty defaults for platform legal print footers.
+ *
+ * Source of truth is the BACKEND (env → /pos restaurant context → platform_legal).
+ * Do not hardcode NIT / names / PII here.
+ */
+
+export type PlatformSoftwareLegal = {
+  role_label: string
+  commercial_name: string | null
+  legal_name: string | null
+  nit: string | null
+  iva_responsibility_label: string | null
+  not_issuer_disclaimer: string
+}
+
+export type PlatformFacturadorLegal = {
+  role_label: string
+  brand_name: string | null
+  legal_name: string | null
+  nit: string | null
+  not_issuer_disclaimer: string
+  slug: string
+}
+
+export type PlatformLegalPrint = {
+  software: PlatformSoftwareLegal
+  facturador: PlatformFacturadorLegal
+}
+
+export const EMPTY_PLATFORM_LEGAL: PlatformLegalPrint = {
+  software: {
+    role_label: 'Proveedor tecnologico / software',
+    commercial_name: null,
+    legal_name: null,
+    nit: null,
+    iva_responsibility_label: null,
+    not_issuer_disclaimer: 'No es el emisor de esta venta',
+  },
+  facturador: {
+    role_label: 'Facturador tecnico DIAN',
+    brand_name: null,
+    legal_name: null,
+    nit: null,
+    not_issuer_disclaimer: 'No es el emisor de esta venta',
+    slug: 'matias',
+  },
+}

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -2407,6 +2407,8 @@ const printReceipt = async () => {
 // the cashier doesn't need MI_NEGOCIO. The /facturacion owner panel reads
 // /api/api/tenant/fiscal-data directly with its richer write surface.
 const fiscalData = computed(() => settingsData.value?.data?.fiscal_data ?? null)
+/** WARO + Matias print labels from backend env (not tenant issuer). */
+const platformLegal = computed(() => settingsData.value?.data?.platform_legal ?? null)
 
 const receiptPrintSettings = computed(() =>
   settingsData.value?.data?.receipt_print_settings ?? { document_label: 'Prefactura', tip_label: 'Propina', show_logo: true },
@@ -2591,6 +2593,13 @@ const receiptInvoiceTaxLines = computed(() => {
   ].filter(line => Number(line.amount) > 0)
 })
 
+const receiptIssuerLabel = computed(() => {
+  const name = fiscalData.value?.business_name?.trim() || null
+  const nit = fiscalData.value?.nit?.trim() || null
+  if (name && nit) return `${name} - NIT ${nit}`
+  return name || (nit ? `NIT ${nit}` : null)
+})
+
 const receiptInvoice = computed(() => {
   const invoice = invoiceResult.value
   if (!invoice) return null
@@ -2603,6 +2612,8 @@ const receiptInvoice = computed(() => {
     issuedAt: receiptInvoiceIssuedAt.value,
     paymentLabel: receiptSinglePaymentLabel.value,
     taxLines: receiptInvoiceTaxLines.value,
+    // Emisor FE = tenant fiscal only (Matias client_uuid is technical; WARO is not issuer)
+    issuerLabel: receiptIssuerLabel.value,
   }
 })
 
@@ -5034,6 +5045,7 @@ onUnmounted(() => {
     <PosReceiptPrintTicket
       v-if="orderResult"
       :fiscal-data="fiscalData"
+      :platform-legal="platformLegal"
       :display-name="businessProfile?.display_name"
       :address="businessProfile?.address"
       :city="businessProfile?.city"
@@ -5211,6 +5223,8 @@ onUnmounted(() => {
     <!-- Issue #535 — Legal disclaimer: do NOT remove. -->
     <div class="receipt-footer receipt-small" style="font-weight:bold;">PREFACTURA — DOCUMENTO INFORMATIVO</div>
     <div class="receipt-footer receipt-small">No es comprobante fiscal ni factura electrónica DIAN</div>
+    <!-- WARO = software/tecnología; emisor/vendedor = establecimiento (tenant) -->
+    <PosReceiptPlatformFooter document-kind="prefactura" :platform-legal="platformLegal" />
   </div>
 
   <!-- Hidden receipt for printing — only visible via @media print -->
@@ -5369,6 +5383,9 @@ onUnmounted(() => {
       <div class="receipt-divider">================================</div>
       <div class="receipt-row" style="font-weight:bold;">FACTURA ELECTRÓNICA</div>
       <div class="receipt-row">{{ invoiceResult.prefix }}-{{ invoiceResult.invoice_number }}</div>
+      <div v-if="receiptIssuerLabel" class="receipt-row receipt-small">
+        Emisor: {{ receiptIssuerLabel }}
+      </div>
       <div v-if="invoiceResult.cufe" class="receipt-row receipt-small receipt-cufe">
         CUFE: {{ invoiceResult.cufe }}
       </div>
@@ -5380,6 +5397,16 @@ onUnmounted(() => {
       >
       <div v-if="invoiceResult.cufe" class="receipt-row receipt-small">Verificar en DIAN</div>
       <div class="receipt-divider">================================</div>
+      <PosReceiptPlatformFooter document-kind="fe" :platform-legal="platformLegal" />
+    </template>
+    <template v-else>
+      <div class="receipt-divider receipt-small">--------------------------------</div>
+      <div class="receipt-row receipt-small" style="font-weight:bold;">COMPROBANTE DE VENTA</div>
+      <div class="receipt-row receipt-small">No es factura electrónica DIAN</div>
+      <div v-if="receiptIssuerLabel" class="receipt-row receipt-small">
+        Vendedor: {{ receiptIssuerLabel }}
+      </div>
+      <PosReceiptPlatformFooter document-kind="sale" :platform-legal="platformLegal" />
     </template>
   </div>
 

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -112,6 +112,7 @@ const { data: invoiceData, status: invoiceStatus, refetch: refetchInvoice } = us
 const isInvoicingReady = computed(() => settingsData.value?.data?.invoicing_ready === true)
 const isReadinessLoading = computed(() => !settingsData.value)
 const fiscalData = computed(() => settingsData.value?.data?.fiscal_data ?? null)
+const platformLegal = computed(() => settingsData.value?.data?.platform_legal ?? null)
 
 // Invoice emit state
 const isEmittingInvoice = ref(false)
@@ -543,6 +544,22 @@ const saleReceiptInvoiceTaxLines = computed(() => {
   ].filter(line => Number(line.amount) > 0)
 })
 
+const saleReceiptIssuerLabel = computed(() => {
+  // Prefer API presentation.issuer (fiscal-only); fallback to local fiscal_data.
+  const presentation = (invoiceData.value as any)?.presentation
+  const issuer = presentation?.issuer
+  if (issuer?.name || issuer?.fiscal_id) {
+    const name = String(issuer.name || '').trim()
+    const nit = String(issuer.fiscal_id || '').trim()
+    if (name && nit) return `${name} - NIT ${nit}`
+    return name || (nit ? `NIT ${nit}` : null)
+  }
+  const name = fiscalData.value?.business_name?.trim() || null
+  const nit = fiscalData.value?.nit?.trim() || null
+  if (name && nit) return `${name} - NIT ${nit}`
+  return name || (nit ? `NIT ${nit}` : null)
+})
+
 const saleReceiptInvoice = computed(() => {
   if (!invoiceData.value) return null
   return {
@@ -554,6 +571,7 @@ const saleReceiptInvoice = computed(() => {
     issuedAt: invoiceData.value.emitted_at ? formatDate(invoiceData.value.emitted_at) : null,
     paymentLabel: saleReceiptSinglePaymentLabel.value,
     taxLines: saleReceiptInvoiceTaxLines.value,
+    issuerLabel: saleReceiptIssuerLabel.value,
   }
 })
 
@@ -1843,6 +1861,7 @@ onUnmounted(() => {
     <PosReceiptPrintTicket
       v-if="order"
       :fiscal-data="fiscalData"
+      :platform-legal="platformLegal"
       :display-name="businessProfile?.display_name"
       :address="businessProfile?.address"
       :city="businessProfile?.city"


### PR DESCRIPTION
## Summary
- Prefactura, sale without FE, and FE tickets use backend `platform_legal`.
- Tenant remains establishment/issuer; WARO software + Matias facturador are footers only.
- No hard-coded NIT/PII in the frontend constants.

## Test plan
- [ ] POS restaurant-context returns `platform_legal` after API deploy.
- [ ] Print prefactura, sale receipt without FE, and FE ticket.