### PR TITLE
Prefill login for existing registrations

### DIFF
--- a/components/Auth/LoginForm.vue
+++ b/components/Auth/LoginForm.vue
@@ -193,6 +193,7 @@ const verifyingCode = ref(false)
 const showCustomerPortalLink = ref(false)
 const toast = useToast()
 const router = useRouter()
+const route = useRoute()
 const authStore = useAuthStore()
 const accessStore = useAccessStore()
 const { syncAuthenticatedLocale } = useAppLocale()
@@ -268,6 +269,11 @@ const {
 
 // Verificar si ya hay sesión al cargar el componente y configurar observer de emojis
 onMounted(async () => {
+  const emailQuery = Array.isArray(route.query.email) ? route.query.email[0] : route.query.email
+  if (typeof emailQuery === 'string') {
+    email.value = emailQuery.trim().toLowerCase()
+  }
+
   // Configurar observer de emojis
   if (foodBgContainer.value) {
     const rect = foodBgContainer.value.getBoundingClientRect()
@@ -301,7 +307,6 @@ onMounted(async () => {
       const expectedTenantName = config.siteName || 'Waro Colombia'
       if (session.user.tenant_name === expectedTenantName) {
 
-        const route = useRoute()
         await syncAuthenticatedLocale(session)
         await accessStore.load()
         const redirectUrl = getAccessAwareRedirect(route.query.redirect, accessStore, router)
@@ -331,7 +336,6 @@ async function handleSubmit() {
   error.value = ''
 
   try {
-    const route = useRoute()
     await $fetch('/api/auth/sign-in-magic-link', {
       method: 'POST',
       credentials: 'include',
@@ -393,7 +397,6 @@ async function verifyCode() {
     toast.success(t('auth.accessGranted'))
 
     // Redirigir con recarga completa para asegurar que la cookie se incluya
-    const route = useRoute()
     await accessStore.load()
     const redirectUrl = getAccessAwareRedirect(route.query.redirect, accessStore, router)
 

--- a/components/Auth/RegistrationForm.vue
+++ b/components/Auth/RegistrationForm.vue
@@ -309,6 +309,11 @@ interface PhoneCountryOption {
   calling_code: number
 }
 
+interface RegistrationMagicLinkResult {
+  success: boolean
+  action: 'verification_sent' | 'login_required'
+}
+
 const { t, locale } = useI18n()
 const route = useRoute()
 const router = useRouter()
@@ -470,7 +475,7 @@ const sendRegistration = async (isResend: boolean) => {
   error.value = ''
   try {
     const draft = currentDraft()
-    await $fetch('/api/auth/register-magic-link', {
+    const result = await $fetch<RegistrationMagicLinkResult>('/api/auth/register-magic-link', {
       method: 'POST',
       credentials: 'include',
       headers: {
@@ -479,6 +484,16 @@ const sendRegistration = async (isResend: boolean) => {
       },
       body: buildRegistrationPayload(draft),
     })
+    if (result.action === 'login_required') {
+      const normalizedEmail = email.value.trim().toLocaleLowerCase()
+      if (import.meta.client) clearRegistrationDraft(window.sessionStorage)
+      toast.info(`${t('auth.alreadyHaveAccount')} ${t('auth.signIn')}`)
+      await navigateTo({
+        path: '/auth/login',
+        query: { email: normalizedEmail },
+      }, { replace: true })
+      return
+    }
     phase.value = 'code'
     sentAt.value = Date.now()
     persistDraft()


### PR DESCRIPTION
## What changed
- redirect existing registrations to the login page
- prefill the normalized email
- avoid showing the registration code screen or sending duplicate codes

## Why
Existing pending owners must resume onboarding through the normal login flow.

## Validation
- Nuxt typecheck passed
- i18n validation passed for 8 locales