### PR TITLE
fix(pos): checkout cutover to POS customer and invoice APIs

### DIFF
--- a/components/pos/CustomerIdentificationModal.test.ts
+++ b/components/pos/CustomerIdentificationModal.test.ts
@@ -32,6 +32,7 @@ const mountModal = () => {
   vi.stubGlobal('useI18n', () => ({
     t: (key: string) => translations[key] ?? key,
   }))
+  vi.stubGlobal('useRoute', () => ({ path: '/ventas/crear' }))
 
   return mount(CustomerIdentificationModal, {
     attachTo: document.body,

--- a/components/pos/CustomerIdentificationModal.vue
+++ b/components/pos/CustomerIdentificationModal.vue
@@ -510,6 +510,11 @@ interface Emits {
 }
 
 const props = defineProps<Props>()
+
+const route = useRoute()
+const customerApiBase = computed(() =>
+  route.path.startsWith('/pos') ? '/api/pos/customers' : '/api/customers',
+)
 const emit = defineEmits<Emits>()
 
 // UI state
@@ -581,7 +586,7 @@ const commitSearch = useDebounceFn(async (q: string) => {
   }
   try {
     const data = await $fetch<{ success: boolean; data: CustomerSummary[] }>(
-      '/api/customers/search-by-query',
+      `${customerApiBase.value}/search-by-query`,
       { query: { q, limit: 20 } }
     )
     searchResults.value = data?.data ?? []
@@ -677,7 +682,7 @@ const selectCustomer = async (customer: CustomerSummary) => {
   if (isHydratingSelection.value) return
   isHydratingSelection.value = true
   try {
-    const res = await $fetch<CustomerApiResponse>(`/api/customers/${customer.id}`)
+    const res = await $fetch<CustomerApiResponse>(`${customerApiBase.value}/${customer.id}`)
     if (res?.success) {
       completeSelection(toSelected(res.data))
       return
@@ -723,7 +728,7 @@ const toSelected = (data: CustomerApiResponse['data']): SelectedCustomer => ({
 const selectGenericCustomer = async () => {
   isCreatingGeneric.value = true
   try {
-    const response = await $fetch<CustomerApiResponse>('/api/customers/search-or-create', {
+    const response = await $fetch<CustomerApiResponse>(`${customerApiBase.value}/search-or-create`, {
       method: 'POST',
       body: { phone_number: '0000000000', name: t('pos.customer.customerNoData') }
     })
@@ -755,7 +760,7 @@ const handleCreate = async () => {
       fiscal_email: createForm.value.email?.trim() || null,
     } : {}
 
-    const response = await $fetch<CustomerApiResponse>('/api/customers/search-or-create', {
+    const response = await $fetch<CustomerApiResponse>(`${customerApiBase.value}/search-or-create`, {
       method: 'POST',
       body: {
         phone_number: createForm.value.phone_number,
@@ -791,7 +796,7 @@ const handleSaveFiscal = async () => {
   createError.value = ''
   try {
     const response = await $fetch<CustomerApiResponse>(
-      `/api/customers/${fiscalForm.value.customer_id}`,
+      `${customerApiBase.value}/${fiscalForm.value.customer_id}`,
       {
         method: 'PATCH',
         body: {

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1558,7 +1558,7 @@ watch(selectedCustomer, async (customer) => {
   // Fetch insights + Waros in parallel so the right column doesn't fill in step by step.
   const insightsPromise = (async () => {
     try {
-      const res = await $fetch<{ data: CustomerInsights }>(`/api/customers/${customer.id}/insights`)
+      const res = await $fetch<{ data: CustomerInsights }>(`/api/pos/customers/${customer.id}/insights`)
       customerInsights.value = res.data
     } catch {
       customerInsights.value = null
@@ -2356,7 +2356,7 @@ const generateInvoice = async () => {
     for (let i = 0; i < ids.length; i++) {
       if (ids.length > 1) invoiceProgress.value = t('pos.checkout.invoice.billingProgress', { current: i + 1, total: ids.length })
       try {
-        const result = await $fetch(`/api/orders/${ids[i]}/invoice`, { method: 'POST' }) as any
+        const result = await $fetch(`/api/pos/orders/${ids[i]}/invoice`, { method: 'POST' }) as any
         if (result.status === 'accepted') {
           invoiceResults.value.push({
             order_id: ids[i],
@@ -2379,7 +2379,7 @@ const generateInvoice = async () => {
         if (ids.length === 1 && result.status === 'accepted') {
           let invoiceDetail: any = null
           try {
-            invoiceDetail = await $fetch(`/api/orders/${ids[i]}/invoice`)
+            invoiceDetail = await $fetch(`/api/pos/orders/${ids[i]}/invoice`)
           } catch {
             // The accepted POST remains authoritative; without presentation we
             // omit the acquirer instead of guessing it from the mutable profile.
@@ -2826,7 +2826,7 @@ const submitFiscalAndInvoice = async () => {
   fiscalWizardError.value = ''
   try {
     const res = await $fetch<{ success: boolean; data: PosCustomer }>(
-      `/api/customers/${selectedCustomer.value.id}`,
+      `/api/pos/customers/${selectedCustomer.value.id}`,
       {
         method: 'PATCH',
         body: {
@@ -3101,7 +3101,7 @@ watch(
     autoSelectAttempted.value = true
     try {
       const res = await $fetch<{ success: boolean; data: PosCustomer }>(
-        '/api/customers/search-or-create',
+        '/api/pos/customers/search-or-create',
         {
           method: 'POST',
           body: { phone_number: '0000000000', name: t('pos.checkout.customerNoData') },


### PR DESCRIPTION
## Summary
- `/pos/checkout` uses `/api/pos/customers/*` and `/api/pos/orders/*/invoice`.
- `CustomerIdentificationModal` picks POS customer base automatically on `/pos/*` routes; ventas unchanged.

Requires API PR: https://github.com/uno0uno/api-warolabs/pull/684

Part of api-warolabs#681

## Test plan
- [ ] Cashier checkout: identify customer, pay, emit invoice — no 403
- [ ] Ventas customer modal still hits `/api/customers/*`

## Validation evidence
```
npx vitest run components/pos/CustomerIdentificationModal.test.ts
# 3 passed
```

## wr-context
Companion to api-warolabs `.wr/681.yaml`.