### PR TITLE
fix(ui): align public pages, docs, and ciudades with header layout

### DIFF
--- a/assets/css/design-tokens.css
+++ b/assets/css/design-tokens.css
@@ -272,6 +272,15 @@
 
   --shell-header-bg: var(--surface);
   --shell-header-border: var(--border);
+  --layout-public-header-height: 3.75rem; /* 60px inner bar */
+  --layout-public-header-offset: calc(var(--layout-public-header-height) + 1px); /* incl. border-b */
+  --layout-public-bottom-nav-height: 3.625rem; /* 58px — LayoutBottomNav */
+  --layout-public-page-max-width: 87.5rem; /* 1400px — matches LayoutHeader inner */
+  --layout-public-page-padding-x: 0.75rem; /* 12px — header px-3 */
+  --layout-public-page-padding-x-sm: 1rem; /* 16px — header sm:px-4 */
+  --layout-public-page-padding-x-md: 1.5rem; /* 24px — header md:px-6 */
+  --layout-public-page-padding-top: 2rem; /* 32px — aligns with blog hero pt-8 */
+  --layout-public-page-padding-top-md: 2rem;
   --shell-title-text: var(--text-primary);
   --shell-subtitle-text: var(--text-secondary);
   --shell-cta-bg: var(--action-primary-bg);

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -2,9 +2,68 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Article Layout Container */
+/* Public page layout — shared by blog, ciudades, docs (horizontal alignment with header) */
+.public-page-container {
+  width: 100%;
+  max-width: var(--layout-public-page-max-width);
+  margin-inline: auto;
+  padding-inline: var(--layout-public-page-padding-x);
+}
+
+@media (min-width: 640px) {
+  .public-page-container {
+    padding-inline: var(--layout-public-page-padding-x-sm);
+  }
+}
+
+@media (min-width: 768px) {
+  .public-page-container {
+    padding-inline: var(--layout-public-page-padding-x-md);
+  }
+}
+
+.public-page-shell {
+  flex: 1 1 auto;
+  width: 100%;
+  max-width: var(--layout-public-page-max-width);
+  margin-inline: auto;
+  padding-inline: var(--layout-public-page-padding-x);
+  padding-top: var(--layout-public-page-padding-top);
+  padding-bottom: calc(2rem + var(--layout-public-bottom-nav-height));
+}
+
+@media (min-width: 640px) {
+  .public-page-shell {
+    padding-inline: var(--layout-public-page-padding-x-sm);
+  }
+}
+
+@media (min-width: 768px) {
+  .public-page-shell {
+    padding-inline: var(--layout-public-page-padding-x-md);
+    padding-top: var(--layout-public-page-padding-top-md);
+    padding-bottom: 2rem;
+  }
+}
+
+/* Article Layout Container — alias of public-page-container for blog prose */
 .article-container {
-  @apply px-3 sm:px-5 md:px-8 lg:px-16 xl:px-24 2xl:px-48;
+  width: 100%;
+  max-width: var(--layout-public-page-max-width);
+  margin-inline: auto;
+  padding-inline: var(--layout-public-page-padding-x);
+}
+
+@media (min-width: 640px) {
+  .article-container {
+    padding-inline: var(--layout-public-page-padding-x-sm);
+  }
+}
+
+@media (min-width: 768px) {
+  .article-container {
+    padding-inline: var(--layout-public-page-padding-x-md);
+  }
 }
 
 .p-cards{

--- a/components/layout/BottomNav.vue
+++ b/components/layout/BottomNav.vue
@@ -1,6 +1,6 @@
 <template>
-  <nav aria-label="Navegación móvil" class="md:hidden fixed bottom-0 start-0 end-0 z-[50] bg-surface/95 backdrop-blur-sm border-t border-titan-200 shadow-[0_-1px_4px_rgba(0,0,0,0.06)] pb-[env(safe-area-inset-bottom)]">
-    <div class="flex items-stretch h-[58px]">
+  <nav aria-label="Navegación móvil" class="md:hidden fixed bottom-0 start-0 end-0 z-[50] bg-surface border-t border-titan-200 pb-[env(safe-area-inset-bottom)]">
+    <div class="flex items-stretch h-[var(--layout-public-bottom-nav-height)]">
 
       <!-- Inicio -->
       <NuxtLink to="/" class="nav-item" :class="route.path === '/' ? 'active' : 'inactive'">

--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -1,6 +1,6 @@
 <template>
-  <header class="sticky top-0 z-[100] bg-surface/95 backdrop-blur-sm border-b border-titan-200 shadow-[0_1px_4px_rgba(0,0,0,0.06)] w-full">
-    <div class="flex items-center gap-2 px-3 sm:gap-3 sm:px-4 md:gap-4 md:px-6 h-[60px] max-w-[1400px] mx-auto w-full">
+  <header class="sticky top-0 z-[100] shrink-0 box-border h-[var(--layout-public-header-offset)] bg-surface border-b border-titan-200 w-full">
+    <div class="flex h-[var(--layout-public-header-height)] items-center gap-2 px-3 sm:gap-3 sm:px-4 md:gap-4 md:px-6 max-w-[1400px] mx-auto w-full">
 
       <!-- Logo -->
       <NuxtLink to="/" class="flex items-center gap-2.5 no-underline shrink-0">

--- a/components/layout/PublicShell.vue
+++ b/components/layout/PublicShell.vue
@@ -1,10 +1,10 @@
 <template>
-  <div :class="[rootClass, 'bg-surface text-text-primary']">
+  <div :class="[rootClass, 'public-shell bg-surface text-text-primary']">
     <NuxtLoadingIndicator />
     <LayoutHeader />
-    <div :class="contentClass">
+    <main :class="[contentClass, 'public-shell__content']">
       <slot />
-    </div>
+    </main>
     <LayoutFooter v-if="showFooter" :class="footerClass" />
     <LayoutBottomNav v-if="showBottomNav" />
   </div>
@@ -18,10 +18,21 @@ withDefaults(defineProps<{
   showFooter?: boolean
   showBottomNav?: boolean
 }>(), {
-  rootClass: 'min-h-screen flex flex-col',
-  contentClass: 'flex-1 pb-[58px] md:pb-0',
+  rootClass: 'min-h-dvh flex flex-col',
+  contentClass: 'flex-1 w-full',
   footerClass: 'hidden md:block',
   showFooter: true,
   showBottomNav: true,
 })
 </script>
+
+<style scoped>
+.public-shell {
+  min-height: 100dvh;
+}
+
+.public-shell__content {
+  flex: 1 1 auto;
+  width: 100%;
+}
+</style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,7 +1,7 @@
 <template>
   <LayoutPublicShell
-    root-class="w-screen h-screen flex flex-col overflow-x-hidden"
-    content-class="flex-1 pb-8 px-4 md:px-16 2xl:px-[30rem] pb-[calc(2rem+58px)] md:pb-8"
+    root-class="w-full flex flex-col overflow-x-hidden"
+    content-class="public-page-shell"
   >
     <slot />
   </LayoutPublicShell>

--- a/layouts/docs.vue
+++ b/layouts/docs.vue
@@ -89,12 +89,12 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="docs-shell">
+  <div class="docs-shell bg-surface">
     <NuxtLoadingIndicator />
 
     <Header />
 
-    <div class="docs-body">
+    <div class="docs-body public-page-container">
 
       <!-- Sidebar -->
       <aside class="docs-sidebar">
@@ -181,8 +181,7 @@ onMounted(() => {
 .docs-shell {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
-  background: hsl(var(--background));
+  min-height: 100dvh;
   font-family: 'Lato', sans-serif;
 }
 
@@ -319,19 +318,20 @@ onMounted(() => {
   display: flex;
   flex: 1;
   width: 100%;
+  --layout-docs-column-top: 20px;
 }
 
 /* ─── Sidebar ────────────────────────────────────────── */
 .docs-sidebar {
   width: 256px;
   flex-shrink: 0;
-  background: hsl(var(--background));
+  background: hsl(var(--surface));
   display: flex;
   flex-direction: column;
   position: sticky;
-  top: 58px;
+  top: var(--layout-public-header-offset);
   align-self: flex-start;
-  height: calc(100vh - 58px);
+  height: calc(100dvh - var(--layout-public-header-offset));
   overflow-y: auto;
   overflow-x: hidden;
   scrollbar-width: thin;
@@ -351,7 +351,7 @@ onMounted(() => {
 
 /* ─── Nav card ───────────────────────────────────────── */
 .docs-nav-card {
-  margin: 20px 12px 0;
+  margin: var(--layout-docs-column-top) 12px 0;
   background: hsl(var(--surface));
   border: 1px solid hsl(var(--border));
   border-radius: 10px;
@@ -525,25 +525,30 @@ onMounted(() => {
 .docs-main {
   flex: 1;
   min-width: 0;
-  padding: 24px 24px 64px 32px;
-  background: hsl(var(--background));
+  padding-top: var(--layout-docs-column-top);
+  padding-bottom: 64px;
+  background: hsl(var(--surface));
   display: flex;
   flex-direction: column;
   align-items: center;
 }
 
-/* Tablet */
 @media (max-width: 1023px) {
   .docs-main {
-    padding: 16px 12px calc(64px + 58px);
+    padding-bottom: calc(64px + var(--layout-public-bottom-nav-height));
   }
 }
 
 /* Mobile — sin padding lateral, el card maneja su propio espacio */
 @media (max-width: 639px) {
+  .docs-body.public-page-container {
+    max-width: none;
+    padding-inline: 0;
+  }
+
   .docs-main {
-    padding: 0 0 calc(48px + 58px);
-    background: hsl(var(--background));
+    padding-inline: 0;
+    padding-bottom: calc(48px + var(--layout-public-bottom-nav-height));
     align-items: stretch;
   }
 }
@@ -553,8 +558,8 @@ onMounted(() => {
   width: 248px;
   flex-shrink: 0;
   display: none;
-  padding: 20px 12px 0;
-  background: hsl(var(--background));
+  padding: var(--layout-docs-column-top) 12px 0;
+  background: hsl(var(--surface));
 }
 
 @media (min-width: 1280px) {
@@ -565,12 +570,12 @@ onMounted(() => {
 
 .docs-toc-inner {
   position: sticky;
-  top: calc(58px + 20px);
+  top: calc(var(--layout-public-header-offset) + 20px);
   background: hsl(var(--surface));
   border: 1px solid hsl(var(--border));
   border-radius: 10px;
   padding: 14px 16px 16px;
-  max-height: calc(100vh - 120px);
+  max-height: calc(100dvh - var(--layout-public-header-offset) - 40px);
   overflow-y: auto;
   scrollbar-width: none;
   box-shadow: 0 1px 4px hsl(var(--overlay-backdrop-bg) / 0.04);

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 
+definePageMeta({
+  layout: 'blog',
+  publicAccess: true,
+})
+
 // Efecto de máquina de escribir para el título del hero
 const heroTitle = 'El conocimiento que necesita tu restaurante'
 const displayedTitle = ref('')
@@ -153,7 +158,7 @@ useHead({
 </script>
 
 <template>
-  <div class="min-h-screen bg-background flex flex-col font-sans">
+  <div class="min-h-dvh bg-background flex flex-col font-sans">
 
     <!-- ════════════════════════════════════════
          HERO SECTION
@@ -167,7 +172,7 @@ useHead({
       <!-- Accent blob superior derecho -->
       <div class="absolute -top-32 -end-32 w-96 h-96 bg-badge-primary-bg/40 rounded-full blur-3xl pointer-events-none" aria-hidden="true"></div>
 
-      <div class="relative z-10 max-w-5xl mx-auto px-5 lg:px-12 pt-16 pb-12 lg:pt-28 lg:pb-24 text-center">
+      <div class="relative z-10 public-page-container pt-16 pb-12 lg:pt-28 lg:pb-24 text-center">
         <!-- Eyebrow badge -->
         <div class="inline-flex items-center gap-2 mb-5 lg:mb-7">
           <span class="w-5 h-px bg-badge-primary-border"></span>
@@ -203,7 +208,7 @@ useHead({
     <!-- ════════════════════════════════════════
          MAIN CONTENT
     ════════════════════════════════════════ -->
-    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12 lg:py-16 w-full flex-1">
+    <div class="public-page-container flex-1 w-full py-8 sm:py-12 lg:py-16 pb-[calc(2rem+var(--layout-public-bottom-nav-height))] md:pb-16">
 
       <!-- Loading State -->
       <div v-if="isLoading" class="flex items-center justify-center min-h-[400px]">
@@ -242,7 +247,7 @@ useHead({
         />
 
       </template>
-    </main>
+    </div>
   </div>
 </template>
 

--- a/pages/ciudades.vue
+++ b/pages/ciudades.vue
@@ -135,11 +135,8 @@ useHead({
 
 <style scoped>
 .ciudades-page {
-  min-height: calc(100vh - 60px);
-  padding: 48px 24px 80px;
-  max-width: 1200px;
-  margin: 0 auto;
-  background: transparent;
+  padding: 0 0 80px;
+  width: 100%;
 }
 
 /* Hero */
@@ -186,33 +183,22 @@ useHead({
   color: hsl(262, 83%, 58%);
 }
 
-/* Row — horizontal scroll on mobile, grid on wider viewports.
-   Matches the "Próximos Viajes" card-strip pattern. */
+/* Grid — 2 cols on mobile, auto-fit from md up. */
 .ciudades-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
-  overflow-x: auto;
-  padding-bottom: 16px;
-  scroll-snap-type: x mandatory;
-  -webkit-overflow-scrolling: touch;
-}
-.ciudades-row > * {
-  scroll-snap-align: start;
 }
 @media (min-width: 768px) {
   .ciudades-row {
-    display: grid;
     grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    overflow: visible;
-    padding-bottom: 0;
   }
 }
 
 /* Card — outer pill, inner image with rounded-[28px], meta row below. */
 .city-card {
   display: block;
-  flex: 0 0 240px;
-  min-width: 240px;
+  min-width: 0;
   background: #ffffff;
   border-radius: 32px;
   padding: 8px;
@@ -221,12 +207,6 @@ useHead({
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
   border: 1px solid hsl(220, 14%, 92%);
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-@media (min-width: 768px) {
-  .city-card {
-    flex: initial;
-    min-width: 0;
-  }
 }
 .city-card:hover {
   transform: translateY(-2px);
@@ -360,10 +340,39 @@ useHead({
   padding: 80px 24px;
 }
 
-@media (max-width: 640px) {
-  .ciudades-page {
-    padding: 32px 16px 64px;
+@media (max-width: 767px) {
+  .city-card {
+    border-radius: 24px;
+    padding: 6px;
   }
+  .city-card__image {
+    height: 140px;
+    border-radius: 20px;
+    margin-bottom: 8px;
+  }
+  .city-card__overlay-name {
+    font-size: 1rem;
+    padding: 0 10px;
+  }
+  .city-card__meta {
+    padding: 0 8px 6px;
+    gap: 6px;
+  }
+  .city-card__meta-text {
+    font-size: 0.75rem;
+  }
+  .city-card__count-pill {
+    bottom: 8px;
+    right: 8px;
+    padding: 3px 8px;
+    font-size: 0.65rem;
+  }
+  .city-card__count-pill > span:first-child {
+    font-size: 0.8rem;
+  }
+}
+
+@media (max-width: 640px) {
   .ciudades-hero {
     margin-bottom: 40px;
   }

--- a/pages/docs/[...slug].vue
+++ b/pages/docs/[...slug].vue
@@ -126,8 +126,9 @@ function handleClick(e: MouseEvent) {
   background: hsl(var(--surface));
   border: 1px solid hsl(220 13% 91%);
   border-radius: 14px;
-  padding: 48px 56px 64px;
+  padding: 32px 56px 64px;
   max-width: 860px;
+  width: 100%;
   box-shadow: 0 1px 4px hsl(var(--overlay-backdrop-bg) / 0.04);
 }
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -36,7 +36,7 @@ useHead({
 <style scoped>
 .index-page {
     position: relative;
-    min-height: 100vh;
+    min-height: 100%;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     background: transparent;
     color: hsl(250, 30%, 16%); /* Ebony 900 - Texto oscuro con alto contraste */


### PR DESCRIPTION
## Summary
- Unify public page max-width (1400px) and horizontal gutters with the header across blog, ciudades, and docs
- Fix docs layout to use header offset tokens, column top alignment, and constrained body width
- Improve public shell/header styling and mobile ciudades 2-column grid

## Test plan
- [x] `/ciudades` — content aligns with header, 2-col grid on mobile
- [x] `/blog` and `/blog/:slug` — hero/content gutters match header
- [x] `/docs/usuarios/primeros-pasos` — sidebar, main card, and TOC align horizontally and vertically

Made with [Cursor](https://cursor.com)