### PR TITLE
fix(facturacion): hide Matias/DIAN UI when matias_dian is off

### DIFF
--- a/composables/useTenantFinancialProfile.ts
+++ b/composables/useTenantFinancialProfile.ts
@@ -146,6 +146,9 @@ export const useTenantFinancialProfile = () => {
   const isColombiaPuc = computed(() =>
     isColombiaPucProfile(response.value, currentTenant.value?.id),
   )
+  const isMatiasDian = computed(() =>
+    Boolean(response.value?.capabilities.matias_dian),
+  )
   const isWaroCommercial = computed(() =>
     profile.value?.document_mode === 'waro_commercial',
   )
@@ -189,6 +192,7 @@ export const useTenantFinancialProfile = () => {
     profile,
     isFiscalIntegrated,
     isColombiaPuc,
+    isMatiasDian,
     isWaroCommercial,
     currencyMinorUnits,
     isLoading: computed(() => !!currentTenant.value && status.value === 'pending'),

--- a/middleware/z-matias-dian.global.ts
+++ b/middleware/z-matias-dian.global.ts
@@ -1,0 +1,81 @@
+/**
+ * z-matias-dian.global.ts — warocol.com#1775
+ *
+ * Deep-link guard for DIAN-only Facturación audit.
+ * When capabilities.matias_dian is false, redirect
+ * /facturacion/audit → /facturacion.
+ *
+ * Filename `z-` so this runs after tenants.global.js (Nuxt alphabetical order).
+ * Do NOT call useTenantFinancialProfile() here — it creates useQuery on every
+ * navigation. Mirror billing-gate / z-colombia-payroll: useQueryCache + $fetch.
+ */
+import {
+  financialProfileQueryKey,
+  type TenantFinancialProfileResponse,
+} from '~/composables/useTenantFinancialProfile'
+
+const isDianAuditRoute = (path: string) =>
+  path === '/facturacion/audit'
+  || path.startsWith('/facturacion/audit/')
+
+export default defineNuxtRouteMiddleware(async (to) => {
+  if (process.server) return
+  if (!isDianAuditRoute(to.path)) return
+
+  const authStore = useAuthStore()
+  if (!(authStore as any).session?.success) return
+
+  const tenantsStore = useTenantsStore()
+  if (!tenantsStore.hasTenants && !tenantsStore.isLoading) {
+    try {
+      await tenantsStore.fetchUserTenants()
+    } catch {
+      return navigateTo('/facturacion', { replace: true })
+    }
+  }
+
+  if (tenantsStore.isLoading) {
+    const started = Date.now()
+    while (tenantsStore.isLoading && Date.now() - started < 5000) {
+      await new Promise((r) => setTimeout(r, 50))
+    }
+  }
+
+  const { currentTenant } = useTenantReactive()
+  if (!currentTenant.value?.id && tenantsStore.hasTenants) {
+    await nextTick()
+    const started = Date.now()
+    while (!currentTenant.value?.id && Date.now() - started < 1000) {
+      await new Promise((r) => setTimeout(r, 25))
+    }
+  }
+
+  const tenantId = currentTenant.value?.id
+  if (!tenantId) {
+    return navigateTo('/facturacion', { replace: true })
+  }
+
+  const cacheKey = financialProfileQueryKey(tenantId)
+  const cache = useQueryCache()
+
+  let profileResponse = cache.getQueryData<TenantFinancialProfileResponse | null>(cacheKey)
+
+  if (profileResponse === undefined) {
+    try {
+      profileResponse = await $fetch<TenantFinancialProfileResponse>(
+        '/api/api/tenant/financial-profile',
+      )
+      cache.setQueryData(cacheKey, profileResponse)
+    } catch {
+      return navigateTo('/facturacion', { replace: true })
+    }
+  }
+
+  if (!profileResponse || profileResponse.profile.tenant_id !== tenantId) {
+    return navigateTo('/facturacion', { replace: true })
+  }
+
+  if (!profileResponse.capabilities.matias_dian) {
+    return navigateTo('/facturacion', { replace: true })
+  }
+})

--- a/pages/facturacion/audit.vue
+++ b/pages/facturacion/audit.vue
@@ -18,6 +18,7 @@ const route = useRoute()
 const { formatDate } = useFormatters()
 const {
   isFiscalIntegrated,
+  isMatiasDian,
   isLoading: isFinancialProfileLoading,
 } = useTenantFinancialProfile()
 
@@ -120,7 +121,7 @@ const reasonClass = (reason: string) => {
   </div>
 
   <section
-    v-else-if="!isFiscalIntegrated"
+    v-else-if="!isMatiasDian || !isFiscalIntegrated"
     class="rounded-xl border-2 border-state-info-border bg-state-info-bg p-5"
     role="status"
   >

--- a/pages/facturacion/index.vue
+++ b/pages/facturacion/index.vue
@@ -23,6 +23,7 @@ const { formatDate } = useFormatters()
 const cache = useQueryCache()
 const {
   isFiscalIntegrated,
+  isMatiasDian,
   isWaroCommercial,
   isLoading: isFinancialProfileLoading,
 } = useTenantFinancialProfile()
@@ -431,7 +432,7 @@ const taxLevels = [
   <div v-else class="space-y-6">
 
     <section
-      v-if="isWaroCommercial"
+      v-if="!isMatiasDian || isWaroCommercial"
       class="rounded-xl border-2 border-state-info-border bg-state-info-bg p-4 sm:p-6"
       role="status"
       aria-live="polite"


### PR DESCRIPTION
## Summary
- Commercial shell when `!matias_dian` (module stays visible)
- Deep-link middleware: `/facturacion/audit` → `/facturacion` when capability off
- DIAN/Matias blocks remain behind `isFiscalIntegrated`

Closes #1775 (epic #1772 batch 3). Pair with api-warolabs PR for server-side gate.

## Test plan
- [ ] MX: `/facturacion` opens without Matias UUID / DIAN setup pressure
- [ ] MX: `/facturacion/audit` redirects to `/facturacion`
- [ ] CO: DIAN/Matias flows unchanged
- [x] API gate tests (see paired api-warolabs PR)

## Validation evidence
Front: no unit suite for middleware; API evidence from paired PR:
```
tests/test_account_role_resolution.py -k matias_dian
2 passed, 7 deselected in 0.03s
```

Made with [Cursor](https://cursor.com)