### PR TITLE
fix(ui): unify public canvas background with white header

### DIFF
--- a/.wr/1728.yaml
+++ b/.wr/1728.yaml
@@ -1,0 +1,40 @@
+issue: 1728
+title: Unify public page background with white header (fix grey seam under nav)
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1728-public-bg-white
+
+paths:
+  - assets/css/design-tokens.css
+  - components/layout/PublicShell.vue
+  - components/layout/Header.vue
+  - components/layout/BottomNav.vue
+  - pages/index.vue
+  - pages/ciudades.vue
+
+ac:
+  - PublicShell bg-surface end-to-end
+  - Remove titan-100 hardcode on index and ciudades
+  - Light --background aligned to titan-50 / surface white
+  - Header and BottomNav use bg-surface/95
+
+out_of_scope:
+  - Dark theme token redesign
+  - Intentional grey hero sections inside pages
+
+hints:
+  entry: components/layout/PublicShell.vue
+  pattern: assets/css/design-tokens.css:96 --surface white
+  tests: none (manual visual QA)
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color]
+
+next:
+  after_pr: visual QA /, /ciudades, /blog, /docs, one dashboard route

--- a/assets/css/design-tokens.css
+++ b/assets/css/design-tokens.css
@@ -62,7 +62,7 @@
   --ebony-900: 250 30% 16%; /* #1F1D35 */
 
   /* === TEMA CLARO (Titan White Base) === */
-  --background: var(--titan-200); /* Fondo claro suave */
+  --background: var(--titan-50); /* Canvas alineado con surface (blanco) */
   --foreground: var(--ebony-900); /* Texto oscuro */
   
   --card: 0 0% 100%; /* Tarjetas blancas */
@@ -571,7 +571,7 @@
 
 /* === TEMA CLARO EXPLÍCITO === */
 .light {
-  --background: var(--titan-100); /* Fondo claro */
+  --background: var(--titan-50); /* Canvas alineado con surface (blanco) */
   --foreground: var(--ebony-900); /* Texto oscuro */
   
   --card: var(--titan-50); /* Tarjetas blanco puro */

--- a/components/layout/BottomNav.vue
+++ b/components/layout/BottomNav.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav aria-label="Navegación móvil" class="md:hidden fixed bottom-0 start-0 end-0 z-[50] bg-white/95 backdrop-blur-sm border-t border-titan-200 shadow-[0_-1px_4px_rgba(0,0,0,0.06)] pb-[env(safe-area-inset-bottom)]">
+  <nav aria-label="Navegación móvil" class="md:hidden fixed bottom-0 start-0 end-0 z-[50] bg-surface/95 backdrop-blur-sm border-t border-titan-200 shadow-[0_-1px_4px_rgba(0,0,0,0.06)] pb-[env(safe-area-inset-bottom)]">
     <div class="flex items-stretch h-[58px]">
 
       <!-- Inicio -->

--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="sticky top-0 z-[100] bg-white/95 backdrop-blur-sm border-b border-titan-200 shadow-[0_1px_4px_rgba(0,0,0,0.06)] w-full">
+  <header class="sticky top-0 z-[100] bg-surface/95 backdrop-blur-sm border-b border-titan-200 shadow-[0_1px_4px_rgba(0,0,0,0.06)] w-full">
     <div class="flex items-center gap-2 px-3 sm:gap-3 sm:px-4 md:gap-4 md:px-6 h-[60px] max-w-[1400px] mx-auto w-full">
 
       <!-- Logo -->
@@ -32,7 +32,7 @@
           placeholder="Buscar..."
           readonly
         />
-        <span class="absolute end-3 text-[10px] text-ebony-400 bg-white border border-titan-200 py-[1px] px-1.5 rounded tracking-[0.02em] font-mono">⌘K</span>
+        <span class="absolute end-3 text-[10px] text-ebony-400 bg-surface border border-titan-200 py-[1px] px-1.5 rounded tracking-[0.02em] font-mono">⌘K</span>
       </div>
 
       <!-- Acciones derecha -->

--- a/components/layout/PublicShell.vue
+++ b/components/layout/PublicShell.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="rootClass">
+  <div :class="[rootClass, 'bg-surface text-text-primary']">
     <NuxtLoadingIndicator />
     <LayoutHeader />
     <div :class="contentClass">

--- a/pages/ciudades.vue
+++ b/pages/ciudades.vue
@@ -139,7 +139,7 @@ useHead({
   padding: 48px 24px 80px;
   max-width: 1200px;
   margin: 0 auto;
-  background: hsl(220, 14%, 97%);
+  background: transparent;
 }
 
 /* Hero */

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -38,7 +38,7 @@ useHead({
     position: relative;
     min-height: 100vh;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    background: hsl(220, 14%, 97%); /* Titan 100 - Fondo claro neutral */
+    background: transparent;
     color: hsl(250, 30%, 16%); /* Ebony 900 - Texto oscuro con alto contraste */
     overflow-x: hidden;
 }


### PR DESCRIPTION
## Summary
- Light-theme `--background` now matches white `--surface` / `--titan-50` (no bluish `#EBF0FF` canvas).
- `LayoutPublicShell` always applies `bg-surface`; header and bottom nav use `bg-surface/95`.
- Removed grey hardcoded backgrounds from `/` and `/ciudades` so they inherit the unified shell.

Closes #1728

## Test plan
- [ ] `/ciudades` — no seam under sticky header; page background matches nav
- [ ] `/` — same white canvas behind hero
- [ ] `/blog`, `/docs` — `bg-background` pages match header white
- [ ] One dashboard route — header + scroll area visually consistent

## Validation evidence
```
No automated test target for CSS/token changes in this repo scope.
Manual visual QA required on routes above.
```

## wr-context
See `.wr/1728.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)