### PR TITLE
feat(menu): use tenant display currency across menu money UI

### DIFF
--- a/.wr/1744.yaml
+++ b/.wr/1744.yaml
@@ -1,0 +1,44 @@
+# Compact plan — wr-fast #1744. Keep <=80 lines.
+issue: 1744
+title: "feat(menu): use tenant display currency across menu money UI"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1744-menu-display-currency
+
+paths:
+  - pages/menu/productos/crear.vue
+  - pages/menu/productos/[id].vue
+  - pages/menu/productos/index.vue
+  - pages/menu/modificadores/index.vue
+  - composables/useModifierOptionForm.ts
+  - components/menu/MenuModifierOptionEditor.vue
+  - components/menu/ProductQuickCreatePanel.vue
+  - .wr/1744.yaml
+
+ac:
+  - Product create/edit/list use useFormatters formatCurrency — no local COP helpers
+  - Modifier list + option editor use shared formatter; formatModifierCurrency not COP-hardcoded
+  - Quick-create panel uses tenant currency indicator
+  - Input prefixes / amounts reflect tenant currency (e.g. MXN)
+  - Recipes list smoke-ok; no FX/API/FE changes
+  - Optional: UiDecimalInput precision from currencyMinorUnits
+
+out_of_scope:
+  - FX, ledger conversion, FE/DIAN, abastecimiento non-menu, API price schema
+
+hints:
+  entry: "useFormatters currencyCode + formatCurrency; mirror pages/menu/recetas/index.vue"
+  pattern: "composables/useFormatters.ts:71-82; utils/currencyDisplay.ts formatMoney"
+  tests: "bun test utils/currencyDisplay.test.ts composables/useModifierOptionForm.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "ready-for-review + wr-review"

--- a/components/menu/MenuModifierOptionEditor.vue
+++ b/components/menu/MenuModifierOptionEditor.vue
@@ -29,11 +29,11 @@
       <div class="md:col-span-2">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.additionalUnitPrice') }}</label>
         <div class="relative">
-          <span class="absolute start-3 top-1/2 -translate-y-1/2 text-text-secondary text-sm">$</span>
+          <span class="absolute start-3 top-1/2 -translate-y-1/2 text-xs font-medium text-text-secondary">{{ currencyCode }}</span>
           <UiDecimalInput
             v-model="modifier.price"
-            :precision="0"
-            class="input-base w-full ps-8 pe-3 py-2 text-sm"
+            :precision="currencyMinorUnits"
+            class="input-base w-full ps-12 pe-3 py-2 text-sm"
           />
         </div>
       </div>
@@ -335,7 +335,6 @@ import {
   applyModifierIncludedQuantity,
   applyModifierMaxLimit,
   applyModifierUiOptionType,
-  formatModifierCurrency,
   getModifierUiOptionType,
   type ModifierFormRow,
   type ModifierRecipeLineForm,
@@ -345,6 +344,7 @@ import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 import { fetchResaleLinkedIngredient } from '~/composables/useResaleLinkedIngredient'
 
 const { t } = useI18n({ useScope: 'global' })
+const { formatCurrency, currencyCode, currencyMinorUnits } = useFormatters()
 const WAREHOUSE_COPY = useWarehouseCopy()
 
 const props = defineProps<{
@@ -498,24 +498,24 @@ function estimateRecipeCost(): number | null {
 }
 
 const ingredientCostLabel = computed(() => {
-  if (props.modifier.unit_cost != null) return formatModifierCurrency(props.modifier.unit_cost)
+  if (props.modifier.unit_cost != null) return formatCurrency(props.modifier.unit_cost)
   const ing = props.modifier.ingredient_id
     ? props.getIngredientById(props.modifier.ingredient_id)
     : undefined
   const unit = Number(ing?.costo_unitario ?? 0)
   const qty = Number(props.modifier.ingredient_quantity) || 0
   if (!unit || !qty) return '—'
-  return formatModifierCurrency(unit * qty)
+  return formatCurrency(unit * qty)
 })
 
 const recipeCostLabel = computed(() => {
-  if (props.modifier.unit_cost != null) return formatModifierCurrency(props.modifier.unit_cost)
+  if (props.modifier.unit_cost != null) return formatCurrency(props.modifier.unit_cost)
   const est = estimateRecipeCost()
-  return est != null ? formatModifierCurrency(est) : '—'
+  return est != null ? formatCurrency(est) : '—'
 })
 
 const productCostLabel = computed(() => {
-  if (props.modifier.unit_cost != null) return formatModifierCurrency(props.modifier.unit_cost)
+  if (props.modifier.unit_cost != null) return formatCurrency(props.modifier.unit_cost)
   return '—'
 })
 </script>

--- a/components/menu/ProductQuickCreatePanel.vue
+++ b/components/menu/ProductQuickCreatePanel.vue
@@ -88,14 +88,14 @@
               Precio de venta <span class="text-destructive">*</span>
             </label>
             <div class="relative">
-              <span class="absolute start-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
+              <span class="absolute start-3 top-1/2 -translate-y-1/2 text-xs font-medium text-text-secondary">{{ currencyCode }}</span>
               <UiDecimalInput
                 id="product-quick-price"
                 v-model="form.price"
                 :min="0"
-                :precision="0"
+                :precision="currencyMinorUnits"
                 placeholder="2500"
-                class="h-10 w-full rounded-lg border-2 border-border bg-background ps-8 pe-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 transition-colors"
+                class="h-10 w-full rounded-lg border-2 border-border bg-background ps-12 pe-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 transition-colors"
                 @input="clearError('price')"
               />
             </div>
@@ -107,14 +107,14 @@
               Mi costo del plato
             </label>
             <div class="relative">
-              <span class="absolute start-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
+              <span class="absolute start-3 top-1/2 -translate-y-1/2 text-xs font-medium text-text-secondary">{{ currencyCode }}</span>
               <UiDecimalInput
                 id="product-quick-costo"
                 v-model="form.costo_percibido"
                 :min="0"
-                :precision="0"
+                :precision="currencyMinorUnits"
                 placeholder="Opcional"
-                class="h-10 w-full rounded-lg border-2 border-border bg-background ps-8 pe-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 transition-colors"
+                class="h-10 w-full rounded-lg border-2 border-border bg-background ps-12 pe-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 transition-colors"
               />
             </div>
             <p class="text-xs text-text-tertiary">
@@ -215,6 +215,7 @@ const emit = defineEmits<Emits>()
 const cache = useQueryCache()
 const toast = useToast()
 const { currentTenant } = useTenantReactive()
+const { currencyCode, currencyMinorUnits } = useFormatters()
 
 const inputClass = 'h-10 w-full rounded-lg border-2 border-border bg-background px-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 transition-colors'
 

--- a/composables/useModifierOptionForm.ts
+++ b/composables/useModifierOptionForm.ts
@@ -409,11 +409,12 @@ export function formatModifierOptionTypeLabel(type: string): string {
   }
 }
 
-export function formatModifierCurrency(value: number | null | undefined): string {
+import { formatMoney } from '~/utils/currencyDisplay'
+
+export function formatModifierCurrency(
+  value: number | null | undefined,
+  currency?: string | null,
+): string {
   if (value == null) return '—'
-  return new Intl.NumberFormat('es-CO', {
-    style: 'currency',
-    currency: 'COP',
-    minimumFractionDigits: 0,
-  }).format(value)
+  return formatMoney(value, { currency })
 }

--- a/composables/useModifierOptionForm.ts
+++ b/composables/useModifierOptionForm.ts
@@ -408,13 +408,3 @@ export function formatModifierOptionTypeLabel(type: string): string {
       return type
   }
 }
-
-import { formatMoney } from '~/utils/currencyDisplay'
-
-export function formatModifierCurrency(
-  value: number | null | undefined,
-  currency?: string | null,
-): string {
-  if (value == null) return '—'
-  return formatMoney(value, { currency })
-}

--- a/pages/menu/modificadores/index.vue
+++ b/pages/menu/modificadores/index.vue
@@ -286,7 +286,8 @@
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import { useTenantReactive } from '@/composables/useTenantReactive'
-const { t, locale } = useI18n({ useScope: 'global' })
+const { t } = useI18n({ useScope: 'global' })
+const { formatCurrency } = useFormatters()
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
@@ -446,14 +447,6 @@ const gruposTableColumns = [
     align: 'center'
   }
 ]
-
-const formatCurrency = (value: number) => {
-  return new Intl.NumberFormat(toNumberLocaleTag(locale.value), {
-    style: 'currency',
-    currency: 'COP',
-    minimumFractionDigits: 0
-  }).format(value)
-}
 
 const toggleExpanded = (grupoId: string) => {
   if (expandedRows.value.has(grupoId)) {

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -183,13 +183,13 @@
                   {{ t('menu.productos.salePriceRequired') }}
                 </label>
                 <div class="relative">
-                  <span class="absolute start-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
+                  <span class="absolute start-3 top-1/2 -translate-y-1/2 text-xs font-medium text-text-secondary">{{ currencyCode }}</span>
                   <UiDecimalInput
                     v-model="form.price"
                     required
-                    :precision="0"
+                    :precision="currencyMinorUnits"
                     :min="0"
-                    class="input-base w-full ps-8 pe-4 py-2"
+                    class="input-base w-full ps-12 pe-4 py-2"
                     placeholder="15000"
                   />
                 </div>
@@ -200,12 +200,11 @@
                   {{ t('menu.productos.realCostSystem') }}
                 </label>
                 <div class="relative">
-                  <span class="absolute start-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
                   <input
                     :value="displayRealCost === null ? '—' : formatCurrency(displayRealCost)"
                     type="text"
                     disabled
-                    class="input-base w-full ps-8 pe-4 py-2 bg-surface-secondary cursor-not-allowed"
+                    class="input-base w-full px-4 py-2 bg-surface-secondary cursor-not-allowed"
                     placeholder="0"
                   />
                 </div>
@@ -222,12 +221,12 @@
                   {{ t('menu.productos.dishCost') }}
                 </label>
                 <div class="relative">
-                  <span class="absolute start-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
+                  <span class="absolute start-3 top-1/2 -translate-y-1/2 text-xs font-medium text-text-secondary">{{ currencyCode }}</span>
                   <UiDecimalInput
                     v-model="form.costo_percibido"
-                    :precision="0"
+                    :precision="currencyMinorUnits"
                     :min="0"
-                    class="input-base w-full ps-8 pe-4 py-2"
+                    class="input-base w-full ps-12 pe-4 py-2"
                     :placeholder="t('menu.productos.optional')"
                   />
                 </div>
@@ -905,7 +904,8 @@ const route = useRoute()
 const router = useRouter()
 const cache = useQueryCache()
 const toast = useToast()
-const { t, locale } = useI18n({ useScope: 'global' })
+const { t } = useI18n({ useScope: 'global' })
+const { formatCurrency, currencyCode, currencyMinorUnits } = useFormatters()
 const WAREHOUSE_COPY = useWarehouseCopy()
 const { currentTenant, businessProfile } = useTenantReactive()
 
@@ -1698,14 +1698,6 @@ const confirmDelete = async () => {
 const cancel = () => {
   // clearNuxtData()
   router.push('/menu/productos')
-}
-
-const formatCurrency = (value: number) => {
-  return new Intl.NumberFormat(toNumberLocaleTag(locale.value), {
-    style: 'currency',
-    currency: 'COP',
-    minimumFractionDigits: 0
-  }).format(value)
 }
 
 useHead({

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -200,13 +200,13 @@
                     {{ t('menu.productos.salePriceRequired') }}
                   </label>
                   <div class="relative">
-                    <span class="absolute start-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
+                    <span class="absolute start-3 top-1/2 -translate-y-1/2 text-xs font-medium text-text-secondary">{{ currencyCode }}</span>
                     <UiDecimalInput
                       v-model="form.price"
                       required
-                      :precision="0"
+                      :precision="currencyMinorUnits"
                       :min="0"
-                      class="input-base w-full ps-8 pe-4 py-2"
+                      class="input-base w-full ps-12 pe-4 py-2"
                       placeholder="15000"
                     />
                   </div>
@@ -217,12 +217,11 @@
                     {{ t('menu.productos.calculatedCost') }}
                   </label>
                   <div class="relative">
-                    <span class="absolute start-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
                     <input
                       :value="calculatedCost === null ? '—' : formatCurrency(calculatedCost)"
                       type="text"
                       disabled
-                      class="input-base w-full ps-8 pe-4 py-2 bg-surface-secondary cursor-not-allowed"
+                      class="input-base w-full px-4 py-2 bg-surface-secondary cursor-not-allowed"
                       placeholder="0"
                     />
                   </div>
@@ -236,12 +235,12 @@
                     {{ t('menu.productos.dishCost') }} <span class="text-text-tertiary font-normal">{{ t('menu.recetas.form.optionalSuffix') }}</span>
                   </label>
                   <div class="relative">
-                    <span class="absolute start-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
+                    <span class="absolute start-3 top-1/2 -translate-y-1/2 text-xs font-medium text-text-secondary">{{ currencyCode }}</span>
                     <UiDecimalInput
                       v-model="form.costo_percibido"
-                      :precision="0"
+                      :precision="currencyMinorUnits"
                       :min="0"
-                      class="input-base w-full ps-8 pe-4 py-2"
+                      class="input-base w-full ps-12 pe-4 py-2"
                       :placeholder="t('menu.productos.referenceInternal')"
                     />
                   </div>
@@ -738,7 +737,8 @@ definePageMeta({
   module: 'menu',
 })
 
-const { t, locale } = useI18n({ useScope: 'global' })
+const { t } = useI18n({ useScope: 'global' })
+const { formatCurrency, currencyCode, currencyMinorUnits } = useFormatters()
 const WAREHOUSE_COPY = useWarehouseCopy()
 
 useHead({ title: t('menu.recetas.form.createTitle') })
@@ -1377,12 +1377,4 @@ async function submitProduct() {
   }
 }
 
-function formatCurrency(value: number) {
-  if (!value) return '$0'
-  return new Intl.NumberFormat(toNumberLocaleTag(locale.value), {
-    style: 'currency',
-    currency: 'COP',
-    minimumFractionDigits: 0
-  }).format(value)
-}
 </script>

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -273,14 +273,14 @@
                   />
                   <div class="flex flex-wrap gap-2 mt-2">
                     <div class="relative w-fit shrink-0">
-                      <span class="absolute start-2 top-1/2 -translate-y-1/2 text-text-secondary text-xs pointer-events-none">$</span>
+                      <span class="absolute start-2 top-1/2 -translate-y-1/2 text-text-secondary text-[10px] font-medium pointer-events-none">{{ currencyCode }}</span>
                       <label class="sr-only" :for="`mobile-price-${item.id}`">{{ t('menu.common.precio') }}</label>
                       <UiDecimalInput
                         :id="`mobile-price-${item.id}`"
                         v-model="ensureDraft(item).price"
                         :min="0"
-                        :precision="0"
-                        class="input-base input-money w-fit min-w-[7rem] max-w-none ps-5 pe-2 py-1.5 text-sm tabular-nums text-end"
+                        :precision="currencyMinorUnits"
+                        class="input-base input-money w-fit min-w-[7rem] max-w-none ps-9 pe-2 py-1.5 text-sm tabular-nums text-end"
                         :style="{ width: moneyInputWidth(ensureDraft(item).price) }"
                         :placeholder="t('menu.common.precio')"
                       />
@@ -291,7 +291,7 @@
                         :id="`mobile-costo-${item.id}`"
                         v-model="ensureDraft(item).costo_percibido"
                         :min="0"
-                        :precision="0"
+                        :precision="currencyMinorUnits"
                         class="input-base input-money w-fit min-w-[7rem] max-w-none px-2 py-1.5 text-sm tabular-nums text-end"
                         :style="{ width: moneyInputWidth(ensureDraft(item).costo_percibido) }"
                         :placeholder="t('menu.productos.miCosto')"
@@ -509,12 +509,12 @@
               class="relative w-fit ms-auto shrink-0"
               @click.stop
             >
-              <span class="absolute start-2 top-1/2 -translate-y-1/2 text-text-secondary text-xs pointer-events-none">$</span>
+              <span class="absolute start-2 top-1/2 -translate-y-1/2 text-text-secondary text-[10px] font-medium pointer-events-none">{{ currencyCode }}</span>
               <UiDecimalInput
                 v-model="ensureDraft(item).price"
                 :min="0"
-                :precision="0"
-                class="input-base input-money w-fit min-w-[7rem] max-w-none ps-5 pe-2 py-1.5 text-sm text-end tabular-nums"
+                :precision="currencyMinorUnits"
+                class="input-base input-money w-fit min-w-[7rem] max-w-none ps-9 pe-2 py-1.5 text-sm text-end tabular-nums"
                 :style="{ width: moneyInputWidth(ensureDraft(item).price) }"
                 :aria-label="`Precio de ${item.name}`"
                 placeholder="0"
@@ -542,7 +542,7 @@
                 <UiDecimalInput
                   v-model="ensureDraft(item).costo_percibido"
                   :min="0"
-                  :precision="0"
+                  :precision="currencyMinorUnits"
                   class="input-base input-money w-fit min-w-[7rem] max-w-none px-2 py-1.5 text-sm text-end tabular-nums"
                   :style="{ width: moneyInputWidth(ensureDraft(item).costo_percibido) }"
                   :aria-label="`Mi costo de ${item.name}`"
@@ -885,7 +885,8 @@ import { useMenuCatalogEditMode } from '@/composables/useMenuCatalogEditMode'
 import { useMenuCatalogSelection } from '@/composables/useMenuCatalogSelection'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 import { useToast } from '@/composables/useToast'
-const { t, locale } = useI18n({ useScope: 'global' })
+const { t } = useI18n({ useScope: 'global' })
+const { formatCurrency, currencyCode, currencyMinorUnits } = useFormatters()
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
@@ -1665,21 +1666,11 @@ const productosTableColumns = computed(() => {
   return cols
 })
 
-/** Ancho dinámico en `ch` para inputs de montos (incl. $ y padding). */
+/** Ancho dinámico en `ch` para inputs de montos (incl. código moneda y padding). */
 function moneyInputWidth(value: number | null | undefined): string {
   if (value == null || Number.isNaN(Number(value))) return '7rem'
   const digits = String(Math.abs(Math.round(Number(value)))).length
   return `${Math.max(11, digits + 5)}ch`
-}
-
-// Format currency
-const formatCurrency = (value: number) => {
-  if (!value) return '$0'
-  return new Intl.NumberFormat(toNumberLocaleTag(locale.value), {
-    style: 'currency',
-    currency: 'COP',
-    minimumFractionDigits: 0
-  }).format(value)
 }
 
 const {


### PR DESCRIPTION
## Summary
- Wire `/menu/*` product and modifier money UI to `useFormatters` (tenant `base_currency_code`, e.g. MXN)
- Replace hardcoded `$` / COP helpers with `currencyCode` prefixes and shared `formatCurrency`
- Align money `UiDecimalInput` precision with `currencyMinorUnits`

Closes #1744

## Test plan
- [ ] On MXN tenant: product create/edit/list show MXN (not COP/$)
- [ ] Modifier list + option editor prices/costs use tenant currency
- [ ] Product quick-create panel prefixes show tenant currency code
- [ ] Recipes list still formats costs correctly
- [ ] COP tenant unchanged (still displays COP)

## Validation evidence
```
$ bun test utils/currencyDisplay.test.ts composables/useModifierOptionForm.test.ts
bun test v1.2.21
23 pass
0 fail
43 expect() calls
Ran 23 tests across 2 files. [167.00ms]
```

## wr-context
See `.wr/1744.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)