### PR TITLE
feat(i18n): locale number I/O (es/en) — Batch 3 #1601

### DIFF
--- a/components/checkout/CashTenderPanel.vue
+++ b/components/checkout/CashTenderPanel.vue
@@ -1,4 +1,12 @@
 <script setup lang="ts">
+import {
+  formatIntegerMoney,
+  normalizeUiLocale,
+  parseIntegerMoney,
+  toNumberLocaleTag,
+  type UiLocale,
+} from '~/utils/parseLocaleDecimal'
+
 const cashReceived = defineModel<number>({ default: 0 })
 
 const props = withDefaults(defineProps<{
@@ -10,6 +18,11 @@ const props = withDefaults(defineProps<{
   requireInputForFeedback: false,
 })
 
+const tenantsStore = useTenantsStore()
+const uiLocale = computed<UiLocale>(() =>
+  normalizeUiLocale((tenantsStore.businessProfile as { locale?: string } | null | undefined)?.locale),
+)
+
 const cashPresetsExtra = [
   { label: '+ $1.000', offset: 1000 },
   { label: '+ $5.000', offset: 5000 },
@@ -18,7 +31,7 @@ const cashPresetsExtra = [
 ] as const
 
 const formatCurrency = (value: number): string =>
-  new Intl.NumberFormat('es-CO', {
+  new Intl.NumberFormat(toNumberLocaleTag(uiLocale.value), {
     style: 'currency',
     currency: 'COP',
     minimumFractionDigits: 0,
@@ -31,14 +44,14 @@ const cashShortfall = computed(() =>
   Math.max(0, props.amountToCharge - (cashReceived.value || 0)),
 )
 const cashReceivedDisplay = computed(() =>
-  cashReceived.value > 0 ? cashReceived.value.toLocaleString('es-CO') : '',
+  formatIntegerMoney(cashReceived.value, uiLocale.value),
 )
 
 const onCashReceivedInput = (e: Event) => {
   const input = e.target as HTMLInputElement
-  const raw = Number(input.value.replace(/\./g, '').replace(/\D/g, ''))
-  cashReceived.value = Number.isFinite(raw) ? raw : 0
-  input.value = raw ? raw.toLocaleString('es-CO') : ''
+  const raw = parseIntegerMoney(input.value, uiLocale.value)
+  cashReceived.value = raw
+  input.value = formatIntegerMoney(raw, uiLocale.value)
 }
 
 const showVuelto = computed(() => {

--- a/components/checkout/TipSelector.vue
+++ b/components/checkout/TipSelector.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import {
+  formatIntegerMoney,
+  normalizeUiLocale,
+  parseIntegerMoney,
+  toNumberLocaleTag,
+  type UiLocale,
+} from '~/utils/parseLocaleDecimal'
 
 // Reusable tip selector for POS and online checkouts (warocol.com#639).
 // Props-driven, layout-agnostic — fills the parent container.
@@ -26,6 +33,11 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{
   (e: 'update:modelValue', value: TipModel): void
 }>()
+
+const tenantsStore = useTenantsStore()
+const uiLocale = computed<UiLocale>(() =>
+  normalizeUiLocale((tenantsStore.businessProfile as { locale?: string } | null | undefined)?.locale),
+)
 
 type Mode = { kind: 'preset'; index: number } | { kind: 'custom' } | { kind: 'none' }
 
@@ -91,7 +103,7 @@ watch(
 )
 
 const formatCurrency = (value: number): string =>
-  new Intl.NumberFormat('es-CO', {
+  new Intl.NumberFormat(toNumberLocaleTag(uiLocale.value), {
     style: 'currency',
     currency: 'COP',
     minimumFractionDigits: 0,
@@ -113,13 +125,13 @@ const selectNone = () => {
 
 const onCustomInput = (e: Event) => {
   const input = e.target as HTMLInputElement
-  const raw = Number(input.value.replace(/\./g, '').replace(/\D/g, ''))
-  customAmount.value = Number.isFinite(raw) ? raw : 0
-  input.value = raw ? raw.toLocaleString('es-CO') : ''
+  const raw = parseIntegerMoney(input.value, uiLocale.value)
+  customAmount.value = raw
+  input.value = formatIntegerMoney(raw, uiLocale.value)
 }
 
 const customDisplay = computed(() =>
-  customAmount.value > 0 ? customAmount.value.toLocaleString('es-CO') : ''
+  formatIntegerMoney(customAmount.value, uiLocale.value),
 )
 
 const isActivePreset = (i: number) => activeMode.value.kind === 'preset' && activeMode.value.index === i

--- a/components/ui/DecimalInput.vue
+++ b/components/ui/DecimalInput.vue
@@ -54,9 +54,11 @@ const resolvedLocale = computed<UiLocale>(() => {
 
 function formatModelForDisplay(value: number | null | undefined): string {
   if (value === null || value === undefined || Number.isNaN(value)) return ''
+  // No thousands grouping: es-CO "5.000" would parse as 5 under only-dot decimal rules.
   return formatLocaleNumber(value, resolvedLocale.value, {
     minimumFractionDigits: 0,
     maximumFractionDigits: props.precision,
+    useGrouping: false,
   })
 }
 

--- a/components/ui/DecimalInput.vue
+++ b/components/ui/DecimalInput.vue
@@ -2,11 +2,15 @@
 /**
  * Locale-safe decimal input — avoids HTML5 `type="number"` step validation.
  * Use in purchase/quantity forms (see epic #1074). Batch migrations: pass field-specific `precision`.
+ * Display/parse punctuation follows tenant UI locale (es|en); defaults es-CO.
  */
 import {
+  formatLocaleNumber,
+  normalizeUiLocale,
   parseLocaleDecimal,
   roundToPrecision,
   type DecimalPrecision,
+  type UiLocale,
 } from '~/utils/parseLocaleDecimal'
 
 const props = withDefaults(
@@ -21,10 +25,13 @@ const props = withDefaults(
     required?: boolean
     id?: string
     class?: string
+    /** Optional override; defaults to tenant businessProfile.locale → es. */
+    locale?: UiLocale | string | null
   }>(),
   {
     modelValue: null,
     precision: 2,
+    locale: undefined,
   },
 )
 
@@ -32,19 +39,32 @@ const emit = defineEmits<{
   'update:modelValue': [value: number | null]
 }>()
 
+const tenantsStore = useTenantsStore()
 const inputRef = ref<HTMLInputElement>()
 const displayValue = ref('')
 
+const resolvedLocale = computed<UiLocale>(() => {
+  if (props.locale != null && props.locale !== '') {
+    return normalizeUiLocale(props.locale)
+  }
+  return normalizeUiLocale(
+    (tenantsStore.businessProfile as { locale?: string } | null | undefined)?.locale,
+  )
+})
+
 function formatModelForDisplay(value: number | null | undefined): string {
   if (value === null || value === undefined || Number.isNaN(value)) return ''
-  return String(value)
+  return formatLocaleNumber(value, resolvedLocale.value, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: props.precision,
+  })
 }
 
 watch(
-  () => props.modelValue,
-  (value) => {
+  [() => props.modelValue, resolvedLocale, () => props.precision],
+  () => {
     if (document.activeElement === inputRef.value) return
-    displayValue.value = formatModelForDisplay(value ?? null)
+    displayValue.value = formatModelForDisplay(props.modelValue ?? null)
   },
   { immediate: true },
 )
@@ -59,7 +79,7 @@ function onInput(event: Event) {
 }
 
 function commitValue() {
-  const parsed = parseLocaleDecimal(displayValue.value)
+  const parsed = parseLocaleDecimal(displayValue.value, resolvedLocale.value)
   if (parsed === null) {
     emit('update:modelValue', null)
     displayValue.value = ''

--- a/composables/useFormatters.ts
+++ b/composables/useFormatters.ts
@@ -1,6 +1,23 @@
+import {
+  DEFAULT_UI_LOCALE,
+  formatLocaleNumber,
+  normalizeUiLocale,
+  toNumberLocaleTag,
+  type UiLocale,
+} from '~/utils/parseLocaleDecimal'
+
 export const useFormatters = () => {
   const { timezone, dateAtNoon } = useTenantTimezone()
+  const tenantsStore = useTenantsStore()
 
+  /** Tenant UI locale for number punctuation (B1 surface when present; default es). */
+  const uiLocale = computed<UiLocale>(() =>
+    normalizeUiLocale((tenantsStore.businessProfile as { locale?: string } | null | undefined)?.locale),
+  )
+
+  const numberLocaleTag = computed(() => toNumberLocaleTag(uiLocale.value))
+
+  // Dates stay es-CO until B4; only number/currency punctuation follows uiLocale.
   const dateFormatter = computed(() => new Intl.DateTimeFormat('es-CO', {
     day: '2-digit', month: '2-digit', year: '2-digit',
     timeZone: timezone.value,
@@ -32,13 +49,22 @@ export const useFormatters = () => {
     return dateFormatter.value.format(new Date(dateString))
   }
 
+  /** Currency display: COP code until B5; punctuation follows uiLocale. */
   const formatCurrency = (value: number | null): string => {
     if (value === null || value === undefined) return '$0'
-    return new Intl.NumberFormat('es-CO', {
+    return new Intl.NumberFormat(numberLocaleTag.value, {
       style: 'currency',
       currency: 'COP',
-      minimumFractionDigits: 0
+      minimumFractionDigits: 0,
     }).format(value)
+  }
+
+  const formatNumber = (
+    value: number | null | undefined,
+    options?: { minimumFractionDigits?: number; maximumFractionDigits?: number },
+  ): string => {
+    if (value === null || value === undefined || !Number.isFinite(value)) return ''
+    return formatLocaleNumber(value, uiLocale.value, options)
   }
 
   const formatDateTime = (dateString: string | null | undefined): string => {
@@ -59,10 +85,14 @@ export const useFormatters = () => {
   }
 
   return {
+    uiLocale,
+    numberLocaleTag,
+    defaultUiLocale: DEFAULT_UI_LOCALE,
     formatDate,
     formatCalendarDate,
     formatDateShort,
     formatCurrency,
+    formatNumber,
     formatDateTime,
     formatRelativeDate,
   }

--- a/utils/domainNumberFormat.test.ts
+++ b/utils/domainNumberFormat.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { formatDomainQuantity, normalizeDomainNumber } from './domainNumberFormat.ts'
 
 describe('formatDomainQuantity', () => {
-  it('keeps meaningful sub-unit precision without long tails', () => {
+  it('keeps meaningful sub-unit precision without long tails (es default)', () => {
     assert.equal(formatDomainQuantity(1.345), '1,345')
     assert.equal(formatDomainQuantity(0.3333333333333), '0,3333')
     assert.equal(formatDomainQuantity(0.3333333333333, 6), '0,333333')
@@ -17,6 +17,12 @@ describe('formatDomainQuantity', () => {
 
   it('formats tiny float residue as a clean zero', () => {
     assert.equal(formatDomainQuantity(0.1 + 0.2 - 0.3), '0')
+  })
+
+  it('formats en-US punctuation when locale is en', () => {
+    assert.equal(formatDomainQuantity(1.345, 4, 'en'), '1.345')
+    assert.equal(formatDomainQuantity(1000, 6, 'en'), '1,000')
+    assert.equal(formatDomainQuantity(0.3333333333333, 4, 'en'), '0.3333')
   })
 })
 

--- a/utils/domainNumberFormat.ts
+++ b/utils/domainNumberFormat.ts
@@ -1,6 +1,14 @@
+/** Product locale for quantity display punctuation (aligned with parseLocaleDecimal). */
+export type DomainUiLocale = 'es' | 'en'
+
+function numberLocaleTag(locale: DomainUiLocale = 'es'): string {
+  return locale === 'en' ? 'en-US' : 'es-CO'
+}
+
 export function formatDomainQuantity(
   value: number | string | null | undefined,
   maxFractionDigits = 4,
+  locale: DomainUiLocale = 'es',
 ): string {
   if (value === null || value === undefined || value === '') return '-'
 
@@ -9,7 +17,7 @@ export function formatDomainQuantity(
 
   const normalized = Object.is(numericValue, -0) ? 0 : numericValue
 
-  return new Intl.NumberFormat('es-CO', {
+  return new Intl.NumberFormat(numberLocaleTag(locale), {
     minimumFractionDigits: 0,
     maximumFractionDigits: maxFractionDigits,
   }).format(normalized)

--- a/utils/parseLocaleDecimal.test.ts
+++ b/utils/parseLocaleDecimal.test.ts
@@ -102,6 +102,44 @@ describe('formatLocaleNumber', () => {
     assert.equal(formatLocaleNumber(1234.56, 'en', { maximumFractionDigits: 2 }), '1,234.56')
     assert.equal(formatLocaleNumber(1.5, 'en', { maximumFractionDigits: 2 }), '1.5')
   })
+
+  it('supports useGrouping false for editable inputs', () => {
+    assert.equal(
+      formatLocaleNumber(5000, 'es', { maximumFractionDigits: 2, useGrouping: false }),
+      '5000',
+    )
+    assert.equal(
+      formatLocaleNumber(1234.56, 'es', { maximumFractionDigits: 2, useGrouping: false }),
+      '1234,56',
+    )
+    assert.equal(
+      formatLocaleNumber(1234.56, 'en', { maximumFractionDigits: 2, useGrouping: false }),
+      '1234.56',
+    )
+  })
+
+  it('round-trips format→parse for input-style (no grouping) es/en', () => {
+    const cases: Array<{ n: number; locale: 'es' | 'en' }> = [
+      { n: 1.5, locale: 'es' },
+      { n: 1234.56, locale: 'es' },
+      { n: 5000, locale: 'es' },
+      { n: 1234567, locale: 'es' },
+      { n: 1.5, locale: 'en' },
+      { n: 1234.56, locale: 'en' },
+      { n: 5000, locale: 'en' },
+    ]
+    for (const { n, locale } of cases) {
+      const formatted = formatLocaleNumber(n, locale, {
+        maximumFractionDigits: 2,
+        useGrouping: false,
+      })
+      assert.equal(
+        parseLocaleDecimal(formatted, locale),
+        n,
+        `round-trip ${locale} ${n} via "${formatted}"`,
+      )
+    }
+  })
 })
 
 describe('integer money helpers', () => {
@@ -119,6 +157,18 @@ describe('integer money helpers', () => {
     assert.equal(formatIntegerMoney(1234, 'es'), '1.234')
     assert.equal(formatIntegerMoney(1234, 'en'), '1,234')
     assert.equal(formatIntegerMoney(0, 'es'), '')
+  })
+
+  it('round-trips integer money format→parse for es/en', () => {
+    for (const locale of ['es', 'en'] as const) {
+      for (const n of [1, 1234, 5000, 1234567]) {
+        assert.equal(
+          parseIntegerMoney(formatIntegerMoney(n, locale), locale),
+          n,
+          `integer money round-trip ${locale} ${n}`,
+        )
+      }
+    }
   })
 })
 

--- a/utils/parseLocaleDecimal.test.ts
+++ b/utils/parseLocaleDecimal.test.ts
@@ -1,8 +1,33 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { parseLocaleDecimal, parseReceiptDecimal, roundToPrecision } from './parseLocaleDecimal.ts'
+import {
+  formatIntegerMoney,
+  formatLocaleNumber,
+  normalizeUiLocale,
+  parseIntegerMoney,
+  parseLocaleDecimal,
+  parseReceiptDecimal,
+  roundToPrecision,
+  toNumberLocaleTag,
+} from './parseLocaleDecimal.ts'
 
-describe('parseLocaleDecimal', () => {
+describe('normalizeUiLocale / toNumberLocaleTag', () => {
+  it('defaults missing and junk to es', () => {
+    assert.equal(normalizeUiLocale(null), 'es')
+    assert.equal(normalizeUiLocale(''), 'es')
+    assert.equal(normalizeUiLocale('fr'), 'es')
+    assert.equal(toNumberLocaleTag('es'), 'es-CO')
+  })
+
+  it('accepts en variants', () => {
+    assert.equal(normalizeUiLocale('en'), 'en')
+    assert.equal(normalizeUiLocale('en-US'), 'en')
+    assert.equal(normalizeUiLocale('EN_GB'), 'en')
+    assert.equal(toNumberLocaleTag('en'), 'en-US')
+  })
+})
+
+describe('parseLocaleDecimal (heuristic / legacy)', () => {
   it('parses comma decimal', () => {
     assert.equal(parseLocaleDecimal('1,50'), 1.5)
   })
@@ -40,7 +65,64 @@ describe('parseLocaleDecimal', () => {
   })
 })
 
-describe('parseReceiptDecimal', () => {
+describe('parseLocaleDecimal es vs en matrix', () => {
+  it('es: decimal comma and CO thousands', () => {
+    assert.equal(parseLocaleDecimal('1,50', 'es'), 1.5)
+    assert.equal(parseLocaleDecimal('1.234,56', 'es'), 1234.56)
+    assert.equal(parseLocaleDecimal('1.50', 'es'), 1.5)
+  })
+
+  it('en: decimal point and US thousands', () => {
+    assert.equal(parseLocaleDecimal('1.50', 'en'), 1.5)
+    assert.equal(parseLocaleDecimal('1,234.56', 'en'), 1234.56)
+    assert.equal(parseLocaleDecimal('1,234', 'en'), 1234)
+  })
+
+  it('disambiguates 2,000 by locale', () => {
+    // heuristic / es: comma decimal → 2
+    assert.equal(parseLocaleDecimal('2,000'), 2)
+    assert.equal(parseLocaleDecimal('2,000', 'es'), 2)
+    // en: thousands → 2000
+    assert.equal(parseLocaleDecimal('2,000', 'en'), 2000)
+  })
+
+  it('es only-dot stays decimal quantity (integer money uses parseIntegerMoney)', () => {
+    assert.equal(parseLocaleDecimal('1.345', 'es'), 1.345)
+    assert.equal(parseLocaleDecimal('12.345', 'es'), 12.345)
+  })
+})
+
+describe('formatLocaleNumber', () => {
+  it('formats es-CO punctuation by default', () => {
+    assert.equal(formatLocaleNumber(1234.56, 'es', { maximumFractionDigits: 2 }), '1.234,56')
+    assert.equal(formatLocaleNumber(1.5, 'es', { maximumFractionDigits: 2 }), '1,5')
+  })
+
+  it('formats en-US punctuation', () => {
+    assert.equal(formatLocaleNumber(1234.56, 'en', { maximumFractionDigits: 2 }), '1,234.56')
+    assert.equal(formatLocaleNumber(1.5, 'en', { maximumFractionDigits: 2 }), '1.5')
+  })
+})
+
+describe('integer money helpers', () => {
+  it('parses es thousands dots', () => {
+    assert.equal(parseIntegerMoney('1.234', 'es'), 1234)
+    assert.equal(parseIntegerMoney('$ 5.000', 'es'), 5000)
+  })
+
+  it('parses en thousands commas', () => {
+    assert.equal(parseIntegerMoney('1,234', 'en'), 1234)
+    assert.equal(parseIntegerMoney('$ 5,000', 'en'), 5000)
+  })
+
+  it('formats integer money by locale', () => {
+    assert.equal(formatIntegerMoney(1234, 'es'), '1.234')
+    assert.equal(formatIntegerMoney(1234, 'en'), '1,234')
+    assert.equal(formatIntegerMoney(0, 'es'), '')
+  })
+})
+
+describe('parseReceiptDecimal (CO-oriented OCR; not UI locale)', () => {
   it('parses FRUVAR-style COP amounts with comma or dot thousands', () => {
     assert.equal(parseReceiptDecimal('2,000', 'amount'), 2000)
     assert.equal(parseReceiptDecimal('2.000', 'amount'), 2000)

--- a/utils/parseLocaleDecimal.ts
+++ b/utils/parseLocaleDecimal.ts
@@ -140,6 +140,9 @@ export function parseLocaleDecimal(
 /**
  * Format a number for display with locale punctuation.
  * Defaults preserve es-CO separators.
+ *
+ * Editable inputs should pass `useGrouping: false` so format→parse round-trips
+ * safely under es (grouped `"5.000"` is ambiguous with decimal-only-dot parse).
  */
 export function formatLocaleNumber(
   value: number | null | undefined,
@@ -147,6 +150,8 @@ export function formatLocaleNumber(
   options?: {
     minimumFractionDigits?: number
     maximumFractionDigits?: number
+    /** Default true for read-only display; false for editable inputs. */
+    useGrouping?: boolean
   },
 ): string {
   if (value === null || value === undefined || !Number.isFinite(value)) return ''
@@ -154,6 +159,7 @@ export function formatLocaleNumber(
   return new Intl.NumberFormat(toNumberLocaleTag(locale), {
     minimumFractionDigits: options?.minimumFractionDigits ?? 0,
     maximumFractionDigits: options?.maximumFractionDigits ?? 20,
+    useGrouping: options?.useGrouping ?? true,
   }).format(normalized)
 }
 

--- a/utils/parseLocaleDecimal.ts
+++ b/utils/parseLocaleDecimal.ts
@@ -4,13 +4,121 @@ export type DecimalPrecision = number
 /** OCR receipt fields: qty vs COP amounts interpret separators differently. */
 export type ReceiptNumberKind = 'quantity' | 'amount'
 
+/** Tenant/UI language codes that drive number punctuation (epic #1598 B3). */
+export type UiLocale = 'es' | 'en'
+
+export const DEFAULT_UI_LOCALE: UiLocale = 'es'
+
+/** Map product locale → Intl number tag (es → es-CO, en → en-US). */
+export function toNumberLocaleTag(locale: UiLocale = DEFAULT_UI_LOCALE): string {
+  return locale === 'en' ? 'en-US' : 'es-CO'
+}
+
+/** Normalize free-form locale strings to es|en. Missing/junk → es. */
+export function normalizeUiLocale(value: unknown): UiLocale {
+  if (value === null || value === undefined) return DEFAULT_UI_LOCALE
+  const raw = String(value).trim().toLowerCase().replace(/_/g, '-')
+  if (!raw) return DEFAULT_UI_LOCALE
+  if (raw === 'en' || raw.startsWith('en-')) return 'en'
+  if (raw === 'es' || raw.startsWith('es-')) return 'es'
+  return DEFAULT_UI_LOCALE
+}
+
+function stripCurrencyNoise(value: string): string {
+  return value.replace(/[$\s\u00A0]/g, '')
+}
+
+/** Heuristic parse (no locale): supports mixed es-CO / en-US when both separators present. */
+function parseLocaleDecimalHeuristic(normalized: string): number | null {
+  let work = normalized
+  const hasComma = work.includes(',')
+  const hasDot = work.includes('.')
+
+  if (hasComma && hasDot) {
+    const lastComma = work.lastIndexOf(',')
+    const lastDot = work.lastIndexOf('.')
+    if (lastComma > lastDot) {
+      // es-CO thousands with dot, decimal comma: 1.234,56
+      work = work.replace(/\./g, '').replace(',', '.')
+    } else {
+      // en-US thousands with comma: 1,234.56
+      work = work.replace(/,/g, '')
+    }
+  } else if (hasComma) {
+    // Single comma → decimal (legacy): "2,000" → 2
+    work = work.replace(',', '.')
+  }
+
+  const parsed = Number(work)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function parseLocaleDecimalEs(normalized: string): number | null {
+  let work = normalized
+  const hasComma = work.includes(',')
+  const hasDot = work.includes('.')
+
+  if (hasComma && hasDot) {
+    const lastComma = work.lastIndexOf(',')
+    const lastDot = work.lastIndexOf('.')
+    if (lastComma > lastDot) {
+      work = work.replace(/\./g, '').replace(/,/g, '.')
+    } else {
+      work = work.replace(/,/g, '')
+    }
+  } else if (hasComma) {
+    // es: comma is decimal separator (1,50 → 1.5; 2,000 → 2.000 legacy decimal)
+    work = work.replace(/\./g, '').replace(',', '.')
+  }
+  // only-dot: treat as decimal quantity (1.345 → 1.345). Integer COP uses parseIntegerMoney.
+
+  const parsed = Number(work)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function parseLocaleDecimalEn(normalized: string): number | null {
+  let work = normalized
+  const hasComma = work.includes(',')
+  const hasDot = work.includes('.')
+
+  if (hasComma && hasDot) {
+    const lastComma = work.lastIndexOf(',')
+    const lastDot = work.lastIndexOf('.')
+    if (lastDot > lastComma) {
+      work = work.replace(/,/g, '')
+    } else {
+      work = work.replace(/\./g, '').replace(/,/g, '.')
+    }
+  } else if (hasComma) {
+    // en: comma is thousands (1,234 → 1234). Lone European-style 1,50 → still decimal for resilience.
+    if (/^\d{1,3}(,\d{3})+$/.test(work)) {
+      work = work.replace(/,/g, '')
+    } else if (/^\d+,\d{1,2}$/.test(work)) {
+      work = work.replace(',', '.')
+    } else {
+      work = work.replace(/,/g, '')
+    }
+  }
+  // only-dot: standard en decimal (1.50 → 1.5; 12.345 → 12.345)
+
+  const parsed = Number(work)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
 /**
- * Parse a locale-formatted decimal (es-CO comma or dot separators).
+ * Parse a locale-formatted decimal.
  * Returns `null` for empty or invalid input.
  *
- * Examples: `"1,50"` → 1.5, `"1.234,56"` → 1234.56, `"12.345"` → 12.345
+ * When `locale` is omitted, uses a mixed es/en heuristic (legacy callers).
+ * When `locale` is `es`|`en`, separators follow that locale explicitly.
+ *
+ * Examples (es): `"1,50"` → 1.5, `"1.234,56"` → 1234.56
+ * Examples (en): `"1.50"` → 1.5, `"1,234.56"` → 1234.56
  */
-export function parseLocaleDecimal(value: string | number | null | undefined): number | null {
+export function parseLocaleDecimal(
+  value: string | number | null | undefined,
+  locale?: UiLocale | null,
+): number | null {
   if (value === null || value === undefined) return null
 
   if (typeof value === 'number') {
@@ -20,32 +128,79 @@ export function parseLocaleDecimal(value: string | number | null | undefined): n
   const trimmed = String(value).trim()
   if (!trimmed) return null
 
-  let normalized = trimmed.replace(/[$\s\u00A0]/g, '')
+  const normalized = stripCurrencyNoise(trimmed)
+  if (!normalized) return null
 
-  const hasComma = normalized.includes(',')
-  const hasDot = normalized.includes('.')
+  const resolved = locale == null ? null : normalizeUiLocale(locale)
+  if (resolved === 'es') return parseLocaleDecimalEs(normalized)
+  if (resolved === 'en') return parseLocaleDecimalEn(normalized)
+  return parseLocaleDecimalHeuristic(normalized)
+}
 
-  if (hasComma && hasDot) {
-    const lastComma = normalized.lastIndexOf(',')
-    const lastDot = normalized.lastIndexOf('.')
-    if (lastComma > lastDot) {
-      // es-CO thousands with dot, decimal comma: 1.234,56
-      normalized = normalized.replace(/\./g, '').replace(',', '.')
-    } else {
-      // en-US thousands with comma: 1,234.56
-      normalized = normalized.replace(/,/g, '')
-    }
-  } else if (hasComma) {
-    normalized = normalized.replace(',', '.')
+/**
+ * Format a number for display with locale punctuation.
+ * Defaults preserve es-CO separators.
+ */
+export function formatLocaleNumber(
+  value: number | null | undefined,
+  locale: UiLocale = DEFAULT_UI_LOCALE,
+  options?: {
+    minimumFractionDigits?: number
+    maximumFractionDigits?: number
+  },
+): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return ''
+  const normalized = Object.is(value, -0) ? 0 : value
+  return new Intl.NumberFormat(toNumberLocaleTag(locale), {
+    minimumFractionDigits: options?.minimumFractionDigits ?? 0,
+    maximumFractionDigits: options?.maximumFractionDigits ?? 20,
+  }).format(normalized)
+}
+
+/**
+ * Integer money (COP pesos UI): parse typed cash/tip with locale thousands.
+ * Strips non-digits after removing the locale thousands separator.
+ */
+export function parseIntegerMoney(
+  value: string | number | null | undefined,
+  locale: UiLocale = DEFAULT_UI_LOCALE,
+): number {
+  if (value === null || value === undefined) return 0
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? Math.round(Math.abs(value)) : 0
   }
 
-  const parsed = Number(normalized)
-  return Number.isFinite(parsed) ? parsed : null
+  let work = stripCurrencyNoise(String(value).trim())
+  if (!work) return 0
+
+  const resolved = normalizeUiLocale(locale)
+  if (resolved === 'en') {
+    work = work.replace(/,/g, '')
+  } else {
+    work = work.replace(/\./g, '')
+  }
+  work = work.replace(/\D/g, '')
+  if (!work) return 0
+
+  const parsed = Number(work)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+/** Format integer money with locale thousands (empty when 0). */
+export function formatIntegerMoney(
+  value: number | null | undefined,
+  locale: UiLocale = DEFAULT_UI_LOCALE,
+): string {
+  if (value === null || value === undefined || !Number.isFinite(value) || value <= 0) return ''
+  return new Intl.NumberFormat(toNumberLocaleTag(locale), {
+    maximumFractionDigits: 0,
+  }).format(Math.round(value))
 }
 
 /**
  * Parse numbers from Colombian POS receipt OCR (Gemini JSON).
  * Amounts often use thousands (`2.000`, `2,000`, `8.900`); qty may be decimal (`1.345`).
+ * Intentionally CO-oriented (not driven by tenant UI locale) — see epic #1598 B3.
  */
 export function parseReceiptDecimal(
   value: string | number | null | undefined,
@@ -57,7 +212,7 @@ export function parseReceiptDecimal(
   const trimmed = String(value).trim()
   if (!trimmed) return null
 
-  const normalized = trimmed.replace(/[$\s\u00A0]/g, '')
+  const normalized = stripCurrencyNoise(trimmed)
   if (!normalized || !/^[\d.,]+$/.test(normalized)) return null
 
   const hasComma = normalized.includes(',')


### PR DESCRIPTION
## Summary
- Locale-aware `parseLocaleDecimal` / `formatLocaleNumber` / integer money helpers (`es` → es-CO, `en` → en-US; default es).
- `DecimalInput` formats on blur/display and parses with tenant `businessProfile.locale` (stub-safe until B1).
- Checkout `CashTenderPanel` + `TipSelector` use shared integer COP parse/format.
- `useFormatters.formatNumber` + currency punctuation follow uiLocale (COP code still B5).
- `parseReceiptDecimal` unchanged and documented as CO OCR.

Epic: #1598

## Tests
```bash
node --test utils/parseLocaleDecimal.test.ts utils/domainNumberFormat.test.ts
```
(32 pass; no Nuxt build)

## Out of scope
- B4 strings, B5 currency_code, mass POS display-only rewrites, api-facturacion

Closes #1601