### PR TITLE
Starter front navigation — plan gating, hide Finance/Billing, home redirect

### DIFF
--- a/components/DashboardSidebar.vue
+++ b/components/DashboardSidebar.vue
@@ -19,7 +19,7 @@
   >
     <template #brand>
       <NuxtLink
-        to="/financiero"
+        :to="dashboardHome"
         class="flex h-11 w-[7.25rem] min-w-0 items-center justify-center overflow-hidden"
         :aria-label="t('shell.goToDashboardHome')"
       >
@@ -174,6 +174,7 @@ import {
   type ActivePage,
   type DashboardNavItem,
 } from '~/constants/dashboardNavigation'
+import { getDashboardHome } from '~/utils/internalAccess'
 
 interface Props {
   activePage?: ActivePage
@@ -212,6 +213,10 @@ const authStore = useAuthStore()
 const { can } = useModuleAccess()
 const { hasFeature } = useFeatureAccess()
 const accessStore = useAccessStore()
+
+const dashboardHome = computed(() =>
+  getDashboardHome(accessStore.modules, { isLoaded: accessStore.isLoaded }),
+)
 
 const canSeeNavItem = (item: DashboardNavItem) =>
   can(item.module).value && (!item.feature || hasFeature(item.feature).value)

--- a/components/dashboard/DashboardShellHeader.vue
+++ b/components/dashboard/DashboardShellHeader.vue
@@ -4,7 +4,7 @@
       <div class="flex min-w-0 items-center gap-2 sm:gap-4">
         <NuxtLink
           v-if="!hideLogo"
-          to="/financiero"
+          :to="dashboardHome"
           class="dashboard-header-logo hidden xl:flex h-12 w-fit min-w-[214px] flex-shrink-0 items-center justify-center overflow-visible"
           :aria-label="t('shell.goToDashboardHome')"
         >
@@ -108,8 +108,15 @@
 </template>
 
 <script setup lang="ts">
+import { getDashboardHome } from '~/utils/internalAccess'
+
 const route = useRoute()
 const { t } = useI18n()
+const accessStore = useAccessStore()
+
+const dashboardHome = computed(() =>
+  getDashboardHome(accessStore.modules, { isLoaded: accessStore.isLoaded }),
+)
 
 const logoAnimationSrc = computed(() =>
   `/brand/waro-colombia-animated.svg?route=${encodeURIComponent(route.fullPath)}`,

--- a/composables/useBilling.ts
+++ b/composables/useBilling.ts
@@ -52,7 +52,7 @@ export interface TenantSubscription {
 }
 
 export interface AccessStatus {
-  level: 'free' | 'full' | 'full_with_warning' | 'read_only' | 'blocked'
+  level: 'free' | 'starter' | 'full' | 'full_with_warning' | 'read_only' | 'blocked'
   grace_days_remaining: number | null
   subscription_status: string | null
   next_payment_date: string | null

--- a/composables/useModuleAccess.ts
+++ b/composables/useModuleAccess.ts
@@ -24,6 +24,7 @@ export const useModuleAccess = () => {
   const store = useAccessStore()
 
   const role = computed(() => store.role)
+  const planSlug = computed(() => store.planSlug)
   const enforcementMode = computed(() => store.enforcementMode)
   const isLoaded = computed(() => store.isLoaded)
 
@@ -31,20 +32,11 @@ export const useModuleAccess = () => {
    * Returns a `ComputedRef<boolean>` that's `true` when the current user
    * can access `module`.
    *
-   * Fail-open semantics — always `true` when `enforcementMode` is
-   * `'disabled'` or `'shadow'`. Only `'enforce'` mode actually checks
-   * membership. This mirrors the backend's gate behavior so the UI matches
-   * runtime authorization without surprises.
-   *
-   * Usage in templates:
-   *   <button v-if="can('finanzas').value">Ver finanzas</button>
-   *
-   * Usage in script setup:
-   *   const finanzasAccess = can('finanzas')
-   *   watch(finanzasAccess, (newVal) => { ... })
+   * After access loads, membership reflects effective modules from
+   * `/me/access` (role ∩ plan). Pre-load fail-open preserves hydration UX.
    */
   const can = (module: Module): ComputedRef<boolean> =>
     computed(() => store.can(module))
 
-  return { role, enforcementMode, isLoaded, can }
+  return { role, planSlug, enforcementMode, isLoaded, can }
 }

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -36,7 +36,7 @@
           <nav v-if="showBreadcrumb" class="flex mb-6" :aria-label="t('shell.breadcrumb')">
             <ol class="inline-flex items-center space-x-1 md:space-x-3">
               <li class="inline-flex items-center">
-                <NuxtLink to="/financiero"
+                <NuxtLink :to="dashboardHome"
                   class="text-sm font-medium text-text-secondary hover:text-primary transition-colors">
                   {{ t('shell.financiero') }}
                 </NuxtLink>
@@ -86,6 +86,7 @@ import {
 import { useNotifications } from '~/composables/useNotifications'
 import { useBilling } from '~/composables/useBilling'
 import { usePosMobileCart } from '~/composables/usePosMobileCart'
+import { getDashboardHome } from '~/utils/internalAccess'
 
 const { t } = useI18n()
 
@@ -94,6 +95,9 @@ const { unreadCount: notificationsUnreadCount } = useNotifications()
 
 // Billing access status — drives banner and blocked redirect (Mi Plan roles only)
 const accessStore = useAccessStore()
+const dashboardHome = computed(() =>
+  getDashboardHome(accessStore.modules, { isLoaded: accessStore.isLoaded }),
+)
 const { accessStatus, fetchAccessStatus } = useBilling({ overview: false })
 const isBillingBlocked = computed(() =>
   accessStore.can('mi_plan') && accessStatus.value?.level === 'blocked',

--- a/middleware/billing-gate.global.ts
+++ b/middleware/billing-gate.global.ts
@@ -69,7 +69,11 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   }
 
   const level = accessStatus?.level
-  const hasAccess = level === 'free' || level === 'full' || level === 'full_with_warning' || level === 'read_only'
+  const hasAccess = level === 'free'
+    || level === 'starter'
+    || level === 'full'
+    || level === 'full_with_warning'
+    || level === 'read_only'
 
   if (!hasAccess) {
     return navigateTo('/gestion/billing')

--- a/middleware/module-access.global.ts
+++ b/middleware/module-access.global.ts
@@ -1,38 +1,26 @@
 /**
- * module-access.global.ts — Epic 4 (warocol.com#489) sub-task #557.
+ * module-access.global.ts — Epic 4 (#557) + Starter plan gating (#695).
  *
- * Route-level enforcement of module access. Activates only when:
- *   1. The destination page declares `definePageMeta({ module: 'X' })` (#558).
- *   2. The tenant's `enforcement_mode` is `'enforce'` (flipped per-tenant in
- *      Epic 6).
+ * Route-level enforcement for pages with `definePageMeta({ module })`.
+ * Uses effective modules from GET /me/access (role ∩ plan). Starter tenants
+ * are redirected to Mi Plan; role-only denials go to /403.
  *
- * Otherwise no-op (fail-open). Mirrors the backend's behavior — backend's
- * `require_module()` also passes through on `'disabled'` / `'shadow'` modes,
- * so the frontend gate matches what the API would actually return.
- *
- * Execution order: runs after `auth.global.js` (which hydrates
- * `useAccessStore`) and after `billing-gate.global.ts` (no point gating
- * modules for a user who's about to be redirected to billing).
- *
- * Redirect target `/403` ships in #561. Until that lands, a denial would
- * hit a 404 — but denial only triggers when `enforcement_mode === 'enforce'`
- * AND a page has `module` meta, neither of which exists in production
- * today. The coordination requirement: #561 must merge BEFORE any tenant
- * is flipped to `'enforce'`.
+ * Runs after auth.global.js (hydrates access store) and billing-gate.global.ts.
  */
-export default defineNuxtRouteMiddleware((to) => {
+import type { Module } from '~/stores/access'
+import { getModuleAccessDenialRedirect } from '~/utils/internalAccess'
+
+export default defineNuxtRouteMiddleware(async (to) => {
   if (process.server) return
 
-  // Skip-list: routes that never require module gating. Mirrors the lists
-  // in auth.global.js and billing-gate.global.ts. If this list drifts,
-  // extract to utils/route-helpers.ts as a follow-up.
   const skipExact = ['/', '/bogota']
   const skipPrefixes = [
     '/auth/',
     '/proveedor/',
     '/blog',
     '/docs',
-    '/403', // prevent infinite redirect loop if /403 itself gets gated
+    '/403',
+    '/gestion/billing',
   ]
   const skipLayouts = ['public-restaurant', 'customer-portal', 'kds']
 
@@ -43,19 +31,15 @@ export default defineNuxtRouteMiddleware((to) => {
     to.meta?.publicAccess === true
   ) return
 
-  // Page didn't opt in to module gating → pass through.
-  // PageMeta.module type augmentation lives in app.d.ts (added in #558).
-  const moduleKey = to.meta.module
+  const moduleKey = to.meta.module as Module | undefined
   if (!moduleKey) return
 
-  const { can, enforcementMode } = useModuleAccess()
+  const accessStore = useAccessStore()
+  if (!accessStore.isLoaded) {
+    await accessStore.load()
+  }
 
-  // Fail-open: only 'enforce' mode actually denies. 'disabled' and 'shadow'
-  // let the request through (backend behavior matches).
-  if (enforcementMode.value !== 'enforce') return
-
-  // Denied → redirect to /403 (page ships in #561).
-  if (!can(moduleKey).value) {
-    return navigateTo('/403')
+  if (!accessStore.can(moduleKey)) {
+    return navigateTo(getModuleAccessDenialRedirect(accessStore))
   }
 })

--- a/pages/financiero.vue
+++ b/pages/financiero.vue
@@ -1,10 +1,20 @@
 <script setup lang="ts">
-// Redirect /financiero to /finanzas/gastos
+import { getFirstAccessibleHome } from '~/utils/internalAccess'
+
 definePageMeta({
-  layout: 'dashboard'
+  layout: 'dashboard',
 })
 
-navigateTo('/finanzas/gastos')
+const accessStore = useAccessStore()
+if (!accessStore.isLoaded) {
+  await accessStore.load()
+}
+
+const target = accessStore.modules.includes('finanzas')
+  ? '/finanzas/gastos'
+  : getFirstAccessibleHome(accessStore.modules)
+
+await navigateTo(target, { replace: true })
 </script>
 
 <template>

--- a/plugins/access-watcher.client.ts
+++ b/plugins/access-watcher.client.ts
@@ -1,40 +1,24 @@
 /**
- * access-watcher.client.ts — Epic 4 (warocol.com#489) sub-task #562.
+ * access-watcher.client.ts — Epic 4 (#562) + Starter plan gating (#695).
  *
- * Detects mid-session permission changes and silently redirects the user
- * off any page they can no longer access. Complements:
- *   - `module-access.global.ts` (#557) — gates on navigation
- *   - `useAccessStore.armPolling()` (#562) — refreshes state every 60s
- *
- * This plugin closes the gap: when the polling tick updates `modules` while
- * the user is parked on a static page, the route middleware never re-fires,
- * so we need a reactive watcher to yank them off the now-forbidden route.
- *
- * Client-only by file extension — Nuxt skips it during SSR, so the watcher
- * + navigateTo() never run on the server.
+ * Redirects when polling updates modules while the user is on a gated page.
  */
+import type { Module } from '~/stores/access'
+import { getModuleAccessDenialRedirect } from '~/utils/internalAccess'
+
 export default defineNuxtPlugin(() => {
   const accessStore = useAccessStore()
   const route = useRoute()
 
-  // Single derived gate. Reads `route.path`, `route.meta.module`, and
-  // (through store.can) `enforcementMode` + `modulesSet` — all reactive,
-  // so this recomputes whenever any input changes.
   const canStayOnRoute = computed<boolean>(() => {
-    // Defensive: prevent redirect loop if /403 itself is somehow gated.
-    if (route.path === '/403') return true
-    // Page didn't opt in to module gating → always allowed.
-    const moduleKey = route.meta.module
+    if (route.path === '/403' || route.path.startsWith('/gestion/billing')) return true
+    const moduleKey = route.meta.module as Module | undefined
     if (!moduleKey) return true
-    // store.can() returns true when enforcementMode !== 'enforce' (fail-open),
-    // so today's `disabled`/`shadow` tenants never trigger the redirect.
+    if (!accessStore.isLoaded) return true
     return accessStore.can(moduleKey)
   })
 
-  // `flush: 'post'` ensures the watcher runs after Vue Router has finished
-  // committing the navigation, so `route.meta.module` is the destination's
-  // value, not the source's.
   watch(canStayOnRoute, (allowed) => {
-    if (!allowed) navigateTo('/403')
+    if (!allowed) navigateTo(getModuleAccessDenialRedirect(accessStore))
   }, { flush: 'post' })
 })

--- a/stores/access.ts
+++ b/stores/access.ts
@@ -39,6 +39,7 @@ type AccessFeatures = Partial<Record<AccessFeature, boolean>>
 interface AccessResponse {
   role: string | null
   modules: string[]
+  plan_slug?: string | null
   enforcement_mode: EnforcementMode
   features?: AccessFeatures
 }
@@ -54,6 +55,7 @@ let pollingHandle: ReturnType<typeof setInterval> | null = null
 export const useAccessStore = defineStore('access', () => {
   const role = ref<string | null>(null)
   const modules = ref<string[]>([])
+  const planSlug = ref<string | null>(null)
   const enforcementMode = ref<EnforcementMode>('disabled')
   const features = ref<AccessFeatures>({})
   const isLoaded = ref(false)
@@ -68,6 +70,7 @@ export const useAccessStore = defineStore('access', () => {
       const data = await $fetch<AccessResponse>('/api/me/access')
       role.value = data.role
       modules.value = data.modules ?? []
+      planSlug.value = data.plan_slug ?? null
       enforcementMode.value = data.enforcement_mode ?? 'disabled'
       features.value = data.features ?? {}
       isLoaded.value = true
@@ -89,6 +92,7 @@ export const useAccessStore = defineStore('access', () => {
     stopPolling()
     role.value = null
     modules.value = []
+    planSlug.value = null
     enforcementMode.value = 'disabled'
     features.value = {}
     isLoaded.value = false
@@ -113,14 +117,15 @@ export const useAccessStore = defineStore('access', () => {
   /**
    * Returns true if the current user can access `module`.
    *
-   * Fail-open semantics: when enforcementMode is 'disabled' or 'shadow',
-   * always returns true so the frontend renders today's behavior (no menu
-   * items hidden, no redirects). Backend mirrors this — shadow mode logs
-   * but does not deny.
-   *
-   * Only 'enforce' mode actually checks membership against `modules`.
+   * `/me/access` modules are already role ∩ plan (api-warolabs#694). Once
+   * loaded, membership is always enforced so Starter nav/routes match the API
+   * regardless of RBAC enforcement_mode. Pre-load keeps Epic 4 fail-open so
+   * the shell does not flash empty during hydration.
    */
   function can(module: Module): boolean {
+    if (isLoaded.value) {
+      return modulesSet.value.has(module)
+    }
     if (enforcementMode.value !== 'enforce') return true
     return modulesSet.value.has(module)
   }
@@ -137,6 +142,7 @@ export const useAccessStore = defineStore('access', () => {
   return {
     role: readonly(role),
     modules: readonly(modules),
+    planSlug: readonly(planSlug),
     enforcementMode: readonly(enforcementMode),
     features: readonly(features),
     isLoaded: readonly(isLoaded),

--- a/utils/internalAccess.test.ts
+++ b/utils/internalAccess.test.ts
@@ -3,7 +3,9 @@ import assert from 'node:assert/strict'
 import {
   canUseInternalSession,
   getAccessAwareRedirect,
+  getDashboardHome,
   getFirstAccessibleHome,
+  getModuleAccessDenialRedirect,
   hasExplicitInternalAccessAllow,
   hasExplicitInternalAccessDenial,
 } from './internalAccess.ts'
@@ -131,5 +133,38 @@ describe('module-aware internal redirects', () => {
 
   it('returns public home when no modules are available', () => {
     assert.equal(getFirstAccessibleHome([]), '/')
+  })
+})
+
+describe('dashboard home helpers', () => {
+  it('returns POS for starter-like module sets', () => {
+    assert.equal(
+      getDashboardHome(['pos', 'ventas', 'menu', 'mi_negocio', 'mi_plan']),
+      '/pos',
+    )
+  })
+
+  it('falls back to POS before access loads', () => {
+    assert.equal(getDashboardHome([], { isLoaded: false }), '/pos')
+  })
+
+  it('sends starter owners with mi_plan to billing on plan denial', () => {
+    assert.equal(
+      getModuleAccessDenialRedirect({
+        planSlug: 'starter',
+        can: (module) => module === 'mi_plan',
+      }),
+      '/gestion/billing',
+    )
+  })
+
+  it('sends non-starter denials to /403', () => {
+    assert.equal(
+      getModuleAccessDenialRedirect({
+        planSlug: 'pro',
+        can: () => false,
+      }),
+      '/403',
+    )
   })
 })

--- a/utils/internalAccess.ts
+++ b/utils/internalAccess.ts
@@ -204,6 +204,24 @@ export const getFirstAccessibleHome = (modules: readonly string[] | undefined | 
   return '/'
 }
 
+export const getDashboardHome = (
+  modules: readonly string[] | undefined | null,
+  options?: { isLoaded?: boolean },
+) => {
+  if (options?.isLoaded === false) return INTERNAL_APP_HOME
+  return getFirstAccessibleHome(modules)
+}
+
+export const getModuleAccessDenialRedirect = (accessStore: {
+  planSlug: string | null
+  can: (module: string) => boolean
+}) => {
+  if (accessStore.planSlug === 'starter' && accessStore.can('mi_plan')) {
+    return '/gestion/billing'
+  }
+  return '/403'
+}
+
 const getSafeRedirectTarget = (redirect: unknown) => {
   const target = Array.isArray(redirect) ? redirect[0] : redirect
   if (typeof target !== 'string') return null


### PR DESCRIPTION
## Summary
- Always enforce `/me/access` module membership once loaded (API already applies role ∩ plan from api-warolabs#694)
- Persist `plan_slug` in access store; allow `starter` in billing gate and `AccessStatus`
- Plan-aware home links and `/financiero` redirect to `/pos` when Finance is unavailable
- Route middleware + access watcher redirect starter plan blocks to Mi Plan; role denials → `/403`

Refs uno0uno/api-warolabs#695 (epic #692 batch 3)

## Validation evidence

```
$ bun test utils/internalAccess.test.ts
(pass) dashboard home helpers > returns POS for starter-like module sets
(pass) dashboard home helpers > falls back to POS before access loads
(pass) dashboard home helpers > sends starter owners with mi_plan to billing on plan denial
(pass) dashboard home helpers > sends non-starter denials to /403
 18 pass
 0 fail
```

## Manual AC (staging)
- [ ] Starter owner: sidebar hides finanzas, facturacion, equipo, integraciones, despacho, asistente
- [ ] Starter owner: `/finanzas/gastos` → `/gestion/billing`; post-login → `/pos`
- [ ] Pro owner: nav and `/financiero` → `/finanzas/gastos` unchanged

## Test plan
- [x] `bun test utils/internalAccess.test.ts`
- [ ] Manual starter + pro owner smoke on dev tenant


Made with [Cursor](https://cursor.com)