### PR TITLE
fix(i18n): pagos 500 — no t() in definePageMeta

### DIFF
--- a/pages/finanzas/pagos/index.vue
+++ b/pages/finanzas/pagos/index.vue
@@ -217,14 +217,14 @@ import { useFormatters } from '~/composables/useFormatters'
 
 definePageMeta({
   layout: 'dashboard',
-  title: t('finanzas.pagos.title'),
+  title: 'Gestión de Pagos', // static — definePageMeta is not setup; use useHead for i18n
   module: 'finanzas',
 })
 
 useHead({
-  title: 'Gestión de Pagos - Warocol',
+  title: () => t('finanzas.head.pagos'),
   meta: [
-    { name: 'description', content: t('finanzas.pagos.subtitle') }
+    { name: 'description', content: () => t('finanzas.pagos.subtitle') }
   ]
 })
 

--- a/pages/finanzas/pagos/registrar.vue
+++ b/pages/finanzas/pagos/registrar.vue
@@ -23,11 +23,11 @@ import { useRoute, navigateTo } from '#app'
 
 definePageMeta({
   layout: 'dashboard',
-  title: t('finanzas.pagos.registerTitle'),
+  title: 'Registrar Pago',
   module: 'finanzas',
 })
 
-useHead({ title: t('finanzas.pagos.registerTitle') })
+useHead({ title: () => t('finanzas.pagos.registerTitle') })
 
 const route = useRoute()
 const loading = ref(true)


### PR DESCRIPTION
## Summary
- Fixes 500 on `/finanzas/pagos`: `t()` was used inside `definePageMeta`, which is not Vue setup context.
- Affects `pages/finanzas/pagos/index.vue` and `registrar.vue`.
- Static `title` in page meta; i18n titles via `useHead(() => t(...))`.

## Test plan
- [ ] Open `/finanzas/pagos` — no 500
- [ ] Open `/finanzas/pagos/registrar` — no 500
- [ ] `waro_locale=en` — document title EN via useHead