### PR TITLE
fix(menu): align category ingredient rows with base recipes

### DIFF
--- a/.wr/1750.yaml
+++ b/.wr/1750.yaml
@@ -1,0 +1,41 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1750
+title: "fix(menu): align category ingredient rows UI with base recipes"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1750-category-ingredient-row-ui
+
+paths:
+  - components/ingredientes/WarehouseCategoryIngredientSelector.vue
+  - pages/menu/productos/crear.vue
+  - pages/menu/productos/[id].vue
+  - components/ingredientes/WarehouseCategoryIngredientSelector.test.ts
+
+ac:
+  - Category prepared rows match Recetas base compact flex row (item, qty, unit, remove)
+  - Same layout on product create and edit
+  - Manual additional ingredient lines use the same compact row pattern
+  - Behavior unchanged for qty/unit/remove/submit
+  - No regressions on empty/loading/category header
+
+out_of_scope:
+  - API/cost logic
+  - Recipe base data model
+  - Warehouse category search behavior
+
+hints:
+  entry: "WarehouseCategoryIngredientSelector prepared rows + product manual ingredient rows"
+  pattern: "pages/menu/productos/[id].vue recipe_bases flex card row (~486)"
+  tests: "bunx vitest run components/ingredientes/WarehouseCategoryIngredientSelector.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: ""

--- a/components/ingredientes/WarehouseCategoryIngredientSelector.vue
+++ b/components/ingredientes/WarehouseCategoryIngredientSelector.vue
@@ -98,15 +98,12 @@
                   v-for="row in group.rows"
                   :key="row.ingredient_id"
                   role="listitem"
-                  class="rounded-lg border border-border bg-background p-3 sm:p-4"
+                  class="flex items-start gap-3 p-3 bg-surface-secondary rounded-lg border border-border"
                 >
-                  <div class="grid grid-cols-1 gap-3 md:grid-cols-12">
-                    <div class="min-w-0 md:col-span-5">
-                      <p class="mb-1 text-xs font-medium text-text-secondary">
-                        {{ t('abastecimiento.glossary.warehouseItemOrResaleRequired') }}
-                      </p>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex flex-col sm:flex-row gap-2">
                       <div
-                        class="input-base flex min-h-[38px] items-center gap-2 px-3 py-2 text-sm text-text-primary"
+                        class="input-base flex flex-1 min-h-[44px] min-w-0 items-center gap-2 px-3 py-2 text-sm text-text-primary"
                         :title="row.name"
                       >
                         <svg class="h-4 w-4 flex-shrink-0 text-text-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -114,31 +111,21 @@
                         </svg>
                         <span class="truncate">{{ row.name }}</span>
                       </div>
-                    </div>
-
-                    <label class="md:col-span-3">
-                      <span class="mb-1 block text-xs font-medium text-text-secondary">
-                        {{ t('abastecimiento.glossary.categoryIngredientQuantity') }} *
-                      </span>
                       <input
                         type="number"
                         min="0"
                         step="any"
-                        class="input-base w-full px-3 py-2 text-sm"
+                        class="input-base w-full sm:w-24 min-h-[44px] px-3 py-2 text-sm"
                         :value="row.quantity ?? ''"
+                        :aria-label="t('abastecimiento.glossary.categoryIngredientQuantity')"
                         @input="onQuantityInput(row.ingredient_id, $event)"
                       />
-                    </label>
-
-                    <label class="md:col-span-3">
-                      <span class="mb-1 block text-xs font-medium text-text-secondary">
-                        {{ t('abastecimiento.glossary.categoryIngredientUnit') }}
-                      </span>
                       <select
                         v-if="unitOptions"
                         :value="row.unit ?? ''"
                         :disabled="loadingUnitIds?.has(row.ingredient_id)"
-                        class="input-base w-full px-3 py-2 text-sm disabled:opacity-50"
+                        class="input-base w-full sm:w-36 min-h-[44px] px-3 py-2 text-sm disabled:opacity-50"
+                        :aria-label="t('abastecimiento.glossary.categoryIngredientUnit')"
                         @change="onUnitInput(row.ingredient_id, $event)"
                       >
                         <option
@@ -152,27 +139,24 @@
                       <input
                         v-else
                         type="text"
-                        class="input-base w-full px-3 py-2 text-sm"
+                        class="input-base w-full sm:w-36 min-h-[44px] px-3 py-2 text-sm"
                         :value="row.unit ?? ''"
+                        :aria-label="t('abastecimiento.glossary.categoryIngredientUnit')"
                         @input="onUnitInput(row.ingredient_id, $event)"
                       />
-                    </label>
-
-                    <div class="md:col-span-1">
-                      <span class="mb-1 hidden text-xs font-medium text-text-secondary md:block" aria-hidden="true">&nbsp;</span>
-                      <button
-                        type="button"
-                        class="flex min-h-[38px] w-full items-center justify-center rounded-lg text-destructive transition-colors hover:bg-destructive/5 focus:outline-none focus:ring-2 focus:ring-destructive/30"
-                        :aria-label="t('abastecimiento.glossary.removePreparedIngredient', { name: row.name })"
-                        :title="t('abastecimiento.glossary.removePreparedIngredientAction')"
-                        @click="removePreparedRow(row.ingredient_id)"
-                      >
-                        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7 18.133 19.142A2 2 0 0 1 16.138 21H7.862a2 2 0 0 1-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v3M4 7h16" />
-                        </svg>
-                      </button>
                     </div>
                   </div>
+                  <button
+                    type="button"
+                    class="min-h-[44px] min-w-[44px] p-2 bg-destructive/10 text-destructive hover:bg-destructive/15 rounded-lg transition-all focus:outline-none focus:ring-2 focus:ring-destructive/30"
+                    :aria-label="t('abastecimiento.glossary.removePreparedIngredient', { name: row.name })"
+                    :title="t('abastecimiento.glossary.removePreparedIngredientAction')"
+                    @click="removePreparedRow(row.ingredient_id)"
+                  >
+                    <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7 18.133 19.142A2 2 0 0 1 16.138 21H7.862a2 2 0 0 1-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v3M4 7h16" />
+                    </svg>
+                  </button>
                 </div>
               </div>
             </section>

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -584,51 +584,53 @@
               <div
                 v-for="(ingredient, index) in form.ingredients"
                 :key="index"
-                class="flex items-start gap-3 p-4 bg-surface-secondary rounded-lg border border-border"
+                class="flex items-start gap-3 p-3 bg-surface-secondary rounded-lg border border-border"
               >
-                <div class="flex-1 grid grid-cols-1 sm:grid-cols-3 gap-3">
-                  <div>
-                    <label class="block text-xs font-medium text-text-secondary mb-1">{{ WAREHOUSE_COPY.warehouseItemOrResaleRequired }}</label>
-                    <UiIngredientSearchInput
-                      :key="ingredient.ingredient_id || `new-${index}`"
-                      :initial-value="ingredient.ingredient_name || ingredientCache[ingredient.ingredient_id]?.name || ''"
-                      :allow-create="true"
-                      @select="(ing) => selectIngredient(ing, index)"
-                      @create="(name) => openCustomIngModal(name, index)"
-                    />
-                  </div>
-                  <div>
+                <div class="flex-1 min-w-0">
+                  <div class="flex flex-col sm:flex-row gap-2">
+                    <div class="flex-1 min-w-0">
+                      <UiIngredientSearchInput
+                        :key="ingredient.ingredient_id || `new-${index}`"
+                        :initial-value="ingredient.ingredient_name || ingredientCache[ingredient.ingredient_id]?.name || ''"
+                        :allow-create="true"
+                        :aria-label="WAREHOUSE_COPY.warehouseItemOrResaleRequired"
+                        @select="(ing) => selectIngredient(ing, index)"
+                        @create="(name) => openCustomIngModal(name, index)"
+                      />
+                    </div>
                     <UiDecimalInput
                       v-model="ingredient.quantity"
                       :min="0.01"
                       :precision="6"
                       :placeholder="t('menu.productos.quantity')"
                       required
-                      class="input-base w-full px-3 py-2 text-sm"
+                      class="input-base w-full sm:w-24 min-h-[44px] px-3 py-2 text-sm"
+                      :aria-label="t('menu.productos.quantity')"
                     />
-                  </div>
-                  <div class="relative">
-                    <select
-                      v-model="ingredient.unit"
-                      :disabled="loadingUnits.has(ingredient.ingredient_id)"
-                      class="input-base w-full py-2 pe-3 text-sm disabled:opacity-50"
-                      :class="loadingUnits.has(ingredient.ingredient_id) ? 'ps-7' : 'ps-3'"
-                    >
-                      <option v-if="!ingredient.ingredient_id" value="" disabled>
-                        {{ WAREHOUSE_COPY.selectWarehouseItem }}
-                      </option>
-                      <option
-                        v-for="opt in getIngredientUnitOptions(ingredient.ingredient_id)"
-                        :key="opt.value"
-                        :value="opt.value"
-                      >{{ opt.label }}</option>
-                    </select>
-                    <span v-if="loadingUnits.has(ingredient.ingredient_id)" class="absolute start-2 top-2.5 pointer-events-none text-text-secondary">
-                      <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
-                      </svg>
-                    </span>
+                    <div class="relative w-full sm:w-36">
+                      <select
+                        v-model="ingredient.unit"
+                        :disabled="loadingUnits.has(ingredient.ingredient_id)"
+                        class="input-base w-full min-h-[44px] py-2 pe-3 text-sm disabled:opacity-50"
+                        :class="loadingUnits.has(ingredient.ingredient_id) ? 'ps-7' : 'ps-3'"
+                        :aria-label="t('abastecimiento.glossary.categoryIngredientUnit')"
+                      >
+                        <option v-if="!ingredient.ingredient_id" value="" disabled>
+                          {{ WAREHOUSE_COPY.selectWarehouseItem }}
+                        </option>
+                        <option
+                          v-for="opt in getIngredientUnitOptions(ingredient.ingredient_id)"
+                          :key="opt.value"
+                          :value="opt.value"
+                        >{{ opt.label }}</option>
+                      </select>
+                      <span v-if="loadingUnits.has(ingredient.ingredient_id)" class="absolute start-2 top-1/2 -translate-y-1/2 pointer-events-none text-text-secondary">
+                        <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+                          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
+                        </svg>
+                      </span>
+                    </div>
                   </div>
                 </div>
                 <button
@@ -636,6 +638,7 @@
                   @click="removeIngredient(index)"
                   class="min-h-[44px] min-w-[44px] p-2 bg-destructive/10 text-destructive hover:bg-destructive/15 rounded-lg transition-all focus:outline-none focus:ring-2 focus:ring-destructive/30"
                   :title="WAREHOUSE_COPY.removeWarehouseItemLine"
+                  :aria-label="WAREHOUSE_COPY.removeWarehouseItemLine"
                 >
                   <Icon name="heroicons:trash" class="h-5 w-5" />
                 </button>

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -466,50 +466,52 @@
                   <div
                     v-for="(ingredient, index) in form.ingredients"
                     :key="index"
-                    class="flex items-start gap-3 p-4 bg-surface-secondary rounded-lg border border-border"
+                    class="flex items-start gap-3 p-3 bg-surface-secondary rounded-lg border border-border"
                   >
-                    <div class="flex-1 grid grid-cols-1 sm:grid-cols-3 gap-3">
-                      <div>
-                        <label class="block text-xs font-medium text-text-secondary mb-1">{{ WAREHOUSE_COPY.warehouseItemOrResaleRequired }}</label>
-                        <UiIngredientSearchInput
-                          :key="ingredient.ingredient_id || `new-${index}`"
-                          :initial-value="getIngredientSearchLabel(ingredient)"
-                          :allow-create="true"
-                          @select="(ing) => selectIngredient(ing, index)"
-                          @create="(name) => openCustomIngModal(name, index)"
-                        />
-                      </div>
-                      <div>
+                    <div class="flex-1 min-w-0">
+                      <div class="flex flex-col sm:flex-row gap-2">
+                        <div class="flex-1 min-w-0">
+                          <UiIngredientSearchInput
+                            :key="ingredient.ingredient_id || `new-${index}`"
+                            :initial-value="getIngredientSearchLabel(ingredient)"
+                            :allow-create="true"
+                            :aria-label="WAREHOUSE_COPY.warehouseItemOrResaleRequired"
+                            @select="(ing) => selectIngredient(ing, index)"
+                            @create="(name) => openCustomIngModal(name, index)"
+                          />
+                        </div>
                         <UiDecimalInput
                           v-model="ingredient.quantity"
                           :min="0.01"
                           :placeholder="t('menu.productos.quantity')"
                           :precision="6"
-                          class="input-base w-full px-3 py-2 text-sm"
+                          class="input-base w-full sm:w-24 min-h-[44px] px-3 py-2 text-sm"
+                          :aria-label="t('menu.productos.quantity')"
                         />
-                      </div>
-                      <div class="relative">
-                        <select
-                          v-model="ingredient.unit"
-                          :disabled="loadingUnits.has(ingredient.ingredient_id)"
-                          class="input-base w-full py-2 pe-3 text-sm disabled:opacity-50"
-                          :class="loadingUnits.has(ingredient.ingredient_id) ? 'ps-7' : 'ps-3'"
-                        >
-                          <option v-if="!ingredient.ingredient_id" value="" disabled>
-                            {{ WAREHOUSE_COPY.selectWarehouseItem }}
-                          </option>
-                          <option
-                            v-for="opt in getIngredientUnitOptions(ingredient.ingredient_id)"
-                            :key="opt.value"
-                            :value="opt.value"
-                          >{{ opt.label }}</option>
-                        </select>
-                        <span v-if="loadingUnits.has(ingredient.ingredient_id)" class="absolute start-2 top-2.5 pointer-events-none text-text-secondary">
-                          <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
-                          </svg>
-                        </span>
+                        <div class="relative w-full sm:w-36">
+                          <select
+                            v-model="ingredient.unit"
+                            :disabled="loadingUnits.has(ingredient.ingredient_id)"
+                            class="input-base w-full min-h-[44px] py-2 pe-3 text-sm disabled:opacity-50"
+                            :class="loadingUnits.has(ingredient.ingredient_id) ? 'ps-7' : 'ps-3'"
+                            :aria-label="t('abastecimiento.glossary.categoryIngredientUnit')"
+                          >
+                            <option v-if="!ingredient.ingredient_id" value="" disabled>
+                              {{ WAREHOUSE_COPY.selectWarehouseItem }}
+                            </option>
+                            <option
+                              v-for="opt in getIngredientUnitOptions(ingredient.ingredient_id)"
+                              :key="opt.value"
+                              :value="opt.value"
+                            >{{ opt.label }}</option>
+                          </select>
+                          <span v-if="loadingUnits.has(ingredient.ingredient_id)" class="absolute start-2 top-1/2 -translate-y-1/2 pointer-events-none text-text-secondary">
+                            <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+                              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
+                            </svg>
+                          </span>
+                        </div>
                       </div>
                     </div>
                     <button
@@ -517,6 +519,7 @@
                       @click="removeIngredient(index)"
                       class="min-h-[44px] min-w-[44px] p-2 bg-destructive/10 text-destructive hover:bg-destructive/15 rounded-lg transition-all focus:outline-none focus:ring-2 focus:ring-destructive/30"
                       :title="WAREHOUSE_COPY.removeWarehouseItemLine"
+                      :aria-label="WAREHOUSE_COPY.removeWarehouseItemLine"
                     >
                       <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />


### PR DESCRIPTION
## Summary
- Compact category prepared rows to match Recetas base (item + qty + unit + remove)
- Apply the same flex row pattern to manual ingredient lines on product create/edit
- Drop dense per-field labels that caused cramped/overlapping UI

Closes #1750

## Test plan
- [ ] Open `/menu/productos/crear`, add category ingredients — rows look like Recetas base
- [ ] Edit a product with category + manual lines — same compact layout
- [ ] Change quantity/unit, remove row/category, submit still works

## Validation evidence
```text
$ bunx vitest run components/ingredientes/WarehouseCategoryIngredientSelector.test.ts
 ✓ components/ingredientes/WarehouseCategoryIngredientSelector.test.ts (6 tests) 65ms
 Test Files  1 passed (1)
 Tests  6 passed (6)
```

## wr-context
See `.wr/1750.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)