### PR TITLE
fix(pos): stop double-counting BOGO free units in tab promo totals

### DIFF
--- a/.wr/1697.yaml
+++ b/.wr/1697.yaml
@@ -1,0 +1,34 @@
+issue: 1697
+repo: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1697-pos-bogo-crossline-fallback
+title: fix(pos) panel Orden Actual duplica unidades gratis BOGO cuando el API las asigna a la linea hermana
+
+paths:
+  - composables/usePosOrderPromoTotals.ts
+  - composables/usePosOrderPromoTotals.test.ts
+
+ac:
+  - Caso 4+2 con API (linea 1 = 66000, linea 2 = 0): panel muestra -66000 / total 170000; no inventa el gratis extra.
+  - El fallback client-side no contradice la evaluacion del servidor cuando existe (0 por linea es respuesta valida).
+  - Si el servidor no evaluo (todas las lineas en 0), el fallback agrega BOGO cross-line por producto+promo (cheapest-first), no por linea aislada.
+  - Tests unitarios del composable: API 66000+0; fallback cross-line 4+2 -> 3 gratis; optOut -> 0; control linea sola x2 -> 22000.
+  - Sin cambios en lineas de carrito de mostrador ni badges de catalogo.
+
+hints:
+  root_cause: usePosOrderPromoTotals.ts tabLinePromoSavings trata promoSavings=0 del API como
+    "no evaluado" y cae a linePromoSavingsForProduct por linea aislada, duplicando unidades
+    gratis que el servidor asigno a la linea hermana (cross-line cheapest-first, api #1023/#665).
+  store_mapping: usePOSStore.ts:151 mapea promoSavings numerico siempre (0 si no hay).
+  server_rule: agrupar por producto+promo, expandir unidades, gratis cheapest-first, cap por subtotal.
+  case_real: mesa 11 Rebel Rebel orden 16759 — panel -88000/148000 vs checkout correcto 170000.
+  tests:
+    - npx vitest run composables/usePosOrderPromoTotals.test.ts
+
+plan:
+  - apiTabEvaluated = alguna linea del tab con promoSavings > 0 -> confiar en valores API por linea.
+  - Si no, fallback cross-line: agrupar lineas del tab por producto, elegir mejor promo, si es bogo
+    asignar unidades gratis cheapest-first entre lineas; si no es bogo, calculo por linea actual.
+  - orderPromoSavings suma tab (API o fallback) + cart (sin cambios).
+  - Tests vitest del composable con stubs de usePOSStore y useActivePromotions.

--- a/composables/usePosOrderPromoTotals.test.ts
+++ b/composables/usePosOrderPromoTotals.test.ts
@@ -1,0 +1,112 @@
+import { computed, ref } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  usePosOrderPromoTotals,
+  type PosPromoTabItem,
+} from './usePosOrderPromoTotals'
+
+const OKTOBERT = 'prod-oktobert'
+const BOGO_PROMO = {
+  id: 'promo-hofbrau',
+  name: 'HofBrau Ockteber',
+  promo_type: 'bogo',
+  value_json: { buy_qty: 1, get_qty: 1 },
+  scope_type: 'products',
+  priority: 10,
+  stackable: false,
+  category_ids: [],
+  product_ids: [OKTOBERT],
+}
+
+function stubGlobals(promos: unknown[] = [BOGO_PROMO]) {
+  vi.stubGlobal('computed', computed)
+  vi.stubGlobal('usePOSStore', () => ({
+    getProduct: () => null,
+  }))
+  vi.stubGlobal('useActivePromotions', () => ({
+    activePromos: ref(promos),
+    promoPickOptions: ref(undefined),
+  }))
+}
+
+function tabLine(
+  productId: string,
+  quantity: number,
+  subtotal: number,
+  promoSavings = 0,
+): PosPromoTabItem {
+  return { productId, quantity, subtotal, promoSavings }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('usePosOrderPromoTotals — tab BOGO cross-line (#1697)', () => {
+  it('trusts API per-line values when the server evaluated (4+2 -> 66000)', () => {
+    stubGlobals()
+    const items = [
+      tabLine(OKTOBERT, 4, 88000, 66000),
+      tabLine(OKTOBERT, 2, 44000, 0),
+    ]
+    const { orderPromoSavings, tabLinePromoSavings } = usePosOrderPromoTotals(
+      () => [],
+      () => items,
+      () => 132000,
+    )
+    expect(orderPromoSavings.value).toBe(66000)
+    expect(tabLinePromoSavings(items[0])).toBe(66000)
+    expect(tabLinePromoSavings(items[1])).toBe(0)
+  })
+
+  it('cross-line fallback allocates free units across sibling lines (4+2 -> 3 free)', () => {
+    stubGlobals()
+    const items = [tabLine(OKTOBERT, 4, 88000), tabLine(OKTOBERT, 2, 44000)]
+    const { orderPromoSavings } = usePosOrderPromoTotals(
+      () => [],
+      () => items,
+      () => 132000,
+    )
+    // 6 units BOGO 1+1 -> 3 free -> 66000 total, never 4 free (88000)
+    expect(orderPromoSavings.value).toBe(66000)
+  })
+
+  it('cross-line fallback matches a single-line evaluation (x2 -> 1 free)', () => {
+    stubGlobals()
+    const items = [tabLine(OKTOBERT, 2, 44000)]
+    const { orderPromoSavings, tabLinePromoSavings } = usePosOrderPromoTotals(
+      () => [],
+      () => items,
+      () => 44000,
+    )
+    expect(orderPromoSavings.value).toBe(22000)
+    expect(tabLinePromoSavings(items[0])).toBe(22000)
+  })
+
+  it('respects promoOptOut on tab lines', () => {
+    stubGlobals()
+    const items: PosPromoTabItem[] = [
+      { ...tabLine(OKTOBERT, 4, 88000), promoOptOut: true },
+      tabLine(OKTOBERT, 2, 44000),
+    ]
+    const { orderPromoSavings } = usePosOrderPromoTotals(
+      () => [],
+      () => items,
+      () => 132000,
+    )
+    // Only 2 eligible units -> 1 free
+    expect(orderPromoSavings.value).toBe(22000)
+  })
+
+  it('returns zero when no promo matches the product', () => {
+    stubGlobals()
+    const items = [tabLine('prod-sin-promo', 4, 88000)]
+    const { orderPromoSavings } = usePosOrderPromoTotals(
+      () => [],
+      () => items,
+      () => 88000,
+    )
+    expect(orderPromoSavings.value).toBe(0)
+  })
+})

--- a/composables/usePosOrderPromoTotals.ts
+++ b/composables/usePosOrderPromoTotals.ts
@@ -1,6 +1,8 @@
 import {
+  computeLinePromoSavings,
   computePromoEligibleSubtotal,
   linePromoSavingsForProduct,
+  pickBestPromotionForProduct,
   promoBadgeForProduct,
   type PromoBadgeDisplay,
 } from '~/utils/promoProductMatch'
@@ -76,18 +78,87 @@ export function usePosOrderPromoTotals(
     )
   }
 
+  /**
+   * Server-truth rule (#1697): when the API evaluated the tab (any line reports
+   * savings), per-line API values are authoritative — a sibling line reporting 0
+   * is a valid answer (cross-line allocation granted the free units to another
+   * line), not "unevaluated". The client fallback only runs when the server did
+   * not evaluate at all, and mirrors the server cross-line BOGO allocation
+   * (cheapest-first per product+promo) instead of per-line isolated math.
+   */
+  const apiTabEvaluated = computed(() =>
+    getTabItems().some(
+      (item) => !item.promoOptOut && (Number(item.promoSavings) || 0) > 0,
+    ),
+  )
+
+  /** Cross-line fallback per tab-line index — mirrors the server rule (#1023). */
+  const tabFallbackSavings = computed((): number[] => {
+    const items = getTabItems()
+    const result = items.map(() => 0)
+    const bogoGroups = new Map<
+      string,
+      { promo: NonNullable<ReturnType<typeof pickBestPromotionForProduct>>; indices: number[] }
+    >()
+
+    items.forEach((item, idx) => {
+      if (item.promoOptOut) return
+      const categoryId = item.categoryId ?? categoryForProduct(item.productId)
+      const promo = pickBestPromotionForProduct(
+        activePromos.value,
+        item.productId,
+        categoryId,
+        promoPickOptions.value,
+      )
+      if (!promo) return
+      if (promo.promo_type === 'bogo') {
+        const key = `${item.productId}:${promo.id}`
+        const group = bogoGroups.get(key) ?? { promo, indices: [] }
+        group.indices.push(idx)
+        bogoGroups.set(key, group)
+      } else {
+        result[idx] = computeLinePromoSavings(
+          { subtotal: item.subtotal, quantity: item.quantity },
+          promo,
+        )
+      }
+    })
+
+    for (const { promo, indices } of bogoGroups.values()) {
+      const valueJson = (promo.value_json ?? {}) as Record<string, unknown>
+      const buyQty = Number(valueJson.buy_qty) || 0
+      const getQty = Number(valueJson.get_qty) || 0
+      if (buyQty < 1 || getQty < 1) continue
+      const bundle = buyQty + getQty
+
+      // Expand sibling lines to units; free units go cheapest-first (stable).
+      const units: Array<{ idx: number; unitPrice: number }> = []
+      for (const idx of indices) {
+        const item = items[idx]
+        const qty = Math.max(0, Math.floor(Number(item.quantity) || 0))
+        const unitPrice = qty > 0 ? (Number(item.subtotal) || 0) / qty : 0
+        for (let u = 0; u < qty; u++) units.push({ idx, unitPrice })
+      }
+      const freeCount = Math.floor(units.length / bundle) * getQty
+      if (freeCount <= 0) continue
+      const sorted = [...units].sort((a, b) => a.unitPrice - b.unitPrice)
+      for (const unit of sorted.slice(0, freeCount)) {
+        const lineCap = Math.round(Number(items[unit.idx].subtotal) || 0)
+        result[unit.idx] = Math.min(
+          Math.round(result[unit.idx] + unit.unitPrice),
+          lineCap,
+        )
+      }
+    }
+
+    return result
+  })
+
   function tabLinePromoSavings(item: PosPromoTabItem): number {
     if (item.promoOptOut) return 0
-    const fromApi = Number(item.promoSavings) || 0
-    if (fromApi > 0) return fromApi
-    const categoryId = item.categoryId ?? categoryForProduct(item.productId)
-    return linePromoSavingsForProduct(
-      activePromos.value,
-      item.productId,
-      { subtotal: item.subtotal, quantity: item.quantity },
-      categoryId,
-      promoPickOptions.value,
-    )
+    if (apiTabEvaluated.value) return Number(item.promoSavings) || 0
+    const idx = getTabItems().indexOf(item)
+    return idx >= 0 ? tabFallbackSavings.value[idx] : 0
   }
 
   function linePromoBadge(


### PR DESCRIPTION
## Summary

- El panel "Orden Actual" del POS trataba `promoSavings = 0` del API como "no evaluado" y recalculaba por línea aislada, inventando una unidad gratis que el servidor ya había asignado a la línea hermana (caso real mesa 11: panel -$88.000 / $148.000 vs checkout correcto $170.000).
- Ahora: si el API evaluó el tab, sus valores por línea mandan (el 0 es respuesta válida); el fallback client-side solo corre cuando el servidor no evaluó, y replica la regla cross-line cheapest-first del backend.

Closes #1697

## Test plan
- [x] API 66.000 + 0 → panel -$66.000 (no inventa el gratis extra)
- [x] Fallback cross-line 4+2 → 3 gratis ($66.000), no 4
- [x] Control línea sola ×2 → 1 gratis ($22.000)
- [x] promoOptOut excluye la línea del pool
- [x] Producto sin promo → 0

## Validation evidence

```text
$ npx vitest run composables/usePosOrderPromoTotals.test.ts
 ✓ composables/usePosOrderPromoTotals.test.ts (5 tests) 3ms
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

## wr-context
See `.wr/1697.yaml` on this branch (LLM contract).
