### PR TITLE
fix(print): blank first page on receipt print; product-line numbers in prefactura

### DIFF
--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -631,6 +631,14 @@ const printableItems = computed(() =>
     visibility: hidden;
   }
 
+  /* Remove the hidden app from print layout entirely. The ticket is
+     teleported to <body>; siblings that stay in flow (visibility:hidden
+     still occupies space) would push the static ticket to page 2,
+     producing a blank first page. */
+  body.printing-receipt-ticket > :not(.receipt-print-ticket) {
+    display: none !important;
+  }
+
   body.printing-receipt-ticket #pos-receipt,
   body.printing-receipt-ticket #pos-receipt *,
   body.printing-receipt-ticket #pos-prefactura,

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -5190,30 +5190,30 @@ onUnmounted(() => {
     </template>
     <div class="receipt-divider">--------------------------------</div>
 
-    <div class="receipt-grid-header receipt-small">
+    <div class="receipt-product-header receipt-small">
       <span class="receipt-col-desc">{{ t('pos.receipt.description') }}</span>
-      <span class="receipt-col-qty">{{ t('pos.receipt.qty') }}</span>
-      <span class="receipt-col-price">{{ t('pos.receipt.price') }}</span>
       <span class="receipt-col-total">{{ t('pos.receipt.total') }}</span>
     </div>
     <template v-for="item in printablePrefacturaItems" :key="item.id ?? item.orderItemId">
-      <div class="receipt-grid-row receipt-small">
-        <span class="receipt-col-desc">
+      <div class="receipt-product-line receipt-small">
+        <div class="receipt-product-name">
           {{ item.product?.name || item.name }}<span v-if="isKitchenServiceMode && item.fired === false"> *</span>
-        </span>
-        <span class="receipt-col-qty">{{ item.quantity }}</span>
-        <span class="receipt-col-price">{{ formatCurrency(getItemUnitPrice(item)) }}</span>
-        <span class="receipt-col-total">{{ formatCurrency(getItemTotal(item)) }}</span>
+        </div>
+        <div class="receipt-product-values">
+          <span>{{ item.quantity }} × {{ formatCurrency(getItemUnitPrice(item)) }}</span>
+          <strong>{{ formatCurrency(getItemTotal(item)) }}</strong>
+        </div>
       </div>
       <div
         v-for="mod in (item.modifiers ?? [])"
         :key="`${item.id ?? item.orderItemId}-${mod.id}`"
-        class="receipt-grid-row receipt-small receipt-modifier-row"
+        class="receipt-product-line receipt-small receipt-modifier-row"
       >
-        <span class="receipt-col-desc">{{ formatModifierPrintDesc(mod) }}</span>
-        <span class="receipt-col-qty">{{ (Number(mod.quantity) || 1) > 1 ? mod.quantity : '' }}</span>
-        <span class="receipt-col-price">{{ formatCurrency(Number(mod.price) || 0) }}</span>
-        <span class="receipt-col-total">{{ formatCurrency(getModifierLineTotal(mod)) }}</span>
+        <div class="receipt-product-name">{{ formatModifierPrintDesc(mod) }}</div>
+        <div class="receipt-product-values">
+          <span>{{ (Number(mod.quantity) || 1) > 1 ? `${mod.quantity} × ` : '' }}{{ formatCurrency(Number(mod.price) || 0) }}</span>
+          <span>{{ formatCurrency(getModifierLineTotal(mod)) }}</span>
+        </div>
       </div>
     </template>
     <div class="receipt-divider">--------------------------------</div>
@@ -5535,6 +5535,44 @@ onUnmounted(() => {
 .receipt-col-total { text-align: right; white-space: nowrap; }
 .receipt-grid-header { font-weight: bold; border-bottom: 1px dashed #000; padding-bottom: 2px; margin-bottom: 4px; }
 .receipt-modifier-row .receipt-col-desc { padding-left: 8px; font-size: 0.92em; }
+
+/* Prefactura product-line layout — mirrors ReceiptPrintTicket so numbers
+   (qty × price = total) never overlap on narrow thermal paper. */
+#pos-prefactura .receipt-product-header {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 2mm;
+  align-items: baseline;
+  font-weight: bold;
+  border-bottom: 1px dashed #000;
+  padding-bottom: 2px;
+  margin-bottom: 3px;
+}
+#pos-prefactura .receipt-product-line {
+  margin: 0 0 3px;
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+#pos-prefactura .receipt-product-name {
+  overflow-wrap: anywhere;
+}
+#pos-prefactura .receipt-product-values {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 2mm;
+  align-items: baseline;
+  padding-left: 2mm;
+}
+#pos-prefactura .receipt-product-values span:last-child,
+#pos-prefactura .receipt-product-values strong {
+  text-align: right;
+  white-space: nowrap;
+}
+#pos-prefactura .receipt-modifier-row {
+  padding-left: 2mm;
+  margin-top: -1px;
+  font-size: 0.92em;
+}
 </style>
 
 <style>


### PR DESCRIPTION
## Summary

- **Blank first page when printing receipts/invoices** (e.g. `/ventas/[id]`): the ticket is teleported to `<body>` and everything else is only `visibility:hidden`, which keeps layout space. Since 13b97dc7 switched the print position from `fixed` to `static`, the ticket flowed after the hidden page content and started on page 2. Now direct body siblings are `display:none` in print, so the ticket starts at the top of page 1. `position: static` is kept so long receipts still paginate (restoring `fixed` would clip them).
- **POS prefactura numbers overlap**: `#pos-prefactura` items now mirror the `ReceiptPrintTicket` product-line layout (product name row, then `qty × price = total` on a `1fr auto` grid) instead of the old 4-column grid that could overlap on 64mm paper.

## Tests

- `npx nuxi prepare` OK
- Manual: print `/ventas/[id]` (no blank page, ticket starts at top); POS prefactura print (aligned numbers, no overlap); POS receipt unchanged; long receipts paginate without clipping

## Out of scope

- POS `#pos-receipt` inline block keeps the grid layout (unchanged)