### PR TITLE
fix(abastecimiento): Contado requires payment method on direct purchases

### DIFF
--- a/.wr/1759.yaml
+++ b/.wr/1759.yaml
@@ -1,0 +1,43 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1759
+title: "Compras directas: Contado must require payment method (else Crédito)"
+repo: both
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-1759-contado-requires-payment
+
+paths:
+  - pages/abastecimiento/compras-directas/crear.vue
+  - pages/abastecimiento/compras-directas/[id]/editar.vue
+  - ../api_warocol.com/app/services/direct_purchase_service.py
+  - ../api_warocol.com/app/models/purchase.py
+  - ../api_warocol.com/app/routers/purchases.py
+  - ../api_warocol.com/tests/test_direct_purchase_payment_type.py
+
+ac:
+  - Create/edit: contado requires payment method before submit
+  - Sin pago aun only with credito (or deferred); clearing method on contado → credito
+  - OCR/default unpaid → credito
+  - API POST/PUT rejects contado without payment_method with 400
+  - Contado+method paid path; credito+empty pending payment
+
+out_of_scope:
+  - ACCOUNT_ROLE_MISSING / ACCOUNTS_PAYABLE provisioning
+  - GL posting changes
+  - DIAN XML import
+
+hints:
+  entry: "assert_contado_requires_payment_method + crear/editar validateForm"
+  pattern: "direct_purchase_service create/update payment_method gates status paid"
+  tests: "python3 -m pytest tests/test_direct_purchase_payment_type.py -q"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "merge API then front; manual Contado+method and Credito+Sin pago"

--- a/pages/abastecimiento/compras-directas/[id]/editar.vue
+++ b/pages/abastecimiento/compras-directas/[id]/editar.vue
@@ -432,7 +432,25 @@
                 <div class="space-y-4">
                   <div>
                     <label class="block text-sm font-medium text-text-secondary mb-2">
+                      Tipo de pago
+                    </label>
+                    <select
+                      v-model="form.payment_type"
+                      class="input-base w-full px-4 py-2"
+                    >
+                      <option value="credito">Credito - Pago Diferido</option>
+                      <option value="contado">Contado - Pago Inmediato</option>
+                      <option value="contraentrega">Contraentrega</option>
+                    </select>
+                    <p v-if="form.payment_type === 'contado' && !hasPaymentSelected" class="mt-1.5 text-xs text-warning">
+                      Contado exige un método de pago. Sin pago, usa Crédito.
+                    </p>
+                  </div>
+
+                  <div>
+                    <label class="block text-sm font-medium text-text-secondary mb-2">
                       Metodo de Pago
+                      <span v-if="form.payment_type === 'contado'" class="text-destructive">*</span>
                     </label>
                     <select
                       v-model="paymentSelectValue"
@@ -818,6 +836,7 @@ const form = ref({
   notes: '',
   invoice_number: '',
   invoice_files: [] as File[],
+  payment_type: 'credito' as string,
   payment_method: '',
   payment_method_id: null as string | null,
   payment_reference: '',
@@ -825,7 +844,6 @@ const form = ref({
   items: [] as PurchaseItem[]
 })
 
-// Fetch existing purchase
 // Payment methods
 const { data: paymentMethodsData } = useFetch<{ success: boolean; data: import('~/utils/paymentDefaults').PosPaymentGroup[] }>(
   '/api/pos/payment-methods',
@@ -836,6 +854,17 @@ const paymentGroups = computed(() =>
 )
 const { resolveLabel: resolvePaymentLabel } = usePaymentLabel(paymentGroups)
 const { paymentSelectValue, hasPaymentSelected } = usePaymentSelectValue(form, paymentGroups)
+
+watch(hasPaymentSelected, (selected) => {
+  if (selected) return
+  form.value.payment_reference = ''
+  if (form.value.payment_type === 'contado') {
+    form.value.payment_type = 'credito'
+  }
+})
+
+// Fetch existing purchase
+// (payment helpers above — originalPurchase watch fills form)
 
 const { data: purchaseResponse, pending: loadingPurchase, error: fetchError } = useFetch(`/api/suppliers/purchases/direct/${purchaseId}`, {
   server: false
@@ -859,9 +888,14 @@ watch(originalPurchase, (purchase) => {
       : localDateAtNoon(todayISO())
     form.value.notes = purchase.notes || ''
     form.value.invoice_number = purchase.invoice_number || ''
+    form.value.payment_type = purchase.payment_type || 'credito'
     form.value.payment_method = purchase.payment_method || ''
     form.value.payment_method_id = purchase.payment_method_id || null
     form.value.payment_reference = purchase.payment_reference || ''
+    // Contado without method is invalid on load — normalize to crédito
+    if (form.value.payment_type === 'contado' && !form.value.payment_method && !form.value.payment_method_id) {
+      form.value.payment_type = 'credito'
+    }
     form.value.items = (purchase.items || []).map((item: any) => {
       const purchaseQty = item.purchase_quantity || item.quantity || 1
       const totalCost = item.total_cost || 0
@@ -921,7 +955,11 @@ const isStepValid = computed(() => {
       item.unit_cost >= 0
     )
   }
-  // Step 2 (documents) is always valid
+  if (currentStep.value === 2 || currentStep.value === 3) {
+    if (form.value.payment_type === 'contado' && !hasPaymentSelected.value) {
+      return false
+    }
+  }
   return true
 })
 
@@ -1113,6 +1151,7 @@ const handleSubmit = async () => {
       purchase_date: form.value.purchase_date ? purchaseDatePayloadISO(form.value.purchase_date) : null,
       notes: form.value.notes,
       invoice_number: form.value.invoice_number,
+      payment_type: form.value.payment_type,
       payment_method: form.value.payment_method || null,
       payment_method_id: form.value.payment_method_id || null,
       payment_reference: form.value.payment_reference || null,

--- a/pages/abastecimiento/compras-directas/[id]/editar.vue
+++ b/pages/abastecimiento/compras-directas/[id]/editar.vue
@@ -765,7 +765,7 @@
               v-else
               type="button"
               @click="handleSubmit"
-              :disabled="isSubmitting"
+              :disabled="!isStepValid || isSubmitting"
               class="btn-primary px-4 sm:px-6 py-2 rounded-lg disabled:opacity-50 text-sm sm:text-base"
             >
               <span class="hidden sm:inline">{{ isSubmitting ? 'Guardando...' : 'Guardar Cambios' }}</span>
@@ -1132,7 +1132,12 @@ const previousStep = () => {
 // Submit
 // Submit
 const handleSubmit = async () => {
-  if (!isStepValid.value) return
+  if (!isStepValid.value) {
+    if (form.value.payment_type === 'contado' && !hasPaymentSelected.value) {
+      alert('Contado requiere un método de pago. Elige uno o cambia a Crédito.')
+    }
+    return
+  }
 
   isSubmitting.value = true
 

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -181,10 +181,13 @@
                   v-model="form.payment_type"
                   class="input-base w-full px-4 py-2"
                 >
-                  <option value="contado">Contado - Pago Inmediato</option>
                   <option value="credito">Credito - Pago Diferido</option>
+                  <option value="contado">Contado - Pago Inmediato</option>
                   <option value="contraentrega">Contraentrega</option>
                 </select>
+                <p v-if="form.payment_type === 'contado' && !hasPaymentSelected" class="mt-1.5 text-xs text-warning">
+                  Contado exige un método de pago abajo. Sin pago, usa Crédito.
+                </p>
               </div>
 
               <div>
@@ -480,7 +483,10 @@
                 </h4>
 
                 <div>
-                  <label class="block text-sm font-medium text-text-primary mb-1.5">Método de pago</label>
+                  <label class="block text-sm font-medium text-text-primary mb-1.5">
+                    Método de pago
+                    <span v-if="form.payment_type === 'contado'" class="text-destructive">*</span>
+                  </label>
                   <select v-model="paymentSelectValue" class="input-base w-full px-4 py-2">
                     <option value="">Sin pago aun</option>
                     <template v-for="group in paymentGroups" :key="group.slug">
@@ -781,7 +787,7 @@ const localPurchaseUnits = ref<LocalPurchaseUnit[]>([])
 // Form
 const form = ref({
   supplier_id: '',
-  payment_type: 'contado',
+  payment_type: 'credito',
   purchase_date: localDateAtNoon(todayISO()) as Date | null,
   notes: '',
   invoice_number: '',
@@ -827,6 +833,10 @@ watch(hasPaymentSelected, (selected) => {
   form.value.payment_reference = ''
   form.value.payment_date = null
   form.value.payment_files = []
+  // Contado without method is invalid — treat unpaid as crédito
+  if (form.value.payment_type === 'contado') {
+    form.value.payment_type = 'credito'
+  }
 })
 
 // Fetch next purchase number
@@ -925,6 +935,11 @@ function validateForm(): boolean {
   )
   if (invalidItem) {
     submitError.value = WAREHOUSE_COPY.purchaseCompleteItemsError
+    return false
+  }
+
+  if (form.value.payment_type === 'contado' && !hasPaymentSelected.value) {
+    submitError.value = 'Contado requiere un método de pago. Elige uno o cambia a Crédito.'
     return false
   }
 
@@ -1507,6 +1522,10 @@ const handleScanFileSelect = async (event: Event) => {
       // Pre-fill invoice fields for Step 3
       if (data.numero_factura) form.value.invoice_number = data.numero_factura
       form.value.invoice_files = [optimizedFile]
+      // OCR does not detect payment — unpaid stays as crédito (not Contado)
+      if (!hasPaymentSelected.value) {
+        form.value.payment_type = 'credito'
+      }
     }
   } catch (e) {
     const err = e as { data?: { detail?: { error?: string; scans_used?: number; scans_limit?: number; period_end?: string } }; status?: number }


### PR DESCRIPTION
## Summary
- Default unpaid / OCR path to Crédito (not Contado + Sin pago)
- Contado requires a payment method on create and edit; clearing method auto-switches to Crédito
- Companion API: https://github.com/uno0uno/api-warolabs/pull/708

Closes #1759

## Test plan
- [ ] Create compra: Contado without method → blocked with message
- [ ] Create: Crédito + Sin pago aun → saves
- [ ] Create: Contado + método → saves as paid path
- [ ] OCR scan leaves Crédito when no payment selected
- [ ] Edit: same Contado/Crédito rules

## Validation evidence
```
cd api_warocol.com && pytest tests/test_direct_purchase_payment_type.py -q --tb=short
....
4 passed in 0.02s
```
(Front: no targeted unit test harness for these Vue pages; API contract tests above.)

## wr-context
See `.wr/1759.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)