### PR TITLE
fix(negocio): save profile and city selector (#1740)

### DIFF
--- a/.wr/1740.yaml
+++ b/.wr/1740.yaml
@@ -1,0 +1,33 @@
+issue: 1740
+title: Fix Mi Negocio save and city selector for Bubablue (add Aguasul if missing)
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-1740-negocio-save-city
+
+paths:
+  - front_nuxt/pages/negocio.vue
+  - front_nuxt/composables/useCityCatalog.ts
+  - front_nuxt/composables/useCityCatalog.search.test.ts
+  - api_warocol.com/sql/20260722_public_cities_missing_municipalities.sql
+
+ac:
+  - PATCH public-profile excludes country/currency_code
+  - City combobox commits valid matches on blur (Bogotá sticks)
+  - aguasul typo resolves to aguazul catalog entry
+  - 19 missing DIVIPOLA municipalities inserted (incl. San Andrés isla)
+  - Friendly validation toast on save errors
+
+out_of_scope:
+  - API validator changes for country on public-profile
+  - Full catalog rebuild (1103 already present)
+
+hints:
+  entry: negocio.vue saveChanges — remove country from payload
+  pattern: useCityCatalog.ts — pure search helpers + CITY_SEARCH_ALIASES
+  tests: node --test composables/useCityCatalog.search.test.ts
+  api: apply sql/20260722_public_cities_missing_municipalities.sql on prod after deploy
+
+skip:
+  audits: [ux, color, typography]

--- a/composables/useCityCatalog.search.test.ts
+++ b/composables/useCityCatalog.search.test.ts
@@ -1,0 +1,46 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  filterCityCatalog,
+  resolveCityFromSearchTerm,
+  formatApiValidationError,
+  type PublicCity,
+} from './useCityCatalog.ts'
+
+const catalog: PublicCity[] = [
+  {
+    country: 'Colombia',
+    city: 'Aguazul',
+    city_slug: 'aguazul',
+    tenant_count: 0,
+    department_name: 'Casanare',
+  },
+  {
+    country: 'Colombia',
+    city: 'Bogotá',
+    city_slug: 'bogota',
+    tenant_count: 3,
+    department_name: 'Bogotá, D.C.',
+  },
+]
+
+describe('city catalog search helpers', () => {
+  it('maps aguasul typo to Aguazul', () => {
+    const results = filterCityCatalog(catalog, 'aguasul')
+    assert.equal(results.length, 1)
+    assert.equal(results[0]?.city_slug, 'aguazul')
+  })
+
+  it('resolves Bogotá on blur-style exact match', () => {
+    const match = resolveCityFromSearchTerm(catalog, 'Bogotá')
+    assert.equal(match?.city_slug, 'bogota')
+  })
+
+  it('formats pydantic validation arrays for toast copy', () => {
+    const message = formatApiValidationError(
+      [{ msg: 'country and currency_code are read-only here; use /financial-profile' }],
+      'fallback',
+    )
+    assert.match(message, /read-only/)
+  })
+})

--- a/composables/useCityCatalog.ts
+++ b/composables/useCityCatalog.ts
@@ -26,6 +26,96 @@ export interface PublicCity {
   department_name?: string | null
 }
 
+/** Common misspellings / spoken variants → catalog slug (warocol.com#1740). */
+export const CITY_SEARCH_ALIASES: Record<string, string> = {
+  aguasul: 'aguazul',
+}
+
+export function normalizeCitySearch(value: string | null | undefined): string {
+  return (value ?? '')
+    .toLocaleLowerCase('es-CO')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+}
+
+export function cityDepartmentLabel(city: PublicCity): string | null {
+  return city.department_name || city.department || null
+}
+
+export function citySearchHaystack(city: PublicCity): string {
+  return normalizeCitySearch([
+    city.city,
+    city.city_slug,
+    cityDepartmentLabel(city),
+  ].filter(Boolean).join(' '))
+}
+
+export function filterCityCatalog(
+  cities: PublicCity[],
+  query: string,
+  limit = 20,
+): PublicCity[] {
+  const normalized = normalizeCitySearch(query)
+  if (!normalized) return cities.slice(0, limit)
+
+  const aliasSlug = CITY_SEARCH_ALIASES[normalized]
+  if (aliasSlug) {
+    const aliased = cities.find((city) => city.city_slug === aliasSlug)
+    if (aliased) return [aliased]
+  }
+
+  const startsWithMatches: PublicCity[] = []
+  const includesMatches: PublicCity[] = []
+
+  for (const city of cities) {
+    const cityName = normalizeCitySearch(city.city)
+    const haystack = citySearchHaystack(city)
+    if (cityName.startsWith(normalized)) {
+      startsWithMatches.push(city)
+    } else if (haystack.includes(normalized)) {
+      includesMatches.push(city)
+    }
+    if (startsWithMatches.length + includesMatches.length >= limit) break
+  }
+
+  return [...startsWithMatches, ...includesMatches].slice(0, limit)
+}
+
+export function resolveCityFromSearchTerm(
+  cities: PublicCity[],
+  term: string,
+): PublicCity | null {
+  const normalized = normalizeCitySearch(term)
+  if (!normalized) return null
+
+  const aliasSlug = CITY_SEARCH_ALIASES[normalized]
+  if (aliasSlug) {
+    return cities.find((city) => city.city_slug === aliasSlug) ?? null
+  }
+
+  const exactMatches = cities.filter((city) => normalizeCitySearch(city.city) === normalized)
+  if (exactMatches.length === 1) return exactMatches[0]
+
+  const filtered = filterCityCatalog(cities, term, 5)
+  if (filtered.length === 1) {
+    const only = filtered[0]
+    const onlyName = normalizeCitySearch(only.city)
+    if (onlyName === normalized || onlyName.startsWith(normalized)) return only
+  }
+
+  return null
+}
+
+export function formatApiValidationError(detail: unknown, fallback: string): string {
+  if (typeof detail === 'string') return detail
+  if (Array.isArray(detail) && detail.length > 0) {
+    const first = detail[0] as { msg?: string }
+    if (typeof first?.msg === 'string') return first.msg
+  }
+  return fallback
+}
+
 export function useCityCatalog() {
   const cities = useState<PublicCity[]>('city-catalog', () => [])
   const isLoading = useState<boolean>('city-catalog-loading', () => false)

--- a/pages/negocio.vue
+++ b/pages/negocio.vue
@@ -734,7 +734,15 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onMounted, watch } from 'vue'
-import { useCityCatalog, type PublicCity } from '~/composables/useCityCatalog'
+import {
+  useCityCatalog,
+  type PublicCity,
+  normalizeCitySearch,
+  cityDepartmentLabel,
+  filterCityCatalog,
+  resolveCityFromSearchTerm,
+  formatApiValidationError,
+} from '~/composables/useCityCatalog'
 import { useCatalogSearchDropdownPlacement } from '~/composables/useCatalogSearchDropdownPlacement'
 import { usePOSStore } from '~/stores/usePOSStore'
 import {
@@ -822,47 +830,15 @@ const citySearchTerm = ref('')
 const citySearchOpen = ref(false)
 const citySearchActiveIndex = ref(0)
 
-const normalizeCitySearch = (value: string | null | undefined) =>
-  (value ?? '')
-    .toLocaleLowerCase('es-CO')
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .trim()
-
-const cityDepartment = (city: PublicCity) => city.department_name || city.department || null
-
-const citySearchText = (city: PublicCity) =>
-  normalizeCitySearch([city.city, city.city_slug, cityDepartment(city)].filter(Boolean).join(' '))
+const cityDepartment = (city: PublicCity) => cityDepartmentLabel(city)
 
 const selectedCity = computed(() =>
   cityCatalog.value.find((c) => c.city_slug === editForm.city_slug) ?? null,
 )
 
-const visibleCityResults = computed(() => {
-  const query = normalizeCitySearch(citySearchTerm.value)
-  const source = cityCatalog.value
-
-  if (!query) {
-    return source.slice(0, CITY_RESULT_LIMIT)
-  }
-
-  const startsWithMatches: PublicCity[] = []
-  const includesMatches: PublicCity[] = []
-
-  for (const city of source) {
-    const cityName = normalizeCitySearch(city.city)
-    const haystack = citySearchText(city)
-    if (cityName.startsWith(query)) {
-      startsWithMatches.push(city)
-    } else if (haystack.includes(query)) {
-      includesMatches.push(city)
-    }
-
-    if (startsWithMatches.length + includesMatches.length >= CITY_RESULT_LIMIT) break
-  }
-
-  return [...startsWithMatches, ...includesMatches].slice(0, CITY_RESULT_LIMIT)
-})
+const visibleCityResults = computed(() =>
+  filterCityCatalog(cityCatalog.value, citySearchTerm.value, CITY_RESULT_LIMIT),
+)
 
 const cityDropdownOpen = computed(() =>
   citySearchOpen.value
@@ -902,7 +878,6 @@ const onCityChange = (slug: string) => {
   editForm.city_slug = slug
   const entry = cityCatalog.value.find((c) => c.city_slug === slug)
   editForm.city = entry?.city || ''
-  editForm.country = entry?.country || 'Colombia'
   syncCitySearchTerm()
 }
 
@@ -915,18 +890,22 @@ const clearCitySelection = () => {
   citySearchTerm.value = ''
   editForm.city_slug = ''
   editForm.city = ''
-  editForm.country = 'Colombia'
   citySearchActiveIndex.value = 0
   citySearchOpen.value = true
   nextTick(updateCitySearchPlacement)
 }
 
 const onCitySearchInput = () => {
-  const currentSelection = selectedCity.value
-  if (!currentSelection || normalizeCitySearch(citySearchTerm.value) !== normalizeCitySearch(currentSelection.city)) {
-    editForm.city_slug = ''
-    editForm.city = ''
-    editForm.country = 'Colombia'
+  const resolved = resolveCityFromSearchTerm(cityCatalog.value, citySearchTerm.value)
+  if (resolved) {
+    editForm.city_slug = resolved.city_slug
+    editForm.city = resolved.city
+  } else {
+    const currentSelection = selectedCity.value
+    if (!currentSelection || normalizeCitySearch(citySearchTerm.value) !== normalizeCitySearch(currentSelection.city)) {
+      editForm.city_slug = ''
+      editForm.city = ''
+    }
   }
   citySearchActiveIndex.value = 0
   citySearchOpen.value = true
@@ -938,6 +917,10 @@ const openCitySearch = () => {
 }
 
 const closeCitySearch = () => {
+  if (!editForm.city_slug && citySearchTerm.value.trim()) {
+    const match = resolveCityFromSearchTerm(cityCatalog.value, citySearchTerm.value)
+    if (match) onCityChange(match.city_slug)
+  }
   citySearchOpen.value = false
   citySearchActiveIndex.value = 0
   syncCitySearchTerm()
@@ -1239,7 +1222,6 @@ const saveChanges = async () => {
       phone_number: editForm.phone_number || null,
       email: editForm.email || null,
       address: editForm.address || null,
-      country: editForm.country || 'Colombia',
       city: editForm.city || null,
       city_slug: editForm.city_slug || null,
       neighborhood: editForm.neighborhood || null,
@@ -1260,7 +1242,10 @@ const saveChanges = async () => {
     isEditMode.value = false
     toast.success(t('negocio.profileSaved'), { title: t('negocio.saved') })
   } catch (error: any) {
-    toast.error(error.data?.detail || t('negocio.saveError'), { title: t('negocio.error') })
+    toast.error(
+      formatApiValidationError(error.data?.detail, t('negocio.saveError')),
+      { title: t('negocio.error') },
+    )
   } finally {
     isSaving.value = false
   }


### PR DESCRIPTION
## Summary
- Stop sending read-only `country` on `/tenant/public-profile` PATCH so Mi Negocio saves succeed
- City combobox commits valid catalog matches on blur; `aguasul` typo resolves to **Aguazul**
- Friendlier validation error toast (no raw JSON blob)

Closes #1740

## Test plan
- [ ] Open `/negocio`, edit profile, save — no 422 on country
- [ ] Search `aguasul` → pick Aguazul → field stays; save works
- [ ] Type `Bogotá`, blur — city persists
- [ ] `node --test composables/useCityCatalog.search.test.ts`

## wr-context
See `.wr/1740.yaml` on this branch.

## Companion
API PR adds 19 missing DIVIPOLA municipalities (`uno0uno/api-warolabs`).

Made with [Cursor](https://cursor.com)