### PR TITLE
Fix catalog searches in slide-overs

### DIFF
--- a/components/ui/CatalogSearchCombobox.test.ts
+++ b/components/ui/CatalogSearchCombobox.test.ts
@@ -138,13 +138,22 @@ describe('CatalogSearchCombobox', () => {
   })
 
   it('renders loading, error, and empty feedback states', async () => {
-    const loading = mountCombobox({ options: [], loading: true })
+    const loading = mountCombobox({
+      modelValue: 'cate',
+      loading: true,
+      allowCreate: true,
+    })
     await loading.get('input').trigger('focus')
     expect(loading.text()).toContain('Cargando')
+    expect(loading.find('.animate-spin').exists()).toBe(true)
+    expect(loading.text()).not.toContain('Primera')
+    expect(loading.text()).not.toContain('Vacío')
+    expect(loading.text()).not.toContain('Create "cate"')
 
-    const error = mountCombobox({ options: [], error: new Error('boom') })
+    const error = mountCombobox({ error: new Error('boom') })
     await error.get('input').trigger('focus')
     expect(error.get('[role="alert"]').text()).toBe('Error')
+    expect(error.text()).not.toContain('Primera')
 
     const empty = mountCombobox({ modelValue: 'zzz', options: [] })
     await empty.get('input').trigger('focus')

--- a/components/ui/CatalogSearchCombobox.test.ts
+++ b/components/ui/CatalogSearchCombobox.test.ts
@@ -150,4 +150,17 @@ describe('CatalogSearchCombobox', () => {
     await empty.get('input').trigger('focus')
     expect(empty.text()).toContain('Vacío')
   })
+
+  it('keeps the empty feedback visible when creating the typed value is allowed', async () => {
+    const wrapper = mountCombobox({
+      modelValue: 'cate',
+      options: [],
+      allowCreate: true,
+    })
+
+    await wrapper.get('input').trigger('focus')
+
+    expect(wrapper.text()).toContain('Vacío')
+    expect(wrapper.text()).toContain('Create "cate"')
+  })
 })

--- a/components/ui/CatalogSearchCombobox.vue
+++ b/components/ui/CatalogSearchCombobox.vue
@@ -46,8 +46,12 @@
         <li
           v-if="loading"
           role="presentation"
-          class="px-3 py-2 text-sm text-text-secondary select-none"
+          class="px-3 py-2 text-sm text-text-secondary select-none flex items-center gap-2"
         >
+          <svg class="w-4 h-4 animate-spin flex-shrink-0" aria-hidden="true" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+          </svg>
           <span role="status">{{ loadingLabel }}</span>
         </li>
 
@@ -59,65 +63,67 @@
           <span role="alert">{{ errorLabel }}</span>
         </li>
 
-        <template v-for="option in options" :key="optionKey(option)">
+        <template v-if="!loading && !error">
+          <template v-for="option in options" :key="optionKey(option)">
+            <li
+              v-if="option.kind === 'presentation'"
+              role="presentation"
+              aria-hidden="true"
+              class="px-3 py-1 text-xs font-semibold text-text-secondary uppercase tracking-wide bg-surface-secondary/40 select-none"
+            >
+              <slot name="presentation" :option="option">
+                {{ option.label }}
+              </slot>
+            </li>
+            <li
+              v-else
+              :id="optionDomId(option.id)"
+              role="option"
+              :aria-selected="activeKey === option.id"
+              :class="[
+                'px-3 py-2 text-sm text-text-primary cursor-pointer min-h-[40px]',
+                activeKey === option.id ? 'bg-surface-secondary' : 'hover:bg-surface-secondary',
+                option.class,
+              ]"
+              @mouseenter="activeKey = option.id"
+              @mousedown.prevent
+              @click="chooseOption(option)"
+            >
+              <slot name="option" :option="option" :active="activeKey === option.id">
+                {{ option.label }}
+              </slot>
+            </li>
+          </template>
+
           <li
-            v-if="option.kind === 'presentation'"
+            v-if="showEmptyState"
             role="presentation"
-            aria-hidden="true"
-            class="px-3 py-1 text-xs font-semibold text-text-secondary uppercase tracking-wide bg-surface-secondary/40 select-none"
+            class="px-3 py-2 text-sm text-text-secondary/60 select-none"
           >
-            <slot name="presentation" :option="option">
-              {{ option.label }}
-            </slot>
+            <span role="status">{{ emptyLabel }}</span>
           </li>
+
           <li
-            v-else
-            :id="optionDomId(option.id)"
+            v-if="showCreate"
+            :id="optionDomId(CREATE_KEY)"
             role="option"
-            :aria-selected="activeKey === option.id"
+            :aria-selected="activeKey === CREATE_KEY"
             :class="[
-              'px-3 py-2 text-sm text-text-primary cursor-pointer min-h-[40px]',
-              activeKey === option.id ? 'bg-surface-secondary' : 'hover:bg-surface-secondary',
-              option.class,
+              'px-3 py-2 text-sm text-primary border-t border-border cursor-pointer flex items-start gap-1.5 min-h-[40px]',
+              activeKey === CREATE_KEY ? 'bg-surface-secondary' : 'hover:bg-surface-secondary',
             ]"
-            @mouseenter="activeKey = option.id"
+            @mouseenter="activeKey = CREATE_KEY"
             @mousedown.prevent
-            @click="chooseOption(option)"
+            @click="chooseCreate"
           >
-            <slot name="option" :option="option" :active="activeKey === option.id">
-              {{ option.label }}
-            </slot>
+            <svg class="w-3.5 h-3.5 flex-shrink-0 mt-0.5" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+            </svg>
+            <span class="min-w-0 flex-1 whitespace-normal break-words leading-snug">
+              {{ resolvedCreateLabel }}
+            </span>
           </li>
         </template>
-
-        <li
-          v-if="showEmptyState"
-          role="presentation"
-          class="px-3 py-2 text-sm text-text-secondary/60 select-none"
-        >
-          <span role="status">{{ emptyLabel }}</span>
-        </li>
-
-        <li
-          v-if="showCreate"
-          :id="optionDomId(CREATE_KEY)"
-          role="option"
-          :aria-selected="activeKey === CREATE_KEY"
-          :class="[
-            'px-3 py-2 text-sm text-primary border-t border-border cursor-pointer flex items-start gap-1.5 min-h-[40px]',
-            activeKey === CREATE_KEY ? 'bg-surface-secondary' : 'hover:bg-surface-secondary',
-          ]"
-          @mouseenter="activeKey = CREATE_KEY"
-          @mousedown.prevent
-          @click="chooseCreate"
-        >
-          <svg class="w-3.5 h-3.5 flex-shrink-0 mt-0.5" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-          </svg>
-          <span class="min-w-0 flex-1 whitespace-normal break-words leading-snug">
-            {{ resolvedCreateLabel }}
-          </span>
-        </li>
       </ul>
     </Teleport>
   </div>

--- a/components/ui/CatalogSearchCombobox.vue
+++ b/components/ui/CatalogSearchCombobox.vue
@@ -210,7 +210,7 @@ const dropdownOpen = computed(
   ),
 )
 const showEmptyState = computed(
-  () => !props.loading && !props.error && selectableOptions.value.length === 0 && !showCreate.value,
+  () => !props.loading && !props.error && selectableOptions.value.length === 0,
 )
 const resolvedCreateLabel = computed(
   () => props.createLabel || `Create "${trimmedValue.value}"`,

--- a/composables/useCategorySearch.test.ts
+++ b/composables/useCategorySearch.test.ts
@@ -1,0 +1,70 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent, h, nextTick } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useCategorySearch, type CategoryRow } from './useCategorySearch'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+const category = (id: string, name: string): CategoryRow => ({
+  id,
+  name,
+  description: null,
+  tenant_id: null,
+  created_at: '',
+  updated_at: '',
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('useCategorySearch', () => {
+  it('ignores a late initial response after a typed search has completed', async () => {
+    vi.useFakeTimers()
+    const initialRequest = deferred<{ data: CategoryRow[] }>()
+    const typedRequest = deferred<{ data: CategoryRow[] }>()
+    const fetchMock = vi.fn()
+      .mockReturnValueOnce(initialRequest.promise)
+      .mockReturnValueOnce(typedRequest.promise)
+    vi.stubGlobal('$fetch', fetchMock)
+
+    let search!: ReturnType<typeof useCategorySearch>
+    const Host = defineComponent({
+      setup() {
+        search = useCategorySearch()
+        return () => h('div')
+      },
+    })
+    const wrapper = mount(Host)
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/menu/categories', {
+      query: { limit: 50 },
+    })
+
+    search.query.value = 'cate'
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(300)
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/menu/categories', {
+      query: { search: 'cate', limit: 50 },
+    })
+
+    typedRequest.resolve({ data: [category('latest', 'Categoría muestra')] })
+    await flushPromises()
+    expect(search.results.value.map(item => item.id)).toEqual(['latest'])
+
+    initialRequest.resolve({ data: [category('stale', 'Respuesta anterior')] })
+    await flushPromises()
+    expect(search.results.value.map(item => item.id)).toEqual(['latest'])
+    expect(search.loading.value).toBe(false)
+
+    wrapper.unmount()
+  })
+})

--- a/composables/useCategorySearch.ts
+++ b/composables/useCategorySearch.ts
@@ -1,4 +1,6 @@
+import { onMounted, ref, watch } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
+import { createLatestRequestTracker } from '~/utils/latestRequestTracker'
 
 /**
  * Composable for debounced server-side category search (issue #458).
@@ -25,33 +27,42 @@ export const useCategorySearch = () => {
   const loading = ref(false)
   const error = ref<Error | null>(null)
   const query = ref('')
+  const requestTracker = createLatestRequestTracker()
 
-  const doSearch = useDebounceFn(async (q: string) => {
-    loading.value = true
-    error.value = null
+  const doSearch = useDebounceFn(async (q: string, requestId: number) => {
+    if (!requestTracker.isLatest(requestId)) return
+
     try {
       const data = await $fetch<{ data: CategoryRow[] }>('/api/menu/categories', {
         query: q && q.trim().length > 0
           ? { search: q.trim(), limit: 50 }
           : { limit: 50 },
       })
+      if (!requestTracker.isLatest(requestId)) return
       results.value = data?.data ?? []
     } catch (e: any) {
+      if (!requestTracker.isLatest(requestId)) return
       error.value = e
       results.value = []
     } finally {
-      loading.value = false
+      if (requestTracker.isLatest(requestId)) {
+        loading.value = false
+      }
     }
   }, 300)
 
-  watch(query, (val) => {
-    loading.value = true // immediate spinner before the debounce fires
-    doSearch(val)
-  })
+  function scheduleSearch(value: string) {
+    const requestId = requestTracker.next()
+    loading.value = true
+    error.value = null
+    void doSearch(value, requestId)
+  }
+
+  watch(query, scheduleSearch)
 
   // Initial load — show full list when the input is opened with empty query
   onMounted(() => {
-    doSearch('')
+    scheduleSearch(query.value)
   })
 
   return { query, results, loading, error }

--- a/composables/useIngredientSearch.ts
+++ b/composables/useIngredientSearch.ts
@@ -1,6 +1,7 @@
-import type { Ref } from 'vue'
+import { computed, onMounted, ref, watch, type Ref } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
 import { rankCatalogSearchOptions } from '~/utils/catalogSearchRanking'
+import { createLatestRequestTracker } from '~/utils/latestRequestTracker'
 
 /**
  * Composable for debounced server-side ingredient search.
@@ -30,15 +31,11 @@ export const useIngredientSearch = ({
   const loading = ref(false)
   const error = ref<Error | null>(null)
   const query = ref('')
+  const requestTracker = createLatestRequestTracker()
 
-  const doSearch = useDebounceFn(async (q: string) => {
-    if ((!q || q.trim().length < 1) && !searchOnEmpty) {
-      results.value = []
-      loading.value = false
-      return
-    }
-    loading.value = true
-    error.value = null
+  const doSearch = useDebounceFn(async (q: string, requestId: number) => {
+    if (!requestTracker.isLatest(requestId)) return
+
     try {
       const fetchQuery: Record<string, any> = { limit: 50 }
       if (q.trim()) fetchQuery.search = q.trim()
@@ -48,29 +45,38 @@ export const useIngredientSearch = ({
       const data = await $fetch<any>('/api/suppliers/ingredients', {
         query: fetchQuery
       })
+      if (!requestTracker.isLatest(requestId)) return
       results.value = data?.data ?? []
     } catch (e: any) {
+      if (!requestTracker.isLatest(requestId)) return
       error.value = e
       results.value = []
     } finally {
-      loading.value = false
+      if (requestTracker.isLatest(requestId)) {
+        loading.value = false
+      }
     }
   }, 300)
 
-  watch(query, (val) => {
-    if ((!val || val.trim().length < 1) && !searchOnEmpty) {
+  function scheduleSearch(value: string) {
+    const requestId = requestTracker.next()
+    error.value = null
+
+    if ((!value || value.trim().length < 1) && !searchOnEmpty) {
       results.value = []
       loading.value = false
       return
     }
-    loading.value = true // show loading immediately on keystroke, before debounce fires
-    doSearch(val)
-  })
+
+    loading.value = true
+    void doSearch(value, requestId)
+  }
+
+  watch(query, scheduleSearch)
 
   if (searchOnEmpty) {
     onMounted(() => {
-      loading.value = true
-      doSearch('')
+      scheduleSearch(query.value)
     })
   }
 

--- a/composables/useProductSearch.ts
+++ b/composables/useProductSearch.ts
@@ -1,4 +1,6 @@
+import { onMounted, ref, watch } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
+import { createLatestRequestTracker } from '~/utils/latestRequestTracker'
 
 /**
  * Debounced server-side product search for pickers (promotions scope, etc.).
@@ -21,10 +23,11 @@ export const useProductSearch = (options: UseProductSearchOptions = {}) => {
   const loading = ref(false)
   const error = ref<Error | null>(null)
   const query = ref('')
+  const requestTracker = createLatestRequestTracker()
 
-  const doSearch = useDebounceFn(async (q: string) => {
-    loading.value = true
-    error.value = null
+  const doSearch = useDebounceFn(async (q: string, requestId: number) => {
+    if (!requestTracker.isLatest(requestId)) return
+
     try {
       const baseQuery: Record<string, string | number | boolean> = {
         limit: 50,
@@ -39,23 +42,31 @@ export const useProductSearch = (options: UseProductSearchOptions = {}) => {
       const res = await $fetch<{ success?: boolean; data?: ProductRow[] }>('/api/menu/products', {
         query: baseQuery,
       })
+      if (!requestTracker.isLatest(requestId)) return
       const items = Array.isArray(res?.data) ? res.data : []
       results.value = items.map((p) => ({ id: p.id, name: p.name }))
     } catch (e: any) {
+      if (!requestTracker.isLatest(requestId)) return
       error.value = e
       results.value = []
     } finally {
-      loading.value = false
+      if (requestTracker.isLatest(requestId)) {
+        loading.value = false
+      }
     }
   }, 300)
 
-  watch(query, (val) => {
+  function scheduleSearch(value: string) {
+    const requestId = requestTracker.next()
     loading.value = true
-    doSearch(val)
-  })
+    error.value = null
+    void doSearch(value, requestId)
+  }
+
+  watch(query, scheduleSearch)
 
   onMounted(() => {
-    doSearch('')
+    scheduleSearch(query.value)
   })
 
   return { query, results, loading, error }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "i18n:check:ar": "node scripts/check-i18n.mjs --locale ar",
     "i18n:check:all": "node scripts/check-i18n.mjs --all",
     "i18n:translate": "node scripts/translate-i18n.mjs",
-    "test:catalog-search": "vitest run components/ui/CatalogSearchCombobox.test.ts"
+    "test:catalog-search": "vitest run components/ui/CatalogSearchCombobox.test.ts composables/useCategorySearch.test.ts utils/latestRequestTracker.test.ts"
   },
   "dependencies": {
     "@heroicons/vue": "^2.0.18",

--- a/utils/latestRequestTracker.test.ts
+++ b/utils/latestRequestTracker.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { createLatestRequestTracker } from './latestRequestTracker'
+
+describe('createLatestRequestTracker', () => {
+  it('prevents an older search response from replacing the latest results', () => {
+    const tracker = createLatestRequestTracker()
+    const olderRequest = tracker.next()
+    const latestRequest = tracker.next()
+    let result = ''
+
+    if (tracker.isLatest(latestRequest)) result = 'latest'
+    if (tracker.isLatest(olderRequest)) result = 'older'
+
+    expect(result).toBe('latest')
+    expect(tracker.isLatest(olderRequest)).toBe(false)
+  })
+})

--- a/utils/latestRequestTracker.ts
+++ b/utils/latestRequestTracker.ts
@@ -1,0 +1,19 @@
+/**
+ * Tracks the latest scheduled async request.
+ *
+ * A request becomes stale as soon as a newer search is scheduled, including
+ * while the newer search is still waiting for its debounce delay.
+ */
+export function createLatestRequestTracker() {
+  let latestRequestId = 0
+
+  return {
+    next() {
+      latestRequestId += 1
+      return latestRequestId
+    },
+    isLatest(requestId: number) {
+      return requestId === latestRequestId
+    },
+  }
+}


### PR DESCRIPTION
## Qué cambió

- Evita que respuestas antiguas de búsquedas reemplacen los resultados más recientes.
- Aplica la protección compartida a categorías, productos e ingredientes.
- Presenta estados exclusivos: primero spinner + `Buscando…`, después resultados, error o `Sin resultados` + `Crear`.
- Oculta opciones anteriores mientras la búsqueda nueva está en curso.

## Causa raíz

Las búsquedas usan debounce y podían mantener más de una petición asíncrona en curso. Si la carga inicial o una búsqueda anterior terminaba después de la consulta actual, sobrescribía la lista correcta. Además, el componente podía mezclar el estado de carga con opciones anteriores, haciendo poco clara la secuencia de búsqueda.

## Impacto

Los selectores de catálogo dentro de slide-overs conservan siempre la respuesta correspondiente al texto más reciente y muestran claramente cuándo están buscando antes de presentar el resultado.

## Validación

- `npm run test:catalog-search`
- 3 archivos de prueba, 10 pruebas aprobadas
- Sin build, según lo solicitado

Follow-up de #1667.
