### PR TITLE
fix(i18n): POS delete product modal EN/ES

### DIFF
--- a/components/pos/PosDestructiveReasonModal.vue
+++ b/components/pos/PosDestructiveReasonModal.vue
@@ -54,7 +54,7 @@
               :for="reasonInputId"
               class="block text-xs font-medium text-text-secondary uppercase tracking-wide mt-4 mb-1.5"
             >
-              Motivo <span class="text-destructive">*</span>
+              {{ t('pos.destructive.reasonLabel') }} <span class="text-destructive">{{ t('pos.destructive.reasonRequired') }}</span>
             </label>
             <textarea
               :id="reasonInputId"
@@ -76,7 +76,7 @@
               class="flex-1 min-h-[44px] rounded-xl border border-border text-sm font-semibold text-text-secondary hover:bg-surface-secondary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 disabled:opacity-40 disabled:cursor-not-allowed"
               @click="close"
             >
-              Cancelar
+              {{ t('pos.destructive.cancel') }}
             </button>
             <button
               type="button"
@@ -88,7 +88,7 @@
               @click="submit"
             >
               <UiLoadingDots v-if="loading" size="9px" :color="variant === 'warning' ? 'white' : 'white'" />
-              <span v-else>{{ confirmLabel }}</span>
+              <span v-else>{{ resolvedConfirmLabel }}</span>
             </button>
           </div>
         </div>
@@ -112,7 +112,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   message: '',
-  confirmLabel: 'Confirmar',
+  confirmLabel: undefined,
   // defineProps defaults are hoisted — cannot call t() here
   reasonPlaceholder: undefined,
   loading: false,
@@ -128,6 +128,9 @@ const emit = defineEmits<{
 
 const resolvedReasonPlaceholder = computed(
   () => props.reasonPlaceholder || t('pos.destructive.reasonPlaceholder'),
+)
+const resolvedConfirmLabel = computed(
+  () => props.confirmLabel || t('pos.destructive.confirm'),
 )
 
 const uid = useId()

--- a/i18n/locales/en/pos.json
+++ b/i18n/locales/en/pos.json
@@ -149,7 +149,28 @@
       "registeredBy": "Advance registered for {amount}"
     },
     "destructive": {
-      "reasonPlaceholder": "e.g. customer changed their mind"
+      "reasonPlaceholder": "e.g. customer changed their mind",
+      "reasonLabel": "Reason",
+      "reasonRequired": "*",
+      "cancel": "Cancel",
+      "confirm": "Confirm",
+      "removeProductTitle": "Delete product?",
+      "reduceQtyTitle": "Reduce quantity?",
+      "clearBarTitle": "Clear the bar?",
+      "confirmActionTitle": "Confirm action?",
+      "firedNotifyVoid": "{name} was already sent to the kitchen. The cook will be notified to void it.",
+      "firedNotifyQty": "{name} was already sent to the kitchen. The cook will be notified of the quantity change.",
+      "removeFromTab": "{name} will be removed from the tab.",
+      "clearTableAndCart": "All pending items on the {table} and in the cart will be cleared.",
+      "releaseWithBalance": "This {table} has {amount} in consumption. Releasing now closes it without charging.",
+      "releaseEmpty": "The {table} will be closed without charging.",
+      "clearBarMessage": "All pending bar items will be cleared. The session stays open.",
+      "yesRelease": "Yes, release {table}",
+      "deleteProductError": "Error deleting product",
+      "updateQtyError": "Error updating quantity",
+      "releaseError": "Error releasing {table}",
+      "clearBarError": "Error clearing the bar",
+      "clearCartError": "Error clearing the cart"
     },
     "floor": {
       "minCovered": "Minimum cover met",

--- a/i18n/locales/es/pos.json
+++ b/i18n/locales/es/pos.json
@@ -149,7 +149,28 @@
       "registeredBy": "Anticipo registrado por {amount}"
     },
     "destructive": {
-      "reasonPlaceholder": "Ej: cliente cambió de opinión"
+      "reasonPlaceholder": "Ej: cliente cambió de opinión",
+      "reasonLabel": "Motivo",
+      "reasonRequired": "*",
+      "cancel": "Cancelar",
+      "confirm": "Confirmar",
+      "removeProductTitle": "¿Eliminar producto?",
+      "reduceQtyTitle": "¿Reducir cantidad?",
+      "clearBarTitle": "¿Limpiar la barra?",
+      "confirmActionTitle": "¿Confirmar acción?",
+      "firedNotifyVoid": "{name} ya fue enviado a cocina. Se notificará al cocinero que lo anule.",
+      "firedNotifyQty": "{name} ya fue enviado a cocina. Se notificará al cocinero del cambio de cantidad.",
+      "removeFromTab": "Se eliminará {name} de la cuenta.",
+      "clearTableAndCart": "Se borrarán todos los ítems pendientes de la {table} y del carrito.",
+      "releaseWithBalance": "Esta {table} tiene {amount} en consumo. Si la liberas ahora, se cerrará sin cobrar.",
+      "releaseEmpty": "Se cerrará la {table} sin cobrar.",
+      "clearBarMessage": "Se borrarán todos los ítems pendientes de la barra. La sesión permanece abierta.",
+      "yesRelease": "Sí, liberar {table}",
+      "deleteProductError": "Error al eliminar el producto",
+      "updateQtyError": "Error al actualizar la cantidad",
+      "releaseError": "Error al liberar la {table}",
+      "clearBarError": "Error al limpiar la barra",
+      "clearCartError": "Error al limpiar el carrito"
     },
     "floor": {
       "minCovered": "Mínimo cubierto",

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -856,19 +856,19 @@ const destructiveModalTitle = computed(() => {
   if (!flow) return ''
   switch (flow.kind) {
     case 'remove-tab-item':
-      return '¿Eliminar producto?'
+      return t('pos.destructive.removeProductTitle')
     case 'decrease-tab-item':
-      return '¿Reducir cantidad?'
+      return t('pos.destructive.reduceQtyTitle')
     case 'clear-cart':
       return posStore.activeTableSession ? t('pos.banner.clearAccount') : t('pos.banner.clearCartQ')
     case 'remove-cart-item':
-      return '¿Eliminar producto?'
+      return t('pos.destructive.removeProductTitle')
     case 'release-table':
       return t('pos.banner.releaseTableQ', { table: tableSingularLower.value })
     case 'clear-bar-tab':
-      return '¿Limpiar la barra?'
+      return t('pos.destructive.clearBarTitle')
     default:
-      return '¿Confirmar acción?'
+      return t('pos.destructive.confirmActionTitle')
   }
 })
 
@@ -880,18 +880,18 @@ const destructiveModalMessage = computed(() => {
       const item = storeTabItems.value.find((i: TabItem) => i.orderItemId === flow.orderItemId)
       const name = item?.productName ?? t('pos.banner.thisProduct')
       if (comandasEnabled.value && isTabItemFired(flow.orderItemId)) {
-        return `${name} ya fue enviado a cocina. Se notificará al cocinero que lo anule.`
+        return t('pos.destructive.firedNotifyVoid', { name })
       }
-      return `Se eliminará ${name} de la cuenta.`
+      return t('pos.destructive.removeFromTab', { name })
     }
     case 'decrease-tab-item': {
       const item = storeTabItems.value.find((i: TabItem) => i.orderItemId === flow.orderItemId)
       const name = item?.productName ?? t('pos.banner.thisProduct')
-      return `${name} ya fue enviado a cocina. Se notificará al cocinero del cambio de cantidad.`
+      return t('pos.destructive.firedNotifyQty', { name })
     }
     case 'clear-cart':
       return posStore.activeTableSession
-        ? `Se borrarán todos los ítems pendientes de la ${tableSingularLower.value} y del carrito.`
+        ? t('pos.destructive.clearTableAndCart', { table: tableSingularLower.value })
         : t('pos.banner.clearCartItems')
     case 'remove-cart-item': {
       const item = posStore.cart[flow.index]
@@ -900,12 +900,15 @@ const destructiveModalMessage = computed(() => {
     case 'release-table': {
       const session = posStore.activeTableSession
       if (session && session.runningTotal > 0) {
-        return `Esta ${tableSingularLower.value} tiene ${formatCurrencyPOS(session.runningTotal)} en consumo. Si la liberas ahora, se cerrará sin cobrar.`
+        return t('pos.destructive.releaseWithBalance', {
+          table: tableSingularLower.value,
+          amount: formatCurrencyPOS(session.runningTotal),
+        })
       }
-      return `Se cerrará la ${tableSingularLower.value} sin cobrar.`
+      return t('pos.destructive.releaseEmpty', { table: tableSingularLower.value })
     }
     case 'clear-bar-tab':
-      return 'Se borrarán todos los ítems pendientes de la barra. La sesión permanece abierta.'
+      return t('pos.destructive.clearBarMessage')
     default:
       return ''
   }
@@ -923,7 +926,7 @@ const destructiveModalConfirmLabel = computed(() => {
     case 'clear-cart':
       return t('pos.banner.yesClear')
     case 'release-table':
-      return `Sí, liberar ${tableSingularLower.value}`
+      return t('pos.destructive.yesRelease', { table: tableSingularLower.value })
     case 'clear-bar-tab':
       return t('pos.banner.yesClear')
     default:
@@ -1014,7 +1017,7 @@ const executeRemoveTabItem = async (orderItemId: string, reason?: string) => {
   } catch (e: unknown) {
     bumpTableSessionFetchGen()
     posStore.setTabItems(previousTabItems)
-    const errText = destructiveFetchError(e, 'Error al eliminar el producto')
+    const errText = destructiveFetchError(e, t('pos.destructive.deleteProductError'))
     if (destructiveFlow.value?.kind === 'remove-tab-item') {
       destructiveError.value = errText
     } else {
@@ -1039,7 +1042,7 @@ const updateTabItemQuantity = async (orderItemId: string, quantity: number, reas
     })
     await refreshTableSession()
   } catch (e: unknown) {
-    const errText = destructiveFetchError(e, 'Error al actualizar la cantidad')
+    const errText = destructiveFetchError(e, t('pos.destructive.updateQtyError'))
     if (destructiveFlow.value?.kind === 'decrease-tab-item') {
       destructiveError.value = errText
     } else {
@@ -1174,7 +1177,7 @@ const executeBannerClose = async (reason: string) => {
       body: { reason: reason.trim() || null },
     })
   } catch (e: unknown) {
-    destructiveError.value = destructiveFetchError(e, `Error al liberar la ${tableSingularLower.value}`)
+    destructiveError.value = destructiveFetchError(e, t('pos.destructive.releaseError', { table: tableSingularLower.value }))
     return
   }
   resetComandaPrintState()
@@ -1195,7 +1198,7 @@ const executeClearBarTab = async (reason: string) => {
     posStore.clearAll()
     queryCache.invalidateQueries({ key: ['tables', currentTenant.value?.id] })
   } catch (e: unknown) {
-    destructiveError.value = destructiveFetchError(e, 'Error al limpiar la barra')
+    destructiveError.value = destructiveFetchError(e, t('pos.destructive.clearBarError'))
   } finally {
     posStore.isCancellingMesa = false
   }
@@ -1535,7 +1538,7 @@ const executeClearCart = async (reason: string) => {
   try {
     await posStore.clearCart(reason)
   } catch (e: unknown) {
-    destructiveError.value = destructiveFetchError(e, 'Error al limpiar el carrito')
+    destructiveError.value = destructiveFetchError(e, t('pos.destructive.clearCartError'))
   }
 }
 


### PR DESCRIPTION
## Summary
- Localizes `PosDestructiveReasonModal` labels (Reason, Cancel, Confirm).
- Wires all destructive flow titles/messages/confirm labels from `pages/pos/index.vue` via `pos.destructive.*`.
- Covers fired-to-kitchen delete copy the user reported mixed ES/EN.

## Test plan
- [ ] locale=en: delete fired product → EN title/body/Motivo/Cancel/Yes delete
- [ ] locale=es: same modal matches previous Spanish
- [ ] Product name still comes from catalog data (unchanged)