### PR TITLE
fix(billing): restore subscription action

### DIFF
--- a/pages/gestion/billing/index.vue
+++ b/pages/gestion/billing/index.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { useBilling, type BillingPlan, type BillingQuotaKey } from '~/composables/useBilling'
 import { useFormatters } from '~/composables/useFormatters'
+import {
+  canStartBillingSubscription,
+  shouldShowBillingRecoveryAlert,
+} from '~/utils/billingPresentation'
 
 interface Column {
   key: string
@@ -307,22 +311,24 @@ const handleExistingCheckout = async (checkoutUrl?: string | null) => {
 // ── Should show subscribe/reactivate button ──────────────────────
 const isAccessBlocked = computed(() => accessStatus.value?.level === 'blocked')
 const hasExistingCheckout = computed(() => !!subscription.value?.checkout_url)
+const billingPresentationState = computed(() => ({
+  subscriptionStatus: subscription.value?.status ?? null,
+  checkoutUrl: subscription.value?.checkout_url ?? null,
+  accessLevel: accessStatus.value?.level ?? null,
+}))
 const showBillingRecoveryAlert = computed(() =>
-  subscription.value?.status === 'past_due' || isAccessBlocked.value
+  shouldShowBillingRecoveryAlert(billingPresentationState.value)
 )
 const requiresTermsAcceptance = computed(() =>
   termsStatus.value?.pending === true || termsStatus.value?.accepted === false
 )
 const canSubscribe = computed(() => {
-  const s = subscription.value?.status
-  return !subscription.value ||
-    s === 'cancelled' ||
-    s === 'expired' ||
-    (s === 'pending' && !subscription.value.checkout_url) ||
-    (isAccessBlocked.value && !subscription.value.checkout_url)
+  return canStartBillingSubscription(billingPresentationState.value)
 })
 const primaryBillingActionLabel = computed(() => {
-  if (!subscription.value) return t('billing.subscribe')
+  if (!subscription.value || subscription.value.status === 'pending') {
+    return t('billing.subscribe')
+  }
   if (isAccessBlocked.value) return t('billing.reactivate')
   return t('billing.reactivate')
 })

--- a/utils/billingPresentation.test.ts
+++ b/utils/billingPresentation.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  canStartBillingSubscription,
+  shouldShowBillingRecoveryAlert,
+} from './billingPresentation.ts'
+
+test('payment-pending onboarding without a subscription can subscribe', () => {
+  const state = {
+    subscriptionStatus: null,
+    checkoutUrl: null,
+    accessLevel: 'blocked',
+  }
+
+  assert.equal(canStartBillingSubscription(state), true)
+  assert.equal(shouldShowBillingRecoveryAlert(state), false)
+})
+
+test('pending subscription with checkout completes the existing payment', () => {
+  const state = {
+    subscriptionStatus: 'pending',
+    checkoutUrl: 'https://checkout.example.test',
+    accessLevel: 'blocked',
+  }
+
+  assert.equal(canStartBillingSubscription(state), false)
+  assert.equal(shouldShowBillingRecoveryAlert(state), false)
+})
+
+test('pending subscription without checkout can restart payment', () => {
+  const state = {
+    subscriptionStatus: 'pending',
+    checkoutUrl: null,
+    accessLevel: 'blocked',
+  }
+
+  assert.equal(canStartBillingSubscription(state), true)
+  assert.equal(shouldShowBillingRecoveryAlert(state), false)
+})
+
+test('active subscription does not expose subscription actions', () => {
+  const state = {
+    subscriptionStatus: 'active',
+    checkoutUrl: null,
+    accessLevel: 'full',
+  }
+
+  assert.equal(canStartBillingSubscription(state), false)
+  assert.equal(shouldShowBillingRecoveryAlert(state), false)
+})
+
+test('cancelled, expired and overdue subscriptions use recovery alert', () => {
+  for (const subscriptionStatus of ['cancelled', 'expired', 'past_due']) {
+    assert.equal(shouldShowBillingRecoveryAlert({
+      subscriptionStatus,
+      checkoutUrl: null,
+      accessLevel: 'blocked',
+    }), true)
+  }
+})

--- a/utils/billingPresentation.ts
+++ b/utils/billingPresentation.ts
@@ -1,0 +1,24 @@
+export interface BillingPresentationState {
+  subscriptionStatus?: string | null
+  checkoutUrl?: string | null
+  accessLevel?: string | null
+}
+
+export const canStartBillingSubscription = ({
+  subscriptionStatus,
+  checkoutUrl,
+  accessLevel,
+}: BillingPresentationState) =>
+  !subscriptionStatus ||
+  subscriptionStatus === 'cancelled' ||
+  subscriptionStatus === 'expired' ||
+  (subscriptionStatus === 'pending' && !checkoutUrl) ||
+  (accessLevel === 'blocked' && !checkoutUrl)
+
+export const shouldShowBillingRecoveryAlert = ({
+  subscriptionStatus,
+  accessLevel,
+}: BillingPresentationState) =>
+  !!subscriptionStatus &&
+  subscriptionStatus !== 'pending' &&
+  (subscriptionStatus === 'past_due' || accessLevel === 'blocked')


### PR DESCRIPTION
## Qué cambió

- Muestra Suscribirse para payment_pending sin tenant_subscriptions.
- Conserva Completar pago para suscripciones pending con checkout.
- Permite reiniciar un pago pending sin checkout.
- Separa la lógica visual en un resolvedor cubierto por pruebas.

## Por qué

Las condiciones de Mi Plan ocultaban simultáneamente el CTA principal y la alerta de recuperación para tenants bloqueados sin suscripción.

## Validación

- 16 pruebas Node de billing/onboarding aprobadas.
- Frontend local responde 200.
- No se ejecutó build por solicitud expresa.