### PR TITLE
fix(onboarding): resume payment flow after login

### DIFF
--- a/pages/onboarding/index.vue
+++ b/pages/onboarding/index.vue
@@ -300,7 +300,7 @@ const handleBusinessSubmit = async (draft: OnboardingBusinessDraft) => {
 }
 
 const handleTermsAccepted = async () => {
-  await redirectToBilling()
+  await reload()
 }
 
 const handleCheckout = async () => {

--- a/utils/onboardingFlow.test.ts
+++ b/utils/onboardingFlow.test.ts
@@ -62,6 +62,10 @@ test('uses server status and returns a safe error for unknown next steps', () =>
   assert.equal(normalizeOnboardingNextStep('unexpected'), null)
 })
 
+test('keeps payment-pending tenants inside onboarding to select a plan', () => {
+  assert.equal(resolveOnboardingView({ nextStep: 'payment', termsAccepted: true }), 'plan')
+})
+
 test('requires a real business name instead of the server placeholder', () => {
   assert.equal(getEditableBusinessName('  Negocio   pendiente  '), '')
   assert.equal(getEditableBusinessName('  Cafe   Central  '), 'Cafe Central')


### PR DESCRIPTION
## Resumen
- recarga el estado del onboarding después de aceptar términos
- mantiene `payment_pending` dentro del selector de plan
- evita saltar prematuramente al billing externo

## Validación
- `node --test utils/onboardingFlow.test.ts`
- `npm run i18n:check:all`
- parseo de `pages/onboarding/index.vue` con Vue SFC compiler
- sin build, según solicitud

Closes #1655