### PR TITLE
fix(modificadores): stop category bulk resolve feedback loop

### DIFF
--- a/.wr/1716.yaml
+++ b/.wr/1716.yaml
@@ -1,0 +1,40 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1716
+title: "fix(modificadores): category bulk selection clears options after resolve feedback loop"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1716-category-resolve-loop
+
+paths:
+  - components/ingredientes/WarehouseCategoryIngredientSelector.vue
+  - components/ingredientes/WarehouseCategoryIngredientSelector.test.ts
+  - composables/useModifierOptionForm.test.ts
+
+ac:
+  - Category select adds options and they stay visible on edit/create
+  - Category panel keeps prepared rows after sync (no flash to empty)
+  - API-loaded INGREDIENT options without warehouse_category_id preserved
+  - Manual delete dismiss flow from #1714 still works
+  - Unit test covers category select → sync → no second resolve wipe
+
+out_of_scope:
+  - API changes
+  - Deploy
+  - syncWarehouseModifiersFromCategory rewrite
+
+hints:
+  entry: "WarehouseCategoryIngredientSelector watch existingIngredientIds"
+  pattern: "Remove resolve() on id growth; keep removePreparedRow on shrink only (#1714 regression)"
+  tests: "npx vitest run composables/useModifierOptionForm.test.ts components/ingredientes/WarehouseCategoryIngredientSelector.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "Deploy front prod when ready"

--- a/components/ingredientes/WarehouseCategoryIngredientSelector.test.ts
+++ b/components/ingredientes/WarehouseCategoryIngredientSelector.test.ts
@@ -93,6 +93,7 @@ describe('WarehouseCategoryIngredientSelector', () => {
         body: {
           category_ids: ['category-1'],
           exclude_ingredient_ids: ['manual-ingredient'],
+          exclude_resale: false,
         },
       },
     )
@@ -157,7 +158,8 @@ describe('WarehouseCategoryIngredientSelector', () => {
     await wrapper.setProps({ existingIngredientIds: ['manual-ingredient'] })
     await flushPromises()
     expect(wrapper.text()).toContain('Granos')
-    expect(wrapper.text()).toContain('No se pudo cargar')
+    expect(wrapper.text()).not.toContain('No se pudo cargar')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
 
     await wrapper.findAll('button').find(button => button.text() === 'Reintentar')?.trigger('click')
     await flushPromises()
@@ -198,5 +200,49 @@ describe('WarehouseCategoryIngredientSelector', () => {
     const select = wrapper.find('select')
     expect(select.exists()).toBe(true)
     expect(select.findAll('option').map(option => option.attributes('value'))).toEqual(['gr', 'kg'])
+  })
+
+  it('does not re-resolve when existing ingredient ids grow after category sync', async () => {
+    const fetchMock = vi.fn(async (_url: string, options: any) => ({
+      data: {
+        ingredients: (options.body.exclude_ingredient_ids?.length ?? 0) > 0
+          ? []
+          : [{
+              ingredient_id: 'ingredient-1',
+              name: 'Arroz',
+              unit: 'gr',
+              warehouse_category_id: 'category-1',
+            }],
+        empty_category_ids: [],
+        unavailable_category_ids: [],
+      },
+    }))
+    vi.stubGlobal('$fetch', fetchMock)
+    vi.stubGlobal('useI18n', () => ({ t: (key: string) => key }))
+    const wrapper = mount(WarehouseCategoryIngredientSelector, {
+      props: { existingIngredientIds: [] },
+      global: {
+        components: { UiWarehouseCategorySearchInput: WarehouseCategorySearchInputStub },
+      },
+    })
+
+    await wrapper.get('[data-test="select-category"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.text()).toContain('Arroz')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await wrapper.setProps({ existingIngredientIds: ['ingredient-1'] })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Arroz')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const emittedRows = wrapper.emitted('update:preparedRows') ?? []
+    expect(emittedRows.at(-1)?.[0]).toEqual([{
+      ingredient_id: 'ingredient-1',
+      name: 'Arroz',
+      quantity: null,
+      unit: 'gr',
+      warehouse_category_id: 'category-1',
+    }])
   })
 })

--- a/components/ingredientes/WarehouseCategoryIngredientSelector.vue
+++ b/components/ingredientes/WarehouseCategoryIngredientSelector.vue
@@ -270,17 +270,11 @@ watch(
 
     const previous = new Set(previousIds ?? [])
     const current = new Set(ids ?? [])
-    let dismissed = false
 
     for (const ingredientId of previous) {
       if (!current.has(ingredientId)) {
         removePreparedRow(ingredientId)
-        dismissed = true
       }
-    }
-
-    if (!dismissed && current.size > previous.size) {
-      void resolve()
     }
   },
   { deep: true },

--- a/composables/useModifierOptionForm.test.ts
+++ b/composables/useModifierOptionForm.test.ts
@@ -214,6 +214,29 @@ describe('included modifier quantity form contract', () => {
     expect(categoryRow.warehouse_category_id).toBe('cat-1')
   })
 
+  it('preserves API-loaded warehouse options when category sync adds bulk rows', () => {
+    const manual = mapModifierFromApi({
+      id: 'mod-1',
+      name: 'Manual',
+      option_type: 'INGREDIENT',
+      ingredient_id: 'ing-manual',
+      ingredient: { id: 'ing-manual', name: 'Manual' },
+    })
+    const categoryRow = {
+      ingredient_id: 'ing-bulk',
+      name: 'Bulk',
+      quantity: 1,
+      unit: 'gr',
+      warehouse_category_id: 'cat-1',
+    }
+
+    const synced = syncWarehouseModifiersFromCategory([manual], [categoryRow])
+    expect(synced).toHaveLength(2)
+    expect(synced[0]?.ingredient_id).toBe('ing-manual')
+    expect(synced[1]?.ingredient_id).toBe('ing-bulk')
+    expect(isCategoryBulkWarehouseModifier(synced[1]!)).toBe(true)
+  })
+
   it('hydrates resale ingredient mode from API rows', () => {
     const row = mapModifierFromApi({
       name: 'Gaseosa',


### PR DESCRIPTION
## Summary
- Stop re-calling `resolve()` when `existingIngredientIds` grows after category sync (fixes empty prepared rows + wiped options)
- Keep dismiss-on-delete when ingredient ids shrink (#1714 behavior)
- Add regression tests for growth-after-sync and API-loaded option preservation

Closes #1716

## Test plan
- [ ] Select warehouse category on modifier edit — options stay visible
- [ ] Delete a category-synced option — does not immediately re-add
- [ ] Existing API-loaded ingredients remain when adding a category

## Validation evidence
```
npx vitest run composables/useModifierOptionForm.test.ts components/ingredientes/WarehouseCategoryIngredientSelector.test.ts

 Test Files  2 passed (2)
      Tests  15 passed (15)
```

## wr-context
See `.wr/1716.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)