### PR TITLE
fix(pos): identify loader dots + compact checkout customer card

### DIFF
--- a/.wr/1767.yaml
+++ b/.wr/1767.yaml
@@ -1,0 +1,31 @@
+# Machine contract for wr-fast — keep ≤80 lines.
+issue: 1767
+title: "POS checkout: Genérico resolution, create loader dots, compact customer card"
+repo: both
+repo_remote: uno0uno/warocol.com + uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA
+stack: both
+branch: wr-1767-pos-generico-loader-card
+
+paths:
+  - api_warocol.com/app/services/customers_service.py
+  - api_warocol.com/tests/test_anonymous_customer_resolution.py
+  - front_nuxt/components/pos/CustomerIdentificationModal.vue
+  - front_nuxt/pages/pos/checkout.vue
+
+ac:
+  - Identify modal create/save uses UiLoadingDots (not CommonsTheCustomLoader)
+  - Phone 0000000000 lookup prefers Genérico (generico@warocol.com / name Genérico)
+  - Checkout Datos del cliente card denser L→R; keep Cambiar + wallet
+
+out_of_scope:
+  - Merging duplicate 0000000000 profiles in DB
+  - Changing shared Genérico email data
+
+hints:
+  entry: "search-or-create + search_by_phone — customers_service.py"
+  pattern: "ORDER BY email/name rank then created_at; rank_anonymous_phone_profile for unit tests"
+  tests: "./venv/bin/pytest tests/test_anonymous_customer_resolution.py -q"
+
+skip:
+  audits: [ux, color, typography]

--- a/components/pos/CustomerIdentificationModal.vue
+++ b/components/pos/CustomerIdentificationModal.vue
@@ -194,7 +194,8 @@
                   <path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
                 </svg>
               </div>
-              <span class="font-semibold text-sm text-text-primary leading-tight text-center">
+              <span class="font-semibold text-sm text-text-primary leading-tight text-center inline-flex items-center gap-2">
+                <UiLoadingDots v-if="isCreatingGeneric" size="7px" color="currentColor" />
                 {{ isCreatingGeneric ? t('common.loading') : t('pos.customer.noData') }}
               </span>
             </button>
@@ -354,7 +355,7 @@
                 :disabled="!canSubmitCreate || isCreating"
                 class="flex-1 min-h-[44px] px-4 py-3 bg-action-primary-bg text-action-primary-text font-semibold rounded-xl hover:bg-action-primary-hover-bg active:scale-95 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
               >
-                <CommonsTheCustomLoader v-if="isCreating" size="small" />
+                <UiLoadingDots v-if="isCreating" size="8px" color="currentColor" />
                 <span>{{ isCreating ? t('common.loading') : t('pos.customer.saveAndContinue') }}</span>
               </button>
             </div>
@@ -449,7 +450,7 @@
                 :disabled="!canSubmitFiscal || isCreating"
                 class="flex-1 min-h-[44px] px-4 py-3 bg-action-primary-bg text-action-primary-text font-semibold rounded-xl hover:bg-action-primary-hover-bg active:scale-95 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
               >
-                <CommonsTheCustomLoader v-if="isCreating" size="small" />
+                <UiLoadingDots v-if="isCreating" size="8px" color="currentColor" />
                 <span>{{ isCreating ? t('common.loading') : t('pos.customer.saveData') }}</span>
               </button>
             </div>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -3326,25 +3326,30 @@ onUnmounted(() => {
             {{ t('pos.checkout.customerData') }}
           </h2>
 
-          <!-- Customer selected: show card -->
-          <div v-if="selectedCustomer" class="flex items-center gap-4 p-4 bg-primary/5 border border-primary/20 rounded-xl">
-            <div class="w-10 h-10 rounded-full bg-primary/10 text-primary flex items-center justify-center font-bold text-sm flex-shrink-0">
+          <!-- Customer selected: compact contact | fiscal layout -->
+          <div v-if="selectedCustomer" class="flex items-start gap-3 p-3 md:p-4 bg-primary/5 border border-primary/20 rounded-xl">
+            <div class="w-9 h-9 md:w-10 md:h-10 rounded-full bg-primary/10 text-primary flex items-center justify-center font-bold text-sm flex-shrink-0">
               {{ selectedCustomer.name?.charAt(0)?.toUpperCase() || selectedCustomer.phone_number?.charAt(0) || '?' }}
             </div>
-            <div class="flex-1 min-w-0">
-              <p class="text-[10px] font-bold uppercase tracking-wider text-text-tertiary">
-                {{ t('pos.receipt.saleContact') }}
-              </p>
-              <p class="font-semibold text-text-primary truncate">{{ selectedCustomerDisplayName }}</p>
-              <p class="text-sm text-text-secondary truncate">{{ selectedCustomer.phone_number || t('pos.checkout.noPhone') }}</p>
-              <p v-if="selectedCustomer.email" class="text-xs text-text-secondary truncate">{{ selectedCustomer.email }}</p>
-              <p v-if="selectedCustomer.fiscal_id && !selectedCustomerIdentity.showSeparateAcquirer" class="text-xs text-state-success-text truncate mt-0.5 flex items-center gap-1">
-                <svg class="h-[1em] w-[1em]" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
-                {{ t('pos.checkout.invoiceFiscalPrefix', { type: selectedCustomer.fiscal_id_type, id: selectedCustomer.fiscal_id }) }}
-              </p>
+            <div
+              class="flex-1 min-w-0 grid grid-cols-1 gap-3 md:gap-4"
+              :class="selectedCustomerIdentity.showSeparateAcquirer ? 'md:grid-cols-2' : ''"
+            >
+              <div class="min-w-0">
+                <p class="text-[10px] font-bold uppercase tracking-wider text-text-tertiary">
+                  {{ t('pos.receipt.saleContact') }}
+                </p>
+                <p class="font-semibold text-text-primary truncate">{{ selectedCustomerDisplayName }}</p>
+                <p class="text-sm text-text-secondary truncate">{{ selectedCustomer.phone_number || t('pos.checkout.noPhone') }}</p>
+                <p v-if="selectedCustomer.email" class="text-xs text-text-secondary truncate">{{ selectedCustomer.email }}</p>
+                <p v-if="selectedCustomer.fiscal_id && !selectedCustomerIdentity.showSeparateAcquirer" class="text-xs text-state-success-text truncate mt-0.5 flex items-center gap-1">
+                  <svg class="h-[1em] w-[1em]" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+                  {{ t('pos.checkout.invoiceFiscalPrefix', { type: selectedCustomer.fiscal_id_type, id: selectedCustomer.fiscal_id }) }}
+                </p>
+              </div>
               <div
                 v-if="selectedCustomerIdentity.showSeparateAcquirer"
-                class="mt-2 border-t border-primary/15 pt-2"
+                class="min-w-0 md:border-s md:border-primary/15 md:ps-4"
               >
                 <p class="text-[10px] font-bold uppercase tracking-wider text-state-warning-text">
                   {{ t('pos.receipt.fiscalAcquirer') }}
@@ -3361,7 +3366,7 @@ onUnmounted(() => {
               </div>
               <div
                 v-if="!isAnonymousCustomer"
-                class="flex flex-wrap gap-2 mt-2"
+                class="flex flex-wrap gap-2 md:col-span-2"
                 aria-live="polite"
               >
                 <div
@@ -3379,7 +3384,7 @@ onUnmounted(() => {
             </div>
             <button
               @click="showCustomerModal = true"
-              class="min-h-[44px] px-3 py-2 text-sm text-primary font-medium hover:bg-primary/10 rounded-lg transition-colors flex-shrink-0"
+              class="min-h-[44px] px-3 py-2 text-sm text-primary font-medium hover:bg-primary/10 rounded-lg transition-colors flex-shrink-0 self-center"
             >
               {{ t('pos.checkout.changeCustomer') }}
             </button>


### PR DESCRIPTION
## Summary
- Identify modal create/save (and Genérico CTA) use `UiLoadingDots` instead of `CommonsTheCustomLoader`.
- Checkout “Datos del cliente” card is denser: contact and fiscal acquirer side-by-side on desktop; Cambiar + wallet kept.

Closes #1767

Companion API: prefer Genérico on `0000000000` (api-warolabs PR).

## Test plan
- [ ] Identify → create customer: dots on save button, no matrix loader
- [ ] Checkout with selected customer: card denser; separate acquirer shows L→R on desktop
- [ ] Cambiar and wallet badge still work

## wr-context
See `.wr/1767.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)