### PR TITLE
fix(pos): remove floor plan status legend taking too much space

### DIFF
--- a/.wr/1693.yaml
+++ b/.wr/1693.yaml
@@ -1,0 +1,40 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1693
+title: "POS: eliminar/reducir barra de estados (Ocupada/Cuenta/Libre) en vista de planta principal"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1693-pos-floor-legend
+
+paths:
+  - components/pos/MesasFloorPlan.vue
+
+ac:
+  - La barra de estados Ocupada/Cuenta/Libre ya no ocupa una franja dedicada en la vista de planta principal
+  - El estado de cada mesa sigue distinguible en el propio tile (dot de color, label, strip de estado)
+  - El layout del floor plan no deja huecos ni saltos tras el cambio
+  - Sin regresion visual en movil y desktop en /pos
+  - Tests del modulo pos siguen pasando
+
+out_of_scope:
+  - cambios de API
+  - cambios en la logica de estados de mesa
+  - otras vistas del POS
+  - limpieza de claves i18n pos.floor.* (siguen en uso en los tiles)
+  - computed sin uso preexistentes (freeCount/openCount/billCount/totalVentas)
+
+hints:
+  entry: "pages/pos/index.vue -> components/pos/MesasFloorPlan.vue"
+  pattern: "components/pos/MesasFloorPlan.vue:279-300 bloque Legend eliminado"
+  tests: "npx vitest run components/pos"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "/wr-review del PR abierto"

--- a/components/pos/MesasFloorPlan.vue
+++ b/components/pos/MesasFloorPlan.vue
@@ -276,29 +276,6 @@ onUnmounted(() => {
 
     <!-- Content -->
     <div v-else>
-      <!-- Legend -->
-      <div class="flex items-center justify-between mb-6 flex-wrap gap-3">
-        <p class="text-sm text-text-secondary">{{ t('pos.floor.mainPlan') }}</p>
-        <div class="flex gap-2 flex-wrap">
-          <div class="flex items-center gap-1.5 bg-surface px-3 py-1.5 rounded-lg border border-border shadow-sm">
-            <div class="w-3 h-3 rounded-sm bg-status-warning-bg border border-status-warning-text/40" />
-            <span class="text-xs font-medium text-text-secondary">{{ t('pos.floor.bar') }}</span>
-          </div>
-          <div class="flex items-center gap-1.5 bg-surface px-3 py-1.5 rounded-lg border border-border shadow-sm">
-            <div class="w-3 h-3 rounded-sm bg-status-success-bg border border-status-success-text/40" />
-            <span class="text-xs font-medium text-text-secondary">{{ t('pos.floor.occupied') }}</span>
-          </div>
-          <div class="flex items-center gap-1.5 bg-surface px-3 py-1.5 rounded-lg border border-border shadow-sm">
-            <div class="w-3 h-3 rounded-sm bg-status-warning-bg border border-status-warning-text/40" />
-            <span class="text-xs font-medium text-text-secondary">{{ t('pos.floor.bill') }}</span>
-          </div>
-          <div class="flex items-center gap-1.5 bg-surface px-3 py-1.5 rounded-lg border border-border shadow-sm">
-            <div class="w-3 h-3 rounded-sm bg-surface border-2 border-border" />
-            <span class="text-xs font-medium text-text-secondary">{{ t('pos.floor.free') }}</span>
-          </div>
-        </div>
-      </div>
-
       <!-- Bar tile — always visible, pinned before regular tables -->
       <div v-if="barTable" class="mb-4">
         <button


### PR DESCRIPTION
## Summary
- Elimina la barra/leyenda de estados (Barra · Ocupada · Cuenta · Libre) y el titulo "Vista de planta principal" que ocupaban una franja dedicada sobre el plano de mesas en `/pos`.
- El estado de cada mesa sigue distinguible en el propio tile (dot de color, label "Libre", strip de estado), por lo que la leyenda era redundante.
- Sin cambios de logica ni de API; un solo archivo: `components/pos/MesasFloorPlan.vue`.

Closes #1693

## Test plan
- [ ] Verificar `/pos` planta principal en desktop: el plano inicia directo con el tile de Barra, sin huecos.
- [ ] Verificar `/pos` en movil: sin regresion visual ni saltos de layout.
- [ ] Confirmar que los estados de mesa se distinguen solo con los tiles.

## Validation evidence
```
$ npx vitest run components/pos
 RUN  v3.2.7 /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
 ✓ components/pos/CustomerIdentificationModal.test.ts (3 tests) 34ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
   Duration  820ms
```
(No existe test dedicado de MesasFloorPlan; se corre el test existente del modulo pos.)

## wr-context
See `.wr/1693.yaml` on this branch (LLM contract).