### PR TITLE
Simplify country and currency settings

### DIFF
--- a/components/operaciones/FinancialProfileSettings.vue
+++ b/components/operaciones/FinancialProfileSettings.vue
@@ -40,9 +40,6 @@ watch(() => draft.value.country_code, () => {
 
 const canSubmit = computed(() => canSubmitFinancialProfile(response.value, draft.value))
 const isLocked = computed(() => response.value?.eligibility.eligible === false)
-const lockTone = computed(() =>
-  response.value?.eligibility.lock_type === 'permanent' ? 'danger' : 'warning',
-)
 
 const makeDisplayNames = (type: 'region' | 'currency') => {
   try {
@@ -56,25 +53,6 @@ const countryLabel = (code: string) => makeDisplayNames('region')?.of(code) ?? c
 const currencyLabel = (code: string) => {
   const name = makeDisplayNames('currency')?.of(code)
   return name && name !== code ? `${name} (${code})` : code
-}
-
-const reasonLabel = (code: string) => {
-  const knownReasons: Record<string, string> = {
-    PERMANENT_FINANCIAL_ACTIVITY: 'permanentActivity',
-    TEMPORARY_OPERATIONAL_ACTIVITY: 'temporaryActivity',
-    permanent_orders: 'permanentOrders',
-    permanent_payments: 'permanentPayments',
-    permanent_journals: 'permanentJournals',
-    permanent_invoices: 'permanentInvoices',
-    permanent_wallet_movements: 'permanentWallet',
-    temporary_open_orders: 'temporaryOrders',
-    temporary_open_shifts: 'temporaryShifts',
-    temporary_activity: 'temporaryActivity',
-  }
-  const key = knownReasons[code]
-  return key
-    ? t(`operaciones.personalizar.financial.lockReasons.${key}`)
-    : t('operaciones.personalizar.financial.lockReasons.unknown', { code })
 }
 
 const queryErrorMessage = computed(() => {
@@ -157,41 +135,42 @@ const confirmSave = async () => {
     <template v-else>
       <div
         v-if="isLocked"
-        class="mt-4 rounded-lg border p-4"
-        :class="lockTone === 'danger'
-          ? 'border-state-danger-border bg-state-danger-bg'
-          : 'border-state-warning-border bg-state-warning-bg'"
+        class="mt-4 rounded-lg border border-state-warning-border bg-state-warning-bg p-3"
         role="status"
         aria-live="polite"
       >
-        <p
-          class="text-sm font-semibold"
-          :class="lockTone === 'danger' ? 'text-state-danger-text' : 'text-state-warning-text'"
-        >
+        <p class="text-sm font-semibold text-state-warning-text">
           {{ response.eligibility.lock_type === 'permanent'
             ? t('operaciones.personalizar.financial.permanentLockTitle')
             : t('operaciones.personalizar.financial.temporaryLockTitle') }}
         </p>
-        <p
-          class="mt-1 text-xs leading-snug"
-          :class="lockTone === 'danger' ? 'text-state-danger-text/90' : 'text-state-warning-text/90'"
-        >
+        <p class="mt-1 text-xs leading-snug text-state-warning-text/90">
           {{ response.eligibility.lock_type === 'permanent'
             ? t('operaciones.personalizar.financial.permanentLockHelp')
             : t('operaciones.personalizar.financial.temporaryLockHelp') }}
         </p>
-        <ul v-if="response.eligibility.reason_codes.length" class="mt-2 list-disc space-y-1 ps-5 text-xs">
-          <li
-            v-for="reason in response.eligibility.reason_codes"
-            :key="reason"
-            :class="lockTone === 'danger' ? 'text-state-danger-text' : 'text-state-warning-text'"
-          >
-            {{ reasonLabel(reason) }}
-          </li>
-        </ul>
       </div>
 
-      <fieldset class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2" :disabled="isLocked || isSaving">
+      <dl v-if="isLocked" class="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div class="rounded-lg border border-border bg-surface-secondary px-3 py-2.5">
+          <dt class="text-xs text-text-secondary">
+            {{ t('operaciones.personalizar.financial.country') }}
+          </dt>
+          <dd class="mt-0.5 text-sm font-semibold text-text-primary">
+            {{ countryLabel(draft.country_code) }}
+          </dd>
+        </div>
+        <div class="rounded-lg border border-border bg-surface-secondary px-3 py-2.5">
+          <dt class="text-xs text-text-secondary">
+            {{ t('operaciones.personalizar.financial.currency') }}
+          </dt>
+          <dd class="mt-0.5 text-sm font-semibold text-text-primary">
+            {{ currencyLabel(draft.base_currency_code) }}
+          </dd>
+        </div>
+      </dl>
+
+      <fieldset v-else class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2" :disabled="isSaving">
         <legend class="sr-only">{{ t('operaciones.personalizar.financial.fieldsLegend') }}</legend>
         <div class="flex flex-col gap-1">
           <label for="financial-country" class="text-sm font-medium text-text-primary">
@@ -231,7 +210,7 @@ const confirmSave = async () => {
         </div>
       </fieldset>
 
-      <div class="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+      <div v-if="!isLocked" class="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <p class="max-w-2xl text-xs leading-snug text-text-secondary">
           {{ t('operaciones.personalizar.financial.irreversibleHelp') }}
         </p>

--- a/i18n/locales/en/operaciones.json
+++ b/i18n/locales/en/operaciones.json
@@ -253,11 +253,11 @@
       ,"languageApplying": "Updating the interface…"
       ,"languageSyncing": "Syncing the restaurant…"
       ,"financial": {
-        "title": "Country and base currency", "help": "Define the business financial identity. Compatible options come from WARO.",
+        "title": "Country and currency", "help": "Set the currency used for all operations.",
         "loading": "Loading financial settings…", "loadError": "Financial settings could not be loaded", "retry": "Try again",
-        "permanentLockTitle": "These settings can no longer be changed", "temporaryLockTitle": "Change temporarily blocked",
-        "permanentLockHelp": "The business already has permanent financial activity. Changing country or currency would reinterpret its history.",
-        "temporaryLockHelp": "Complete or cancel the listed open activity and try again.",
+        "permanentLockTitle": "Country and currency protected", "temporaryLockTitle": "Change unavailable for now",
+        "permanentLockHelp": "They cannot be changed because the business already has financial activity.",
+        "temporaryLockHelp": "Close the pending activity and try again.",
         "lockReasons": {
           "permanentActivity": "Financial activity exists whose country and currency must be preserved.", "permanentOrders": "Orders with monetary history exist.", "permanentPayments": "Recorded payments exist.",
           "permanentJournals": "Posted journal entries exist.", "permanentInvoices": "Electronic documents have been issued.",
@@ -265,10 +265,10 @@
           "temporaryShifts": "There are open shifts or registers.", "temporaryActivity": "There is unfinished operational activity.",
           "unknown": "WARO blocked the change because of rule {code}."
         },
-        "fieldsLegend": "Country and base currency settings", "country": "Business country", "currency": "Base currency",
-        "currencyHelp": "All business amounts are interpreted in this currency; no FX conversion is performed.",
-        "irreversibleHelp": "Confirm carefully. Once financial activity exists, this choice becomes irreversible.",
-        "saving": "Saving…", "reviewChange": "Review change", "confirmTitle": "Confirm country and currency",
+        "fieldsLegend": "Country and currency settings", "country": "Country", "currency": "Currency",
+        "currencyHelp": "WARO does not convert amounts between currencies.",
+        "irreversibleHelp": "You can change this setting until financial activity is recorded.",
+        "saving": "Saving…", "reviewChange": "Save changes", "confirmTitle": "Confirm country and currency",
         "confirmMessage": "You will change {currentCountry} / {currentCurrency} to {nextCountry} / {nextCurrency}. You cannot reverse this decision after financial activity is recorded.",
         "confirmAction": "Yes, change settings", "cancel": "Cancel", "saveSuccess": "Country and base currency updated",
         "saveError": "Financial settings could not be updated"

--- a/i18n/locales/es/operaciones.json
+++ b/i18n/locales/es/operaciones.json
@@ -253,11 +253,11 @@
       ,"languageApplying": "Actualizando la interfaz…"
       ,"languageSyncing": "Sincronizando el restaurante…"
       ,"financial": {
-        "title": "País y moneda base", "help": "Define la identidad financiera del negocio. Las opciones compatibles provienen de WARO.",
+        "title": "País y moneda", "help": "Define la moneda usada en todas las operaciones.",
         "loading": "Cargando configuración financiera…", "loadError": "No se pudo cargar la configuración financiera", "retry": "Reintentar",
-        "permanentLockTitle": "Esta configuración ya no se puede cambiar", "temporaryLockTitle": "Cambio temporalmente bloqueado",
-        "permanentLockHelp": "El negocio ya tiene actividad financiera permanente. Cambiar país o moneda reinterpretaría su historial.",
-        "temporaryLockHelp": "Finaliza o cancela la actividad abierta indicada y vuelve a intentarlo.",
+        "permanentLockTitle": "País y moneda protegidos", "temporaryLockTitle": "Cambio no disponible por ahora",
+        "permanentLockHelp": "No se pueden cambiar porque el negocio ya tiene actividad financiera.",
+        "temporaryLockHelp": "Cierra la actividad pendiente y vuelve a intentarlo.",
         "lockReasons": {
           "permanentActivity": "Existe actividad financiera que debe conservar su país y moneda.", "permanentOrders": "Existen pedidos con historia monetaria.", "permanentPayments": "Existen pagos registrados.",
           "permanentJournals": "Existen asientos contables confirmados.", "permanentInvoices": "Existen documentos electrónicos emitidos.",
@@ -265,10 +265,10 @@
           "temporaryShifts": "Hay turnos o cajas abiertas.", "temporaryActivity": "Hay actividad operativa sin cerrar.",
           "unknown": "WARO bloqueó el cambio por la regla {code}."
         },
-        "fieldsLegend": "Configuración de país y moneda base", "country": "País del negocio", "currency": "Moneda base",
-        "currencyHelp": "Todos los importes del negocio se interpretan en esta moneda; no se realiza conversión FX.",
-        "irreversibleHelp": "Confirma con cuidado. Cuando exista actividad financiera, esta elección será irreversible.",
-        "saving": "Guardando…", "reviewChange": "Revisar cambio", "confirmTitle": "Confirmar país y moneda",
+        "fieldsLegend": "Configuración de país y moneda", "country": "País", "currency": "Moneda",
+        "currencyHelp": "WARO no convierte importes entre monedas.",
+        "irreversibleHelp": "Podrás cambiar esta configuración hasta registrar actividad financiera.",
+        "saving": "Guardando…", "reviewChange": "Guardar cambios", "confirmTitle": "Confirmar país y moneda",
         "confirmMessage": "Cambiarás {currentCountry} / {currentCurrency} por {nextCountry} / {nextCurrency}. Después de registrar actividad financiera no podrás revertir esta decisión.",
         "confirmAction": "Sí, cambiar configuración", "cancel": "Cancelar", "saveSuccess": "País y moneda base actualizados",
         "saveError": "No se pudo actualizar la configuración financiera"


### PR DESCRIPTION
## Summary
- present locked country and currency as concise read-only values
- remove repeated lock reasons and unavailable controls/actions
- shorten Spanish and English guidance for editable states

## Verification
- `node --test composables/useTenantFinancialProfile.test.ts` (5 passed)
- Vue SFC parse
- locale JSON parse
- `git diff --check`