### PR TITLE
fix(i18n): POS delete modal single-locale + Table noun

### DIFF
--- a/components/pos/PosDestructiveReasonModal.vue
+++ b/components/pos/PosDestructiveReasonModal.vue
@@ -42,10 +42,10 @@
               </div>
               <div class="flex-1 min-w-0">
                 <h3 :id="titleId" class="text-base font-bold text-text-primary leading-tight">
-                  {{ title }}
+                  {{ resolvedTitle }}
                 </h3>
-                <p v-if="message" class="text-sm text-text-secondary mt-1 leading-snug">
-                  {{ message }}
+                <p v-if="resolvedMessage" class="text-sm text-text-secondary mt-1 leading-snug">
+                  {{ resolvedMessage }}
                 </p>
               </div>
             </div>
@@ -98,12 +98,21 @@
 </template>
 
 <script setup lang="ts">
-const { t } = useI18n()
+const { t, locale } = useI18n()
+import { computed, ref, watch } from 'vue'
+
 interface Props {
   modelValue: boolean
-  title: string
+  /** Pre-translated title (legacy). Prefer titleKey. */
+  title?: string
+  titleKey?: string
+  titleParams?: Record<string, unknown>
   message?: string
+  messageKey?: string
+  messageParams?: Record<string, unknown>
   confirmLabel?: string
+  confirmLabelKey?: string
+  confirmLabelParams?: Record<string, unknown>
   reasonPlaceholder?: string
   loading?: boolean
   error?: string
@@ -111,9 +120,15 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
+  title: '',
+  titleKey: undefined,
+  titleParams: () => ({}),
   message: '',
+  messageKey: undefined,
+  messageParams: () => ({}),
   confirmLabel: undefined,
-  // defineProps defaults are hoisted — cannot call t() here
+  confirmLabelKey: undefined,
+  confirmLabelParams: () => ({}),
   reasonPlaceholder: undefined,
   loading: false,
   error: '',
@@ -126,12 +141,26 @@ const emit = defineEmits<{
   (e: 'cancel'): void
 }>()
 
-const resolvedReasonPlaceholder = computed(
-  () => props.reasonPlaceholder || t('pos.destructive.reasonPlaceholder'),
-)
-const resolvedConfirmLabel = computed(
-  () => props.confirmLabel || t('pos.destructive.confirm'),
-)
+const resolvedTitle = computed(() => {
+  void locale.value
+  if (props.titleKey) return t(props.titleKey, props.titleParams as any)
+  return props.title
+})
+const resolvedMessage = computed(() => {
+  void locale.value
+  if (props.messageKey) return t(props.messageKey, props.messageParams as any)
+  return props.message
+})
+const resolvedReasonPlaceholder = computed(() => {
+  void locale.value
+  return props.reasonPlaceholder || t('pos.destructive.reasonPlaceholder')
+})
+const resolvedConfirmLabel = computed(() => {
+  void locale.value
+  if (props.confirmLabelKey) return t(props.confirmLabelKey, props.confirmLabelParams as any)
+  if (props.confirmLabel) return props.confirmLabel
+  return t('pos.destructive.confirm')
+})
 
 const uid = useId()
 const titleId = `pos-destructive-title-${uid}`
@@ -156,3 +185,4 @@ const submit = () => {
   emit('confirm', reason.value.trim())
 }
 </script>
+

--- a/composables/useTableLabel.ts
+++ b/composables/useTableLabel.ts
@@ -32,6 +32,7 @@ const oldLocalStorageKey = (tenantId: string) => `waro_table_label_${tenantId}`
  * so existing consumers from #612 keep working unchanged.
  */
 export function useTableLabel() {
+  const { t } = useI18n()
   const { currentTenant } = useTenantReactive()
   const cache = useQueryCache()
 
@@ -44,11 +45,12 @@ export function useTableLabel() {
 
   const singular = computed(() => {
     const value = contextData.value?.data?.tables_label_singular
-    return (typeof value === 'string' && value.trim()) ? value.trim() : DEFAULTS.singular
+    // Tenant custom label wins; otherwise follow UI locale (Mesa/Table).
+    return (typeof value === 'string' && value.trim()) ? value.trim() : t('pos.glossary.table')
   })
   const plural = computed(() => {
     const value = contextData.value?.data?.tables_label_plural
-    return (typeof value === 'string' && value.trim()) ? value.trim() : DEFAULTS.plural
+    return (typeof value === 'string' && value.trim()) ? value.trim() : t('pos.glossary.tables')
   })
 
   const setLabel = async (newSingular: string, newPlural: string) => {

--- a/i18n/locales/en/pos.json
+++ b/i18n/locales/en/pos.json
@@ -171,7 +171,10 @@
       "updateQtyError": "Error updating quantity",
       "releaseError": "Error releasing {table}",
       "clearBarError": "Error clearing the bar",
-      "clearCartError": "Error clearing the cart"
+      "clearCartError": "Error clearing the cart",
+      "yesDelete": "Yes, delete",
+      "yesReduce": "Yes, reduce",
+      "yesClear": "Yes, clear"
     },
     "floor": {
       "minCovered": "Minimum cover met",
@@ -310,6 +313,10 @@
       "comanda": "Ticket #{numbers}",
       "station": "Station: {name}",
       "noStation": "No kitchen station"
+    },
+    "glossary": {
+      "table": "Table",
+      "tables": "Tables"
     }
   }
 }

--- a/i18n/locales/es/pos.json
+++ b/i18n/locales/es/pos.json
@@ -171,7 +171,10 @@
       "updateQtyError": "Error al actualizar la cantidad",
       "releaseError": "Error al liberar la {table}",
       "clearBarError": "Error al limpiar la barra",
-      "clearCartError": "Error al limpiar el carrito"
+      "clearCartError": "Error al limpiar el carrito",
+      "yesDelete": "Sí, eliminar",
+      "yesReduce": "Sí, reducir",
+      "yesClear": "Sí, limpiar"
     },
     "floor": {
       "minCovered": "Mínimo cubierto",
@@ -310,6 +313,10 @@
       "comanda": "Comanda #{numbers}",
       "station": "Estación: {name}",
       "noStation": "Sin cocina asignada"
+    },
+    "glossary": {
+      "table": "Mesa",
+      "tables": "Mesas"
     }
   }
 }

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -852,6 +852,7 @@ const isTabItemFired = (orderItemId: string) => {
 }
 
 const destructiveModalTitle = computed(() => {
+  void locale.value
   const flow = destructiveFlow.value
   if (!flow) return ''
   switch (flow.kind) {
@@ -873,6 +874,7 @@ const destructiveModalTitle = computed(() => {
 })
 
 const destructiveModalMessage = computed(() => {
+  void locale.value
   const flow = destructiveFlow.value
   if (!flow) return ''
   switch (flow.kind) {
@@ -915,22 +917,23 @@ const destructiveModalMessage = computed(() => {
 })
 
 const destructiveModalConfirmLabel = computed(() => {
+  void locale.value
   const flow = destructiveFlow.value
-  if (!flow) return t('pos.banner.confirm')
+  if (!flow) return t('pos.destructive.confirm')
   switch (flow.kind) {
     case 'remove-tab-item':
     case 'remove-cart-item':
-      return t('pos.banner.yesDelete')
+      return t('pos.destructive.yesDelete')
     case 'decrease-tab-item':
-      return t('pos.banner.yesReduce')
+      return t('pos.destructive.yesReduce')
     case 'clear-cart':
-      return t('pos.banner.yesClear')
+      return t('pos.destructive.yesClear')
     case 'release-table':
       return t('pos.destructive.yesRelease', { table: tableSingularLower.value })
     case 'clear-bar-tab':
-      return t('pos.banner.yesClear')
+      return t('pos.destructive.yesClear')
     default:
-      return t('pos.banner.confirm')
+      return t('pos.destructive.confirm')
   }
 })
 


### PR DESCRIPTION
## Summary
- Fixes mixed ES/EN delete modal (Spanish title + English Yes delete) by resolving all chrome from `pos.destructive.*` with locale tracking.
- Default table noun follows UI locale (`Table`/`Tables` vs `Mesa`/`Mesas`) unless tenant customized labels.

## Why mixed UI happened
With `locale=en`, missing/stale nested keys fall back to Spanish while older keys (e.g. banner.yesDelete, reasonPlaceholder) stayed English.

## Test plan
- [ ] locale=en: delete fired product → all chrome EN (Delete product?, Reason, Cancel, Yes delete, kitchen message EN)
- [ ] locale=es: full Spanish modal
- [ ] Banner shows Active **Table** (not Active Mesa) when no custom table label
- [ ] Product names remain as catalog data