### PR TITLE
fix(modificadores): sync category bulk rows with option list (#1712)

### DIFF
--- a/.wr/1712.yaml
+++ b/.wr/1712.yaml
@@ -1,0 +1,42 @@
+issue: 1712
+title: Modifier bulk warehouse category sync prepared rows with options list
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1712-category-sync
+
+paths:
+  - composables/useModifierOptionForm.ts
+  - composables/useModifierOptionForm.test.ts
+  - pages/menu/modificadores/crear.vue
+  - pages/menu/modificadores/[id].vue
+  - components/ingredientes/WarehouseCategoryIngredientSelector.vue
+  - i18n/locales/es/abastecimiento.json
+  - i18n/locales/en/abastecimiento.json
+
+ac:
+  - syncWarehouseModifiersFromCategory add/update/remove category-sourced warehouse options
+  - warehouse_category_id tags category bulk options; manual warehouse options untouched
+  - remove category option dismisses prepared row; prepared dismiss syncs modifiers
+  - edit page resets category selector via key
+  - tests for sync; clearer empty category copy
+
+out_of_scope:
+  - API resolve endpoint changes
+  - legacy resale-as-INGREDIENT migration
+
+hints:
+  entry: syncWarehouseModifiersFromCategory in useModifierOptionForm.ts
+  pattern: useWarehouseCategoryIngredientSelector dismissIngredientIds on removePreparedRow
+  tests: bun test composables/useModifierOptionForm.test.ts
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: wr-review

--- a/components/ingredientes/WarehouseCategoryIngredientSelector.vue
+++ b/components/ingredientes/WarehouseCategoryIngredientSelector.vue
@@ -270,6 +270,14 @@ watch(
   },
   { deep: true },
 )
+
+function dismissPreparedIngredient(ingredientId: string) {
+  removePreparedRow(ingredientId)
+}
+
+defineExpose({
+  dismissPreparedIngredient,
+})
 </script>
 
 <style scoped>

--- a/composables/useModifierOptionForm.test.ts
+++ b/composables/useModifierOptionForm.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import {
-  appendWarehouseModifiersFromCategory,
   applyModifierUiOptionType,
   createEmptyModifier,
   collectModifierRecipeExcludedIngredientIds,
+  createWarehouseModifierFromPreparedRow,
   getModifierUiOptionType,
   getRecipeBaseIngredientIds,
+  isCategoryBulkWarehouseModifier,
   mapModifierFromApi,
   serializeModifierForApi,
+  syncWarehouseModifiersFromCategory,
   validateModifierOption,
 } from './useModifierOptionForm.ts'
 
@@ -156,7 +158,7 @@ describe('included modifier quantity form contract', () => {
     ])
   })
 
-  it('maps UI option types and bulk warehouse modifiers from categories', () => {
+  it('maps UI option types and syncs bulk warehouse modifiers from categories', () => {
     const warehouse = createEmptyModifier(0)
     warehouse.option_type = 'INGREDIENT'
     warehouse.ingredient_mode = 'warehouse'
@@ -172,25 +174,44 @@ describe('included modifier quantity form contract', () => {
     expect(warehouse.ingredient_mode).toBe('resale')
     expect(warehouse.ingredient_id).toBeNull()
 
-    const appended = appendWarehouseModifiersFromCategory([], [{
+    const row = {
       ingredient_id: 'ing-1',
       name: 'Harina',
       quantity: 1,
       unit: 'kg',
       warehouse_category_id: 'cat-1',
-    }])
-    expect(appended).toHaveLength(1)
-    expect(appended[0]?.ingredient_mode).toBe('warehouse')
-    expect(appended[0]?.name).toBe('Harina')
+    }
 
-    const deduped = appendWarehouseModifiersFromCategory(appended, [{
-      ingredient_id: 'ing-1',
-      name: 'Harina',
+    const synced = syncWarehouseModifiersFromCategory([], [row])
+    expect(synced).toHaveLength(1)
+    expect(synced[0]?.ingredient_mode).toBe('warehouse')
+    expect(synced[0]?.name).toBe('Harina')
+    expect(isCategoryBulkWarehouseModifier(synced[0]!)).toBe(true)
+
+    const updated = syncWarehouseModifiersFromCategory(synced, [{
+      ...row,
       quantity: 2,
       unit: 'kg',
-      warehouse_category_id: 'cat-1',
     }])
+    expect(updated).toHaveLength(1)
+    expect(updated[0]?.ingredient_quantity).toBe(2)
+
+    const removed = syncWarehouseModifiersFromCategory(updated, [])
+    expect(removed).toHaveLength(0)
+
+    const manual = createEmptyModifier(0)
+    manual.option_type = 'INGREDIENT'
+    manual.ingredient_mode = 'warehouse'
+    manual.ingredient_id = 'ing-1'
+    manual.ingredient_name = 'Harina manual'
+    manual.name = 'Harina manual'
+    const deduped = syncWarehouseModifiersFromCategory([manual], [row])
     expect(deduped).toHaveLength(1)
+    expect(deduped[0]?.name).toBe('Harina manual')
+    expect(isCategoryBulkWarehouseModifier(deduped[0]!)).toBe(false)
+
+    const categoryRow = createWarehouseModifierFromPreparedRow(row, 0)
+    expect(categoryRow.warehouse_category_id).toBe('cat-1')
   })
 
   it('hydrates resale ingredient mode from API rows', () => {

--- a/composables/useModifierOptionForm.ts
+++ b/composables/useModifierOptionForm.ts
@@ -35,6 +35,8 @@ export interface ModifierFormRow {
   linked_product_name: string | null
   linked_product_quantity: number
   unit_cost: number | null
+  /** Front-only: set when the option came from warehouse category bulk-add. */
+  warehouse_category_id: string | null
 }
 
 const OPTION_TYPES: ModifierOptionType[] = ['INGREDIENT', 'RECIPE', 'PRODUCT', 'NONE']
@@ -63,6 +65,7 @@ export function createEmptyModifier(sortOrder: number): ModifierFormRow {
     linked_product_name: null,
     linked_product_quantity: 1,
     unit_cost: null,
+    warehouse_category_id: null,
   }
 }
 
@@ -104,6 +107,7 @@ export function resetModifierFieldsForType(
   modifier.linked_product_name = null
   modifier.linked_product_quantity = 1
   modifier.unit_cost = null
+  modifier.warehouse_category_id = null
 }
 
 export function getRecipeBaseIngredientIds(
@@ -170,6 +174,7 @@ export function mapModifierFromApi(m: Record<string, unknown>): ModifierFormRow 
     linked_product_name: linkedProduct?.name || null,
     linked_product_quantity: Number(m.linked_product_quantity ?? 1),
     unit_cost: m.unit_cost != null ? Number(m.unit_cost) : null,
+    warehouse_category_id: null,
   }
 }
 
@@ -259,6 +264,12 @@ export function validateModifierOption(
   return null
 }
 
+export function isCategoryBulkWarehouseModifier(modifier: ModifierFormRow): boolean {
+  return modifier.option_type === 'INGREDIENT'
+    && modifier.ingredient_mode === 'warehouse'
+    && modifier.warehouse_category_id != null
+}
+
 export function createWarehouseModifierFromPreparedRow(
   row: PreparedWarehouseCategoryIngredient,
   sortOrder: number,
@@ -271,25 +282,66 @@ export function createWarehouseModifierFromPreparedRow(
   modifier.name = row.name
   modifier.ingredient_quantity = row.quantity ?? 1
   modifier.ingredient_unit = row.unit
+  modifier.warehouse_category_id = row.warehouse_category_id
   return modifier
 }
 
+function applyPreparedRowToWarehouseModifier(
+  modifier: ModifierFormRow,
+  row: PreparedWarehouseCategoryIngredient,
+) {
+  modifier.ingredient_id = row.ingredient_id
+  modifier.ingredient_name = row.name
+  modifier.name = row.name
+  modifier.ingredient_quantity = row.quantity ?? modifier.ingredient_quantity ?? 1
+  modifier.ingredient_unit = row.unit ?? modifier.ingredient_unit
+  modifier.warehouse_category_id = row.warehouse_category_id
+}
+
+export function syncWarehouseModifiersFromCategory(
+  modifiers: ModifierFormRow[],
+  rows: PreparedWarehouseCategoryIngredient[],
+): ModifierFormRow[] {
+  const preparedById = new Map(rows.map(row => [row.ingredient_id, row]))
+  const preparedIds = new Set(rows.map(row => row.ingredient_id))
+  const preservedIngredientIds = new Set<string>()
+  const preserved: ModifierFormRow[] = []
+
+  for (const modifier of modifiers) {
+    if (!isCategoryBulkWarehouseModifier(modifier)) {
+      preserved.push(modifier)
+      if (modifier.option_type === 'INGREDIENT' && modifier.ingredient_id) {
+        preservedIngredientIds.add(modifier.ingredient_id)
+      }
+      continue
+    }
+    if (!modifier.ingredient_id || !preparedIds.has(modifier.ingredient_id)) {
+      continue
+    }
+    const row = preparedById.get(modifier.ingredient_id)
+    if (row) {
+      applyPreparedRowToWarehouseModifier(modifier, row)
+    }
+    preserved.push(modifier)
+    preservedIngredientIds.add(modifier.ingredient_id)
+  }
+
+  const synced = [...preserved]
+  for (const row of rows) {
+    if (!row.ingredient_id || preservedIngredientIds.has(row.ingredient_id)) continue
+    synced.push(createWarehouseModifierFromPreparedRow(row, synced.length))
+    preservedIngredientIds.add(row.ingredient_id)
+  }
+
+  return synced.map((modifier, index) => ({ ...modifier, sort_order: index }))
+}
+
+/** @deprecated Use syncWarehouseModifiersFromCategory */
 export function appendWarehouseModifiersFromCategory(
   modifiers: ModifierFormRow[],
   rows: PreparedWarehouseCategoryIngredient[],
 ): ModifierFormRow[] {
-  const existingIds = new Set(
-    modifiers
-      .filter(m => m.option_type === 'INGREDIENT' && m.ingredient_id)
-      .map(m => m.ingredient_id as string),
-  )
-  const next = [...modifiers]
-  for (const row of rows) {
-    if (!row.ingredient_id || existingIds.has(row.ingredient_id)) continue
-    existingIds.add(row.ingredient_id)
-    next.push(createWarehouseModifierFromPreparedRow(row, next.length))
-  }
-  return next
+  return syncWarehouseModifiersFromCategory(modifiers, rows)
 }
 
 export function formatModifierOptionTypeLabel(type: string): string {

--- a/i18n/locales/en/abastecimiento.json
+++ b/i18n/locales/en/abastecimiento.json
@@ -491,7 +491,7 @@
       "categoryIngredientsLoading": "Preparing ingredients…",
       "categoryIngredientsError": "Ingredients could not be prepared. You can retry.",
       "categoryIngredientsRetry": "Retry",
-      "categoryIngredientsEmpty": "No new ingredients in: {categories}.",
+      "categoryIngredientsEmpty": "No new warehouse items in: {categories}. Check that the category has active items or that they are not already in the group options.",
       "categoryIngredientsPartial": "These categories could not be loaded: {categories}.",
       "categoryIngredientQuantity": "Quantity",
       "categoryIngredientUnit": "Unit",

--- a/i18n/locales/es/abastecimiento.json
+++ b/i18n/locales/es/abastecimiento.json
@@ -491,7 +491,7 @@
       "categoryIngredientsLoading": "Preparando ingredientes…",
       "categoryIngredientsError": "No se pudieron preparar los ingredientes. Puedes reintentar.",
       "categoryIngredientsRetry": "Reintentar",
-      "categoryIngredientsEmpty": "Sin ingredientes nuevos en: {categories}.",
+      "categoryIngredientsEmpty": "Sin artículos de bodega nuevos en: {categories}. Verifica que la categoría tenga artículos activos o que no estén ya en las opciones del grupo.",
       "categoryIngredientsPartial": "No se pudieron cargar estas categorías: {categories}.",
       "categoryIngredientQuantity": "Cantidad",
       "categoryIngredientUnit": "Unidad",

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -127,6 +127,8 @@
               <MenuIngredientProductHint class="mb-4" />
 
               <WarehouseCategoryIngredientSelector
+                ref="warehouseCategorySelectorRef"
+                :key="`modifier-edit-category-bulk-${groupId}`"
                 class="mb-4"
                 :input-id="`modifier-edit-warehouse-category-bulk-${groupId}`"
                 :existing-ingredient-ids="existingWarehouseIngredientIds"
@@ -249,10 +251,11 @@ import { useQueryCache } from '@pinia/colada'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 import { useMenuIngredientsQuery } from '@/composables/queries/useMenuIngredients'
 import {
-  appendWarehouseModifiersFromCategory,
   createEmptyModifier,
+  isCategoryBulkWarehouseModifier,
   mapModifierFromApi,
   serializeModifierForApi,
+  syncWarehouseModifiersFromCategory,
   validateModifierOption,
   getRecipeBaseIngredientIds,
   type ModifierFormRow,
@@ -409,7 +412,7 @@ const existingWarehouseIngredientIds = computed(() =>
 )
 
 function onGroupWarehouseCategoryRows(rows: PreparedWarehouseCategoryIngredient[]) {
-  form.value.modifiers = appendWarehouseModifiersFromCategory(form.value.modifiers, rows)
+  form.value.modifiers = syncWarehouseModifiersFromCategory(form.value.modifiers, rows)
   for (const row of rows) {
     cacheIngredientForUnits({
       id: row.ingredient_id,
@@ -556,7 +559,14 @@ function addModifier() {
   form.value.modifiers.push(createEmptyModifier(form.value.modifiers.length))
 }
 
+const warehouseCategorySelectorRef = ref<{ dismissPreparedIngredient: (id: string) => void } | null>(null)
+
 function removeModifier(index: number) {
+  const modifier = form.value.modifiers[index]
+  if (modifier && isCategoryBulkWarehouseModifier(modifier) && modifier.ingredient_id) {
+    warehouseCategorySelectorRef.value?.dismissPreparedIngredient(modifier.ingredient_id)
+    return
+  }
   form.value.modifiers.splice(index, 1)
 }
 

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -128,6 +128,7 @@
                 <MenuIngredientProductHint class="mb-4" />
 
                 <WarehouseCategoryIngredientSelector
+                  ref="warehouseCategorySelectorRef"
                   class="mb-4"
                   input-id="modifier-create-warehouse-category-bulk"
                   :existing-ingredient-ids="existingWarehouseIngredientIds"
@@ -263,9 +264,10 @@
 import { ref, computed, watch } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 import {
-  appendWarehouseModifiersFromCategory,
   createEmptyModifier,
+  isCategoryBulkWarehouseModifier,
   serializeModifierForApi,
+  syncWarehouseModifiersFromCategory,
   validateModifierOption,
   getRecipeBaseIngredientIds,
   type ModifierFormRow,
@@ -385,7 +387,7 @@ function cachePreparedIngredient(row: PreparedWarehouseCategoryIngredient) {
 }
 
 function onGroupWarehouseCategoryRows(rows: PreparedWarehouseCategoryIngredient[]) {
-  form.value.modifiers = appendWarehouseModifiersFromCategory(form.value.modifiers, rows)
+  form.value.modifiers = syncWarehouseModifiersFromCategory(form.value.modifiers, rows)
   for (const row of rows) {
     cachePreparedIngredient(row)
   }
@@ -459,7 +461,14 @@ async function onInlineProductCreated(product: Record<string, unknown>) {
   })
 }
 
+const warehouseCategorySelectorRef = ref<{ dismissPreparedIngredient: (id: string) => void } | null>(null)
+
 function removeModifier(index: number) {
+  const modifier = form.value.modifiers[index]
+  if (modifier && isCategoryBulkWarehouseModifier(modifier) && modifier.ingredient_id) {
+    warehouseCategorySelectorRef.value?.dismissPreparedIngredient(modifier.ingredient_id)
+    return
+  }
   form.value.modifiers.splice(index, 1)
 }
 


### PR DESCRIPTION
## Summary
- Replace append-only `appendWarehouseModifiersFromCategory` with `syncWarehouseModifiersFromCategory` (add/update/remove category-sourced warehouse options)
- Tag bulk options with `warehouse_category_id`; manual warehouse options are preserved
- Deleting a synced option dismisses its prepared row; edit page resets category selector on load

Closes #1712

## Test plan
- [ ] Modificador create: add category → options appear; Quitar prepared row → option removed
- [ ] Change qty/unit in prepared row → option updates
- [ ] Delete synced option from list → prepared row dismissed; re-add category works
- [ ] Manual warehouse option (without category) survives category sync
- [ ] Bubablue: empty category shows clearer message; TOPPINGS with existing options does not duplicate

## Validation evidence
```
bun test composables/useModifierOptionForm.test.ts
 10 pass
 0 fail
 31 expect() calls
```

## wr-context
See `.wr/1712.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)