### PR TITLE
fix(modificadores): hide duplicate category bulk panel rows

### DIFF
--- a/components/ingredientes/WarehouseCategoryIngredientSelector.test.ts
+++ b/components/ingredientes/WarehouseCategoryIngredientSelector.test.ts
@@ -202,6 +202,52 @@ describe('WarehouseCategoryIngredientSelector', () => {
     expect(select.findAll('option').map(option => option.attributes('value'))).toEqual(['gr', 'kg'])
   })
 
+  it('hides compact prepared rows in summary mode while keeping category header', async () => {
+    vi.stubGlobal('$fetch', vi.fn(async () => ({
+      data: {
+        ingredients: [{
+          ingredient_id: 'ingredient-1',
+          name: 'Arroz',
+          unit: 'gr',
+          warehouse_category_id: 'category-1',
+        }],
+        empty_category_ids: [],
+        unavailable_category_ids: [],
+      },
+    })))
+    vi.stubGlobal('useI18n', () => ({
+      t: (key: string, params?: Record<string, string>) => ({
+        'abastecimiento.glossary.categoryIngredientSelectorTitle': 'Agregar ingredientes por categoría',
+        'abastecimiento.glossary.categoryIngredientsBatchLabel': 'Ingredientes por categoría',
+        'abastecimiento.glossary.categoryIngredientSelectorPlaceholder': 'Buscar categoría',
+        'abastecimiento.glossary.warehouseCategorySearchResults': 'Categorías',
+        'abastecimiento.glossary.removeWarehouseCategorySelection': `Quitar ${params?.name}`,
+        'abastecimiento.glossary.categoryIngredientsLoading': 'Cargando',
+      }[key] ?? key),
+    }))
+    const wrapper = mount(WarehouseCategoryIngredientSelector, {
+      props: { hidePreparedIngredientRows: true },
+      global: {
+        components: { UiWarehouseCategorySearchInput: WarehouseCategorySearchInputStub },
+      },
+    })
+
+    await wrapper.get('[data-test="select-category"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Granos')
+    expect(wrapper.find('[data-test="category-prepared-rows"]').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('Arroz')
+    const emittedRows = wrapper.emitted('update:preparedRows') ?? []
+    expect(emittedRows.at(-1)?.[0]).toEqual([{
+      ingredient_id: 'ingredient-1',
+      name: 'Arroz',
+      quantity: null,
+      unit: 'gr',
+      warehouse_category_id: 'category-1',
+    }])
+  })
+
   it('does not re-resolve when existing ingredient ids grow after category sync', async () => {
     const fetchMock = vi.fn(async (_url: string, options: any) => ({
       data: {

--- a/components/ingredientes/WarehouseCategoryIngredientSelector.vue
+++ b/components/ingredientes/WarehouseCategoryIngredientSelector.vue
@@ -88,7 +88,12 @@
                 </button>
               </header>
 
-              <div v-if="group.rows.length" class="space-y-3 bg-surface-secondary/20 p-3" role="list">
+              <div
+                v-if="group.rows.length && !hidePreparedIngredientRows"
+                class="space-y-3 bg-surface-secondary/20 p-3"
+                role="list"
+                data-test="category-prepared-rows"
+              >
                 <div
                   v-for="row in group.rows"
                   :key="row.ingredient_id"
@@ -192,10 +197,13 @@ const props = withDefaults(defineProps<{
   unitOptions?: (ingredientId: string) => Array<{ value: string, label: string }>
   loadingUnitIds?: Set<string>
   excludeResale?: boolean
+  /** Hide compact quantity/unit rows when parent syncs prepared rows elsewhere (e.g. modifier options). */
+  hidePreparedIngredientRows?: boolean
 }>(), {
   existingIngredientIds: () => [],
   inputId: 'warehouse-category-ingredient-selector',
   excludeResale: false,
+  hidePreparedIngredientRows: false,
 })
 
 const emit = defineEmits<{

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -135,6 +135,7 @@
                 :existing-ingredient-ids="existingWarehouseIngredientIds"
                 :unit-options="getIngredientUnitOptions"
                 :loading-unit-ids="loadingUnits"
+                hide-prepared-ingredient-rows
                 exclude-resale
                 @update:prepared-rows="onGroupWarehouseCategoryRows"
               />

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -135,6 +135,7 @@
                   :existing-ingredient-ids="existingWarehouseIngredientIds"
                   :unit-options="getIngredientUnitOptions"
                   :loading-unit-ids="loadingUnits"
+                  hide-prepared-ingredient-rows
                   exclude-resale
                   @update:prepared-rows="onGroupWarehouseCategoryRows"
                 />


### PR DESCRIPTION
## Summary
- Add `hidePreparedIngredientRows` to `WarehouseCategoryIngredientSelector` so modifier pages show category summary only (name + count + remove).
- Category picks still sync to `form.modifiers` and render once in the full `MenuModifierOptionEditor` list (price, Incl., Máx., etc.).
- Product/recipe category bulk UX unchanged (prop defaults to false).

Closes #1719

## Test plan
- [ ] Open `/menu/modificadores/e418d91a-16f6-49a5-be2e-7fb0beed1ec8`, search a warehouse category — compact panel rows should not duplicate the option list below.
- [ ] Category header still shows selected category name, count, and remove (✕).
- [ ] Full option fields editable only in the main Opciones list.
- [ ] Same on `/menu/modificadores/crear`.
- [x] `vitest run WarehouseCategoryIngredientSelector.test.ts useModifierOptionForm.test.ts` (18 passed)

## wr-context
Local contract: `.wr/1719.yaml` (gitignored; see branch implementation).

Made with [Cursor](https://cursor.com)