### PR TITLE
fix(abastecimiento): named stock status badges and sin stock

### DIFF
--- a/.wr/1782.yaml
+++ b/.wr/1782.yaml
@@ -1,0 +1,46 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1782
+title: "Improve abastecimiento stock list: show zero-stock items and named status badges"
+repo: both
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-1782-stock-zero-badges
+
+paths:
+  - ../api_warocol.com/app/services/inventory_service.py
+  - ../api_warocol.com/app/services/ingredients_service.py
+  - ../api_warocol.com/app/routers/inventory.py
+  - ../api_warocol.com/tests/test_inventory.py
+  - components/inventario/StockInventoryView.vue
+  - pages/abastecimiento/stock.vue
+  - pages/inventario/stock.vue
+  - i18n/locales/*/abastecimiento.json
+
+ac:
+  - Stock list includes items with stock 0
+  - Zero-stock rows show 0 and named badge Sin stock
+  - Estado badges use UiStatusBadge value+format=text like Ventas
+  - Row adjust remains available for zero-stock items
+  - New warehouse articles get tenant_inventory at 0 and appear immediately
+  - Shared inventario/stock stays consistent
+
+out_of_scope:
+  - Redesign of adjustment panel
+  - Movements history
+  - Backfill migration for legacy ingredients without inventory rows
+
+hints:
+  entry: "GET /inventory/stock + InventarioStockInventoryView"
+  pattern: "inventory_service.py: remove current_stock != 0; CASE zero; StockInventoryView cell-status like ventas ordenes"
+  tests: "cd api_warocol.com && ./venv/bin/pytest tests/test_inventory.py::test_inventory_stock_includes_zero_and_filters_zero_status tests/test_inventory.py::test_inventory_stock_core_uses_explicit_tenant_without_session -q"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "merge API then front; smoke /abastecimiento/stock"

--- a/components/inventario/StockInventoryView.vue
+++ b/components/inventario/StockInventoryView.vue
@@ -218,8 +218,10 @@
 
         <template #cell-status="{ value }">
           <UiStatusBadge
-            :label="getStatusLabel(value)"
+            :value="getStatusLabel(value)"
             :variant="getStockVariant(value)"
+            size="sm"
+            format="text"
           />
         </template>
 

--- a/i18n/locales/ar/abastecimiento.json
+++ b/i18n/locales/ar/abastecimiento.json
@@ -48,6 +48,7 @@
       "critico": "حرج",
       "bajo": "منخفض",
       "normal": "عادي",
+      "sinStock": "بدون مخزون",
       "compra": "شراء",
       "compras": "مشتريات",
       "consumo": "استهلاك",

--- a/i18n/locales/de/abastecimiento.json
+++ b/i18n/locales/de/abastecimiento.json
@@ -48,6 +48,7 @@
       "critico": "Kritisch",
       "bajo": "Niedrig",
       "normal": "Normal",
+      "sinStock": "Kein Bestand",
       "compra": "Einkauf",
       "compras": "Einkäufe",
       "consumo": "Verbrauch",

--- a/i18n/locales/en/abastecimiento.json
+++ b/i18n/locales/en/abastecimiento.json
@@ -48,6 +48,7 @@
       "critico": "Critical",
       "bajo": "Low",
       "normal": "Normal",
+      "sinStock": "Out of stock",
       "compra": "Purchase",
       "compras": "Purchases",
       "consumo": "Consumption",

--- a/i18n/locales/es/abastecimiento.json
+++ b/i18n/locales/es/abastecimiento.json
@@ -48,6 +48,7 @@
       "critico": "Crítico",
       "bajo": "Bajo",
       "normal": "Normal",
+      "sinStock": "Sin stock",
       "compra": "Compra",
       "compras": "Compras",
       "consumo": "Consumo",

--- a/i18n/locales/fr/abastecimiento.json
+++ b/i18n/locales/fr/abastecimiento.json
@@ -48,6 +48,7 @@
       "critico": "Critique",
       "bajo": "Bas",
       "normal": "Normal",
+      "sinStock": "Rupture de stock",
       "compra": "Achat",
       "compras": "Achats",
       "consumo": "Consommation",

--- a/i18n/locales/hi/abastecimiento.json
+++ b/i18n/locales/hi/abastecimiento.json
@@ -48,6 +48,7 @@
       "critico": "गंभीर",
       "bajo": "कम",
       "normal": "सामान्य",
+      "sinStock": "स्टॉक नहीं",
       "compra": "खरीद",
       "compras": "खरीदें",
       "consumo": "खपत",

--- a/i18n/locales/pt/abastecimiento.json
+++ b/i18n/locales/pt/abastecimiento.json
@@ -48,6 +48,7 @@
       "critico": "Crítico",
       "bajo": "Baixo",
       "normal": "Normal",
+      "sinStock": "Sem estoque",
       "compra": "Compra",
       "compras": "Compras",
       "consumo": "Consumo",

--- a/i18n/locales/zh/abastecimiento.json
+++ b/i18n/locales/zh/abastecimiento.json
@@ -48,6 +48,7 @@
       "critico": "紧急",
       "bajo": "低",
       "normal": "正常",
+      "sinStock": "无库存",
       "compra": "采购",
       "compras": "采购",
       "consumo": "消耗",

--- a/pages/abastecimiento/stock.vue
+++ b/pages/abastecimiento/stock.vue
@@ -117,6 +117,7 @@ const stockCopy = computed(() => ({
 
 const stockStatusOptions = computed(() => [
   { value: 'negative', label: t('abastecimiento.common.critico'), variant: 'destructive' },
+  { value: 'zero', label: t('abastecimiento.common.sinStock'), variant: 'secondary' },
   { value: 'low', label: t('abastecimiento.common.bajo'), variant: 'warning' },
   { value: 'ok', label: t('abastecimiento.common.normal'), variant: 'success' },
 ])

--- a/pages/inventario/stock.vue
+++ b/pages/inventario/stock.vue
@@ -80,7 +80,8 @@ const stockCopy = computed(() => ({
 }))
 
 const stockStatusOptions = computed(() => [
-  { value: 'critical', label: t('abastecimiento.common.critico'), variant: 'destructive' },
+  { value: 'negative', label: t('abastecimiento.common.critico'), variant: 'destructive' },
+  { value: 'zero', label: t('abastecimiento.common.sinStock'), variant: 'secondary' },
   { value: 'low', label: t('abastecimiento.common.bajo'), variant: 'warning' },
   { value: 'ok', label: t('abastecimiento.common.normal'), variant: 'success' },
 ])


### PR DESCRIPTION
## Summary
- Fix Estado column badges (`:value` + `format=\"text\"`) like Ventas — no empty dashes
- Add **Sin stock** status option on abastecimiento + inventario stock pages
- i18n `abastecimiento.common.sinStock` in all locales

Closes #1782

## Test plan
- [ ] `/abastecimiento/stock` shows named badges (Crítico / Bajo / Normal / Sin stock)
- [ ] Zero-stock rows visible after API deploy; row adjust action works
- [ ] `/inventario/stock` badges consistent

## Validation evidence
```
API (companion): ./venv/bin/pytest tests/test_inventory.py::test_inventory_stock_core_uses_explicit_tenant_without_session tests/test_inventory.py::test_inventory_stock_includes_zero_and_filters_zero_status -q
→ 2 passed in 0.03s
Front: no project unit tests for this view; badge prop fix mirrors ventas/ordenes.
```

## wr-context
See `.wr/1782.yaml` on this branch (LLM contract).

Depends on API PR in api-warolabs (same issue).

Made with [Cursor](https://cursor.com)