### PR TITLE
fix(menu): hydrate category headers in bulk ingredient selector

### DIFF
--- a/components/ingredientes/WarehouseCategoryIngredientSelector.test.ts
+++ b/components/ingredientes/WarehouseCategoryIngredientSelector.test.ts
@@ -248,6 +248,50 @@ describe('WarehouseCategoryIngredientSelector', () => {
     }])
   })
 
+  it('hydrates category headers from initial props on mount', async () => {
+    const category = {
+      id: 'category-1',
+      tenant_id: 'tenant-1',
+      name: 'Granos',
+      normalized_name: 'granos',
+      is_active: true,
+      scope: 'tenant',
+      can_manage: true,
+      ingredient_count: 1,
+      global_count: 0,
+      tenant_count: 1,
+    }
+    vi.stubGlobal('useI18n', () => ({
+      t: (key: string, params?: Record<string, string>) => ({
+        'abastecimiento.glossary.categoryIngredientSelectorTitle': 'Agregar ingredientes por categoría',
+        'abastecimiento.glossary.categoryIngredientsBatchLabel': 'Ingredientes por categoría',
+        'abastecimiento.glossary.categoryIngredientSelectorPlaceholder': 'Buscar categoría',
+        'abastecimiento.glossary.warehouseCategorySearchResults': 'Categorías',
+        'abastecimiento.glossary.removeWarehouseCategorySelection': `Quitar ${params?.name}`,
+      }[key] ?? key),
+    }))
+    const wrapper = mount(WarehouseCategoryIngredientSelector, {
+      props: {
+        initialCategories: [category],
+        initialPreparedRows: [{
+          ingredient_id: 'ingredient-1',
+          name: 'Arroz',
+          quantity: 2,
+          unit: 'kg',
+          warehouse_category_id: 'category-1',
+        }],
+      },
+      global: {
+        components: { UiWarehouseCategorySearchInput: WarehouseCategorySearchInputStub },
+      },
+    })
+
+    await flushPromises()
+
+    expect(wrapper.get('[data-test="category-group"] h5').text()).toBe('Granos')
+    expect(wrapper.get('[data-test="category-group"] span.text-xs').text()).toBe('1')
+  })
+
   it('does not re-resolve when existing ingredient ids grow after category sync', async () => {
     const fetchMock = vi.fn(async (_url: string, options: any) => ({
       data: {

--- a/components/ingredientes/WarehouseCategoryIngredientSelector.vue
+++ b/components/ingredientes/WarehouseCategoryIngredientSelector.vue
@@ -193,6 +193,8 @@ import {
 
 const props = withDefaults(defineProps<{
   existingIngredientIds?: string[]
+  initialCategories?: WarehouseCategoryRow[]
+  initialPreparedRows?: PreparedWarehouseCategoryIngredient[]
   inputId?: string
   unitOptions?: (ingredientId: string) => Array<{ value: string, label: string }>
   loadingUnitIds?: Set<string>
@@ -201,6 +203,8 @@ const props = withDefaults(defineProps<{
   hidePreparedIngredientRows?: boolean
 }>(), {
   existingIngredientIds: () => [],
+  initialCategories: () => [],
+  initialPreparedRows: () => [],
   inputId: 'warehouse-category-ingredient-selector',
   excludeResale: false,
   hidePreparedIngredientRows: false,
@@ -220,6 +224,7 @@ const {
   loading,
   error,
   addCategory,
+  hydrateFromSnapshot,
   removeCategory,
   removePreparedRow,
   updatePreparedRow,
@@ -268,6 +273,18 @@ function onUnitInput(ingredientId: string, event: Event) {
 watch(
   preparedRows,
   rows => emit('update:preparedRows', rows.map(row => ({ ...row }))),
+  { deep: true, immediate: true },
+)
+
+watch(
+  () => ({
+    categories: props.initialCategories,
+    rows: props.initialPreparedRows,
+  }),
+  async ({ categories, rows }) => {
+    if (!categories.length || selectedCategories.value.length) return
+    await hydrateFromSnapshot(categories, rows)
+  },
   { deep: true, immediate: true },
 )
 

--- a/composables/useMenuCategoryIngredientRows.test.ts
+++ b/composables/useMenuCategoryIngredientRows.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
+  applyCategorySelectorLayout,
+  buildWarehouseCategorySelectorHydration,
   mapPreparedRowsToProduct,
   mapPreparedRowsToRecipe,
   validateMenuCompositionRows,
@@ -14,6 +16,77 @@ const prepared = [{
 }]
 
 describe('menu category ingredient row adapters', () => {
+  it('builds category hydration grouped by warehouse category', () => {
+    const hydration = buildWarehouseCategorySelectorHydration(
+      [
+        { ingredient_id: 'ingredient-1', quantity: 2, unit: 'kg' },
+        { ingredient_id: 'ingredient-2', base_quantity: 1, unit: 'ml' },
+        { ingredient_id: 'manual-1', quantity: 1, unit: 'und' },
+      ],
+      [
+        {
+          id: 'ingredient-1',
+          name: 'Arroz',
+          unit: 'kg',
+          warehouse_category_id: 'category-1',
+          category: 'Granos',
+        },
+        {
+          id: 'ingredient-2',
+          name: 'Leche',
+          unit: 'ml',
+          warehouse_category_id: 'category-2',
+          category: 'Lácteos',
+        },
+        { id: 'manual-1', name: 'Sal', unit: 'und' },
+      ],
+    )
+
+    expect(hydration.categories.map(category => category.name)).toEqual(['Granos', 'Lácteos'])
+    expect(hydration.preparedRows).toEqual([
+      {
+        ingredient_id: 'ingredient-1',
+        name: 'Arroz',
+        quantity: 2,
+        unit: 'kg',
+        warehouse_category_id: 'category-1',
+      },
+      {
+        ingredient_id: 'ingredient-2',
+        name: 'Leche',
+        quantity: 1,
+        unit: 'ml',
+        warehouse_category_id: 'category-2',
+      },
+    ])
+  })
+
+  it('splits manual rows from category-backed rows for edit hydration', () => {
+    const layout = applyCategorySelectorLayout(
+      [
+        { ingredient_id: 'ingredient-1', ingredient_name: 'Arroz', quantity: 2, unit: 'kg' },
+        { ingredient_id: 'manual-1', ingredient_name: 'Sal', quantity: 1, unit: 'und' },
+      ],
+      [{
+        id: 'ingredient-1',
+        name: 'Arroz',
+        unit: 'kg',
+        warehouse_category_id: 'category-1',
+        category: 'Granos',
+      }, {
+        id: 'manual-1',
+        name: 'Sal',
+        unit: 'und',
+      }],
+    )
+
+    expect(layout.categories).toHaveLength(1)
+    expect(layout.manualRows).toEqual([
+      { ingredient_id: 'manual-1', ingredient_name: 'Sal', quantity: 1, unit: 'und' },
+    ])
+    expect(layout.preparedRows[0]?.warehouse_category_id).toBe('category-1')
+  })
+
   it('maps generic prepared rows to recipe and product payload fields', () => {
     expect(mapPreparedRowsToRecipe(prepared)).toEqual([{
       ingredient_id: 'ingredient-1',

--- a/composables/useMenuCategoryIngredientRows.ts
+++ b/composables/useMenuCategoryIngredientRows.ts
@@ -1,4 +1,75 @@
 import type { PreparedWarehouseCategoryIngredient } from '~/composables/useWarehouseCategoryIngredientSelector'
+import { warehouseCategoryFromIngredient } from '~/composables/useWarehouseCatalogEditMode'
+import type { WarehouseCategoryRow } from '~/composables/useWarehouseCategorySearch'
+
+export interface MenuCategoryIngredientSourceRow {
+  ingredient_id?: string
+  ingredient_name?: string
+  quantity?: number | null
+  base_quantity?: number | null
+  unit?: string | null
+}
+
+export interface MenuCategoryCatalogIngredient {
+  id: string
+  name?: string
+  unit?: string
+  warehouse_category_id?: string | null
+  category?: string | null
+}
+
+export function buildWarehouseCategorySelectorHydration(
+  rows: MenuCategoryIngredientSourceRow[],
+  catalog: MenuCategoryCatalogIngredient[],
+): { categories: WarehouseCategoryRow[], preparedRows: PreparedWarehouseCategoryIngredient[] } {
+  const catalogById = new Map(catalog.map(item => [item.id, item]))
+  const categoriesById = new Map<string, WarehouseCategoryRow>()
+  const preparedRows: PreparedWarehouseCategoryIngredient[] = []
+
+  for (const row of rows) {
+    const ingredientId = row.ingredient_id?.trim()
+    if (!ingredientId) continue
+
+    const catalogItem = catalogById.get(ingredientId)
+    if (!catalogItem) continue
+
+    const category = warehouseCategoryFromIngredient(catalogItem)
+    if (!category) continue
+
+    categoriesById.set(category.id, category)
+    const quantity = row.quantity ?? row.base_quantity ?? null
+    preparedRows.push({
+      ingredient_id: ingredientId,
+      name: row.ingredient_name?.trim() || catalogItem.name || '',
+      quantity: quantity == null || !Number.isFinite(Number(quantity)) ? null : Number(quantity),
+      unit: row.unit?.trim() || catalogItem.unit?.trim() || null,
+      warehouse_category_id: category.id,
+    })
+  }
+
+  return {
+    categories: [...categoriesById.values()],
+    preparedRows,
+  }
+}
+
+export function applyCategorySelectorLayout<T extends MenuCategoryIngredientSourceRow>(
+  rows: T[],
+  catalog: MenuCategoryCatalogIngredient[],
+): {
+  categories: WarehouseCategoryRow[]
+  preparedRows: PreparedWarehouseCategoryIngredient[]
+  manualRows: T[]
+} {
+  const hydration = buildWarehouseCategorySelectorHydration(rows, catalog)
+  const categoryIngredientIds = new Set(hydration.preparedRows.map(row => row.ingredient_id))
+
+  return {
+    categories: hydration.categories,
+    preparedRows: hydration.preparedRows,
+    manualRows: rows.filter(row => !row.ingredient_id || !categoryIngredientIds.has(row.ingredient_id)),
+  }
+}
 
 export interface MenuCompositionIngredientRow {
   ingredient_id: string

--- a/composables/useWarehouseCategoryIngredientSelector.test.ts
+++ b/composables/useWarehouseCategoryIngredientSelector.test.ts
@@ -72,6 +72,7 @@ describe('useWarehouseCategoryIngredientSelector', () => {
         body: {
           category_ids: ['category-1', 'category-2'],
           exclude_ingredient_ids: ['manual-ingredient'],
+          exclude_resale: false,
         },
       },
     )
@@ -161,5 +162,38 @@ describe('useWarehouseCategoryIngredientSelector', () => {
     await firstRequest
 
     expect(selector.preparedRows.value.map(row => row.ingredient_id)).toEqual(['ingredient-new'])
+  })
+
+  it('hydrates selected categories and prepared rows from a snapshot', async () => {
+    const selector = useWarehouseCategoryIngredientSelector()
+    const category = {
+      id: 'category-1',
+      tenant_id: 'tenant-1',
+      name: 'Granos',
+      normalized_name: 'granos',
+      is_active: true,
+      scope: 'tenant' as const,
+      can_manage: true,
+      ingredient_count: 1,
+      global_count: 0,
+      tenant_count: 1,
+    }
+
+    await selector.hydrateFromSnapshot([category], [{
+      ingredient_id: 'ingredient-1',
+      name: 'Arroz',
+      quantity: 2,
+      unit: 'kg',
+      warehouse_category_id: 'category-1',
+    }])
+
+    expect(selector.selectedCategories.value).toEqual([category])
+    expect(selector.preparedRows.value).toEqual([{
+      ingredient_id: 'ingredient-1',
+      name: 'Arroz',
+      quantity: 2,
+      unit: 'kg',
+      warehouse_category_id: 'category-1',
+    }])
   })
 })

--- a/composables/useWarehouseCategoryIngredientSelector.ts
+++ b/composables/useWarehouseCategoryIngredientSelector.ts
@@ -101,6 +101,23 @@ export function useWarehouseCategoryIngredientSelector(options: {
     }
   }
 
+  async function hydrateFromSnapshot(
+    categories: WarehouseCategoryRow[],
+    rows: PreparedWarehouseCategoryIngredient[] = [],
+  ) {
+    const seenCategoryIds = new Set<string>()
+    selectedCategories.value = categories.filter((category) => {
+      if (!category?.id || seenCategoryIds.has(category.id)) return false
+      seenCategoryIds.add(category.id)
+      return true
+    })
+    preparedRows.value = rows.map(row => ({ ...row }))
+    emptyCategoryIds.value = []
+    unavailableCategoryIds.value = []
+    error.value = null
+    loading.value = false
+  }
+
   async function addCategory(category: WarehouseCategoryRow | null) {
     if (!category || selectedCategories.value.some(selected => selected.id === category.id)) {
       return false
@@ -142,6 +159,7 @@ export function useWarehouseCategoryIngredientSelector(options: {
     loading,
     error,
     addCategory,
+    hydrateFromSnapshot,
     removeCategory,
     removePreparedRow,
     updatePreparedRow,

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -133,6 +133,8 @@
                 class="mb-4"
                 :input-id="`modifier-edit-warehouse-category-bulk-${groupId}`"
                 :existing-ingredient-ids="existingWarehouseIngredientIds"
+                :initial-categories="categorySelectorHydration.categories"
+                :initial-prepared-rows="categorySelectorHydration.preparedRows"
                 :unit-options="getIngredientUnitOptions"
                 :loading-unit-ids="loadingUnits"
                 hide-prepared-ingredient-rows
@@ -264,6 +266,7 @@ import {
 } from '~/composables/useModifierOptionForm'
 import type { PreparedWarehouseCategoryIngredient } from '~/composables/useWarehouseCategoryIngredientSelector'
 import WarehouseCategoryIngredientSelector from '~/components/ingredientes/WarehouseCategoryIngredientSelector.vue'
+import { buildWarehouseCategorySelectorHydration } from '~/composables/useMenuCategoryIngredientRows'
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
@@ -463,6 +466,24 @@ const existingWarehouseIngredientIds = computed(() =>
     .filter(m => m.option_type === 'INGREDIENT' && m.ingredient_id)
     .map(m => m.ingredient_id as string),
 )
+
+const categorySelectorHydration = computed(() => {
+  if (!availableIngredients.value.length) {
+    return { categories: [], preparedRows: [] as PreparedWarehouseCategoryIngredient[] }
+  }
+
+  return buildWarehouseCategorySelectorHydration(
+    form.value.modifiers
+      .filter(m => m.option_type === 'INGREDIENT' && m.ingredient_id)
+      .map(m => ({
+        ingredient_id: m.ingredient_id!,
+        ingredient_name: m.ingredient_name ?? undefined,
+        quantity: m.ingredient_quantity,
+        unit: m.ingredient_unit,
+      })),
+    availableIngredients.value,
+  )
+})
 
 function onGroupWarehouseCategoryRows(rows: PreparedWarehouseCategoryIngredient[]) {
   form.value.modifiers = syncWarehouseModifiersFromCategory(form.value.modifiers, rows)

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -549,9 +549,12 @@
 
             <WarehouseCategoryIngredientSelector
               v-if="!isResaleProduct"
+              :key="`product-edit-category-ingredients-${productId}`"
               class="mb-4"
               input-id="product-edit-category-ingredients"
               :existing-ingredient-ids="existingIngredientIds"
+              :initial-categories="categorySelectorCategories"
+              :initial-prepared-rows="categoryPreparedRows"
               :unit-options="getIngredientUnitOptions"
               :loading-unit-ids="loadingUnits"
               @update:prepared-rows="onCategoryPreparedRows"
@@ -878,6 +881,8 @@ import { useTenantReactive } from '@/composables/useTenantReactive'
 import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 import WarehouseCategoryIngredientSelector from '~/components/ingredientes/WarehouseCategoryIngredientSelector.vue'
 import type { PreparedWarehouseCategoryIngredient } from '~/composables/useWarehouseCategoryIngredientSelector'
+import type { WarehouseCategoryRow } from '~/composables/useWarehouseCategorySearch'
+import { applyCategorySelectorLayout } from '~/composables/useMenuCategoryIngredientRows'
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
@@ -1041,6 +1046,7 @@ const ingredientCache = ref<Record<string, any>>({})
 const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 const loadingUnits = ref<Set<string>>(new Set())
 const categoryPreparedRows = ref<PreparedWarehouseCategoryIngredient[]>([])
+const categorySelectorCategories = ref<WarehouseCategoryRow[]>([])
 
 const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient, mergeIngredientUnitFields, rehydrateIngredientCaches } = useIngredientUnitOptions()
 
@@ -1064,6 +1070,24 @@ function cacheIngredientForUnits(ing: any, productFallback?: Record<string, unkn
     merged.unit_weight_unit = 'ml'
   }
   ingredientCache.value[ing.id] = merged
+}
+
+function syncCategorySelectorLayout() {
+  if (!ingredients.value.length) return
+
+  const sourceRows = [
+    ...form.value.ingredients,
+    ...categoryPreparedRows.value.map(row => ({
+      ingredient_id: row.ingredient_id,
+      ingredient_name: row.name,
+      quantity: row.quantity,
+      unit: row.unit,
+    })),
+  ]
+  const layout = applyCategorySelectorLayout(sourceRows, ingredients.value)
+  categorySelectorCategories.value = layout.categories
+  categoryPreparedRows.value = layout.preparedRows
+  form.value.ingredients = layout.manualRows as typeof form.value.ingredients
 }
 
 function rehydrateProductIngredientCaches() {
@@ -1251,6 +1275,7 @@ const tracksInventory = ref(true)
 watch(productData, (data) => {
   if (data?.data) {
     categoryPreparedRows.value = []
+    categorySelectorCategories.value = []
     const product = data.data
     form.value = {
       name: product.name,
@@ -1305,12 +1330,14 @@ watch(productData, (data) => {
     }
     // Pre-fill the category search input with the product's current category name
     selectedCategoryName.value = product.category_name || ''
+    syncCategorySelectorLayout()
   }
 }, { immediate: true })
 
 watch(ingredients, (list) => {
   if (list.length && form.value.ingredients.some(ing => ing.ingredient_id)) {
     rehydrateProductIngredientCaches()
+    syncCategorySelectorLayout()
   }
 })
 

--- a/pages/menu/recetas/[id].vue
+++ b/pages/menu/recetas/[id].vue
@@ -77,9 +77,12 @@
               <MenuIngredientProductHint class="mb-4" />
 
               <WarehouseCategoryIngredientSelector
+                :key="`recipe-edit-category-ingredients-${recipeId}`"
                 class="mb-4"
                 input-id="recipe-edit-category-ingredients"
                 :existing-ingredient-ids="existingIngredientIds"
+                :initial-categories="categorySelectorCategories"
+                :initial-prepared-rows="categoryPreparedRows"
                 :unit-options="getIngredientUnitOptions"
                 :loading-unit-ids="loadingUnits"
                 @update:prepared-rows="onCategoryPreparedRows"
@@ -264,6 +267,8 @@ import { useQueryCache } from '@pinia/colada'
 import { useMenuIngredientsQuery } from '@/composables/queries/useMenuIngredients'
 import WarehouseCategoryIngredientSelector from '~/components/ingredientes/WarehouseCategoryIngredientSelector.vue'
 import type { PreparedWarehouseCategoryIngredient } from '~/composables/useWarehouseCategoryIngredientSelector'
+import type { WarehouseCategoryRow } from '~/composables/useWarehouseCategorySearch'
+import { applyCategorySelectorLayout } from '~/composables/useMenuCategoryIngredientRows'
 
 definePageMeta({
   pageTransition: {
@@ -309,6 +314,25 @@ const ingredientCache = ref<Record<string, any>>({})
 const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 const loadingUnits = ref<Set<string>>(new Set())
 const categoryPreparedRows = ref<PreparedWarehouseCategoryIngredient[]>([])
+const categorySelectorCategories = ref<WarehouseCategoryRow[]>([])
+
+function syncCategorySelectorLayout() {
+  if (!availableIngredients.value.length) return
+
+  const sourceRows = [
+    ...form.value.ingredients,
+    ...categoryPreparedRows.value.map(row => ({
+      ingredient_id: row.ingredient_id,
+      ingredient_name: row.name,
+      base_quantity: row.quantity,
+      unit: row.unit,
+    })),
+  ]
+  const layout = applyCategorySelectorLayout(sourceRows, availableIngredients.value)
+  categorySelectorCategories.value = layout.categories
+  categoryPreparedRows.value = layout.preparedRows
+  form.value.ingredients = layout.manualRows as typeof form.value.ingredients
+}
 
 const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient, mergeIngredientUnitFields, rehydrateIngredientCaches } = useIngredientUnitOptions()
 
@@ -432,6 +456,8 @@ const submitError = ref('')
 
 watch(recipeData, (data) => {
   if (data?.data) {
+    categoryPreparedRows.value = []
+    categorySelectorCategories.value = []
     const recipe = data.data
     form.value = {
       name: recipe.name,
@@ -451,12 +477,15 @@ watch(recipeData, (data) => {
         }
       })
     }
+    syncCategorySelectorLayout()
   }
 }, { immediate: true })
 
 watch(availableIngredients, (list) => {
-  if (list.length && form.value.ingredients.some(ing => ing.ingredient_id)) {
+  if (!list.length) return
+  if (form.value.ingredients.some(ing => ing.ingredient_id) || categoryPreparedRows.value.length) {
     rehydrateRecipeIngredientCaches()
+    syncCategorySelectorLayout()
   }
 })
 


### PR DESCRIPTION
## Summary
- Derive warehouse category groups from the ingredient catalog and hydrate the bulk selector on edit load.
- Split categorized product/recipe lines into category prepared rows so headers show counts without a new search.
- Modifiers edit passes hydration from warehouse modifier options (summary mode unchanged).

Closes #1724

## Test plan
- [ ] Edit modifier/product/recipe with categorized ingredients → category headers visible immediately
- [ ] Remove category header still clears its rows
- [ ] Manual uncategorized ingredient rows unchanged

## Validation evidence
```
npx vitest run composables/useMenuCategoryIngredientRows.test.ts composables/useWarehouseCategoryIngredientSelector.test.ts components/ingredientes/WarehouseCategoryIngredientSelector.test.ts

 Test Files  3 passed (3)
      Tests  14 passed (14)
```

## wr-context
See `.wr/1724.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)