### PR TITLE
fix(equipo): gate salarios and nómina by colombia_payroll

### DIFF
--- a/composables/useTenantFinancialProfile.ts
+++ b/composables/useTenantFinancialProfile.ts
@@ -146,6 +146,9 @@ export const useTenantFinancialProfile = () => {
   const isColombiaPuc = computed(() =>
     isColombiaPucProfile(response.value, currentTenant.value?.id),
   )
+  const isColombiaPayroll = computed(() =>
+    Boolean(response.value?.capabilities.colombia_payroll),
+  )
   const isWaroCommercial = computed(() =>
     profile.value?.document_mode === 'waro_commercial',
   )
@@ -189,6 +192,7 @@ export const useTenantFinancialProfile = () => {
     profile,
     isFiscalIntegrated,
     isColombiaPuc,
+    isColombiaPayroll,
     isWaroCommercial,
     currencyMinorUnits,
     isLoading: computed(() => !!currentTenant.value && status.value === 'pending'),

--- a/middleware/colombia-payroll.global.ts
+++ b/middleware/colombia-payroll.global.ts
@@ -1,0 +1,55 @@
+/**
+ * colombia-payroll.global.ts — warocol.com#1774
+ *
+ * Deep-link guard for Colombia payroll UI under Equipo.
+ * When capabilities.colombia_payroll is false, redirect
+ * /equipo/salarios/** and /equipo/nomina → /equipo/miembros.
+ *
+ * Do NOT call useTenantFinancialProfile() here — it creates useQuery
+ * on every navigation. Mirror billing-gate: useQueryCache + $fetch.
+ */
+import {
+  financialProfileQueryKey,
+  type TenantFinancialProfileResponse,
+} from '~/composables/useTenantFinancialProfile'
+
+const isPayrollRoute = (path: string) =>
+  path === '/equipo/nomina'
+  || path.startsWith('/equipo/nomina/')
+  || path === '/equipo/salarios'
+  || path.startsWith('/equipo/salarios/')
+
+export default defineNuxtRouteMiddleware(async (to) => {
+  if (process.server) return
+  if (!isPayrollRoute(to.path)) return
+
+  const authStore = useAuthStore()
+  if (!(authStore as any).session?.success) return
+
+  const { currentTenant } = useTenantReactive()
+  const tenantId = currentTenant.value?.id
+  if (!tenantId) return
+
+  const cacheKey = financialProfileQueryKey(tenantId)
+  const cache = useQueryCache()
+
+  let profileResponse = cache.getQueryData<TenantFinancialProfileResponse | null>(cacheKey)
+
+  if (profileResponse === undefined) {
+    try {
+      profileResponse = await $fetch<TenantFinancialProfileResponse>(
+        '/api/api/tenant/financial-profile',
+      )
+      cache.setQueryData(cacheKey, profileResponse)
+    } catch {
+      // Fail open — API salaries router still returns 409
+      return
+    }
+  }
+
+  if (!profileResponse || profileResponse.profile.tenant_id !== tenantId) return
+
+  if (!profileResponse.capabilities.colombia_payroll) {
+    return navigateTo('/equipo/miembros', { replace: true })
+  }
+})

--- a/middleware/z-colombia-payroll.global.ts
+++ b/middleware/z-colombia-payroll.global.ts
@@ -45,8 +45,17 @@ export default defineNuxtRouteMiddleware(async (to) => {
     }
   }
 
+  // selectedTenant is set by watch(tenantData) — wait for flush after fetch
   const { currentTenant } = useTenantReactive()
-  const tenantId = currentTenant.value?.id
+  if (!currentTenant.value?.id && tenantsStore.hasTenants) {
+    await nextTick()
+    const started = Date.now()
+    while (!currentTenant.value?.id && Date.now() - started < 1000) {
+      await new Promise((r) => setTimeout(r, 25))
+    }
+  }
+
+  const tenantId = currentTenant.value?.id ?? tenantsStore.tenants[0]?.id
   if (!tenantId) {
     return navigateTo('/equipo/miembros', { replace: true })
   }

--- a/middleware/z-colombia-payroll.global.ts
+++ b/middleware/z-colombia-payroll.global.ts
@@ -55,7 +55,9 @@ export default defineNuxtRouteMiddleware(async (to) => {
     }
   }
 
-  const tenantId = currentTenant.value?.id ?? tenantsStore.tenants[0]?.id
+  // Fail closed if selectedTenant never resolved — do not guess tenants[0]
+  // (multi-tenant accounts can evaluate the wrong financial profile).
+  const tenantId = currentTenant.value?.id
   if (!tenantId) {
     return navigateTo('/equipo/miembros', { replace: true })
   }

--- a/middleware/z-colombia-payroll.global.ts
+++ b/middleware/z-colombia-payroll.global.ts
@@ -1,12 +1,13 @@
 /**
- * colombia-payroll.global.ts — warocol.com#1774
+ * z-colombia-payroll.global.ts — warocol.com#1774
  *
  * Deep-link guard for Colombia payroll UI under Equipo.
  * When capabilities.colombia_payroll is false, redirect
  * /equipo/salarios/** and /equipo/nomina → /equipo/miembros.
  *
- * Do NOT call useTenantFinancialProfile() here — it creates useQuery
- * on every navigation. Mirror billing-gate: useQueryCache + $fetch.
+ * Filename `z-` so this runs after tenants.global.js (Nuxt alphabetical order).
+ * Do NOT call useTenantFinancialProfile() here — it creates useQuery on every
+ * navigation. Mirror billing-gate: useQueryCache + $fetch.
  */
 import {
   financialProfileQueryKey,
@@ -26,9 +27,29 @@ export default defineNuxtRouteMiddleware(async (to) => {
   const authStore = useAuthStore()
   if (!(authStore as any).session?.success) return
 
+  const tenantsStore = useTenantsStore()
+  if (!tenantsStore.hasTenants && !tenantsStore.isLoading) {
+    try {
+      await tenantsStore.fetchUserTenants()
+    } catch {
+      // Tenant load failed — fail closed on payroll routes
+      return navigateTo('/equipo/miembros', { replace: true })
+    }
+  }
+
+  // Wait briefly if fetch already in flight (tenants.global or parallel)
+  if (tenantsStore.isLoading) {
+    const started = Date.now()
+    while (tenantsStore.isLoading && Date.now() - started < 5000) {
+      await new Promise((r) => setTimeout(r, 50))
+    }
+  }
+
   const { currentTenant } = useTenantReactive()
   const tenantId = currentTenant.value?.id
-  if (!tenantId) return
+  if (!tenantId) {
+    return navigateTo('/equipo/miembros', { replace: true })
+  }
 
   const cacheKey = financialProfileQueryKey(tenantId)
   const cache = useQueryCache()
@@ -42,12 +63,14 @@ export default defineNuxtRouteMiddleware(async (to) => {
       )
       cache.setQueryData(cacheKey, profileResponse)
     } catch {
-      // Fail open — API salaries router still returns 409
-      return
+      // Profile fetch failed — fail closed on payroll routes (API still 409s)
+      return navigateTo('/equipo/miembros', { replace: true })
     }
   }
 
-  if (!profileResponse || profileResponse.profile.tenant_id !== tenantId) return
+  if (!profileResponse || profileResponse.profile.tenant_id !== tenantId) {
+    return navigateTo('/equipo/miembros', { replace: true })
+  }
 
   if (!profileResponse.capabilities.colombia_payroll) {
     return navigateTo('/equipo/miembros', { replace: true })

--- a/pages/equipo.vue
+++ b/pages/equipo.vue
@@ -16,9 +16,18 @@ useHead({ title: 'Equipo' })
 const route = useRoute()
 
 const { t } = useI18n({ useScope: 'global' })
-const navigationItems = computed(() => [
-  { to: '/equipo/miembros', label: t('equipo.head.miembros') },
-  { to: '/equipo/salarios', label: t('equipo.head.salarios'), matchPath: '/equipo/salarios' },
-  { to: '/equipo/nomina', label: t('equipo.head.nomina') }
-])
+const { isColombiaPayroll } = useTenantFinancialProfile()
+
+const navigationItems = computed(() => {
+  const items = [
+    { to: '/equipo/miembros', label: t('equipo.head.miembros') },
+  ]
+  if (isColombiaPayroll.value) {
+    items.push(
+      { to: '/equipo/salarios', label: t('equipo.head.salarios'), matchPath: '/equipo/salarios' },
+      { to: '/equipo/nomina', label: t('equipo.head.nomina') },
+    )
+  }
+  return items
+})
 </script>


### PR DESCRIPTION
## Summary
- Hide Equipo Salarios / Nómina tabs when `capabilities.colombia_payroll` is false; keep Miembros and the Equipo module.
- Client middleware redirects `/equipo/salarios/**` and `/equipo/nomina` → `/equipo/miembros` for non-payroll tenants.
- API `/salaries/**` already enforces `require_colombia_payroll_capability` (409 `COLOMBIA_PAYROLL_NOT_AVAILABLE`) — unchanged.

Closes #1774

## Test plan
- [ ] MX trial: Equipo → Miembros works; Salarios/Nómina tabs hidden
- [ ] MX trial: deep link `/equipo/salarios` and `/equipo/nomina` redirects to Miembros
- [ ] CO tenant: Salarios + Nómina tabs and pages unchanged
- [ ] Optional: `/api/salaries/employees` on MX → 409

## Validation evidence

### API payroll gate (existing)
```
cd api_warocol.com && ./venv/bin/pytest tests/test_account_role_resolution.py::test_colombia_payroll_gate_rejects_global_profile -q

============================= test session starts ==============================
collected 1 item
tests/test_account_role_resolution.py .                                  [100%]
============================== 1 passed in 0.15s ===============================
```

Router dep confirmed: `app/routers/salaries.py:81` `Depends(require_colombia_payroll_capability)`.

### Manual (PR author)
Front nav/middleware changes; verify MX/CO in browser after deploy or local.

Made with [Cursor](https://cursor.com)