### PR TITLE
fix(pos): hydrate product detail on cache miss (cashier RBAC)

### DIFF
--- a/pages/pos/producto/[id].vue
+++ b/pages/pos/producto/[id].vue
@@ -43,17 +43,33 @@ const { activePromos } = useActivePromotions()
 // Product ID from route
 const productId = computed(() => route.params.id as string)
 
-// Obtener producto del cache (NO del backend)
+// Obtener producto del cache; si falta, hidratar desde GET /pos/products/{id}
 const cachedProduct = computed(() => posStore.getProduct(productId.value))
 
-// Si no hay producto en cache, redirigir a POS (el usuario navegó directamente)
 const loadingProduct = ref(false)
+const productLoadAttempted = ref(false)
 
-onMounted(() => {
-  if (!cachedProduct.value) {
-    // No hay producto en cache - redirigir a POS para cargar productos
+const ensureProductLoaded = async () => {
+  if (cachedProduct.value) {
+    productLoadAttempted.value = true
+    return
+  }
+  loadingProduct.value = true
+  productLoadAttempted.value = true
+  const loaded = await posStore.fetchAndCacheProduct(productId.value)
+  loadingProduct.value = false
+  if (!loaded) {
     router.push('/pos')
   }
+}
+
+onMounted(() => {
+  ensureProductLoaded()
+})
+
+watch(productId, () => {
+  productLoadAttempted.value = false
+  ensureProductLoaded()
 })
 
 // Redirect on tenant change
@@ -780,12 +796,12 @@ const modifierPriceLabel = (modifier: ModifierOption) => {
   })
 }
 
-// Watch for product availability - redirect if not in cache
-watch(cachedProduct, (p) => {
-  if (!p) {
+// Watch for failed load after fetch attempt (not while loading)
+watch([cachedProduct, loadingProduct, productLoadAttempted], ([p, loading, attempted]) => {
+  if (attempted && !loading && !p) {
     router.push('/pos')
   }
-}, { immediate: true })
+})
 
 // Load cart or tab item data in edit mode
 watch(product, (newProduct) => {

--- a/stores/usePOSStore.ts
+++ b/stores/usePOSStore.ts
@@ -502,6 +502,48 @@ export const usePOSStore = defineStore('pos', () => {
         return cachedProducts.value.find(p => p.id === productId)
     }
 
+    const upsertProduct = (product: CachedProduct) => {
+        const idx = cachedProducts.value.findIndex(p => p.id === product.id)
+        if (idx >= 0) {
+            cachedProducts.value[idx] = product
+        } else {
+            cachedProducts.value.push(product)
+        }
+    }
+
+    const mapApiProductToCached = (p: Record<string, unknown>): CachedProduct | null => {
+        if (p.open_priced) return null
+        const categoryObj = p.category as { name?: string } | null | undefined
+        return {
+            id: String(p.id),
+            name: String(p.name ?? ''),
+            description: String(p.description ?? ''),
+            price: Number(p.price) || 0,
+            image: '🍽️',
+            image_url: (p.image_url as string | null | undefined) ?? null,
+            category: String(p.category_name ?? categoryObj?.name ?? ''),
+            category_id: (p.category_id as string | null | undefined) ?? null,
+            is_available: p.is_available !== false,
+            is_resale: Boolean(p.is_resale),
+            modifier_groups: Array.isArray(p.modifier_groups) ? p.modifier_groups : [],
+        }
+    }
+
+    const fetchAndCacheProduct = async (productId: string): Promise<CachedProduct | null> => {
+        try {
+            const res = await $fetch<{ success: boolean; data: Record<string, unknown> }>(
+                `/api/pos/products/${productId}`,
+            )
+            if (!res?.success || !res.data) return null
+            const cached = mapApiProductToCached(res.data)
+            if (!cached) return null
+            upsertProduct(cached)
+            return cached
+        } catch {
+            return null
+        }
+    }
+
     const hasProducts = computed(() => cachedProducts.value.length > 0)
 
     // Sincronizar carrito local al backend en batch (sin cliente)
@@ -622,6 +664,8 @@ export const usePOSStore = defineStore('pos', () => {
         waitForPendingOperations,
         setProducts,
         getProduct,
+        upsertProduct,
+        fetchAndCacheProduct,
         syncCartBatch
     }
 })


### PR DESCRIPTION
## Summary
- On `/pos/producto/[id]`, fetch `GET /api/pos/products/{id}` when the product is not in Pinia cache (deep link / refresh).
- Add `fetchAndCacheProduct` + `upsertProduct` helpers in `usePOSStore`.

Requires API PR: https://github.com/uno0uno/api-warolabs/pull/682

Part of api-warolabs#680

## Test plan
- [ ] Open `/pos/producto/{id}` directly as cashier — page loads with modifier groups (no redirect to `/pos`)
- [ ] Normal flow from `/pos` catalog unchanged
- [ ] Resale direct-add still skips detail page

## wr-context
Companion to api-warolabs `.wr/680.yaml`.