### PR TITLE
fix(currency): coerce Decimal JSON strings in formatMoney

### DIFF
--- a/composables/useFormatters.ts
+++ b/composables/useFormatters.ts
@@ -70,7 +70,7 @@ export const useFormatters = () => {
 
   /** Display-only money; currency_code from prefs (default COP) + locale punctuation. */
   const formatCurrency = (
-    value: number | null | undefined,
+    value: number | string | null | undefined,
     options?: Pick<FormatMoneyOptions, 'notation'>,
   ): string => {
     return formatMoney(value, {

--- a/utils/currencyDisplay.test.ts
+++ b/utils/currencyDisplay.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import {
   DEFAULT_CURRENCY_CODE,
   DEFAULT_NUMBER_LOCALE,
+  coerceMoneyNumber,
   formatMoney,
   localeToNumberFormatTag,
   normalizeCurrencyCode,
@@ -44,7 +45,30 @@ describe('localeToNumberFormatTag', () => {
   })
 })
 
+describe('coerceMoneyNumber', () => {
+  it('accepts numbers and Decimal-like numeric strings', () => {
+    assert.equal(coerceMoneyNumber(120), 120)
+    assert.equal(coerceMoneyNumber('120.00'), 120)
+    assert.equal(coerceMoneyNumber(' 55.5 '), 55.5)
+    assert.equal(coerceMoneyNumber(null), null)
+    assert.equal(coerceMoneyNumber(''), null)
+    assert.equal(coerceMoneyNumber('abc'), null)
+    assert.equal(coerceMoneyNumber(Number.NaN), null)
+  })
+})
+
 describe('formatMoney', () => {
+  it('formats Decimal JSON strings like finite numbers', () => {
+    const expected = new Intl.NumberFormat('es-CO', {
+      style: 'currency',
+      currency: 'MXN',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(120)
+    assert.equal(formatMoney('120.00', { currency: 'MXN', locale: 'es', minorUnits: 2 }), expected)
+    assert.equal(formatMoney(120, { currency: 'MXN', locale: 'es', minorUnits: 2 }), expected)
+  })
+
   it('formats empty values as zero in the resolved currency', () => {
     const expectedCop = new Intl.NumberFormat('es-CO', {
       style: 'currency',

--- a/utils/currencyDisplay.ts
+++ b/utils/currencyDisplay.ts
@@ -50,18 +50,36 @@ export function normalizeMinorUnits(value?: number | null, fallback = 0): number
 }
 
 /**
+ * Coerce API/display money values to a finite number.
+ * Pydantic Decimals serialize as JSON strings (e.g. `"120.00"`); those must
+ * format correctly. null/undefined/''/non-numeric → null (caller maps to 0).
+ */
+export function coerceMoneyNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    const n = Number(trimmed)
+    return Number.isFinite(n) ? n : null
+  }
+  return null
+}
+
+/**
  * Format a money amount for UI display only.
- * null/undefined/non-finite values render as zero in the resolved currency.
+ * null/undefined/non-numeric values render as zero in the resolved currency.
+ * Accepts numeric strings from Decimal JSON serialization.
  * Does not convert amounts or touch storage/API payloads.
  */
 export function formatMoney(
-  value: number | null | undefined,
+  value: number | string | null | undefined,
   options?: FormatMoneyOptions,
 ): string {
   const currency = normalizeCurrencyCode(options?.currency)
   const localeTag = localeToNumberFormatTag(options?.locale)
   const minorUnits = normalizeMinorUnits(options?.minorUnits, 0)
-  const numericValue = value === null || value === undefined || !Number.isFinite(value) ? 0 : value
+  const numericValue = coerceMoneyNumber(value) ?? 0
 
   return new Intl.NumberFormat(localeTag, {
     style: 'currency',


### PR DESCRIPTION
## Summary
- `formatMoney` now coerces numeric strings (Pydantic `Decimal` JSON) before formatting
- Product list prices no longer render as `MXN 0,00` when the API returns `"120.00"`
- Adds `coerceMoneyNumber` + regression tests

## Test plan
- [ ] `/menu/productos` on MXN tenant shows real prices (e.g. Margarita 120)
- [ ] Resale rows still show Mi costo correctly

## Validation evidence
```text
$ node --test utils/currencyDisplay.test.ts
# tests 12
# pass 12
# fail 0
```

Made with [Cursor](https://cursor.com)