### PR TITLE
fix(pos): editable receipt email for generic/walk-in customers

### DIFF
--- a/.wr/1763.yaml
+++ b/.wr/1763.yaml
@@ -1,0 +1,37 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1763
+title: "POS receipt email: allow edit for generic/walk-in customers"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1763-pos-receipt-email-generic
+
+paths:
+  - pages/pos/checkout.vue
+
+ac:
+  - Generic walk-in (phone 0000000000 or @customer.temp) does not lock confirmation mode
+  - Success modal shows editable email input for generics
+  - Real customers with profile email keep confirmation mode
+  - Receipt send works with typed email
+  - Mesa close uses same generic rule as POS complete
+
+out_of_scope:
+  - Changing Genérico customer creation/storage
+  - API email endpoints
+
+hints:
+  entry: "applyReceiptEmailAfterSale / isGenericReceiptCustomer in checkout.vue"
+  pattern: "components/ventas/InvoiceEmailModal.vue isGenericCustomer (#603)"
+  tests: "rg applyReceiptEmailAfterSale pages/pos/checkout.vue — no targeted Vue unit test"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "manual POS sale as Cliente sin datos — type another email and send"

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1277,6 +1277,28 @@ const { estimatedWaros, earnEligible: warosEarnEligible, isLoadingEstimate, syst
 const selectedWaroReward = ref<WaroReward | null>(null)
 const warosBalance = computed(() => warosSummary.value?.current_balance ?? 0)
 const isAnonymousCustomer = computed(() => selectedCustomer.value?.phone_number === '0000000000')
+
+/** Same rule as InvoiceEmailModal (#603 / #1763): Genérico walk-in must not lock receipt email. */
+function isGenericReceiptCustomer(customer: { phone_number?: string | null; email?: string | null } | null | undefined): boolean {
+  if (!customer) return true
+  const phone = customer.phone_number ?? ''
+  const email = (customer.email ?? '').toLowerCase()
+  return phone === '0000000000' || email.endsWith('@customer.temp')
+}
+
+function applyReceiptEmailAfterSale(customer: { phone_number?: string | null; email?: string | null } | null | undefined) {
+  emailSent.value = false
+  if (isGenericReceiptCustomer(customer)) {
+    receiptEmail.value = ''
+    emailFromProfile.value = false
+    return
+  }
+  const email = customer?.email ?? ''
+  const usable = email && !email.toLowerCase().endsWith('@customer.temp') ? email : ''
+  receiptEmail.value = usable
+  emailFromProfile.value = !!usable
+}
+
 const selectedCustomerDisplayName = computed(() =>
   isAnonymousCustomer.value
     ? t('pos.checkout.customerNoData')
@@ -1966,9 +1988,7 @@ const processOrder = async () => {
           : null,
         singleCashChange: isCashMethod.value ? cashChange.value : null,
       })
-      const customerEmail = selectedCustomer.value?.email ?? ''
-      receiptEmail.value = customerEmail && !customerEmail.endsWith('@customer.temp') ? customerEmail : ''
-      emailSent.value = false
+      applyReceiptEmailAfterSale(selectedCustomer.value)
       posStore.clearAll()
       if (session.isBar) {
         posStore.exitSession()
@@ -2004,9 +2024,6 @@ const processOrder = async () => {
     isProcessing.value = true
     processingError.value = ''
     if (!(await ensureWalletTenderCanPay(finalAmountToCollect.value))) return
-
-    const preEmail = selectedCustomer.value?.email ?? ''
-    const emailForReceipt = preEmail && !preEmail.endsWith('@customer.temp') ? preEmail : undefined
 
     const _discountAmtPos = discountAmount.value
     const _subtotalPos = cartTotal.value
@@ -2107,9 +2124,7 @@ const processOrder = async () => {
           : null,
         singleCashChange: isCashMethod.value ? cashChange.value : null,
       })
-      receiptEmail.value = emailForReceipt ?? ''
-      emailSent.value = false
-      emailFromProfile.value = !!emailForReceipt
+      applyReceiptEmailAfterSale(selectedCustomer.value)
       posStore.clearAll()
       // After a bar POS sale, drop the local session so /pos shows the floor
       // plan again (clearAll keeps bar sessions alive on purpose; here we


### PR DESCRIPTION
## Summary
- Treat Genérico / walk-in (`0000000000` or `@customer.temp`) like InvoiceEmailModal: editable receipt email after sale
- Keep confirmation-locked mode only for real customers with a profile email
- Same rule on mesa close and standard POS complete

Closes #1763

## Test plan
- [ ] Sale with Cliente sin datos + profile email like `test@ejemplo.com` → editable input, can type another email and send
- [ ] Sale with identified customer that has email → Confirmar envío still works
- [ ] Mesa close with Genérico → same editable behavior

## Validation evidence
```
rg -n "isGenericReceiptCustomer|applyReceiptEmailAfterSale|emailFromProfile\.value = !!" pages/pos/checkout.vue
```
(Helper present; no remaining `emailFromProfile.value = !!emailForReceipt`. No targeted Vue unit test for this page.)

## wr-context
See `.wr/1763.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)