### PR TITLE
fix(modificadores): stop save overlay hang on DataCloneError

### DIFF
--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -633,7 +633,6 @@ async function handleSubmit() {
 
   isSubmitting.value = true
   submitError.value = ''
-  const savedFormSnapshot = structuredClone(form.value)
 
   try {
     form.value.tenant_id = currentTenant.value?.id || ''
@@ -646,10 +645,9 @@ async function handleSubmit() {
       },
     })
 
-    // Optimistic: trust the saved form; sync cache without overwriting local edits.
+    // Optimistic: keep current form (products, options, etc.); sync cache only.
     skipNextGroupHydrate.value = true
     groupData.value = response
-    form.value = savedFormSnapshot
     skipNextGroupHydrate.value = false
 
     cache.invalidateQueries({ key: ['menu', 'modifier-groups'] })


### PR DESCRIPTION
## Summary
- Remove `structuredClone(form.value)` that threw `DataCloneError` on Vue reactive proxies
- Fix infinite "Actualizando grupo de modificadores..." overlay (error ran before try/finally)
- Keep optimistic save behavior from #1714 without cloning the form

## Test plan
- [ ] Add a second product to SALSAS group and save — completes without hang
- [ ] Delete an option and save — option stays removed
- [ ] Overlay clears on success and on API error

Made with [Cursor](https://cursor.com)