### PR TITLE
fix(pos): order email history CTAs and pass order_id from checkout

### DIFF
--- a/.wr/1769.yaml
+++ b/.wr/1769.yaml
@@ -1,0 +1,39 @@
+# Machine contract for wr-fast — keep ≤80 lines.
+issue: 1769
+title: "Sale detail + POS: resend order email and unify delivery history"
+repo: both
+repo_remote: uno0uno/warocol.com + uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA
+stack: both
+branch: wr-1769-order-email-history
+
+paths:
+  - api_warocol.com/app/services/orders_service.py
+  - api_warocol.com/app/routers/pos_cart.py
+  - api_warocol.com/app/services/pos_cart_service.py
+  - api_warocol.com/tests/test_invoice_send_email.py
+  - api_warocol.com/tests/test_pos_receipt_email_tracking.py
+  - front_nuxt/pages/ventas/[id].vue
+  - front_nuxt/pages/pos/checkout.vue
+  - front_nuxt/components/ventas/InvoiceEmailModal.vue
+
+ac:
+  - Completed /ventas/[id]: Enviar + Ver historial without accepted DIAN invoice (receipt send)
+  - Accepted invoice: keep invoice email + attachments; resend appends history row
+  - POS /receipt-email with order_id → invoice_email_deliveries (+ pixel) like send_invoice_email
+  - Complete-order fire-and-forget with receipt_email + _order_id also tracks (fail-open)
+  - Historial shows POS + ventas deliveries; empty only if never tracked
+  - Tests: invoice send/history still pass; receipt-without-invoice + POS delivery when order_id
+
+out_of_scope:
+  - Backfill old untracked POS emails
+  - Inventing DIAN invoices
+  - SES template redesign
+
+hints:
+  entry: "orders_service.send_invoice_email; pos_cart SendReceiptRequest + /receipt-email; pos_cart_service complete receipt; ventas/[id] CTA gate"
+  pattern: "Mirror create_pending_delivery + mark_sent/failed + tracking_pixel_url from send_invoice_email (~4377); POS currently skips this"
+  tests: "./venv/bin/pytest tests/test_invoice_send_email.py tests/test_pos_receipt_email_tracking.py -q"
+
+skip:
+  audits: [ux, color, typography]

--- a/components/ventas/InvoiceEmailModal.vue
+++ b/components/ventas/InvoiceEmailModal.vue
@@ -25,7 +25,8 @@ interface Customer {
 interface Props {
   open: boolean
   orderId: string
-  invoiceLabel: string  // e.g. "LZT-5462" for the in-modal copy
+  /** Invoice label (e.g. LZT-5462) or order number fallback (#123) for receipt-only sends. */
+  invoiceLabel: string
   customer: Customer | null
 }
 

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -2906,6 +2906,7 @@ const sendReceiptEmail = async () => {
       body: {
         email: receiptEmail.value,
         order_number: orderResult.value.order_number,
+        order_id: orderResult.value.order_id || orderResult.value.order_ids?.[0] || null,
         total_amount: orderResult.value.total_amount,
         payment_method: orderResult.value.payment_method,
         items: itemsForEmail,

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -375,6 +375,15 @@ const canEmitInvoiceForOrder = computed(() => Boolean(
     && orderHasInvoiceCustomer.value
     && !isCreditOnlyInvoiceBlocked.value
 ))
+/** Completed sales can resend receipt/invoice email + view delivery history (#1769). */
+const canSendOrderEmail = computed(() => order.value?.status === 'completed')
+const orderEmailLabel = computed(() => {
+  if (invoiceData.value?.prefix && invoiceData.value?.invoice_number != null) {
+    return `${invoiceData.value.prefix}-${invoiceData.value.invoice_number}`
+  }
+  const n = order.value?.order_number
+  return n != null ? `#${n}` : t('ventas.detail.emailInvoiceCta')
+})
 const shouldShowInvoiceSection = computed(() => Boolean(
   invoiceData.value
     || isCreditOnlyInvoiceBlocked.value
@@ -1302,7 +1311,7 @@ onUnmounted(() => {
                   </svg>
                   {{ t('ventas.detail.downloadPdfCta') }}
                 </a>
-                <button v-if="invoiceData.status === 'accepted'"
+                <button v-if="canSendOrderEmail"
                   type="button"
                   @click="showEmailModal = true"
                   class="w-full inline-flex items-center justify-center gap-2 min-h-[44px] px-4 py-3 rounded-xl text-sm font-semibold border border-primary/20 text-primary hover:bg-primary/5 transition-colors">
@@ -1312,7 +1321,7 @@ onUnmounted(() => {
                   </svg>
                   {{ t('ventas.detail.emailInvoiceCta') }}
                 </button>
-                <button v-if="invoiceData.status === 'accepted'"
+                <button v-if="canSendOrderEmail"
                   type="button"
                   @click="showInvoiceEmailHistory = true"
                   class="w-full inline-flex items-center justify-center gap-2 min-h-[44px] px-4 py-3 rounded-xl text-sm font-semibold border border-border text-text-primary hover:bg-surface-secondary transition-colors">
@@ -1321,9 +1330,6 @@ onUnmounted(() => {
                   </svg>
                   {{ t('ventas.detail.emailHistoryCta') }}
                 </button>
-                <p v-else class="text-xs text-text-tertiary">
-                  {{ t('ventas.detail.invoiceAcceptedOnly') }}
-                </p>
               </div>
             </div>
 
@@ -1543,6 +1549,30 @@ onUnmounted(() => {
         </template>
         </div>
       </Transition>
+
+      <!-- Receipt email for completed sales without an invoice card CTAs (#1769) -->
+      <div
+        v-if="canSendOrderEmail && !invoiceData"
+        class="bg-surface border border-border rounded-2xl p-5 space-y-3"
+      >
+        <h2 class="text-sm font-bold text-text-primary">{{ t('ventas.detail.emailInvoiceCta') }}</h2>
+        <div class="flex flex-col sm:flex-row gap-2">
+          <button
+            type="button"
+            @click="showEmailModal = true"
+            class="flex-1 inline-flex items-center justify-center gap-2 min-h-[44px] px-4 py-2.5 rounded-xl text-sm font-semibold border border-primary/20 text-primary hover:bg-primary/5 transition-colors"
+          >
+            {{ t('ventas.detail.emailInvoiceCta') }}
+          </button>
+          <button
+            type="button"
+            @click="showInvoiceEmailHistory = true"
+            class="flex-1 inline-flex items-center justify-center gap-2 min-h-[44px] px-4 py-2.5 rounded-xl text-sm font-semibold border border-border text-text-primary hover:bg-surface-secondary transition-colors"
+          >
+            {{ t('ventas.detail.emailHistoryCta') }}
+          </button>
+        </div>
+      </div>
 
       <!-- Status Update Panel (mesa and barra orders) -->
       <div v-if="order.source === 'mesa' || order.source === 'barra'"
@@ -2109,12 +2139,12 @@ onUnmounted(() => {
       </Transition>
     </Teleport>
 
-    <!-- warocol.com#603 — send-invoice-by-email modal (WARO-branded via SES) -->
+    <!-- warocol.com#603 / #1769 — send order email (invoice or receipt) -->
     <VentasInvoiceEmailModal
-      v-if="invoiceData"
+      v-if="canSendOrderEmail"
       v-model:open="showEmailModal"
       :order-id="orderId"
-      :invoice-label="`${invoiceData.prefix}-${invoiceData.invoice_number}`"
+      :invoice-label="orderEmailLabel"
       :customer="orderData?.customer ?? null"
       @sent="onInvoiceEmailSent"
     />


### PR DESCRIPTION
## Summary
- Completed `/ventas/[id]` shows Enviar por correo + Ver historial even without an accepted invoice.
- Checkout receipt-email body includes `order_id` so API can register delivery history.

Closes #1769

Companion API PR links tracking for POS + relaxed ventas send.

## Test plan
- [ ] Completed sale without factura: Enviar + Ver historial visible and usable
- [ ] After POS receipt email with order_id: history lists the delivery
- [ ] Accepted invoice path unchanged for send + download

## Validation evidence
Front change is UI/wiring only — API pytest suite is the automated gate (see companion PR).

## wr-context
See `.wr/1769.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)