### PR TITLE
fix(formatters): import timezone/profile deps explicitly

### DIFF
--- a/composables/useFormatters.ts
+++ b/composables/useFormatters.ts
@@ -1,3 +1,4 @@
+import { computed } from 'vue'
 import { formatMoney, normalizeCurrencyCode, type FormatMoneyOptions } from '~/utils/currencyDisplay'
 import { toNumberLocaleTag } from '~/utils/appLocales'
 import {
@@ -6,6 +7,9 @@ import {
   normalizeUiLocale,
   type UiLocale,
 } from '~/utils/parseLocaleDecimal'
+import { useTenantTimezone } from '~/composables/useTenantTimezone'
+import { useTenantFinancialProfile } from '~/composables/useTenantFinancialProfile'
+import { useTenantsStore } from '~/stores/tenants'
 
 export const useFormatters = () => {
   const { timezone, dateAtNoon } = useTenantTimezone()


### PR DESCRIPTION
## Summary
- Explicit imports for `useTenantTimezone`, `useTenantFinancialProfile`, and `useTenantsStore` in `useFormatters`
- Fixes `useTenantTimezone is not defined` after Vite HMR on the currency formatting change

## Test plan
- [ ] Reload `/menu/productos` — no 500; prices show correctly

Made with [Cursor](https://cursor.com)