### PR TITLE
fix(pos): tenant currency display + remove counter Identify CTA

### DIFF
--- a/.wr/1765.yaml
+++ b/.wr/1765.yaml
@@ -11,6 +11,11 @@ paths:
   - pages/pos/index.vue
   - pages/pos/checkout.vue
   - pages/pos/producto/[id].vue
+  - components/pos/ProductCard.vue
+  - components/pos/CartPanel.vue
+  - components/pos/CartItem.vue
+  - components/pos/MesasFloorPlan.vue
+  - components/pos/TableSessionAdvancePanel.vue
 
 ac:
   - formatCurrencyPOS / POS totals use tenant base_currency_code

--- a/.wr/1765.yaml
+++ b/.wr/1765.yaml
@@ -1,0 +1,42 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1765
+title: "POS: tenant currency display + remove redundant Identify customer (no tables)"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1765-pos-currency-identify
+
+paths:
+  - pages/pos/index.vue
+  - pages/pos/checkout.vue
+  - pages/pos/producto/[id].vue
+
+ac:
+  - formatCurrencyPOS / POS totals use tenant base_currency_code
+  - Checkout summary labels use currencyCode not hardcoded COP
+  - Product page uses useFormatters not currency COP
+  - Mesa/mostrador/barra consistent currency
+  - COP tenants still correct
+  - Hide Identificar cliente CTA when no table session; keep customer chip+Cambiar if selected
+  - Identify remains on checkout
+
+out_of_scope:
+  - Multi-currency ledger/FX
+  - Genérico email DB ops
+  - Removing checkout identify UI
+
+hints:
+  entry: "useFormatters formatCurrency + currencyCode; remove Identify CTA block in index.vue"
+  pattern: "docs/engineering/display-currency.md; checkout already uses formatCurrency"
+  tests: "rg formatCurrencyPOS|currencyCode|>COP<|Identify customer CTA pages/pos"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "manual POS MXN tenant + COP tenant; counter without identify CTA"

--- a/components/pos/CartItem.vue
+++ b/components/pos/CartItem.vue
@@ -163,6 +163,8 @@ import {
   TrashIcon,
 } from '@heroicons/vue/24/outline'
 
+const { formatCurrency } = useFormatters()
+
 interface CartItem {
   product: {
     id: string
@@ -242,14 +244,6 @@ const unitNet = computed(() => {
   const qty = Number(props.item.quantity) || 1
   return netTotal.value / qty
 })
-
-const formatCurrency = (value: number) => {
-  return new Intl.NumberFormat(toNumberLocaleTag(locale.value), {
-    style: 'currency',
-    currency: 'COP',
-    minimumFractionDigits: 0,
-  }).format(value)
-}
 
 const formatTime = (isoString: string) => {
   return new Date(isoString).toLocaleTimeString(toNumberLocaleTag(locale.value), {

--- a/components/pos/CartPanel.vue
+++ b/components/pos/CartPanel.vue
@@ -387,11 +387,12 @@
 </template>
 
 <script setup lang="ts">
-const { t, locale } = useI18n({ useScope: 'global' })
+const { t } = useI18n({ useScope: 'global' })
 import { usePOSStore } from '~/stores/usePOSStore'
 import { storeToRefs } from 'pinia'
 import { usePosOrderPromoTotals } from '~/composables/usePosOrderPromoTotals'
 
+const { formatCurrency } = useFormatters()
 const { singular: tableSingular } = useTableLabel()
 const tableSingularLower = computed(() => tableSingular.value.toLowerCase())
 
@@ -590,14 +591,6 @@ const displayItemCount = computed(() =>
 const onServedByChange = (event: Event) => {
   const target = event.target as HTMLSelectElement
   emit('update:served-by', target.value || null)
-}
-
-const formatCurrency = (value: number) => {
-  return new Intl.NumberFormat(toNumberLocaleTag(locale.value), {
-    style: 'currency',
-    currency: 'COP',
-    minimumFractionDigits: 0
-  }).format(value)
 }
 
 function tabLineStatus(item: TabItem): string {

--- a/components/pos/MesasFloorPlan.vue
+++ b/components/pos/MesasFloorPlan.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-const { t, locale } = useI18n({ useScope: 'global' })
-import { toNumberLocaleTag } from '~/utils/appLocales'
+const { t } = useI18n({ useScope: 'global' })
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { $fetch } from 'ofetch'
 import { displayTableCode, tableCodeTypographyClass } from '~/composables/useTableDisplayCode'
 
+const { formatCurrency } = useFormatters()
 const { singular: tableSingular } = useTableLabel()
 const tableSingularLower = computed(() => tableSingular.value.toLowerCase())
 
@@ -161,9 +161,6 @@ const formatDuration = (openedAt: string): string => {
   const m = totalMins % 60
   return m > 0 ? `${h}h ${m}m` : `${h}h`
 }
-
-const formatCurrency = (amount: number): string =>
-  `$${Math.round(amount).toLocaleString(toNumberLocaleTag(normalizeUiLocale(locale.value)))}`
 
 const minimumConsumptionLabel = (table: any): string | null => {
   const state = table.session?.minimum_consumption

--- a/components/pos/ProductCard.vue
+++ b/components/pos/ProductCard.vue
@@ -41,8 +41,9 @@
 </template>
 
 <script setup lang="ts">
-const { locale } = useI18n({ useScope: 'global' })
 import { ref, computed } from 'vue'
+
+const { formatCurrency } = useFormatters()
 
 interface Product {
   id: string
@@ -167,12 +168,4 @@ const iconSlotStyle = computed(() => {
   const colors = getColorForProduct(props.product.category, props.product.name)
   return { backgroundColor: colors.slotBg }
 })
-
-const formatCurrency = (value: number) => {
-  return new Intl.NumberFormat(toNumberLocaleTag(locale.value), {
-    style: 'currency',
-    currency: 'COP',
-    minimumFractionDigits: 0
-  }).format(value)
-}
 </script>

--- a/components/pos/TableSessionAdvancePanel.vue
+++ b/components/pos/TableSessionAdvancePanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const { t, locale } = useI18n({ useScope: 'global' })
+const { t } = useI18n({ useScope: 'global' })
 import { computed, ref, watch } from 'vue'
 import {
   BanknotesIcon,
@@ -78,8 +78,7 @@ const suggestedAmount = computed(() => {
   return remaining > 0 ? remaining : Number(state.amount) || 0
 })
 
-const formatCurrency = (value: number) =>
-  `$${Math.round(Number(value) || 0).toLocaleString(toNumberLocaleTag(locale.value))}`
+const { formatCurrency } = useFormatters()
 
 const methodLabel = (advance: SessionAdvance) => {
   const group = paymentGroups.value.find(g => g.slug === advance.payment_method)

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1627,7 +1627,7 @@ watch(selectedCustomer, async (customer) => {
 })
 
 // Methods — display currency from tenant prefs (default COP); see display-currency.md
-const { formatCurrency } = useFormatters()
+const { formatCurrency, currencyCode } = useFormatters()
 
 const getItemTotal = (item: any) => {
   const basePrice = Number(item.product.price) || 0
@@ -4038,7 +4038,7 @@ onUnmounted(() => {
 	                <span class="text-text-secondary font-medium">{{ t('pos.checkout.summary.totalToPay') }}</span>
                 <span class="text-3xl font-bold text-primary tabular-nums">{{ formatCurrency(checkoutSummaryAmountDue) }}</span>
               </div>
-              <p class="text-end text-xs text-text-tertiary">COP</p>
+              <p class="text-end text-xs text-text-tertiary">{{ currencyCode }}</p>
             </div>
           </div>
         </div>
@@ -4539,7 +4539,7 @@ onUnmounted(() => {
 	              <span class="text-text-secondary font-medium">{{ t('pos.checkout.summary.totalToPay') }}</span>
               <span class="text-3xl font-bold text-primary tabular-nums">{{ formatCurrency(checkoutSummaryAmountDue) }}</span>
             </div>
-            <p class="text-end text-xs text-text-tertiary">COP</p>
+            <p class="text-end text-xs text-text-tertiary">{{ currencyCode }}</p>
           </div>
         </div>
       </div>

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -28,6 +28,8 @@ definePageMeta({
 
 useHead({ title: () => t('pos.banner.pageTitle') })
 
+const { formatCurrency } = useFormatters()
+
 // Tenant reactivity
 const { currentTenant } = useTenantReactive()
 const { singular: tableSingular, plural: tablePlural } = useTableLabel()
@@ -813,8 +815,7 @@ registerTableSessionRefresh(
   { isMutationActive: isTableSessionMutationActive },
 )
 
-const formatCurrencyPOS = (amount: number): string =>
-  `$${Math.round(amount).toLocaleString(toNumberLocaleTag(normalizeUiLocale(locale.value)))}`
+const formatCurrencyPOS = (amount: number): string => formatCurrency(amount)
 
 const activeMinimumConsumption = computed(() => posStore.activeTableSession?.minimumConsumption ?? null)
 const showActiveMinimumConsumption = computed(() =>
@@ -2037,20 +2038,6 @@ onUnmounted(() => {
             {{ t('pos.banner.change') }}
           </button>
         </div>
-      </div>
-
-      <!-- Identify customer CTA (counter/bar, no table session) -->
-      <div v-else>
-        <button
-          type="button"
-          class="w-full flex items-center justify-center gap-2 min-h-[44px] px-4 py-3 rounded-xl border-2 border-dashed border-badge-primary-border text-badge-primary-text font-semibold text-sm hover:bg-badge-primary-bg transition-colors"
-          @click="showCustomerModal = true"
-        >
-          <svg class="h-[1em] w-[1em]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-          </svg>
-          {{ t('pos.banner.identifyCustomer') }}
-        </button>
       </div>
 
           <!-- Search and Filters -->

--- a/pages/pos/producto/[id].vue
+++ b/pages/pos/producto/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const { t, locale } = useI18n({ useScope: 'global' })
+const { t } = useI18n({ useScope: 'global' })
 import { ref, computed, onMounted, onUnmounted, inject, watch } from 'vue'
 import { $fetch } from 'ofetch'
 import { usePOSStore } from '~/stores/usePOSStore'
@@ -779,13 +779,7 @@ const addToCart = async () => {
   }
 }
 
-const formatCurrency = (value: number) => {
-  return new Intl.NumberFormat(toNumberLocaleTag(locale.value), {
-    style: 'currency',
-    currency: 'COP',
-    minimumFractionDigits: 0
-  }).format(value)
-}
+const { formatCurrency } = useFormatters()
 
 const modifierPriceLabel = (modifier: ModifierOption) => {
   const included = Math.max(0, Number(modifier.included_quantity) || 0)


### PR DESCRIPTION
## Summary
- POS amounts use tenant `base_currency_code` via `useFormatters` (no bare `$` / hardcoded COP)
- Checkout summary currency label uses `currencyCode`
- Counter/no-tables: remove redundant **Identificar cliente** banner (identify stays on checkout)

Closes #1765

## Test plan
- [ ] MXN tenant (`TEST-23-07-2026`): `/pos` cart/banner/checkout/product show MX currency
- [ ] COP tenant: still looks correct
- [ ] No tables: catalog has no Identificar cliente CTA; checkout still identifies
- [ ] With customer already selected on counter: Cambiar chip still works

## Validation evidence
```
rg -n "formatCurrencyPOS|currencyCode|Identify customer CTA|>COP<|currency: 'COP'" pages/pos/index.vue pages/pos/checkout.vue pages/pos/producto/[id].vue
```
(formatCurrencyPOS → formatCurrency; currencyCode labels; no Identify CTA / no hardcoded COP.)

## wr-context
See `.wr/1765.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)