### PR TITLE
Search warehouse categories from the API

### DIFF
--- a/components/ui/WarehouseCategorySearchInput.test.ts
+++ b/components/ui/WarehouseCategorySearchInput.test.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { defineComponent, h, ref } from 'vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import CatalogSearchCombobox from './CatalogSearchCombobox.vue'
@@ -11,8 +11,30 @@ afterEach(() => {
 })
 
 describe('WarehouseCategorySearchInput', () => {
-  it('shows searching feedback before presenting local category matches', async () => {
+  it('searches tenant warehouse categories through the API', async () => {
     vi.useFakeTimers()
+    const fetchMock = vi.fn(async (
+      _url: string,
+      options: { query: { search?: string } },
+    ) => ({
+      data: options.query.search === 'categoria'
+        ? [
+            {
+              name: 'categoria de prueba',
+              ingredient_count: 1,
+              global_count: 0,
+              tenant_count: 1,
+            },
+            {
+              name: 'ingrediente categoria',
+              ingredient_count: 1,
+              global_count: 0,
+              tenant_count: 1,
+            },
+          ]
+        : [],
+    }))
+    vi.stubGlobal('$fetch', fetchMock)
     vi.stubGlobal('useI18n', () => ({
       t: (key: string, params?: { name?: string }) => ({
         'abastecimiento.glossary.searchLoading': 'Buscando…',
@@ -46,26 +68,35 @@ describe('WarehouseCategorySearchInput', () => {
     })
     const input = wrapper.get('input')
 
-    await input.setValue('ace')
+    await vi.advanceTimersByTimeAsync(300)
+    await flushPromises()
+
+    await input.setValue('categoria')
 
     expect(wrapper.text()).toContain('Buscando…')
     expect(wrapper.find('.animate-spin').exists()).toBe(true)
-    expect(wrapper.text()).not.toContain('Aceites')
     expect(wrapper.text()).not.toContain('Sin resultados')
 
     await vi.advanceTimersByTimeAsync(300)
+    await flushPromises()
 
     expect(wrapper.text()).not.toContain('Buscando…')
-    expect(wrapper.text()).toContain('Aceites')
+    expect(wrapper.text()).toContain('categoria de prueba')
+    expect(wrapper.text()).toContain('ingrediente categoria')
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/suppliers/ingredients/categories',
+      { query: { search: 'categoria', limit: 100 } },
+    )
 
     await input.setValue('holanda')
 
     expect(wrapper.text()).toContain('Buscando…')
-    expect(wrapper.text()).not.toContain('Aceites')
+    expect(wrapper.text()).not.toContain('categoria de prueba')
     expect(wrapper.text()).not.toContain('Sin resultados')
     expect(wrapper.text()).not.toContain('Crear "holanda"')
 
     await vi.advanceTimersByTimeAsync(300)
+    await flushPromises()
 
     expect(wrapper.text()).not.toContain('Buscando…')
     expect(wrapper.text()).toContain('Sin resultados')

--- a/components/ui/WarehouseCategorySearchInput.test.ts
+++ b/components/ui/WarehouseCategorySearchInput.test.ts
@@ -1,0 +1,74 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, ref } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import CatalogSearchCombobox from './CatalogSearchCombobox.vue'
+import WarehouseCategorySearchInput from './WarehouseCategorySearchInput.vue'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('WarehouseCategorySearchInput', () => {
+  it('shows searching feedback before presenting local category matches', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('useI18n', () => ({
+      t: (key: string, params?: { name?: string }) => ({
+        'abastecimiento.glossary.searchLoading': 'Buscando…',
+        'abastecimiento.glossary.noSearchResults': 'Sin resultados',
+        'abastecimiento.glossary.searchError': 'Error',
+        'abastecimiento.glossary.createNamed': `Crear "${params?.name ?? ''}"`,
+      }[key] ?? key),
+    }))
+
+    const Host = defineComponent({
+      setup() {
+        const value = ref('')
+        return () => h(WarehouseCategorySearchInput, {
+          modelValue: value.value,
+          'onUpdate:modelValue': (nextValue: string) => {
+            value.value = nextValue
+          },
+        })
+      },
+    })
+    const wrapper = mount(Host, {
+      attachTo: document.body,
+      global: {
+        components: {
+          UiCatalogSearchCombobox: CatalogSearchCombobox,
+        },
+        stubs: {
+          Teleport: true,
+        },
+      },
+    })
+    const input = wrapper.get('input')
+
+    await input.setValue('ace')
+
+    expect(wrapper.text()).toContain('Buscando…')
+    expect(wrapper.find('.animate-spin').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('Aceites')
+    expect(wrapper.text()).not.toContain('Sin resultados')
+
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(wrapper.text()).not.toContain('Buscando…')
+    expect(wrapper.text()).toContain('Aceites')
+
+    await input.setValue('holanda')
+
+    expect(wrapper.text()).toContain('Buscando…')
+    expect(wrapper.text()).not.toContain('Aceites')
+    expect(wrapper.text()).not.toContain('Sin resultados')
+    expect(wrapper.text()).not.toContain('Crear "holanda"')
+
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(wrapper.text()).not.toContain('Buscando…')
+    expect(wrapper.text()).toContain('Sin resultados')
+    expect(wrapper.text()).toContain('Crear "holanda"')
+  })
+})

--- a/components/ui/WarehouseCategorySearchInput.vue
+++ b/components/ui/WarehouseCategorySearchInput.vue
@@ -6,6 +6,7 @@
     :placeholder="placeholder"
     :listbox-label="listboxLabel"
     :loading="loading"
+    :error="error"
     :allow-create="true"
     :can-create="!exactMatch"
     placement="top"
@@ -14,15 +15,14 @@
     :error-label="t('abastecimiento.glossary.searchError')"
     :create-label="t('abastecimiento.glossary.createNamed', { name: modelValue.trim() })"
     @update:model-value="updateValue"
-    @search="scheduleSearch"
-    @focus="scheduleSearch"
+    @search="onSearch"
+    @focus="onSearch"
   />
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
-import { useDebounceFn } from '@vueuse/core'
-import { WAREHOUSE_CATEGORY_SUGGESTIONS } from '~/constants/warehouseCategories'
+import { computed } from 'vue'
+import { useWarehouseCategorySearch } from '~/composables/useWarehouseCategorySearch'
 import { normalizeCatalogSearchText, rankCatalogSearchOptions } from '~/utils/catalogSearchRanking'
 
 const props = withDefaults(defineProps<{
@@ -42,43 +42,29 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n({ useScope: 'global' })
+const { query, results, loading, error } = useWarehouseCategorySearch()
 
-const searchedValue = ref(props.modelValue)
-const loading = ref(false)
-const visibleCategories = ref(
-  rankCatalogSearchOptions(WAREHOUSE_CATEGORY_SUGGESTIONS, props.modelValue, category => category),
+const rankedCategories = computed(() =>
+  rankCatalogSearchOptions(results.value, props.modelValue, category => category.name),
 )
 
 const options = computed(() =>
-  visibleCategories.value.map(category => ({
-    id: normalizeCatalogSearchText(category),
-    label: category,
+  rankedCategories.value.map(category => ({
+    id: category.name,
+    label: category.name,
     raw: category,
   })),
 )
 
 const exactMatch = computed(() => {
   const normalizedValue = normalizeCatalogSearchText(props.modelValue)
-  return !!normalizedValue && WAREHOUSE_CATEGORY_SUGGESTIONS.some(
-    category => normalizeCatalogSearchText(category) === normalizedValue,
+  return !!normalizedValue && results.value.some(
+    category => normalizeCatalogSearchText(category.name) === normalizedValue,
   )
 })
 
-const finishSearch = useDebounceFn((value: string) => {
-  visibleCategories.value = rankCatalogSearchOptions(
-    WAREHOUSE_CATEGORY_SUGGESTIONS,
-    value,
-    category => category,
-  )
-  searchedValue.value = value
-  loading.value = false
-}, 300)
-
-function scheduleSearch(value: string) {
-  if (value === searchedValue.value && !loading.value) return
-
-  loading.value = true
-  void finishSearch(value)
+function onSearch(value: string) {
+  query.value = value
 }
 
 function updateValue(value: string) {

--- a/components/ui/WarehouseCategorySearchInput.vue
+++ b/components/ui/WarehouseCategorySearchInput.vue
@@ -5,6 +5,7 @@
     :input-id="inputId"
     :placeholder="placeholder"
     :listbox-label="listboxLabel"
+    :loading="loading"
     :allow-create="true"
     :can-create="!exactMatch"
     placement="top"
@@ -13,11 +14,14 @@
     :error-label="t('abastecimiento.glossary.searchError')"
     :create-label="t('abastecimiento.glossary.createNamed', { name: modelValue.trim() })"
     @update:model-value="updateValue"
+    @search="scheduleSearch"
+    @focus="scheduleSearch"
   />
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
+import { useDebounceFn } from '@vueuse/core'
 import { WAREHOUSE_CATEGORY_SUGGESTIONS } from '~/constants/warehouseCategories'
 import { normalizeCatalogSearchText, rankCatalogSearchOptions } from '~/utils/catalogSearchRanking'
 
@@ -39,12 +43,14 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' })
 
-const rankedCategories = computed(() =>
+const searchedValue = ref(props.modelValue)
+const loading = ref(false)
+const visibleCategories = ref(
   rankCatalogSearchOptions(WAREHOUSE_CATEGORY_SUGGESTIONS, props.modelValue, category => category),
 )
 
 const options = computed(() =>
-  rankedCategories.value.map(category => ({
+  visibleCategories.value.map(category => ({
     id: normalizeCatalogSearchText(category),
     label: category,
     raw: category,
@@ -57,6 +63,23 @@ const exactMatch = computed(() => {
     category => normalizeCatalogSearchText(category) === normalizedValue,
   )
 })
+
+const finishSearch = useDebounceFn((value: string) => {
+  visibleCategories.value = rankCatalogSearchOptions(
+    WAREHOUSE_CATEGORY_SUGGESTIONS,
+    value,
+    category => category,
+  )
+  searchedValue.value = value
+  loading.value = false
+}, 300)
+
+function scheduleSearch(value: string) {
+  if (value === searchedValue.value && !loading.value) return
+
+  loading.value = true
+  void finishSearch(value)
+}
 
 function updateValue(value: string) {
   emit('update:modelValue', value)

--- a/composables/useWarehouseCategorySearch.ts
+++ b/composables/useWarehouseCategorySearch.ts
@@ -1,0 +1,59 @@
+import { onMounted, ref, watch } from 'vue'
+import { useDebounceFn } from '@vueuse/core'
+import { createLatestRequestTracker } from '~/utils/latestRequestTracker'
+
+export interface WarehouseCategoryRow {
+  name: string
+  ingredient_count: number
+  global_count: number
+  tenant_count: number
+}
+
+export const useWarehouseCategorySearch = () => {
+  const results = ref<WarehouseCategoryRow[]>([])
+  const loading = ref(false)
+  const error = ref<Error | null>(null)
+  const query = ref('')
+  const requestTracker = createLatestRequestTracker()
+
+  const doSearch = useDebounceFn(async (value: string, requestId: number) => {
+    if (!requestTracker.isLatest(requestId)) return
+
+    try {
+      const trimmedValue = value.trim()
+      const response = await $fetch<{ data: WarehouseCategoryRow[] }>(
+        '/api/suppliers/ingredients/categories',
+        {
+          query: trimmedValue
+            ? { search: trimmedValue, limit: 100 }
+            : { limit: 100 },
+        },
+      )
+      if (!requestTracker.isLatest(requestId)) return
+      results.value = response?.data ?? []
+    } catch (searchError: any) {
+      if (!requestTracker.isLatest(requestId)) return
+      error.value = searchError
+      results.value = []
+    } finally {
+      if (requestTracker.isLatest(requestId)) {
+        loading.value = false
+      }
+    }
+  }, 300)
+
+  function scheduleSearch(value: string) {
+    const requestId = requestTracker.next()
+    loading.value = true
+    error.value = null
+    void doSearch(value, requestId)
+  }
+
+  watch(query, scheduleSearch)
+
+  onMounted(() => {
+    scheduleSearch(query.value)
+  })
+
+  return { query, results, loading, error }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "i18n:check:ar": "node scripts/check-i18n.mjs --locale ar",
     "i18n:check:all": "node scripts/check-i18n.mjs --all",
     "i18n:translate": "node scripts/translate-i18n.mjs",
-    "test:catalog-search": "vitest run components/ui/CatalogSearchCombobox.test.ts composables/useCategorySearch.test.ts utils/latestRequestTracker.test.ts"
+    "test:catalog-search": "vitest run components/ui/CatalogSearchCombobox.test.ts components/ui/WarehouseCategorySearchInput.test.ts composables/useCategorySearch.test.ts utils/latestRequestTracker.test.ts"
   },
   "dependencies": {
     "@heroicons/vue": "^2.0.18",


### PR DESCRIPTION
## Qué cambió

- Reemplaza la lista fija del selector de categorías de bodega por búsqueda en la API.
- Muestra `Buscando…` con spinner durante el debounce y la petición.
- Presenta resultados reales, error o `Sin resultados + Crear` al finalizar.
- Protege contra respuestas asíncronas atrasadas.

## Causa raíz

`ing-category` filtraba únicamente 24 sugerencias locales y nunca consultaba las categorías existentes en `ingredients.category`.

## Dependencia

Requiere el endpoint incorporado en `api-warolabs#651`, ya fusionado en `main`.

## Validación

- `npm run test:catalog-search`
- 4 archivos de prueba, 11 pruebas aprobadas.
- Verificación integrada por el proxy Nuxt: `categoria` devuelve `categoria de prueba` e `ingrediente categoria`.
- Sin build.