### PR TITLE
fix(abastecimiento): add pagination UI to ingredientes-propios catalog

### DIFF
--- a/.wr/1702.yaml
+++ b/.wr/1702.yaml
@@ -1,0 +1,28 @@
+issue: 1702
+title: Add pagination UI to warehouse catalog (ingredientes-propios)
+repo: uno0uno/warocol.com
+cwd: front_nuxt
+stack: nuxt
+branch: wr-1702-ingredientes-propios-pagination
+
+paths:
+  - front_nuxt/pages/abastecimiento/ingredientes-propios.vue
+
+reference:
+  - front_nuxt/pages/ventas/ordenes.vue
+
+ac:
+  - Pagination controls (first/prev/current/next/last) like ordenes
+  - Total pages from API total field (IngredientsListResponse.total)
+  - Inline loader when isRefreshing && no cached rows
+  - Stats total from API, not page slice
+  - Filters reset page 1 (existing)
+
+plan:
+  - Add ingredientsTotal, ingredientsTotalPages, goToPage
+  - Wrap table with isRefreshing empty-state loader + v-else on UiResponsiveDataView
+  - Add pagination bar after table (reuse ventas.common aria labels)
+  - Point stats.total at API total
+
+hints:
+  tests: none (front-only, no targeted test command for this page)

--- a/pages/abastecimiento/ingredientes-propios.vue
+++ b/pages/abastecimiento/ingredientes-propios.vue
@@ -95,8 +95,14 @@
         @cancel="onCancelEdit"
       />
 
+      <!-- Table loading (page/filter change, no cached rows yet) -->
+      <div v-if="isRefreshing && sortedIngredients.length === 0" class="flex items-center justify-center min-h-[200px]">
+        <CommonsTheCustomLoader size="medium" />
+      </div>
+
       <!-- Data View -->
       <UiResponsiveDataView
+        v-else
         :columns="tableColumns"
         :data="sortedIngredients"
         :sort-field="sortField"
@@ -298,6 +304,45 @@
           </div>
         </template>
       </UiResponsiveDataView>
+
+      <!-- Pagination -->
+      <div v-if="ingredientsTotal > 0" class="flex items-center justify-end px-1 py-2">
+        <div class="flex items-center gap-1">
+          <button
+            :disabled="currentPage <= 1"
+            @click="goToPage(1)"
+            class="min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg border border-border text-text-secondary hover:bg-surface-secondary disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            :aria-label="t('ventas.common.primeraPagina')"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" /></svg>
+          </button>
+          <button
+            :disabled="currentPage <= 1"
+            @click="goToPage(currentPage - 1)"
+            class="min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg border border-border text-text-secondary hover:bg-surface-secondary disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            :aria-label="t('ventas.common.paginaAnterior')"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" /></svg>
+          </button>
+          <span class="px-3 py-1 text-sm font-medium text-text-primary">{{ currentPage }}</span>
+          <button
+            :disabled="currentPage >= ingredientsTotalPages"
+            @click="goToPage(currentPage + 1)"
+            class="min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg border border-border text-text-secondary hover:bg-surface-secondary disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            :aria-label="t('ventas.common.paginaSiguiente')"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+          </button>
+          <button
+            :disabled="currentPage >= ingredientsTotalPages"
+            @click="goToPage(ingredientsTotalPages)"
+            class="min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg border border-border text-text-secondary hover:bg-surface-secondary disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            :aria-label="t('ventas.common.ultimaPagina')"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7" /></svg>
+          </button>
+        </div>
+      </div>
     </div>
 
     <!-- Create / Edit Panel -->
@@ -457,6 +502,15 @@ const { data: ingredientsData, asyncStatus: queryAsyncStatus, refetch } = useQue
 const isLoading = computed(() => !ingredientsData.value)
 const isRefreshing = computed(() => queryAsyncStatus.value === 'loading' && ingredientsData.value != null)
 
+const ingredientsTotal = computed(() => (ingredientsData.value as any)?.total ?? 0)
+const ingredientsTotalPages = computed(() =>
+  Math.max(1, Math.ceil(ingredientsTotal.value / itemsPerPage.value)),
+)
+
+const goToPage = (page: number) => {
+  currentPage.value = Math.max(1, Math.min(page, ingredientsTotalPages.value))
+}
+
 const ingredients = computed(() => (ingredientsData.value as any)?.data || [])
 
 /** Manual supply ingredients only — resale stock rows are managed from Menú → productos (#869). */
@@ -493,7 +547,7 @@ const {
 })
 
 const stats = computed(() => ({
-  total: supplyIngredients.value.length,
+  total: ingredientsTotal.value,
   withCost: supplyIngredients.value.filter((i: any) => i.costo_unitario != null).length,
 }))
 

--- a/pages/abastecimiento/ingredientes-propios.vue
+++ b/pages/abastecimiento/ingredientes-propios.vue
@@ -487,6 +487,7 @@ const { data: ingredientsData, asyncStatus: queryAsyncStatus, refetch } = useQue
   query: () => {
     const params: Record<string, string | number | boolean> = {
       tenant_only: true,
+      is_resale: false,
       limit: itemsPerPage.value,
       page: currentPage.value,
     }


### PR DESCRIPTION
## Summary
- Add first/prev/next/last pagination controls to `/abastecimiento/ingredientes-propios`, matching `/ventas/ordenes`
- Show inline table loader on page change when no cached rows; stats total uses API `total` field
- Progressive layout loader already wired via `registerProgressiveLoading(isRefreshing)`

Closes #1702

## Test plan
- [ ] Open `/abastecimiento/ingredientes-propios` on a tenant with >50 catalog items
- [ ] Navigate to page 2+ and confirm different rows load
- [ ] Change filters/search/archived → resets to page 1
- [ ] Stats total reflects full catalog count, not just current page

## Validation evidence
```
# Front-only change; no project targeted test for this page.
# read_lints pages/abastecimiento/ingredientes-propios.vue → no linter errors
```

## wr-context
See `.wr/1702.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)