### PR TITLE
fix(stock): unit-cost precision, name truncate, Ventas-like pagination

### DIFF
--- a/components/inventario/StockInventoryView.vue
+++ b/components/inventario/StockInventoryView.vue
@@ -130,7 +130,7 @@
             :class="index % 2 === 0 ? 'bg-surface' : 'bg-surface-secondary/30'"
           >
             <div class="flex-1 min-w-0">
-              <span class="text-sm font-bold text-text-primary">{{ item.ingredient_name }}</span>
+              <span class="text-sm font-bold text-text-primary truncate block" :title="item.ingredient_name">{{ item.ingredient_name }}</span>
               <p class="text-xs text-text-secondary mt-0.5">
                 {{ mobileSubtitle(item) }}
               </p>
@@ -165,7 +165,7 @@
         </template>
 
         <template #cell-ingredient_name="{ value }">
-          <span class="text-sm font-bold text-text-primary">{{ value }}</span>
+          <span class="text-sm font-bold text-text-primary truncate block max-w-[16rem]" :title="value">{{ value }}</span>
         </template>
 
         <template #cell-unit="{ value }">
@@ -230,7 +230,7 @@
         </template>
 
         <template #cell-unit_cost="{ value }">
-          <span v-if="value != null && value !== ''" class="text-sm font-bold text-primary">{{ formatCurrency(value) }}</span>
+          <span v-if="value != null && value !== ''" class="text-sm font-bold text-primary tabular-nums">{{ formatUnitCost(value) }}</span>
           <UiStatusBadge
             v-else
             :value="t('abastecimiento.stock.sinCosto')"
@@ -283,28 +283,49 @@
     </UiResponsiveDataView>
 
     <div
-      v-if="total > itemsPerPage"
-      class="mt-4 bg-white px-4 py-3 flex items-center justify-between border border-titan-200 rounded-lg"
+      v-if="totalPages > 1"
+      class="mt-4 flex items-center justify-between gap-3 px-1 py-2"
     >
-      <p class="text-sm text-titan-700">
+      <p class="text-sm text-text-secondary">
         {{ t('common.pagination.showingRange', { start: startItem, end: endItem, total }) }}
       </p>
-      <div class="flex gap-2">
+      <div class="flex items-center gap-1">
         <button
           type="button"
           :disabled="!canGoPrevious"
-          class="px-4 py-2 border border-titan-300 text-sm rounded-md disabled:opacity-50"
+          class="min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg border border-border text-text-secondary hover:bg-surface-secondary disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          :aria-label="t('ventas.common.primeraPagina')"
+          @click="$emit('go-to-page', 1)"
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" /></svg>
+        </button>
+        <button
+          type="button"
+          :disabled="!canGoPrevious"
+          class="min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg border border-border text-text-secondary hover:bg-surface-secondary disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          :aria-label="t('ventas.common.paginaAnterior')"
           @click="$emit('previous-page')"
         >
-          {{ t('common.previous') }}
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" /></svg>
+        </button>
+        <span class="px-3 py-1 text-sm font-medium text-text-primary">{{ currentPage }}</span>
+        <button
+          type="button"
+          :disabled="!canGoNext"
+          class="min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg border border-border text-text-secondary hover:bg-surface-secondary disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          :aria-label="t('ventas.common.paginaSiguiente')"
+          @click="$emit('next-page')"
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
         </button>
         <button
           type="button"
           :disabled="!canGoNext"
-          class="px-4 py-2 border border-titan-300 text-sm rounded-md disabled:opacity-50"
-          @click="$emit('next-page')"
+          class="min-h-[36px] min-w-[36px] flex items-center justify-center rounded-lg border border-border text-text-secondary hover:bg-surface-secondary disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          :aria-label="t('ventas.common.ultimaPagina')"
+          @click="$emit('go-to-page', totalPages)"
         >
-          {{ t('common.next') }}
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7" /></svg>
         </button>
       </div>
     </div>
@@ -314,9 +335,12 @@
 <script setup lang="ts">
 import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 import { useFormatters } from '~/composables/useFormatters'
+import { localeToNumberFormatTag, normalizeCurrencyCode } from '~/utils/currencyDisplay'
 
 const { t } = useI18n({ useScope: 'global' })
-const { formatCurrency } = useFormatters()
+const { formatCurrency, currencyCode, uiLocale } = useFormatters()
+
+const UNIT_COST_PRECISION = 6
 
 interface StockStats {
   total_ingredients: number
@@ -356,6 +380,8 @@ const props = withDefaults(defineProps<{
   inventory: StockItem[]
   total: number
   itemsPerPage: number
+  currentPage: number
+  totalPages: number
   startItem: number
   endItem: number
   canGoPrevious: boolean
@@ -391,6 +417,7 @@ const emit = defineEmits<{
   sort: [field: string]
   'previous-page': []
   'next-page': []
+  'go-to-page': [page: number]
 }>()
 
 const filterSelectClass = 'h-10 min-h-[44px] px-3 rounded-lg border border-border bg-surface text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 flex-shrink-0'
@@ -542,5 +569,15 @@ const navigateToAdjustment = (ingredientId: string) => {
 
 const formatNumber = (value: number) => {
   return formatDomainQuantity(value)
+}
+
+const formatUnitCost = (price: number) => {
+  const numeric = Number.isFinite(Number(price)) ? Number(price) : 0
+  return new Intl.NumberFormat(localeToNumberFormatTag(uiLocale.value), {
+    style: 'currency',
+    currency: normalizeCurrencyCode(currencyCode.value),
+    minimumFractionDigits: 0,
+    maximumFractionDigits: UNIT_COST_PRECISION,
+  }).format(numeric)
 }
 </script>

--- a/components/inventario/StockInventoryView.vue
+++ b/components/inventario/StockInventoryView.vue
@@ -379,7 +379,6 @@ const props = withDefaults(defineProps<{
   stats: StockStats
   inventory: StockItem[]
   total: number
-  itemsPerPage: number
   currentPage: number
   totalPages: number
   startItem: number

--- a/pages/abastecimiento/stock.vue
+++ b/pages/abastecimiento/stock.vue
@@ -15,6 +15,8 @@
       :inventory="inventory"
       :total="inventoryData?.total ?? 0"
       :items-per-page="itemsPerPage"
+      :current-page="currentPage"
+      :total-pages="totalPages"
       :start-item="startItem"
       :end-item="endItem"
       :can-go-previous="canGoPrevious"
@@ -37,6 +39,7 @@
       @sort="handleSort"
       @previous-page="previousPage"
       @next-page="nextPage"
+      @go-to-page="goToPage"
     />
   </div>
 </template>
@@ -150,6 +153,9 @@ const previousPage = () => {
 }
 const nextPage = () => {
   if (canGoNext.value) currentPage.value++
+}
+const goToPage = (page: number) => {
+  currentPage.value = Math.max(1, Math.min(page, totalPages.value || 1))
 }
 
 const updateStatusFilter = (value: string) => {

--- a/pages/abastecimiento/stock.vue
+++ b/pages/abastecimiento/stock.vue
@@ -14,7 +14,6 @@
       :stats="stats"
       :inventory="inventory"
       :total="inventoryData?.total ?? 0"
-      :items-per-page="itemsPerPage"
       :current-page="currentPage"
       :total-pages="totalPages"
       :start-item="startItem"

--- a/pages/inventario/stock.vue
+++ b/pages/inventario/stock.vue
@@ -14,7 +14,6 @@
       :stats="stats"
       :inventory="displayInventory"
       :total="inventoryData?.total ?? 0"
-      :items-per-page="itemsPerPage"
       :current-page="currentPage"
       :total-pages="totalPages"
       :start-item="startItem"

--- a/pages/inventario/stock.vue
+++ b/pages/inventario/stock.vue
@@ -15,6 +15,8 @@
       :inventory="displayInventory"
       :total="inventoryData?.total ?? 0"
       :items-per-page="itemsPerPage"
+      :current-page="currentPage"
+      :total-pages="totalPages"
       :start-item="startItem"
       :end-item="endItem"
       :can-go-previous="canGoPrevious"
@@ -34,6 +36,7 @@
       @sort="handleSort"
       @previous-page="previousPage"
       @next-page="nextPage"
+      @go-to-page="goToPage"
     />
   </div>
 </template>
@@ -169,6 +172,9 @@ const previousPage = () => {
 }
 const nextPage = () => {
   if (canGoNext.value) currentPage.value++
+}
+const goToPage = (page: number) => {
+  currentPage.value = Math.max(1, Math.min(page, totalPages.value || 1))
 }
 
 const updateStatusFilter = (value: string) => {


### PR DESCRIPTION
## Summary
- Format stock unit cost with up to 6 fractional digits and tenant currency (avoids false `0,00` for tiny costs like Sal rim)
- Truncate long ingredient names with native `title` tooltip on desktop and mobile
- Replace prev/next-only pagination with Ventas-style first/prev/page/next/last when `totalPages > 1`

Closes #1788

## Test plan
- [ ] Open `/abastecimiento/stock` on a MXN tenant; confirm Sal rim (or similar) unit cost shows fractional digits, not `MXN 0,00`
- [ ] Confirm total value column still uses standard money formatting (2 decimals)
- [ ] Confirm null unit cost still shows **Sin costo**
- [ ] Long ingredient names truncate; hover/long-press shows full name
- [ ] With >50 items, pagination shows first/prev/page/next/last and navigates correctly
- [ ] `/inventario/stock` stays consistent via shared view

## wr-context
See local `.wr/1788.yaml` (gitignored LLM contract).


Made with [Cursor](https://cursor.com)