### PR TITLE
feat(auth): redirect unregistered magic-link sign-ins to registration

### DIFF
--- a/.wr/1695.yaml
+++ b/.wr/1695.yaml
@@ -1,0 +1,40 @@
+issue: 1695
+title: "Login magic link: redirigir a registro cuando el correo no está registrado"
+repo: both
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA
+stack: both
+branch: wr-1695-login-registration-redirect
+
+paths:
+  - api_warocol.com/app/models/auth.py
+  - api_warocol.com/app/services/magic_link_service.py
+  - api_warocol.com/tests/test_magic_link_registration_contract.py
+  - front_nuxt/components/Auth/LoginForm.vue
+
+ac:
+  - "MagicLinkResponse incluye action ('email_sent' | 'registration_required'), default retrocompatible"
+  - "send_magic_link devuelve registration_required cuando no hay identidad interna ni draft"
+  - "Tests de contrato: correo inexistente -> registration_required; draft -> email_sent; registrado -> login normal"
+  - "Front: action=registration_required -> prefillRegistrationEmail + toast + navigateTo('/registro')"
+  - "Front: flujo normal (registrado -> revisa tu correo) sin cambios"
+
+out_of_scope:
+  - cambios al endpoint de registro existente
+  - nuevas keys i18n (se reusan auth.noAccount + auth.createAccount)
+  - QA/regresión general (validación manual del usuario)
+
+hints:
+  entry: "POST /auth/sign-in-magic-link -> send_magic_link (magic_link_service.py:245)"
+  pattern: "RegistrationMagicLinkResponse.action (models/auth.py:83) ya expone Literal action"
+  tests: "cd api_warocol.com && pytest tests/test_magic_link_registration_contract.py -q"
+
+risk:
+  sensitive: true
+  areas: [auth]
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "auto review wr-review sobre ambos PRs"

--- a/components/Auth/LoginForm.vue
+++ b/components/Auth/LoginForm.vue
@@ -229,7 +229,7 @@ async function handleSubmit() {
   error.value = ''
 
   try {
-    await $fetch('/api/auth/sign-in-magic-link', {
+    const response = await $fetch('/api/auth/sign-in-magic-link', {
       method: 'POST',
       credentials: 'include',
       headers: {
@@ -241,6 +241,14 @@ async function handleSubmit() {
         redirect: route.query.redirect
       }
     })
+
+    // Correo no registrado: redirigir al registro con el email pre-llenado
+    if (response?.action === 'registration_required') {
+      rememberEmailForRegistration()
+      toast.info(`${t('auth.noAccount')} ${t('auth.createAccount')}`)
+      await navigateTo('/registro')
+      return
+    }
 
     // Mostrar toast de éxito y activar UI de código
     toast.success(t('auth.codeSentToast'))


### PR DESCRIPTION
## Summary
- `LoginForm.vue` reads the sign-in response; when `action === "registration_required"` it prefills the registration draft email, shows an info toast, and redirects to `/registro`.
- Mirrors the existing inverse pattern in `RegistrationForm.vue:477` (`login_required` → toast + redirect to login).
- Reuses existing i18n keys (`auth.noAccount` + `auth.createAccount`) — no locale files touched.

Companion API PR: https://github.com/uno0uno/api-warolabs/pull/664

Closes #1695

## Test plan
- [ ] Unregistered email → toast + redirect to `/registro` with email pre-filled.
- [ ] Registered email → unchanged "check your email" code UI.
- [ ] Manual check on warocol.com tenant with a never-registered email.

## Validation evidence
No targeted test exists for `LoginForm.vue` (per wr-fast: tests-only validation, no builds). API-side contract validated in https://github.com/uno0uno/api-warolabs/pull/664 (`11 passed`).

## wr-context
See `.wr/1695.yaml` on this branch (LLM contract).