### PR TITLE
fix(finanzas): lock country/currency UI after configure

### DIFF
--- a/components/operaciones/FinancialProfileSettings.vue
+++ b/components/operaciones/FinancialProfileSettings.vue
@@ -39,7 +39,8 @@ watch(() => draft.value.country_code, () => {
 })
 
 const canSubmit = computed(() => canSubmitFinancialProfile(response.value, draft.value))
-const isLocked = computed(() => response.value?.eligibility.eligible === false)
+// Hard lock: country/currency read-only after first configure (profile exists).
+const isLocked = computed(() => !!response.value?.profile)
 
 const makeDisplayNames = (type: 'region' | 'currency') => {
   try {
@@ -140,14 +141,16 @@ const confirmSave = async () => {
         aria-live="polite"
       >
         <p class="text-sm font-semibold text-state-warning-text">
-          {{ response.eligibility.lock_type === 'permanent'
-            ? t('operaciones.personalizar.financial.permanentLockTitle')
-            : t('operaciones.personalizar.financial.temporaryLockTitle') }}
+          {{ response.eligibility.lock_type === 'temporary'
+            ? t('operaciones.personalizar.financial.temporaryLockTitle')
+            : t('operaciones.personalizar.financial.permanentLockTitle') }}
         </p>
         <p class="mt-1 text-xs leading-snug text-state-warning-text/90">
-          {{ response.eligibility.lock_type === 'permanent'
-            ? t('operaciones.personalizar.financial.permanentLockHelp')
-            : t('operaciones.personalizar.financial.temporaryLockHelp') }}
+          {{ response.eligibility.lock_type === 'temporary'
+            ? t('operaciones.personalizar.financial.temporaryLockHelp')
+            : response.eligibility.lock_type === 'permanent'
+              ? t('operaciones.personalizar.financial.permanentLockHelp')
+              : t('operaciones.personalizar.financial.irreversibleHelp') }}
         </p>
       </div>
 

--- a/composables/useTenantFinancialProfile.test.ts
+++ b/composables/useTenantFinancialProfile.test.ts
@@ -58,14 +58,14 @@ describe('tenant financial-profile helpers', () => {
     assert.deepEqual(getCompatibleCurrencyCodes(response.catalog, 'XX'), [])
   })
 
-  it('submits only eligible, changed and compatible pairs', () => {
+  it('never submits country/currency changes after hard lock', () => {
     const unchanged = { country_code: 'CO', base_currency_code: 'COP' }
     const panama = { country_code: 'PA', base_currency_code: 'PAB' }
     const invalid = { country_code: 'PA', base_currency_code: 'COP' }
 
     assert.equal(hasFinancialProfileChanges(response.profile, unchanged), false)
     assert.equal(canSubmitFinancialProfile(response, unchanged), false)
-    assert.equal(canSubmitFinancialProfile(response, panama), true)
+    assert.equal(canSubmitFinancialProfile(response, panama), false)
     assert.equal(canSubmitFinancialProfile(response, invalid), false)
     assert.equal(canSubmitFinancialProfile({
       ...response,

--- a/composables/useTenantFinancialProfile.ts
+++ b/composables/useTenantFinancialProfile.ts
@@ -104,12 +104,11 @@ export const hasFinancialProfileChanges = (
 
 export const canSubmitFinancialProfile = (
   response: TenantFinancialProfileResponse | null,
-  draft: FinancialProfileDraft,
+  _draft: FinancialProfileDraft,
 ): boolean => {
-  if (!response?.eligibility.eligible) return false
-  if (!hasFinancialProfileChanges(response.profile, draft)) return false
-  return getCompatibleCurrencyCodes(response.catalog, draft.country_code)
-    .includes(draft.base_currency_code)
+  // Country/currency are immutable once a profile exists (hard lock).
+  void _draft
+  return false
 }
 
 export const useTenantFinancialProfile = () => {

--- a/i18n/locales/en/operaciones.json
+++ b/i18n/locales/en/operaciones.json
@@ -267,7 +267,7 @@
         },
         "fieldsLegend": "Country and currency settings", "country": "Country", "currency": "Currency",
         "currencyHelp": "WARO does not convert amounts between currencies.",
-        "irreversibleHelp": "You can change this setting until financial activity is recorded.",
+        "irreversibleHelp": "Country and currency are set during onboarding and cannot be changed afterward.",
         "saving": "Saving…", "reviewChange": "Save changes", "confirmTitle": "Confirm country and currency",
         "confirmMessage": "You will change {currentCountry} / {currentCurrency} to {nextCountry} / {nextCurrency}. You cannot reverse this decision after financial activity is recorded.",
         "confirmAction": "Yes, change settings", "cancel": "Cancel", "saveSuccess": "Country and base currency updated",

--- a/i18n/locales/es/operaciones.json
+++ b/i18n/locales/es/operaciones.json
@@ -267,7 +267,7 @@
         },
         "fieldsLegend": "Configuración de país y moneda", "country": "País", "currency": "Moneda",
         "currencyHelp": "WARO no convierte importes entre monedas.",
-        "irreversibleHelp": "Podrás cambiar esta configuración hasta registrar actividad financiera.",
+        "irreversibleHelp": "El país y la moneda se definen en el onboarding y no se pueden cambiar después.",
         "saving": "Guardando…", "reviewChange": "Guardar cambios", "confirmTitle": "Confirmar país y moneda",
         "confirmMessage": "Cambiarás {currentCountry} / {currentCurrency} por {nextCountry} / {nextCurrency}. Después de registrar actividad financiera no podrás revertir esta decisión.",
         "confirmAction": "Sí, cambiar configuración", "cancel": "Cancelar", "saveSuccess": "País y moneda base actualizados",


### PR DESCRIPTION
## Summary
- Financial profile country/currency always read-only after configure
- Aligns with API hard lock in api-warolabs (companion PR)
- EN/ES copy for configured lock messaging

Closes #1776

## Test plan
- [ ] Operaciones → personalizar: country/currency shown as locked (no selects)
- [ ] Temporary activity still shows temporary lock help when applicable
- [ ] Companion API PR deployed for 409 hard lock

## Validation evidence
```text
Front: UI/composable hard-lock only (no unit suite run).
API companion: 18 passed (test_tenant_financial_profile + test_accounting_localizations).
```


Made with [Cursor](https://cursor.com)