### PR TITLE
fix(menu): use UiLoadingDots on primary busy buttons

### DIFF
--- a/.wr/1746.yaml
+++ b/.wr/1746.yaml
@@ -1,0 +1,43 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1746
+title: "Menu: replace button spinners with UiLoadingDots"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1746-menu-button-loading-dots
+
+paths:
+  - pages/menu/productos/[id].vue
+  - pages/menu/productos/crear.vue
+  - pages/menu/recetas/[id].vue
+  - pages/menu/recetas/crear.vue
+  - pages/menu/modificadores/[id].vue
+  - pages/menu/modificadores/crear.vue
+
+ac:
+  - Primary busy buttons under /menu show UiLoadingDots instead of arrow-path spin
+  - Idle state keeps check icon + label; busy uses dots + busy label
+  - No arrow-path + animate-spin left on those CTAs
+  - Unit-select and list-toggle spinners unchanged
+
+out_of_scope:
+  - Unit-select SVG spinners
+  - Product list online/QR toggle spinners
+  - API changes
+  - categorias/reventa
+
+hints:
+  entry: "pages/menu/*/crear|[id] submit UiButton busy icon"
+  pattern: "pages/menu/productos/[id].vue delete modal UiLoadingDots size=8px color=currentColor"
+  tests: "none — UI-only; no page unit tests"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "ready-for-review + wr-review subagent"

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -218,7 +218,7 @@
               :disabled="isSubmitting"
             >
               <Icon v-if="!isSubmitting" name="heroicons:check" class="h-5 w-5 me-2" />
-              <Icon v-else name="heroicons:arrow-path" class="h-5 w-5 me-2 animate-spin" />
+              <UiLoadingDots v-else size="8px" color="currentColor" class="me-2" />
               {{ isSubmitting ? t('menu.modificadores.saveBusy') : t('menu.modificadores.saveGroup') }}
             </UiButton>
 

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -230,7 +230,7 @@
                 :disabled="isSubmitting"
               >
                 <Icon v-if="!isSubmitting" name="heroicons:check" class="h-5 w-5 me-2" />
-                <Icon v-else name="heroicons:arrow-path" class="h-5 w-5 me-2 animate-spin" />
+                <UiLoadingDots v-else size="8px" color="currentColor" class="me-2" />
                 {{ isSubmitting ? t('menu.modificadores.createBusyButton') : t('menu.modificadores.createGroup') }}
               </UiButton>
 

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -440,7 +440,7 @@
                 :disabled="isConvertingToResale"
                 @click="confirmConvertToResale"
               >
-                <Icon v-if="isConvertingToResale" name="heroicons:arrow-path" class="h-5 w-5 me-2 animate-spin" />
+                <UiLoadingDots v-if="isConvertingToResale" size="8px" color="currentColor" class="me-2" />
                 {{ isConvertingToResale ? t('menu.productos.converting') : t('menu.productos.confirmConversion') }}
               </UiButton>
               <UiButton
@@ -772,7 +772,7 @@
               :disabled="isSubmitting"
             >
               <Icon v-if="!isSubmitting" name="heroicons:check" class="h-5 w-5 me-2" />
-              <Icon v-else name="heroicons:arrow-path" class="h-5 w-5 me-2 animate-spin" />
+              <UiLoadingDots v-else size="8px" color="currentColor" class="me-2" />
               {{ isSubmitting ? t('menu.productos.saving') : t('menu.productos.updateProduct') }}
             </UiButton>
 

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -665,7 +665,7 @@
                 :disabled="isSubmitting"
               >
                 <Icon v-if="!isSubmitting" name="heroicons:check" class="h-5 w-5 me-2" />
-                <Icon v-else name="heroicons:arrow-path" class="h-5 w-5 me-2 animate-spin" />
+                <UiLoadingDots v-else size="8px" color="currentColor" class="me-2" />
                 {{ isSubmitting ? t('menu.productos.creatingProduct') : t('menu.productos.createProduct') }}
               </UiButton>
 

--- a/pages/menu/recetas/[id].vue
+++ b/pages/menu/recetas/[id].vue
@@ -218,7 +218,7 @@
               :disabled="isSubmitting"
             >
               <Icon v-if="!isSubmitting" name="heroicons:check" class="h-5 w-5 me-2" />
-              <Icon v-else name="heroicons:arrow-path" class="h-5 w-5 me-2 animate-spin" />
+              <UiLoadingDots v-else size="8px" color="currentColor" class="me-2" />
               {{ isSubmitting ? t('menu.recetas.form.saving') : t('menu.recetas.form.saveRecipe') }}
             </UiButton>
 

--- a/pages/menu/recetas/crear.vue
+++ b/pages/menu/recetas/crear.vue
@@ -243,7 +243,7 @@
                 :disabled="isSubmitting"
               >
                 <Icon v-if="!isSubmitting" name="heroicons:check" class="h-5 w-5 me-2" />
-                <Icon v-else name="heroicons:arrow-path" class="h-5 w-5 me-2 animate-spin" />
+                <UiLoadingDots v-else size="8px" color="currentColor" class="me-2" />
                 {{ isSubmitting ? t('menu.recetas.form.creating') : t('menu.recetas.form.createRecipe') }}
               </UiButton>
 


### PR DESCRIPTION
## Summary
- Replace spinning arrow icons on Menu primary save/create/convert buttons with `UiLoadingDots`
- Match delete/confirm busy pattern (`8px`, `currentColor`)
- Leave unit-select overlays and list toggle spinners unchanged

Closes #1746

## Test plan
- [ ] Product create/edit: submit shows dots + busy label
- [ ] Product convert-to-resale confirm shows dots
- [ ] Recipe create/edit submit shows dots
- [ ] Modifier create/edit submit shows dots
- [ ] Unit-select and list toggle loading still use existing spinners

## Validation evidence
```
rg -n 'heroicons:arrow-path' pages/menu/productos/'[id]'.vue pages/menu/productos/crear.vue pages/menu/recetas/'[id]'.vue pages/menu/recetas/crear.vue pages/menu/modificadores/'[id]'.vue pages/menu/modificadores/crear.vue
→ OK: no arrow-path in scoped pages

rg -n 'UiLoadingDots' (same 6 files)
→ 7 busy CTA UiLoadingDots (plus existing non-CTA usages)

No page unit tests for these routes (UI-only).
```

## wr-context
See `.wr/1746.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)