### PR TITLE
fix(menu): use converted recipe-base line cost in UI

### DIFF
--- a/.wr/1748.yaml
+++ b/.wr/1748.yaml
@@ -1,0 +1,39 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1748
+title: "Menu recetas: show recipe-base cost with unit_weight conversion"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1748-recipe-base-cost-display
+
+paths:
+  - utils/recipeIngredientLineCost.ts
+  - utils/recipeIngredientLineCost.test.ts
+  - pages/menu/recetas/index.vue
+  - pages/menu/productos/[id].vue
+  - pages/menu/productos/crear.vue
+
+ac:
+  - /menu/recetas prefers costo_linea; fallback converts via unit_weight
+  - Base Margarita shows ~21 not 15750
+  - Product create/edit base preview uses same conversion + multiplier
+  - Same-unit lines unchanged
+
+out_of_scope:
+  - API (api-warolabs#704 already merged)
+
+hints:
+  entry: "utils/recipeIngredientLineCost.ts + pages/menu/recetas/index.vue"
+  pattern: "API costo_linea from #704"
+  tests: "npx vitest run utils/recipeIngredientLineCost.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "ready-for-review + wr-review"

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -878,6 +878,7 @@ import {
 import { useActiveStationsQuery } from '@/composables/queries/useActiveStations'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 import { formatDomainQuantity } from '~/utils/domainNumberFormat'
+import { recipeIngredientLineCost } from '~/utils/recipeIngredientLineCost'
 import WarehouseCategoryIngredientSelector from '~/components/ingredientes/WarehouseCategoryIngredientSelector.vue'
 import type { PreparedWarehouseCategoryIngredient } from '~/composables/useWarehouseCategoryIngredientSelector'
 import type { WarehouseCategoryRow } from '~/composables/useWarehouseCategorySearch'
@@ -1356,18 +1357,26 @@ const calculatedCost = computed<number | null>(() => {
 
   let totalCost = 0
 
-  if (selectedRecipeBaseIngredients.value.length > 0) {
-    totalCost += selectedRecipeBaseIngredients.value.reduce((sum: number, ing: any) => {
-      const ingredient = ingredients.value.find((i: any) => i.id === ing.ingredient_id)
-      const costPerUnit = ingredient?.costo_unitario || ingredient?.price || 0
-      return sum + (ing.base_quantity * Number(costPerUnit))
-    }, 0)
-  }
+  form.value.recipe_bases.forEach((link) => {
+    if (!link.recipe_base_id) return
+    const selectedRecipe = recipeBases.value.find((r: any) => r.id === link.recipe_base_id)
+    if (!selectedRecipe?.ingredients) return
+    const multiplier = Number(link.quantity) || 1
+    selectedRecipe.ingredients.forEach((ing: any) => {
+      totalCost += recipeIngredientLineCost(ing, { multiplier })
+    })
+  })
 
   totalCost += form.value.ingredients.reduce((sum, ing) => {
     const ingredient = ingredientCache.value[ing.ingredient_id]
-    const costPerUnit = ingredient?.costo_unitario || ingredient?.price || 0
-    return sum + (ing.quantity * Number(costPerUnit))
+    if (!ingredient) return sum
+    return sum + recipeIngredientLineCost({
+      quantity: ing.quantity,
+      unit: ing.unit,
+      stock_unit: ingredient.unit,
+      unit_weight_gr: ingredient.unit_weight_gr,
+      costo_unitario: ingredient.costo_unitario ?? ingredient.price,
+    })
   }, 0)
 
   return totalCost

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -729,6 +729,7 @@ import {
 } from '@/composables/useIngredientPurchaseUnitsDraft'
 import { resolveResaleIngredientId } from '@/composables/useResaleLinkedIngredient'
 import { formatDomainQuantity } from '~/utils/domainNumberFormat'
+import { recipeIngredientLineCost } from '~/utils/recipeIngredientLineCost'
 import WarehouseCategoryIngredientSelector from '~/components/ingredientes/WarehouseCategoryIngredientSelector.vue'
 import type { PreparedWarehouseCategoryIngredient } from '~/composables/useWarehouseCategoryIngredientSelector'
 
@@ -1019,18 +1020,27 @@ const calculatedCost = computed<number | null>(() => {
 
   let totalCost = 0
 
-  if (selectedRecipeBaseIngredients.value.length > 0) {
-    totalCost += selectedRecipeBaseIngredients.value.reduce((sum: number, ing: any) => {
-      const ingredient = availableIngredients.value.find((i: any) => i.id === ing.ingredient_id)
-      return sum + (ing.base_quantity * Number(ingredient?.costo_unitario || ingredient?.price || 0))
-    }, 0)
-  }
+  form.value.recipe_bases.forEach((link) => {
+    if (!link.recipe_base_id) return
+    const selectedRecipe = recipeBases.value.find((r: any) => r.id === link.recipe_base_id)
+    if (!selectedRecipe?.ingredients) return
+    const multiplier = Number(link.quantity) || 1
+    selectedRecipe.ingredients.forEach((ing: any) => {
+      totalCost += recipeIngredientLineCost(ing, { multiplier })
+    })
+  })
 
   totalCost += form.value.ingredients.reduce((sum, ing) => {
     const cached = ingredientCache.value[ing.ingredient_id]
     const ingredient = cached || availableIngredients.value.find((i: any) => i.id === ing.ingredient_id)
     if (!ingredient) return sum
-    return sum + (ing.quantity * Number(ingredient.costo_unitario || ingredient.price || 0))
+    return sum + recipeIngredientLineCost({
+      quantity: ing.quantity,
+      unit: ing.unit,
+      stock_unit: ingredient.unit,
+      unit_weight_gr: ingredient.unit_weight_gr,
+      costo_unitario: ingredient.costo_unitario ?? ingredient.price,
+    })
   }, 0)
 
   return totalCost

--- a/pages/menu/recetas/index.vue
+++ b/pages/menu/recetas/index.vue
@@ -260,6 +260,7 @@ import { ref, computed, onMounted, onUnmounted, inject, watch } from 'vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 import { formatDomainQuantity, normalizeDomainNumber } from '~/utils/domainNumberFormat'
+import { recipeIngredientLineCost } from '~/utils/recipeIngredientLineCost'
 const { t } = useI18n()
 const WAREHOUSE_COPY = useWarehouseCopy()
 const { formatCurrency } = useFormatters()
@@ -353,6 +354,14 @@ const recetas = computed(() => {
     ingredientes: recipeBase.ingredients?.map((ing: any) => {
       const costoUnitario = Number(ing.costo_unitario || 0)
       const cantidad = normalizeDomainNumber(ing.base_quantity, 6)
+      const costoTotal = recipeIngredientLineCost({
+        costo_linea: ing.costo_linea,
+        base_quantity: ing.base_quantity,
+        unit: ing.unit,
+        stock_unit: ing.stock_unit,
+        unit_weight_gr: ing.unit_weight_gr,
+        costo_unitario: costoUnitario,
+      })
       return {
         ingrediente_id: ing.ingredient_id,
         ingrediente_name: ing.ingredient_name,
@@ -360,12 +369,19 @@ const recetas = computed(() => {
         unidad: ing.unit,
         notes: ing.notes,
         costo_unitario: costoUnitario,
-        costo_total: costoUnitario * cantidad,
+        costo_total: costoTotal,
         controla_inventario: ing.controla_inventario || false
       }
     }) || [],
     costo_total: recipeBase.ingredients?.reduce((total: number, ing: any) => {
-      return total + (Number(ing.costo_unitario || 0) * Number(ing.base_quantity || 0))
+      return total + recipeIngredientLineCost({
+        costo_linea: ing.costo_linea,
+        base_quantity: ing.base_quantity,
+        unit: ing.unit,
+        stock_unit: ing.stock_unit,
+        unit_weight_gr: ing.unit_weight_gr,
+        costo_unitario: ing.costo_unitario,
+      })
     }, 0) || 0,
     rendimiento: 1
   }))

--- a/utils/recipeIngredientLineCost.test.ts
+++ b/utils/recipeIngredientLineCost.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+  recipeIngredientLineCost,
+  recipeQtyToStockUnits,
+} from './recipeIngredientLineCost'
+
+describe('recipeQtyToStockUnits', () => {
+  it('converts ml on und via unit_weight', () => {
+    expect(recipeQtyToStockUnits(45, 'ml', 'und', 750)).toBeCloseTo(45 / 750)
+  })
+
+  it('leaves same-unit ml unchanged', () => {
+    expect(recipeQtyToStockUnits(45, 'ml', 'ml')).toBe(45)
+  })
+
+  it('leaves und×und unchanged', () => {
+    expect(recipeQtyToStockUnits(1, 'und', 'und')).toBe(1)
+  })
+})
+
+describe('recipeIngredientLineCost', () => {
+  it('prefers costo_linea', () => {
+    expect(
+      recipeIngredientLineCost({
+        costo_linea: 21,
+        base_quantity: 45,
+        unit: 'ml',
+        stock_unit: 'und',
+        unit_weight_gr: 750,
+        costo_unitario: 350,
+      }),
+    ).toBe(21)
+  })
+
+  it('scales costo_linea by multiplier', () => {
+    expect(recipeIngredientLineCost({ costo_linea: 21 }, { multiplier: 2 })).toBe(42)
+  })
+
+  it('converts bottle ml line without costo_linea → ~21', () => {
+    expect(
+      recipeIngredientLineCost({
+        base_quantity: 45,
+        unit: 'ml',
+        stock_unit: 'und',
+        unit_weight_gr: 750,
+        costo_unitario: 350,
+      }),
+    ).toBeCloseTo(21)
+  })
+
+  it('same-unit ml × unit cost', () => {
+    expect(
+      recipeIngredientLineCost({
+        base_quantity: 20,
+        unit: 'ml',
+        stock_unit: 'ml',
+        costo_unitario: 0.25,
+      }),
+    ).toBeCloseTo(5)
+  })
+})

--- a/utils/recipeIngredientLineCost.ts
+++ b/utils/recipeIngredientLineCost.ts
@@ -1,0 +1,76 @@
+/**
+ * Recipe-line costing aligned with API cost_resolution_service (#702 / #704 / #1748).
+ * Prefer server `costo_linea`; else convert recipe qty → stock unit via unit_weight.
+ */
+
+const CATALOG_TO_BASE: Record<string, { factor: number; base: 'gr' | 'ml' }> = {
+  kg: { factor: 1000, base: 'gr' },
+  libra: { factor: 500, base: 'gr' },
+  arroba: { factor: 12500, base: 'gr' },
+  bulto_25kg: { factor: 25000, base: 'gr' },
+  lt: { factor: 1000, base: 'ml' },
+  botella: { factor: 750, base: 'ml' },
+  galon: { factor: 3785, base: 'ml' },
+}
+
+export type RecipeCostLineInput = {
+  costo_linea?: number | null
+  base_quantity?: number | null
+  quantity?: number | null
+  unit?: string | null
+  stock_unit?: string | null
+  unit_weight_gr?: number | null
+  costo_unitario?: number | null
+  price?: number | null
+}
+
+export function recipeQtyToStockUnits(
+  quantity: number,
+  recipeUnit: string | null | undefined,
+  stockUnit: string | null | undefined,
+  unitWeightGr?: number | null,
+): number {
+  const qty = Number(quantity) || 0
+  const ru = (recipeUnit || stockUnit || '').trim()
+  const su = (stockUnit || '').trim()
+  if (!su || !ru || ru === su) return qty
+
+  const weight = Number(unitWeightGr)
+  const hasWeight = Number.isFinite(weight) && weight > 0
+
+  if (su === 'und' && (ru === 'gr' || ru === 'ml') && hasWeight) return qty / weight
+  if (ru === 'und' && (su === 'gr' || su === 'ml') && hasWeight) return qty * weight
+
+  const catalog = CATALOG_TO_BASE[ru]
+  if (catalog && su === 'und' && hasWeight && (catalog.base === 'gr' || catalog.base === 'ml')) {
+    return (qty * catalog.factor) / weight
+  }
+
+  return qty
+}
+
+/**
+ * @param multiplier - scales API `costo_linea` or raw qty (e.g. recipe-base link quantity)
+ */
+export function recipeIngredientLineCost(
+  ing: RecipeCostLineInput,
+  options?: { multiplier?: number; unitCost?: number | null },
+): number {
+  const multiplier = Number(options?.multiplier ?? 1) || 1
+
+  if (ing.costo_linea != null && Number.isFinite(Number(ing.costo_linea))) {
+    return Number(ing.costo_linea) * multiplier
+  }
+
+  const qty = Number(ing.base_quantity ?? ing.quantity ?? 0) || 0
+  const unitCost = Number(
+    options?.unitCost ?? ing.costo_unitario ?? ing.price ?? 0,
+  ) || 0
+  const stockQty = recipeQtyToStockUnits(
+    qty,
+    ing.unit,
+    ing.stock_unit,
+    ing.unit_weight_gr,
+  )
+  return stockQty * unitCost * multiplier
+}


### PR DESCRIPTION
## Summary
- `/menu/recetas` uses API `costo_linea` (fallback: unit_weight conversion) instead of raw qty × unit cost
- Product create/edit live cost preview uses the same helper for recipe bases and direct lines
- Fixes Base Margarita display (~21 MXN, not 15.750)

Closes #1748

API companion (merged): https://github.com/uno0uno/api-warolabs/issues/704

## Test plan
- [ ] `/menu/recetas` → Base Margarita cost ≈ MXN 21
- [ ] Product with Base Margarita ×1 preview cost ≈ 21 (+ other lines)
- [ ] Same-unit ml recipe lines unchanged

## Validation evidence
```
npx vitest run utils/recipeIngredientLineCost.test.ts
→ Test Files 1 passed | Tests 7 passed
```

## wr-context
See `.wr/1748.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)