### PR TITLE
Integrate category ingredients in menu compositions

### DIFF
--- a/components/ingredientes/WarehouseCategoryIngredientSelector.test.ts
+++ b/components/ingredientes/WarehouseCategoryIngredientSelector.test.ts
@@ -33,7 +33,7 @@ afterEach(() => {
 
 describe('WarehouseCategoryIngredientSelector', () => {
   it('prepares editable local rows once and never calls a persistence endpoint', async () => {
-    const fetchMock = vi.fn(async () => ({
+    const fetchMock = vi.fn(async (_url: string, _options?: unknown) => ({
       data: {
         ingredients: [{
           ingredient_id: 'ingredient-1',
@@ -152,5 +152,41 @@ describe('WarehouseCategoryIngredientSelector', () => {
     await wrapper.findAll('button').find(button => button.text() === 'Reintentar')?.trigger('click')
     await flushPromises()
     expect(wrapper.text()).toContain('Sin nuevos: Granos')
+  })
+
+  it('uses caller-provided compatible unit options when available', async () => {
+    vi.stubGlobal('$fetch', vi.fn(async () => ({
+      data: {
+        ingredients: [{
+          ingredient_id: 'ingredient-1',
+          name: 'Arroz',
+          unit: 'gr',
+          warehouse_category_id: 'category-1',
+        }],
+        empty_category_ids: [],
+        unavailable_category_ids: [],
+      },
+    })))
+    vi.stubGlobal('useI18n', () => ({
+      t: (key: string) => key,
+    }))
+    const wrapper = mount(WarehouseCategoryIngredientSelector, {
+      props: {
+        unitOptions: () => [
+          { value: 'gr', label: 'Gramos' },
+          { value: 'kg', label: 'Kilogramos' },
+        ],
+      },
+      global: {
+        components: { UiWarehouseCategorySearchInput: WarehouseCategorySearchInputStub },
+      },
+    })
+
+    await wrapper.get('[data-test="select-category"]').trigger('click')
+    await flushPromises()
+
+    const select = wrapper.find('select')
+    expect(select.exists()).toBe(true)
+    expect(select.findAll('option').map(option => option.attributes('value'))).toEqual(['gr', 'kg'])
   })
 })

--- a/components/ingredientes/WarehouseCategoryIngredientSelector.vue
+++ b/components/ingredientes/WarehouseCategoryIngredientSelector.vue
@@ -76,7 +76,23 @@
         </label>
         <label class="space-y-1 text-xs text-text-secondary">
           <span>{{ t('abastecimiento.glossary.categoryIngredientUnit') }}</span>
+          <select
+            v-if="unitOptions"
+            :value="row.unit ?? ''"
+            :disabled="loadingUnitIds?.has(row.ingredient_id)"
+            class="w-full rounded-md border border-border bg-surface px-2 py-1.5 text-sm text-text-primary disabled:opacity-50"
+            @change="onUnitInput(row.ingredient_id, $event)"
+          >
+            <option
+              v-for="option in unitOptions(row.ingredient_id)"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </option>
+          </select>
           <input
+            v-else
             type="text"
             class="w-full rounded-md border border-border bg-surface px-2 py-1.5 text-sm text-text-primary"
             :value="row.unit ?? ''"
@@ -107,6 +123,8 @@ import {
 const props = withDefaults(defineProps<{
   existingIngredientIds?: string[]
   inputId?: string
+  unitOptions?: (ingredientId: string) => Array<{ value: string, label: string }>
+  loadingUnitIds?: Set<string>
 }>(), {
   existingIngredientIds: () => [],
   inputId: 'warehouse-category-ingredient-selector',

--- a/components/menu/MenuModifierOptionEditor.vue
+++ b/components/menu/MenuModifierOptionEditor.vue
@@ -110,7 +110,7 @@
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.unit') }}</label>
         <select
           v-model="modifier.ingredient_unit"
-          :disabled="modifier.ingredient_id && loadingUnits.has(modifier.ingredient_id)"
+          :disabled="Boolean(modifier.ingredient_id && loadingUnits.has(modifier.ingredient_id))"
           class="input-base w-full py-2 px-3 text-sm disabled:opacity-50"
         >
           <option
@@ -135,7 +135,7 @@
             @change="onRecipeBaseChange"
           >
             <option value="">{{ t('menu.modificadores.chooseRecipe') }}</option>
-            <option v-for="recipe in recipeBases" :key="recipe.id" :value="recipe.id">
+            <option v-for="recipe in recipeBases" :key="String(recipe.id)" :value="String(recipe.id)">
               {{ recipe.name }}
             </option>
           </select>
@@ -168,6 +168,72 @@
           </div>
         </div>
       </div>
+
+      <WarehouseCategoryIngredientSelector
+        :input-id="`modifier-recipe-category-${index}`"
+        :existing-ingredient-ids="existingRecipeIngredientIds"
+        :unit-options="getIngredientUnitOptions"
+        :loading-unit-ids="loadingUnits"
+        @update:prepared-rows="rows => $emit('prepared-recipe-lines', rows)"
+      />
+
+      <div v-if="modifier.recipe_lines.length" class="space-y-2">
+        <div
+          v-for="(line, lineIndex) in modifier.recipe_lines"
+          :key="`${line.ingredient_id || 'new'}-${lineIndex}`"
+          class="grid grid-cols-1 gap-2 rounded-lg border border-border p-3 md:grid-cols-12"
+        >
+          <div class="md:col-span-5">
+            <UiIngredientSearchInput
+              :key="`modifier-recipe-line-${line.ingredient_id || lineIndex}`"
+              :initial-value="recipeLineSearchLabel(line)"
+              :allow-create="true"
+              @select="ingredient => $emit('select-recipe-line', lineIndex, ingredient)"
+              @create="name => $emit('create-recipe-line', lineIndex, name)"
+            />
+          </div>
+          <div class="md:col-span-3">
+            <UiDecimalInput
+              v-model="line.quantity"
+              :min="0.01"
+              :precision="6"
+              class="input-base w-full px-3 py-2 text-sm"
+              :placeholder="t('menu.modificadores.quantity')"
+            />
+          </div>
+          <div class="md:col-span-3">
+            <select
+              v-model="line.unit"
+              :disabled="!!line.ingredient_id && loadingUnits.has(line.ingredient_id)"
+              class="input-base w-full px-3 py-2 text-sm disabled:opacity-50"
+            >
+              <option
+                v-for="option in getIngredientUnitOptions(line.ingredient_id)"
+                :key="option.value"
+                :value="option.value"
+              >
+                {{ option.label }}
+              </option>
+            </select>
+          </div>
+          <button
+            type="button"
+            class="min-h-9 text-destructive md:col-span-1"
+            :aria-label="t('abastecimiento.glossary.removePreparedIngredient', { name: line.ingredient_name })"
+            @click="removeRecipeLine(lineIndex)"
+          >
+            ×
+          </button>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        class="min-h-9 w-full rounded-lg bg-shell-icon-bg px-3 text-sm font-medium text-shell-icon-text"
+        @click="addRecipeLine"
+      >
+        {{ t('menu.recetas.form.addLine') }}
+      </button>
     </div>
 
     <div v-else-if="modifier.option_type === 'PRODUCT'" class="grid grid-cols-1 md:grid-cols-12 gap-3">
@@ -220,8 +286,11 @@ import {
   resetModifierFieldsForType,
   type ModifierFormRow,
   type ModifierOptionType,
+  type ModifierRecipeLineForm,
 } from '~/composables/useModifierOptionForm'
 import { formatDomainQuantity } from '~/utils/domainNumberFormat'
+import WarehouseCategoryIngredientSelector from '~/components/ingredientes/WarehouseCategoryIngredientSelector.vue'
+import type { PreparedWarehouseCategoryIngredient } from '~/composables/useWarehouseCategoryIngredientSelector'
 
 const { t } = useI18n({ useScope: 'global' })
 
@@ -249,7 +318,33 @@ defineEmits<{
   remove: []
   'select-ingredient': [ingredient: Record<string, unknown>]
   'create-ingredient': [name: string]
+  'select-recipe-line': [lineIndex: number, ingredient: Record<string, unknown>]
+  'create-recipe-line': [lineIndex: number, name: string]
+  'prepared-recipe-lines': [rows: PreparedWarehouseCategoryIngredient[]]
 }>()
+
+const existingRecipeIngredientIds = computed(() =>
+  props.modifier.recipe_lines.map(line => line.ingredient_id).filter(Boolean),
+)
+
+function recipeLineSearchLabel(line: ModifierRecipeLineForm) {
+  if (line.ingredient_name?.trim()) return line.ingredient_name.trim()
+  if (!line.ingredient_id) return ''
+  return String(props.getIngredientById(line.ingredient_id)?.name || '')
+}
+
+function addRecipeLine() {
+  props.modifier.recipe_lines.push({
+    ingredient_id: '',
+    ingredient_name: '',
+    quantity: null,
+    unit: null,
+  })
+}
+
+function removeRecipeLine(lineIndex: number) {
+  props.modifier.recipe_lines.splice(lineIndex, 1)
+}
 
 function onTypeChange(raw: string) {
   resetModifierFieldsForType(props.modifier, raw.toUpperCase() as ModifierOptionType)

--- a/composables/useMenuCategoryIngredientRows.test.ts
+++ b/composables/useMenuCategoryIngredientRows.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  mapPreparedRowsToProduct,
+  mapPreparedRowsToRecipe,
+  validateMenuCompositionRows,
+} from './useMenuCategoryIngredientRows'
+
+const prepared = [{
+  ingredient_id: 'ingredient-1',
+  name: 'Arroz',
+  quantity: 2.5,
+  unit: 'kg',
+  warehouse_category_id: 'category-1',
+}]
+
+describe('menu category ingredient row adapters', () => {
+  it('maps generic prepared rows to recipe and product payload fields', () => {
+    expect(mapPreparedRowsToRecipe(prepared)).toEqual([{
+      ingredient_id: 'ingredient-1',
+      ingredient_name: 'Arroz',
+      base_quantity: 2.5,
+      unit: 'kg',
+      notes: '',
+    }])
+    expect(mapPreparedRowsToProduct(prepared)).toEqual([{
+      ingredient_id: 'ingredient-1',
+      ingredient_name: 'Arroz',
+      quantity: 2.5,
+      unit: 'kg',
+    }])
+  })
+
+  it('rejects incomplete, duplicate, and incompatible combined rows', () => {
+    const valid = { ingredient_id: 'ingredient-1', quantity: 2, unit: 'kg' }
+    expect(validateMenuCompositionRows([valid], () => ['gr', 'kg'])).toBeNull()
+    expect(validateMenuCompositionRows([{ ...valid, quantity: null }])).toBe('incomplete')
+    expect(validateMenuCompositionRows([valid, valid])).toBe('duplicate')
+    expect(validateMenuCompositionRows([valid], () => ['gr'])).toBe('incompatible-unit')
+  })
+})

--- a/composables/useMenuCategoryIngredientRows.ts
+++ b/composables/useMenuCategoryIngredientRows.ts
@@ -1,0 +1,60 @@
+import type { PreparedWarehouseCategoryIngredient } from '~/composables/useWarehouseCategoryIngredientSelector'
+
+export interface MenuCompositionIngredientRow {
+  ingredient_id: string
+  quantity: number | null
+  unit: string | null
+}
+
+export type MenuCompositionValidationError =
+  | 'incomplete'
+  | 'duplicate'
+  | 'incompatible-unit'
+
+export function mapPreparedRowsToRecipe(
+  rows: PreparedWarehouseCategoryIngredient[],
+) {
+  return rows.map(row => ({
+    ingredient_id: row.ingredient_id,
+    ingredient_name: row.name,
+    base_quantity: row.quantity,
+    unit: row.unit ?? '',
+    notes: '',
+  }))
+}
+
+export function mapPreparedRowsToProduct(
+  rows: PreparedWarehouseCategoryIngredient[],
+) {
+  return rows.map(row => ({
+    ingredient_id: row.ingredient_id,
+    ingredient_name: row.name,
+    quantity: row.quantity,
+    unit: row.unit ?? '',
+  }))
+}
+
+export function validateMenuCompositionRows(
+  rows: MenuCompositionIngredientRow[],
+  getCompatibleUnits?: (ingredientId: string) => string[],
+): MenuCompositionValidationError | null {
+  const seen = new Set<string>()
+
+  for (const row of rows) {
+    const ingredientId = row.ingredient_id?.trim()
+    const unit = row.unit?.trim()
+    const quantity = Number(row.quantity)
+    if (!ingredientId || !unit || !Number.isFinite(quantity) || quantity <= 0) {
+      return 'incomplete'
+    }
+    if (seen.has(ingredientId)) return 'duplicate'
+    seen.add(ingredientId)
+
+    const compatibleUnits = getCompatibleUnits?.(ingredientId) ?? []
+    if (compatibleUnits.length && !compatibleUnits.includes(unit)) {
+      return 'incompatible-unit'
+    }
+  }
+
+  return null
+}

--- a/composables/useModifierOptionForm.test.ts
+++ b/composables/useModifierOptionForm.test.ts
@@ -1,5 +1,4 @@
-import { describe, it } from 'node:test'
-import assert from 'node:assert/strict'
+import { describe, expect, it } from 'vitest'
 import {
   createEmptyModifier,
   mapModifierFromApi,
@@ -14,10 +13,10 @@ describe('included modifier quantity form contract', () => {
       option_type: 'NONE',
       max_limit: 3,
     })
-    assert.equal(row.included_quantity, 0)
+    expect(row.included_quantity).toBe(0)
 
     row.included_quantity = 1
-    assert.equal(serializeModifierForApi(row).included_quantity, 1)
+    expect(serializeModifierForApi(row).included_quantity).toBe(1)
   })
 
   it('rejects included quantity above max_limit with the option name', () => {
@@ -27,8 +26,8 @@ describe('included modifier quantity form contract', () => {
     row.max_limit = 1
     row.included_quantity = 2
 
-    assert.match(validateModifierOption(row) ?? '', /Queso/)
-    assert.match(validateModifierOption(row) ?? '', /no puede superar/)
+    expect(validateModifierOption(row) ?? '').toMatch(/Queso/)
+    expect(validateModifierOption(row) ?? '').toMatch(/no puede superar/)
   })
 
   it('requires integer thresholds', () => {
@@ -37,6 +36,51 @@ describe('included modifier quantity form contract', () => {
     row.option_type = 'NONE'
     row.included_quantity = 0.5
 
-    assert.match(validateModifierOption(row) ?? '', /número entero/)
+    expect(validateModifierOption(row) ?? '').toMatch(/número entero/)
+  })
+
+  it('hydrates, validates, and serializes RECIPE recipe_lines', () => {
+    const row = mapModifierFromApi({
+      name: 'Salsa',
+      option_type: 'RECIPE',
+      recipe_lines: [{
+        ingredient_id: 'ingredient-1',
+        quantity: 2,
+        unit: 'gr',
+        ingredient: { name: 'Sal' },
+      }],
+    })
+
+    expect(row.recipe_lines[0]?.ingredient_name).toBe('Sal')
+    expect(validateModifierOption(row)).toBeNull()
+    expect(serializeModifierForApi(row).recipe_lines).toEqual([{
+      ingredient_id: 'ingredient-1',
+      quantity: 2,
+      unit: 'gr',
+    }])
+  })
+
+  it('rejects incomplete and duplicate persisted/prepared RECIPE lines', () => {
+    const row = createEmptyModifier(0)
+    row.name = 'Mezcla'
+    row.option_type = 'RECIPE'
+    row.recipe_lines = [{
+      ingredient_id: 'ingredient-1',
+      ingredient_name: 'Sal',
+      quantity: 1,
+      unit: 'gr',
+    }]
+    row.prepared_recipe_lines = [{
+      ingredient_id: 'ingredient-1',
+      name: 'Sal',
+      quantity: 2,
+      unit: 'gr',
+      warehouse_category_id: 'category-1',
+    }]
+    expect(validateModifierOption(row) ?? '').toMatch(/duplicados/)
+
+    row.prepared_recipe_lines[0]!.ingredient_id = 'ingredient-2'
+    row.prepared_recipe_lines[0]!.quantity = null
+    expect(validateModifierOption(row) ?? '').toMatch(/Completa/)
   })
 })

--- a/composables/useModifierOptionForm.ts
+++ b/composables/useModifierOptionForm.ts
@@ -1,4 +1,13 @@
+import type { PreparedWarehouseCategoryIngredient } from '~/composables/useWarehouseCategoryIngredientSelector'
+
 export type ModifierOptionType = 'INGREDIENT' | 'RECIPE' | 'PRODUCT' | 'NONE'
+
+export interface ModifierRecipeLineForm {
+  ingredient_id: string
+  ingredient_name: string
+  quantity: number | null
+  unit: string | null
+}
 
 export interface ModifierFormRow {
   name: string
@@ -16,6 +25,8 @@ export interface ModifierFormRow {
   recipe_base_type_id: string | null
   recipe_base_name: string | null
   recipe_base_quantity: number
+  recipe_lines: ModifierRecipeLineForm[]
+  prepared_recipe_lines: PreparedWarehouseCategoryIngredient[]
   linked_product_id: string | null
   linked_product_name: string | null
   linked_product_quantity: number
@@ -41,6 +52,8 @@ export function createEmptyModifier(sortOrder: number): ModifierFormRow {
     recipe_base_type_id: null,
     recipe_base_name: null,
     recipe_base_quantity: 1,
+    recipe_lines: [],
+    prepared_recipe_lines: [],
     linked_product_id: null,
     linked_product_name: null,
     linked_product_quantity: 1,
@@ -57,6 +70,8 @@ export function resetModifierFieldsForType(modifier: ModifierFormRow, nextType: 
   modifier.recipe_base_type_id = null
   modifier.recipe_base_name = null
   modifier.recipe_base_quantity = 1
+  modifier.recipe_lines = []
+  modifier.prepared_recipe_lines = []
   modifier.linked_product_id = null
   modifier.linked_product_name = null
   modifier.linked_product_quantity = 1
@@ -68,6 +83,9 @@ export function mapModifierFromApi(m: Record<string, unknown>): ModifierFormRow 
   const ingredient = m.ingredient as { id?: string; name?: string } | undefined
   const recipeBase = m.recipe_base as { id?: string; name?: string } | undefined
   const linkedProduct = m.linked_product as { id?: string; name?: string } | undefined
+  const recipeLines = Array.isArray(m.recipe_lines)
+    ? (m.recipe_lines as Array<Record<string, unknown>>)
+    : []
 
   return {
     name: String(m.name || ''),
@@ -85,6 +103,16 @@ export function mapModifierFromApi(m: Record<string, unknown>): ModifierFormRow 
     recipe_base_type_id: (m.recipe_base_type_id as string) || recipeBase?.id || null,
     recipe_base_name: recipeBase?.name || null,
     recipe_base_quantity: Number(m.recipe_base_quantity ?? 1),
+    recipe_lines: recipeLines.map(line => {
+      const lineIngredient = line.ingredient as { name?: string } | undefined
+      return {
+        ingredient_id: String(line.ingredient_id || ''),
+        ingredient_name: lineIngredient?.name || String(line.ingredient_name || ''),
+        quantity: line.quantity != null ? Number(line.quantity) : null,
+        unit: line.unit ? String(line.unit) : null,
+      }
+    }),
+    prepared_recipe_lines: [],
     linked_product_id: (m.linked_product_id as string) || linkedProduct?.id || null,
     linked_product_name: linkedProduct?.name || null,
     linked_product_quantity: Number(m.linked_product_quantity ?? 1),
@@ -94,6 +122,14 @@ export function mapModifierFromApi(m: Record<string, unknown>): ModifierFormRow 
 
 export function serializeModifierForApi(row: ModifierFormRow) {
   const optionType = row.option_type
+  const recipeLines = [
+    ...row.recipe_lines,
+    ...row.prepared_recipe_lines,
+  ].map(line => ({
+    ingredient_id: line.ingredient_id,
+    quantity: line.quantity,
+    unit: line.unit,
+  }))
   return {
     name: row.name.trim(),
     price: row.price,
@@ -108,6 +144,7 @@ export function serializeModifierForApi(row: ModifierFormRow) {
     ingredient_unit: optionType === 'INGREDIENT' ? row.ingredient_unit : null,
     recipe_base_type_id: optionType === 'RECIPE' ? (row.recipe_base_type_id || null) : null,
     recipe_base_quantity: optionType === 'RECIPE' ? row.recipe_base_quantity : 1,
+    recipe_lines: optionType === 'RECIPE' ? recipeLines : null,
     linked_product_id: optionType === 'PRODUCT' ? (row.linked_product_id || null) : null,
     linked_product_quantity: optionType === 'PRODUCT' ? row.linked_product_quantity : 1,
   }
@@ -137,8 +174,21 @@ export function validateModifierOption(row: ModifierFormRow): string | null {
       return `Indica la unidad del ingrediente en «${row.name}».`
     }
   }
-  if (type === 'RECIPE' && !row.recipe_base_type_id) {
-    return `La opción «${row.name}» requiere una receta base.`
+  if (type === 'RECIPE') {
+    const recipeLines = [...row.recipe_lines, ...row.prepared_recipe_lines]
+    if (!row.recipe_base_type_id && recipeLines.length === 0) {
+      return `La opción «${row.name}» requiere una receta base o ingredientes.`
+    }
+    const seenIds = new Set<string>()
+    for (const line of recipeLines) {
+      if (!line.ingredient_id || line.quantity == null || line.quantity <= 0 || !line.unit?.trim()) {
+        return `Completa ingrediente, cantidad y unidad en la receta de «${row.name}».`
+      }
+      if (seenIds.has(line.ingredient_id)) {
+        return `La receta de «${row.name}» tiene ingredientes duplicados.`
+      }
+      seenIds.add(line.ingredient_id)
+    }
   }
   if (type === 'PRODUCT') {
     if (!row.linked_product_id) return `La opción «${row.name}» requiere un producto del menú.`

--- a/i18n/locales/ar/menu.json
+++ b/i18n/locales/ar/menu.json
@@ -33,7 +33,8 @@
       "listo": "تم",
       "guardado": "تم الحفظ",
       "active": "نشط",
-      "inactive": "غير نشط"
+      "inactive": "غير نشط",
+      "incompatibleUnitError": "اختر وحدة متوافقة لكل مكوّن."
     },
     "productos": {
       "editMode": "وضع التعديل",

--- a/i18n/locales/de/menu.json
+++ b/i18n/locales/de/menu.json
@@ -33,7 +33,8 @@
       "listo": "Fertig",
       "guardado": "Gespeichert",
       "active": "Aktiv",
-      "inactive": "Inaktiv"
+      "inactive": "Inaktiv",
+      "incompatibleUnitError": "Wähle für jede Zutat eine kompatible Einheit."
     },
     "productos": {
       "editMode": "Bearbeitungsmodus",

--- a/i18n/locales/en/menu.json
+++ b/i18n/locales/en/menu.json
@@ -33,7 +33,8 @@
       "listo": "Done",
       "guardado": "Saved",
       "active": "Active",
-      "inactive": "Inactive"
+      "inactive": "Inactive",
+      "incompatibleUnitError": "Select a compatible unit for every ingredient."
     },
     "productos": {
       "editMode": "Edit mode",

--- a/i18n/locales/es/menu.json
+++ b/i18n/locales/es/menu.json
@@ -33,7 +33,8 @@
       "listo": "Listo",
       "guardado": "Guardado",
       "active": "Activa",
-      "inactive": "Inactiva"
+      "inactive": "Inactiva",
+      "incompatibleUnitError": "Selecciona una unidad compatible para cada ingrediente."
     },
     "productos": {
       "editMode": "Modo edición",

--- a/i18n/locales/fr/menu.json
+++ b/i18n/locales/fr/menu.json
@@ -33,7 +33,8 @@
       "listo": "Terminé",
       "guardado": "Enregistré",
       "active": "Active",
-      "inactive": "Inactive"
+      "inactive": "Inactive",
+      "incompatibleUnitError": "Sélectionnez une unité compatible pour chaque ingrédient."
     },
     "productos": {
       "editMode": "Mode édition",

--- a/i18n/locales/hi/menu.json
+++ b/i18n/locales/hi/menu.json
@@ -33,7 +33,8 @@
       "listo": "हो गया",
       "guardado": "सहेजा गया",
       "active": "सक्रिय",
-      "inactive": "निष्क्रिय"
+      "inactive": "निष्क्रिय",
+      "incompatibleUnitError": "हर सामग्री के लिए संगत इकाई चुनें।"
     },
     "productos": {
       "editMode": "संपादन मोड",

--- a/i18n/locales/pt/menu.json
+++ b/i18n/locales/pt/menu.json
@@ -33,7 +33,8 @@
       "listo": "Pronto",
       "guardado": "Salvo",
       "active": "Ativa",
-      "inactive": "Inativa"
+      "inactive": "Inativa",
+      "incompatibleUnitError": "Selecione uma unidade compatível para cada ingrediente."
     },
     "productos": {
       "editMode": "Modo edição",

--- a/i18n/locales/zh/menu.json
+++ b/i18n/locales/zh/menu.json
@@ -33,7 +33,8 @@
       "listo": "完成",
       "guardado": "已保存",
       "active": "启用",
-      "inactive": "禁用"
+      "inactive": "禁用",
+      "incompatibleUnitError": "请为每种配料选择兼容的单位。"
     },
     "productos": {
       "editMode": "编辑模式",

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -144,6 +144,9 @@
                   @remove="removeModifier(index)"
                   @select-ingredient="(ing) => selectIngredient(modifier, ing)"
                   @create-ingredient="(name) => openCustomIngModal(name, index)"
+                  @select-recipe-line="(lineIndex, ing) => selectRecipeLineIngredient(modifier, lineIndex, ing)"
+                  @create-recipe-line="(lineIndex, name) => openCustomRecipeLineModal(name, index, lineIndex)"
+                  @prepared-recipe-lines="rows => onPreparedRecipeLines(modifier, rows)"
                 />
               </div>
             </MenuCatalogInlineCreateBusyOverlay>
@@ -241,6 +244,7 @@ import {
   validateModifierOption,
   type ModifierFormRow,
 } from '~/composables/useModifierOptionForm'
+import type { PreparedWarehouseCategoryIngredient } from '~/composables/useWarehouseCategoryIngredientSelector'
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
@@ -321,15 +325,28 @@ function rehydrateModifierIngredientCaches() {
     if (!m.ingredient_name && catalogRow?.name) {
       m.ingredient_name = catalogRow.name
     }
+    for (const line of m.recipe_lines) {
+      const recipeCatalogRow = availableIngredients.value.find((i: any) => i.id === line.ingredient_id)
+      if (!line.ingredient_name && recipeCatalogRow?.name) {
+        line.ingredient_name = recipeCatalogRow.name
+      }
+    }
   }
   const entries = form.value.modifiers
-    .filter(m => m.ingredient_id)
-    .map(m => ({
+    .flatMap(m => [
+      ...(m.ingredient_id ? [{
       id: m.ingredient_id!,
       name: m.ingredient_name || ingredientCache.value[m.ingredient_id!]?.name,
       unit: ingredientCache.value[m.ingredient_id!]?.unit ?? m.ingredient_unit ?? undefined,
       ...ingredientCache.value[m.ingredient_id!],
-    }))
+      }] : []),
+      ...m.recipe_lines.map(line => ({
+        id: line.ingredient_id,
+        name: line.ingredient_name,
+        unit: line.unit ?? undefined,
+        ...ingredientCache.value[line.ingredient_id],
+      })),
+    ])
   rehydrateIngredientCaches(entries, availableIngredients.value, ingredientCache.value)
 }
 
@@ -367,22 +384,61 @@ function selectIngredient(modifier: ModifierFormRow, ing: any) {
   loadPurchaseUnits(ing.id)
 }
 
+function selectRecipeLineIngredient(modifier: ModifierFormRow, lineIndex: number, ing: any) {
+  const line = modifier.recipe_lines[lineIndex]
+  if (!line) return
+  line.ingredient_id = ing.id
+  line.ingredient_name = ing.name
+  cacheIngredientForUnits(ing)
+  line.unit = defaultUnitForIngredient(ingredientCache.value[ing.id])
+  void loadPurchaseUnits(ing.id)
+}
+
+function onPreparedRecipeLines(
+  modifier: ModifierFormRow,
+  rows: PreparedWarehouseCategoryIngredient[],
+) {
+  modifier.prepared_recipe_lines = rows
+  for (const row of rows) {
+    cacheIngredientForUnits({
+      id: row.ingredient_id,
+      name: row.name,
+      unit: ingredientCache.value[row.ingredient_id]?.unit || row.unit || undefined,
+    })
+    void loadPurchaseUnits(row.ingredient_id)
+  }
+}
+
 const inlineCreateShell = ref<{ openFromSearch: (name: string) => void } | null>(null)
 const customIngModalModIndex = ref(-1)
+const customIngModalRecipeLineIndex = ref(-1)
 const inlineCatalogBusy = ref(false)
 const inlineCatalogBusyLabel = ref('')
 const inlineCatalogBusyHint = ref('')
 
 function openCustomIngModal(name: string, index: number) {
   customIngModalModIndex.value = index
+  customIngModalRecipeLineIndex.value = -1
+  inlineCreateShell.value?.openFromSearch(name)
+}
+
+function openCustomRecipeLineModal(name: string, modifierIndex: number, lineIndex: number) {
+  customIngModalModIndex.value = modifierIndex
+  customIngModalRecipeLineIndex.value = lineIndex
   inlineCreateShell.value?.openFromSearch(name)
 }
 
 function onCustomIngredientCreated(ingredient: any) {
   const index = customIngModalModIndex.value
   if (index < 0 || index >= form.value.modifiers.length) return
-  selectIngredient(form.value.modifiers[index], ingredient)
+  const modifier = form.value.modifiers[index]
+  if (customIngModalRecipeLineIndex.value >= 0) {
+    selectRecipeLineIngredient(modifier, customIngModalRecipeLineIndex.value, ingredient)
+  } else {
+    selectIngredient(modifier, ingredient)
+  }
   customIngModalModIndex.value = -1
+  customIngModalRecipeLineIndex.value = -1
 }
 
 const { linkCreatedProductToRow } = useInlineCatalogProductLink()
@@ -391,8 +447,14 @@ async function onInlineProductCreated(product: Record<string, unknown>) {
   const index = customIngModalModIndex.value
   if (index < 0 || index >= form.value.modifiers.length) return
   await linkCreatedProductToRow(product, async (ingredient) => {
-    selectIngredient(form.value.modifiers[index], ingredient)
+    const modifier = form.value.modifiers[index]
+    if (customIngModalRecipeLineIndex.value >= 0) {
+      selectRecipeLineIngredient(modifier, customIngModalRecipeLineIndex.value, ingredient)
+    } else {
+      selectIngredient(modifier, ingredient)
+    }
     customIngModalModIndex.value = -1
+    customIngModalRecipeLineIndex.value = -1
   })
 }
 
@@ -423,6 +485,18 @@ watch(groupData, (data) => {
           })
           loadPurchaseUnits(row.ingredient_id)
         }
+        for (const line of row.recipe_lines) {
+          const sourceLine = Array.isArray(m.recipe_lines)
+            ? m.recipe_lines.find((candidate: any) => candidate.ingredient_id === line.ingredient_id)
+            : null
+          cacheIngredientForUnits({
+            id: line.ingredient_id,
+            name: line.ingredient_name,
+            unit: line.unit,
+            ...(sourceLine?.ingredient || {}),
+          })
+          loadPurchaseUnits(line.ingredient_id)
+        }
         return row
       }),
       tenant_id: currentTenant.value?.id || ''
@@ -435,7 +509,7 @@ watch(groupData, (data) => {
 }, { immediate: true })
 
 watch(availableIngredients, (list) => {
-  if (list.length && form.value.modifiers.some(m => m.ingredient_id)) {
+  if (list.length && form.value.modifiers.some(m => m.ingredient_id || m.recipe_lines.length)) {
     rehydrateModifierIngredientCaches()
   }
 })
@@ -480,6 +554,16 @@ function validateForm(): boolean {
   }
 
   for (const m of form.value.modifiers) {
+    if (m.option_type === 'RECIPE') {
+      const unitError = validateMenuCompositionRows(
+        [...m.recipe_lines, ...m.prepared_recipe_lines],
+        ingredientId => getIngredientUnitOptions(ingredientId).map(option => option.value),
+      )
+      if (unitError === 'incompatible-unit') {
+        submitError.value = t('menu.common.incompatibleUnitError')
+        return false
+      }
+    }
     const err = validateModifierOption(m)
     if (err) {
       submitError.value = err

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -147,6 +147,9 @@
                     @remove="removeModifier(index)"
                     @select-ingredient="(ing) => selectIngredient(modifier, ing)"
                     @create-ingredient="(name) => openCustomIngModal(name, index)"
+                    @select-recipe-line="(lineIndex, ing) => selectRecipeLineIngredient(modifier, lineIndex, ing)"
+                    @create-recipe-line="(lineIndex, name) => openCustomRecipeLineModal(name, index, lineIndex)"
+                    @prepared-recipe-lines="rows => onPreparedRecipeLines(modifier, rows)"
                   />
                 </div>
               </MenuCatalogInlineCreateBusyOverlay>
@@ -254,6 +257,7 @@ import {
   validateModifierOption,
   type ModifierFormRow,
 } from '~/composables/useModifierOptionForm'
+import type { PreparedWarehouseCategoryIngredient } from '~/composables/useWarehouseCategoryIngredientSelector'
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
@@ -349,22 +353,62 @@ function selectIngredient(modifier: ModifierFormRow, ing: any) {
   loadPurchaseUnits(ing.id)
 }
 
+function selectRecipeLineIngredient(modifier: ModifierFormRow, lineIndex: number, ing: any) {
+  const line = modifier.recipe_lines[lineIndex]
+  if (!line) return
+  line.ingredient_id = ing.id
+  line.ingredient_name = ing.name
+  ingredientCache.value[ing.id] = ing
+  line.unit = defaultUnitForIngredient(ingredientCache.value[ing.id])
+  void loadPurchaseUnits(ing.id)
+}
+
+function onPreparedRecipeLines(
+  modifier: ModifierFormRow,
+  rows: PreparedWarehouseCategoryIngredient[],
+) {
+  modifier.prepared_recipe_lines = rows
+  for (const row of rows) {
+    ingredientCache.value[row.ingredient_id] = {
+      ...ingredientCache.value[row.ingredient_id],
+      id: row.ingredient_id,
+      name: row.name,
+      unit: ingredientCache.value[row.ingredient_id]?.unit || row.unit,
+    }
+    void loadPurchaseUnits(row.ingredient_id)
+  }
+}
+
 const inlineCreateShell = ref<{ openFromSearch: (name: string) => void } | null>(null)
 const customIngModalModIndex = ref(-1)
+const customIngModalRecipeLineIndex = ref(-1)
 const inlineCatalogBusy = ref(false)
 const inlineCatalogBusyLabel = ref('')
 const inlineCatalogBusyHint = ref('')
 
 function openCustomIngModal(name: string, index: number) {
   customIngModalModIndex.value = index
+  customIngModalRecipeLineIndex.value = -1
+  inlineCreateShell.value?.openFromSearch(name)
+}
+
+function openCustomRecipeLineModal(name: string, modifierIndex: number, lineIndex: number) {
+  customIngModalModIndex.value = modifierIndex
+  customIngModalRecipeLineIndex.value = lineIndex
   inlineCreateShell.value?.openFromSearch(name)
 }
 
 function onCustomIngredientCreated(ingredient: any) {
   const index = customIngModalModIndex.value
   if (index < 0 || index >= form.value.modifiers.length) return
-  selectIngredient(form.value.modifiers[index], ingredient)
+  const modifier = form.value.modifiers[index]
+  if (customIngModalRecipeLineIndex.value >= 0) {
+    selectRecipeLineIngredient(modifier, customIngModalRecipeLineIndex.value, ingredient)
+  } else {
+    selectIngredient(modifier, ingredient)
+  }
   customIngModalModIndex.value = -1
+  customIngModalRecipeLineIndex.value = -1
 }
 
 const { linkCreatedProductToRow } = useInlineCatalogProductLink()
@@ -373,8 +417,14 @@ async function onInlineProductCreated(product: Record<string, unknown>) {
   const index = customIngModalModIndex.value
   if (index < 0 || index >= form.value.modifiers.length) return
   await linkCreatedProductToRow(product, async (ingredient) => {
-    selectIngredient(form.value.modifiers[index], ingredient)
+    const modifier = form.value.modifiers[index]
+    if (customIngModalRecipeLineIndex.value >= 0) {
+      selectRecipeLineIngredient(modifier, customIngModalRecipeLineIndex.value, ingredient)
+    } else {
+      selectIngredient(modifier, ingredient)
+    }
     customIngModalModIndex.value = -1
+    customIngModalRecipeLineIndex.value = -1
   })
 }
 
@@ -415,6 +465,16 @@ async function validateForm(): Promise<boolean> {
   }
 
   for (const m of form.value.modifiers) {
+    if (m.option_type === 'RECIPE') {
+      const unitError = validateMenuCompositionRows(
+        [...m.recipe_lines, ...m.prepared_recipe_lines],
+        ingredientId => getIngredientUnitOptions(ingredientId).map(option => option.value),
+      )
+      if (unitError === 'incompatible-unit') {
+        submitError.value = t('menu.common.incompatibleUnitError')
+        return false
+      }
+    }
     const err = validateModifierOption(m)
     if (err) {
       submitError.value = err

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -547,8 +547,18 @@
               {{ quantityError }}
             </p>
 
+            <WarehouseCategoryIngredientSelector
+              v-if="!isResaleProduct"
+              class="mb-4"
+              input-id="product-edit-category-ingredients"
+              :existing-ingredient-ids="existingIngredientIds"
+              :unit-options="getIngredientUnitOptions"
+              :loading-unit-ids="loadingUnits"
+              @update:prepared-rows="onCategoryPreparedRows"
+            />
+
             <!-- Lista de ingredientes -->
-            <div v-if="form.ingredients.length === 0" class="text-center py-8 text-text-secondary border border-dashed border-border/80 rounded-lg mb-4">
+            <div v-if="form.ingredients.length === 0 && categoryPreparedRows.length === 0" class="text-center py-8 text-text-secondary border border-dashed border-border/80 rounded-lg mb-4">
               <p class="text-sm font-medium">{{ t('menu.productos.emptyAdditionalLines') }}</p>
               <p class="text-xs mt-1">{{ WAREHOUSE_COPY.addRecipeCostLinesHelp }}</p>
             </div>
@@ -855,6 +865,8 @@ import {
 import { useActiveStationsQuery } from '@/composables/queries/useActiveStations'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 import { formatDomainQuantity } from '~/utils/domainNumberFormat'
+import WarehouseCategoryIngredientSelector from '~/components/ingredientes/WarehouseCategoryIngredientSelector.vue'
+import type { PreparedWarehouseCategoryIngredient } from '~/composables/useWarehouseCategoryIngredientSelector'
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
@@ -1017,6 +1029,7 @@ const { availableIngredients: ingredients } = useMenuIngredientsQuery()
 const ingredientCache = ref<Record<string, any>>({})
 const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 const loadingUnits = ref<Set<string>>(new Set())
+const categoryPreparedRows = ref<PreparedWarehouseCategoryIngredient[]>([])
 
 const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient, mergeIngredientUnitFields, rehydrateIngredientCaches } = useIngredientUnitOptions()
 
@@ -1071,6 +1084,18 @@ async function loadPurchaseUnits(ingredientId: string) {
     const next = new Set(loadingUnits.value)
     next.delete(ingredientId)
     loadingUnits.value = next
+  }
+}
+
+function onCategoryPreparedRows(rows: PreparedWarehouseCategoryIngredient[]) {
+  categoryPreparedRows.value = rows
+  for (const row of rows) {
+    cacheIngredientForUnits({
+      id: row.ingredient_id,
+      name: row.name,
+      unit: ingredientCache.value[row.ingredient_id]?.unit || row.unit || undefined,
+    })
+    void loadPurchaseUnits(row.ingredient_id)
   }
 }
 
@@ -1195,6 +1220,14 @@ const form = ref({
   costo_percibido: null as number | null,
 })
 
+const existingIngredientIds = computed(() =>
+  form.value.ingredients.map(row => row.ingredient_id).filter(Boolean),
+)
+const combinedIngredients = computed(() => [
+  ...form.value.ingredients,
+  ...mapPreparedRowsToProduct(categoryPreparedRows.value),
+])
+
 const isSubmitting = ref(false)
 const submitError = ref('')
 const duplicateRecipeBaseError = ref('')
@@ -1206,6 +1239,7 @@ const tracksInventory = ref(true)
 // Watch product data and populate form
 watch(productData, (data) => {
   if (data?.data) {
+    categoryPreparedRows.value = []
     const product = data.data
     form.value = {
       name: product.name,
@@ -1400,6 +1434,8 @@ async function confirmConvertToResale() {
 watch(tracksInventory, (on) => {
   if (on) {
     cancelConvertResalePanel()
+  } else {
+    categoryPreparedRows.value = []
   }
 })
 
@@ -1462,9 +1498,20 @@ const handleSubmit = async () => {
 
   // Validate ingredient quantities > 0 (only when tracking inventory)
   if (!isResaleProduct.value && tracksInventory.value) {
-    const hasZeroQuantity = form.value.ingredients.some(ing => !ing.quantity || ing.quantity <= 0)
-    if (hasZeroQuantity) {
+    const validationError = validateMenuCompositionRows(
+      combinedIngredients.value,
+      ingredientId => getIngredientUnitOptions(ingredientId).map(option => option.value),
+    )
+    if (validationError === 'incomplete') {
       quantityError.value = WAREHOUSE_COPY.allRecipeCostLinesNeedQuantity
+      return
+    }
+    if (validationError === 'duplicate') {
+      quantityError.value = WAREHOUSE_COPY.duplicateWarehouseItemInList
+      return
+    }
+    if (validationError === 'incompatible-unit') {
+      quantityError.value = t('menu.common.incompatibleUnitError')
       return
     }
   }
@@ -1512,7 +1559,7 @@ const handleSubmit = async () => {
         ...formScalars,
         recipe_bases: cleanedRecipeBases,
         recipe_base_ids: cleanedRecipeBases.map(l => l.recipe_base_id),
-        ingredients: tracksInventory.value ? form.value.ingredients : [],
+        ingredients: tracksInventory.value ? combinedIngredients.value : [],
         image_url: form.value.image_url || null,
         costo_percibido: form.value.costo_percibido ?? null,
       }

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -432,7 +432,16 @@
               <UiFormSection :title="WAREHOUSE_COPY.recipeCostLines">
                 <MenuIngredientProductHint class="mb-3" />
 
-                <div v-if="form.ingredients.length === 0" class="text-center py-8 text-text-secondary border border-dashed border-border/80 rounded-lg mb-4">
+                <WarehouseCategoryIngredientSelector
+                  class="mb-4"
+                  input-id="product-create-category-ingredients"
+                  :existing-ingredient-ids="existingIngredientIds"
+                  :unit-options="getIngredientUnitOptions"
+                  :loading-unit-ids="loadingUnits"
+                  @update:prepared-rows="onCategoryPreparedRows"
+                />
+
+                <div v-if="form.ingredients.length === 0 && categoryPreparedRows.length === 0" class="text-center py-8 text-text-secondary border border-dashed border-border/80 rounded-lg mb-4">
                     <p class="text-sm font-medium">{{ t('menu.productos.emptyAdditionalLines') }}</p>
                   <p class="text-xs mt-1">{{ WAREHOUSE_COPY.addRecipeCostLinesHelp }}</p>
                 </div>
@@ -705,6 +714,8 @@ import {
 } from '@/composables/useIngredientPurchaseUnitsDraft'
 import { resolveResaleIngredientId } from '@/composables/useResaleLinkedIngredient'
 import { formatDomainQuantity } from '~/utils/domainNumberFormat'
+import WarehouseCategoryIngredientSelector from '~/components/ingredientes/WarehouseCategoryIngredientSelector.vue'
+import type { PreparedWarehouseCategoryIngredient } from '~/composables/useWarehouseCategoryIngredientSelector'
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
@@ -760,6 +771,8 @@ function setProductCreateMode(mode: ProductCreateMode) {
     resaleUnitWeightGr.value = null
     resaleUnitWeightUnit.value = 'gr'
     resalePurchaseUnits.value = defaultUndPurchaseUnitsDraft()
+  } else {
+    categoryPreparedRows.value = []
   }
 }
 
@@ -846,6 +859,15 @@ const inheritedStation = computed(() => {
 const ingredientCache = ref<Record<string, any>>({})
 const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 const loadingUnits = ref<Set<string>>(new Set())
+const categoryPreparedRows = ref<PreparedWarehouseCategoryIngredient[]>([])
+
+const existingIngredientIds = computed(() =>
+  form.value.ingredients.map(row => row.ingredient_id).filter(Boolean),
+)
+const combinedIngredients = computed(() => [
+  ...form.value.ingredients,
+  ...mapPreparedRowsToProduct(categoryPreparedRows.value),
+])
 
 const {
   getIngredientUnitOptions: buildUnitOptions,
@@ -900,6 +922,18 @@ async function loadPurchaseUnits(ingredientId: string) {
     const next = new Set(loadingUnits.value)
     next.delete(ingredientId)
     loadingUnits.value = next
+  }
+}
+
+function onCategoryPreparedRows(rows: PreparedWarehouseCategoryIngredient[]) {
+  categoryPreparedRows.value = rows
+  for (const row of rows) {
+    cacheIngredientForUnits({
+      id: row.ingredient_id,
+      name: row.name,
+      unit: ingredientCache.value[row.ingredient_id]?.unit || row.unit || undefined,
+    })
+    void loadPurchaseUnits(row.ingredient_id)
   }
 }
 
@@ -1051,14 +1085,21 @@ async function validateForm(): Promise<boolean> {
     return true
   }
 
-  if (form.value.ingredients.length > 0) {
-    const invalid = form.value.ingredients.some(
-      i => !i.ingredient_id || !i.quantity || i.quantity <= 0,
-    )
-    if (invalid) {
-      submitError.value = WAREHOUSE_COPY.completeRecipeCostLinesError
-      return false
-    }
+  const validationError = validateMenuCompositionRows(
+    combinedIngredients.value,
+    ingredientId => getIngredientUnitOptions(ingredientId).map(option => option.value),
+  )
+  if (validationError === 'incomplete') {
+    submitError.value = WAREHOUSE_COPY.completeRecipeCostLinesError
+    return false
+  }
+  if (validationError === 'duplicate') {
+    submitError.value = WAREHOUSE_COPY.duplicateWarehouseItemInList
+    return false
+  }
+  if (validationError === 'incompatible-unit') {
+    submitError.value = t('menu.common.incompatibleUnitError')
+    return false
   }
 
   return true
@@ -1288,7 +1329,7 @@ async function submitProduct() {
       ...form.value,
       recipe_bases: cleanedRecipeBases,
       recipe_base_ids: cleanedRecipeBases.map(l => l.recipe_base_id),
-      ingredients: form.value.ingredients,
+      ingredients: combinedIngredients.value,
       image_url: form.value.image_url || null,
       costo_percibido: form.value.costo_percibido ?? null,
     }

--- a/pages/menu/recetas/[id].vue
+++ b/pages/menu/recetas/[id].vue
@@ -75,7 +75,16 @@
             >
               <MenuIngredientProductHint class="mb-4" />
 
-              <div v-if="form.ingredients.length === 0" class="text-center py-10 text-text-secondary border border-dashed border-border rounded-lg">
+              <WarehouseCategoryIngredientSelector
+                class="mb-4"
+                input-id="recipe-edit-category-ingredients"
+                :existing-ingredient-ids="existingIngredientIds"
+                :unit-options="getIngredientUnitOptions"
+                :loading-unit-ids="loadingUnits"
+                @update:prepared-rows="onCategoryPreparedRows"
+              />
+
+              <div v-if="form.ingredients.length === 0 && categoryPreparedRows.length === 0" class="text-center py-10 text-text-secondary border border-dashed border-border rounded-lg">
                 <Icon name="heroicons:cube" class="h-12 w-12 mx-auto mb-3 text-text-tertiary/50" />
                 <p class="text-sm font-medium mb-0.5">{{ t('menu.recetas.form.emptyLines') }}</p>
                 <p class="text-xs text-text-tertiary">{{ WAREHOUSE_COPY.recipeCompositionEmptyHelp }}</p>
@@ -170,7 +179,7 @@
           <div class="space-y-3">
             <div class="flex justify-between text-sm">
               <span class="text-text-secondary">{{ WAREHOUSE_COPY.recipeCompositionSummary }}</span>
-              <span class="font-semibold text-text-primary">{{ form.ingredients.length }}</span>
+              <span class="font-semibold text-text-primary">{{ combinedIngredients.length }}</span>
             </div>
 
             <div class="flex justify-between text-sm items-center gap-2">
@@ -242,6 +251,8 @@
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useQueryCache } from '@pinia/colada'
 import { useMenuIngredientsQuery } from '@/composables/queries/useMenuIngredients'
+import WarehouseCategoryIngredientSelector from '~/components/ingredientes/WarehouseCategoryIngredientSelector.vue'
+import type { PreparedWarehouseCategoryIngredient } from '~/composables/useWarehouseCategoryIngredientSelector'
 
 definePageMeta({
   pageTransition: {
@@ -286,6 +297,7 @@ const { availableIngredients } = useMenuIngredientsQuery()
 const ingredientCache = ref<Record<string, any>>({})
 const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 const loadingUnits = ref<Set<string>>(new Set())
+const categoryPreparedRows = ref<PreparedWarehouseCategoryIngredient[]>([])
 
 const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient, mergeIngredientUnitFields, rehydrateIngredientCaches } = useIngredientUnitOptions()
 
@@ -384,6 +396,26 @@ const form = ref({
   }>
 })
 
+const existingIngredientIds = computed(() =>
+  form.value.ingredients.map(row => row.ingredient_id).filter(Boolean),
+)
+const combinedIngredients = computed(() => [
+  ...form.value.ingredients,
+  ...mapPreparedRowsToRecipe(categoryPreparedRows.value),
+])
+
+function onCategoryPreparedRows(rows: PreparedWarehouseCategoryIngredient[]) {
+  categoryPreparedRows.value = rows
+  for (const row of rows) {
+    cacheIngredientForUnits({
+      id: row.ingredient_id,
+      name: row.name,
+      unit: ingredientCache.value[row.ingredient_id]?.unit || row.unit || undefined,
+    })
+    void loadPurchaseUnits(row.ingredient_id)
+  }
+}
+
 const isSubmitting = ref(false)
 const submitError = ref('')
 
@@ -435,19 +467,24 @@ const handleSubmit = async () => {
   if (isSubmitting.value) return
   submitError.value = ''
 
-  const hasZeroQuantity = form.value.ingredients.some(ing => !ing.base_quantity || ing.base_quantity <= 0)
-  if (hasZeroQuantity) {
+  const validationError = validateMenuCompositionRows(
+    combinedIngredients.value.map(row => ({
+      ingredient_id: row.ingredient_id,
+      quantity: row.base_quantity,
+      unit: row.unit,
+    })),
+    ingredientId => getIngredientUnitOptions(ingredientId).map(option => option.value),
+  )
+  if (validationError === 'incomplete') {
     submitError.value = WAREHOUSE_COPY.allRecipeCostLinesNeedQuantity
     return
   }
-
-  const ingredientIds = form.value.ingredients
-    .map(ing => ing.ingredient_id)
-    .filter(id => id !== '')
-
-  const uniqueIds = new Set(ingredientIds)
-  if (ingredientIds.length !== uniqueIds.size) {
+  if (validationError === 'duplicate') {
     submitError.value = WAREHOUSE_COPY.duplicateWarehouseItemInList
+    return
+  }
+  if (validationError === 'incompatible-unit') {
+    submitError.value = t('menu.common.incompatibleUnitError')
     return
   }
 
@@ -460,7 +497,7 @@ const handleSubmit = async () => {
         name: form.value.name,
         description: form.value.description,
         is_active: form.value.is_active,
-        ingredients: form.value.ingredients.map(ing => ({
+        ingredients: combinedIngredients.value.map(ing => ({
           ingredient_id: ing.ingredient_id,
           ingredient_name: ing.ingredient_name,
           base_quantity: ing.base_quantity,

--- a/pages/menu/recetas/crear.vue
+++ b/pages/menu/recetas/crear.vue
@@ -91,7 +91,16 @@
                   {{ duplicateIngredientError }}
                 </div>
 
-                <div v-if="form.ingredients.length === 0" class="text-center py-10 text-text-secondary border border-dashed border-border rounded-lg">
+                <WarehouseCategoryIngredientSelector
+                  class="mb-4"
+                  input-id="recipe-create-category-ingredients"
+                  :existing-ingredient-ids="existingIngredientIds"
+                  :unit-options="getIngredientUnitOptions"
+                  :loading-unit-ids="loadingUnits"
+                  @update:prepared-rows="onCategoryPreparedRows"
+                />
+
+                <div v-if="form.ingredients.length === 0 && categoryPreparedRows.length === 0" class="text-center py-10 text-text-secondary border border-dashed border-border rounded-lg">
                   <svg class="w-12 h-12 mx-auto mb-3 text-text-tertiary/50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
                   </svg>
@@ -196,7 +205,7 @@
 
               <div class="flex justify-between text-sm">
                 <span class="text-text-secondary">{{ WAREHOUSE_COPY.recipeCompositionSummary }}</span>
-                <span class="font-semibold text-text-primary">{{ form.ingredients.length }}</span>
+                <span class="font-semibold text-text-primary">{{ combinedIngredients.length }}</span>
               </div>
 
               <div class="flex justify-between text-sm items-center gap-2">
@@ -256,6 +265,8 @@
 </template>
 
 <script setup lang="ts">
+import WarehouseCategoryIngredientSelector from '~/components/ingredientes/WarehouseCategoryIngredientSelector.vue'
+import type { PreparedWarehouseCategoryIngredient } from '~/composables/useWarehouseCategoryIngredientSelector'
 import { ref } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 
@@ -293,6 +304,7 @@ const form = ref({
 const ingredientCache = ref<Record<string, any>>({})
 const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 const loadingUnits = ref<Set<string>>(new Set())
+const categoryPreparedRows = ref<PreparedWarehouseCategoryIngredient[]>([])
 
 const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient } = useIngredientUnitOptions()
 
@@ -303,26 +315,50 @@ function getIngredientUnitOptions(ingredientId: string) {
   })
 }
 
+const existingIngredientIds = computed(() =>
+  form.value.ingredients.map(row => row.ingredient_id).filter(Boolean),
+)
+const combinedIngredients = computed(() => [
+  ...form.value.ingredients,
+  ...mapPreparedRowsToRecipe(categoryPreparedRows.value),
+])
+
+async function loadPurchaseUnits(ingredientId: string) {
+  if (!ingredientId || purchaseUnitsCache.value.has(ingredientId)) return
+  loadingUnits.value = new Set([...loadingUnits.value, ingredientId])
+  try {
+    const res = await $fetch<any>(`/api/suppliers/ingredient-purchase-units/ingredient/${ingredientId}`)
+    const updated = new Map(purchaseUnitsCache.value)
+    updated.set(ingredientId, res.data || [])
+    purchaseUnitsCache.value = updated
+  } catch {
+    const updated = new Map(purchaseUnitsCache.value)
+    updated.set(ingredientId, [])
+    purchaseUnitsCache.value = updated
+  } finally {
+    const next = new Set(loadingUnits.value)
+    next.delete(ingredientId)
+    loadingUnits.value = next
+  }
+}
+
 async function onIngredientChange(index: number, ingredientId: string) {
   if (!ingredientId) return
   const ingredient = ingredientCache.value[ingredientId]
   form.value.ingredients[index].unit = defaultUnitForIngredient(ingredient)
-  if (!purchaseUnitsCache.value.has(ingredientId)) {
-    loadingUnits.value = new Set([...loadingUnits.value, ingredientId])
-    try {
-      const res = await $fetch<any>(`/api/suppliers/ingredient-purchase-units/ingredient/${ingredientId}`)
-      const updated = new Map(purchaseUnitsCache.value)
-      updated.set(ingredientId, res.data || [])
-      purchaseUnitsCache.value = updated
-    } catch {
-      const updated = new Map(purchaseUnitsCache.value)
-      updated.set(ingredientId, [])
-      purchaseUnitsCache.value = updated
-    } finally {
-      const next = new Set(loadingUnits.value)
-      next.delete(ingredientId)
-      loadingUnits.value = next
+  await loadPurchaseUnits(ingredientId)
+}
+
+function onCategoryPreparedRows(rows: PreparedWarehouseCategoryIngredient[]) {
+  categoryPreparedRows.value = rows
+  for (const row of rows) {
+    ingredientCache.value[row.ingredient_id] = {
+      ...ingredientCache.value[row.ingredient_id],
+      id: row.ingredient_id,
+      name: row.name,
+      unit: ingredientCache.value[row.ingredient_id]?.unit || row.unit,
     }
+    void loadPurchaseUnits(row.ingredient_id)
   }
 }
 
@@ -394,26 +430,29 @@ async function validateForm(): Promise<boolean> {
     return false
   }
 
-  if (form.value.ingredients.length === 0) {
+  if (combinedIngredients.value.length === 0) {
     submitError.value = WAREHOUSE_COPY.addWarehouseItemToRecipe
     return false
   }
 
-  const invalid = form.value.ingredients.some(
-    i => !i.ingredient_id || !i.base_quantity || i.base_quantity <= 0,
+  const validationError = validateMenuCompositionRows(
+    combinedIngredients.value.map(row => ({
+      ingredient_id: row.ingredient_id,
+      quantity: row.base_quantity,
+      unit: row.unit,
+    })),
+    ingredientId => getIngredientUnitOptions(ingredientId).map(option => option.value),
   )
-  if (invalid) {
+  if (validationError === 'incomplete') {
     submitError.value = WAREHOUSE_COPY.completeRecipeCostLinesError
     return false
   }
-
-  const ingredientIds = form.value.ingredients
-    .map(ing => ing.ingredient_id)
-    .filter(id => id !== '')
-
-  const uniqueIds = new Set(ingredientIds)
-  if (ingredientIds.length !== uniqueIds.size) {
+  if (validationError === 'duplicate') {
     duplicateIngredientError.value = WAREHOUSE_COPY.duplicateWarehouseItemInList
+    return false
+  }
+  if (validationError === 'incompatible-unit') {
+    submitError.value = t('menu.common.incompatibleUnitError')
     return false
   }
 
@@ -436,7 +475,7 @@ async function submitRecipe() {
         name: form.value.name,
         description: form.value.description,
         is_active: form.value.is_active,
-        ingredients: form.value.ingredients.map(ing => ({
+        ingredients: combinedIngredients.value.map(ing => ({
           ingredient_id: ing.ingredient_id,
           base_quantity: ing.base_quantity,
           unit: ing.unit,


### PR DESCRIPTION
## Summary
- integrate warehouse-category ingredient drafts in recipe and product create/edit flows
- support modifier RECIPE recipe_lines with manual and category rows
- validate quantities, compatible units, and duplicates before submit

## Tests
- `npx vitest run components/ingredientes/WarehouseCategoryIngredientSelector.test.ts composables/useMenuCategoryIngredientRows.test.ts composables/useModifierOptionForm.test.ts`
- `npm run i18n:check:all`
- `git diff --check`

Closes #1671