### PR TITLE
fix(compras-directas): show tenant currency on list, detail, and form prefixes

### DIFF
--- a/pages/abastecimiento/compras-directas/[id]/editar.vue
+++ b/pages/abastecimiento/compras-directas/[id]/editar.vue
@@ -276,13 +276,13 @@
                       Precio Unit. *
                     </label>
                     <div class="relative">
-                      <span class="absolute start-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
+                      <span class="absolute start-3 top-1/2 -translate-y-1/2 text-xs font-medium text-text-secondary pointer-events-none">{{ currencyCode }}</span>
                       <UiDecimalInput
                         v-model="item.unit_cost"
                         :min="0"
                         :precision="UNIT_COST_PRECISION"
                         required
-                        class="w-full ps-8 pe-4 py-2"
+                        class="w-full ps-12 pe-4 py-2"
                         @update:model-value="updateItemTotal(index)"
                       />
                     </div>

--- a/pages/abastecimiento/compras-directas/[id]/index.vue
+++ b/pages/abastecimiento/compras-directas/[id]/index.vue
@@ -153,13 +153,13 @@
               <div class="px-4 py-3 flex items-center justify-between gap-4">
                 <div>
                   <p class="text-[11px] text-text-secondary mb-0.5 uppercase tracking-wide">{{ t('abastecimiento.compraDirectaDetalle.price') }}</p>
-                  <p class="text-sm font-medium text-text-primary">${{ formatUnitCost(getPurchaseUnitCost(item)) }}</p>
+                  <p class="text-sm font-medium text-text-primary">{{ formatUnitCost(getPurchaseUnitCost(item)) }}</p>
                   <p class="text-[11px] text-text-secondary">/ {{ item.purchase_unit || item.unit }}</p>
                 </div>
                 <div class="h-8 w-px bg-border"></div>
                 <div class="text-end">
                   <p class="text-[11px] text-text-secondary mb-0.5 uppercase tracking-wide">{{ t('abastecimiento.compraDirectaDetalle.total') }}</p>
-                  <p class="text-base font-bold text-text-primary">${{ formatCurrency(item.total_cost) }}</p>
+                  <p class="text-base font-bold text-text-primary">{{ formatCurrency(item.total_cost) }}</p>
                 </div>
               </div>
               <div v-if="item.notes" class="px-4 pb-3">
@@ -169,7 +169,7 @@
             <!-- Mobile total -->
             <div class="flex items-center justify-between px-4 py-3 rounded-xl bg-primary/10 border border-primary/20">
               <span class="text-sm font-medium text-primary">{{ t('abastecimiento.compraDirectaDetalle.purchaseTotal') }}</span>
-              <span class="text-lg font-bold text-primary">${{ formatCurrency(purchase.total_amount) }}</span>
+              <span class="text-lg font-bold text-primary">{{ formatCurrency(purchase.total_amount) }}</span>
             </div>
           </div>
 
@@ -207,10 +207,10 @@
                     <span class="text-sm text-text-primary">{{ item.purchase_unit || item.unit }}</span>
                   </td>
                   <td class="px-4 py-3.5 text-end border-r border-dashed border-border/60">
-                    <span class="text-sm text-text-primary tabular-nums">${{ formatUnitCost(getPurchaseUnitCost(item)) }}</span>
+                    <span class="text-sm text-text-primary tabular-nums">{{ formatUnitCost(getPurchaseUnitCost(item)) }}</span>
                   </td>
                   <td class="px-4 py-3.5 text-end">
-                    <span class="text-sm font-bold text-text-primary tabular-nums">${{ formatCurrency(item.total_cost) }}</span>
+                    <span class="text-sm font-bold text-text-primary tabular-nums">{{ formatCurrency(item.total_cost) }}</span>
                   </td>
                 </tr>
               </tbody>
@@ -218,7 +218,7 @@
                 <tr class="bg-primary/5 border-t-2 border-primary/20">
                   <td colspan="6" class="px-4 py-3.5 text-sm font-semibold text-text-secondary text-end border-r border-dashed border-border/60">{{ t('abastecimiento.compraDirectaDetalle.purchaseTotal') }}</td>
                   <td class="px-4 py-3.5 text-end">
-                    <span class="text-base font-bold text-primary tabular-nums">${{ formatCurrency(purchase.total_amount) }}</span>
+                    <span class="text-base font-bold text-primary tabular-nums">{{ formatCurrency(purchase.total_amount) }}</span>
                   </td>
                 </tr>
               </tfoot>
@@ -295,7 +295,7 @@
               <div>
                 <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('abastecimiento.compraDirectaDetalle.total') }}</label>
                 <div class="input-base w-full px-3 py-2 text-sm bg-primary/10 text-primary font-bold">
-                  ${{ formatCurrency(item.total_cost) }}
+                  {{ formatCurrency(item.total_cost) }}
                 </div>
               </div>
             </div>
@@ -398,7 +398,7 @@
                 <div>
                   <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('abastecimiento.compraDirectaDetalle.total') }}</label>
                   <div class="input-base w-full px-3 py-2 text-sm bg-primary/10 text-primary font-bold">
-                    ${{ formatCurrency(roundMoney(newItem.purchase_quantity * newItem.unit_cost)) }}
+                    {{ formatCurrency(roundMoney(newItem.purchase_quantity * newItem.unit_cost)) }}
                   </div>
                 </div>
               </div>
@@ -433,7 +433,7 @@
         <div v-if="isEditMode" class="flex justify-end mt-4">
           <div class="bg-primary/10 border border-primary/20 rounded-xl px-5 py-3 flex items-center gap-4">
             <p class="text-sm font-medium text-primary">{{ t('abastecimiento.compraDirectaDetalle.purchaseTotal') }}</p>
-            <p class="text-xl font-bold text-primary">${{ formatCurrency(editTotal) }}</p>
+            <p class="text-xl font-bold text-primary">{{ formatCurrency(editTotal) }}</p>
           </div>
         </div>
 
@@ -646,6 +646,7 @@ import { format as fnsFormat } from 'date-fns'
 import { enUS, es } from 'date-fns/locale'
 import { computed } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
+import { localeToNumberFormatTag, normalizeCurrencyCode } from '~/utils/currencyDisplay'
 import { useQuery } from '@pinia/colada'
 import { INGREDIENTS_FETCH_LIMIT } from '@/composables/useMenuIngredients'
 import { useWarehouseCopy } from '~/composables/useWarehouseCopy'
@@ -1033,20 +1034,17 @@ const copyPurchaseLink = async () => {
 }
 
 // Formatting methods
-const { formatDate: _fmtDate } = useFormatters()
+const { formatDate: _fmtDate, formatCurrency, currencyCode, uiLocale } = useFormatters()
 const formatDate = (date: string) => _fmtDate(date)
 
-const formatCurrency = (value: number) => {
-  if (!value) return '0'
-  return value.toLocaleString(toNumberLocaleTag(locale.value), { minimumFractionDigits: 0, maximumFractionDigits: 0 })
-}
-
 const formatUnitCost = (value: number) => {
-  if (!value) return '0'
-  return value.toLocaleString(toNumberLocaleTag(locale.value), {
+  const numeric = Number.isFinite(Number(value)) ? Number(value) : 0
+  return new Intl.NumberFormat(localeToNumberFormatTag(uiLocale.value), {
+    style: 'currency',
+    currency: normalizeCurrencyCode(currencyCode.value),
     minimumFractionDigits: 0,
     maximumFractionDigits: UNIT_COST_PRECISION,
-  })
+  }).format(numeric)
 }
 
 const getStatusText = (status: string) => {

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -346,13 +346,13 @@
                           </span>
                         </label>
                         <div class="relative">
-                          <span class="absolute start-2 top-1.5 text-text-secondary text-xs">$</span>
+                          <span class="absolute start-2 top-1.5 text-text-secondary text-[10px] font-medium pointer-events-none">{{ currencyCode }}</span>
                           <UiDecimalInput
                             v-model="item.unit_cost"
                             :min="0"
                             :precision="UNIT_COST_PRECISION"
                             required
-                            class="input-base w-full ps-5 pe-2 py-1.5 text-sm"
+                            class="input-base w-full ps-10 pe-2 py-1.5 text-sm"
                             @update:model-value="() => onUnitCostChange(index)"
                             placeholder="0"
                           />
@@ -361,13 +361,13 @@
                       <div>
                         <label class="block text-xs font-medium text-text-primary mb-1">Total *</label>
                         <div class="relative">
-                          <span class="absolute start-2 top-1.5 text-text-secondary text-xs">$</span>
+                          <span class="absolute start-2 top-1.5 text-text-secondary text-[10px] font-medium pointer-events-none">{{ currencyCode }}</span>
                           <UiDecimalInput
                             v-model="item.total_cost"
                             :min="0"
                             :precision="MONEY_PRECISION"
                             required
-                            class="input-base w-full ps-5 pe-2 py-1.5 text-sm"
+                            class="input-base w-full ps-10 pe-2 py-1.5 text-sm"
                             @update:model-value="() => onTotalCostChange(index)"
                             placeholder="0"
                           />

--- a/pages/abastecimiento/compras-directas/index.vue
+++ b/pages/abastecimiento/compras-directas/index.vue
@@ -136,7 +136,7 @@
               </p>
             </div>
             <div class="flex flex-col items-end gap-1.5 flex-shrink-0">
-              <p class="text-sm font-bold text-primary tabular-nums">${{ formatCurrency(item.total_amount) }}</p>
+              <p class="text-sm font-bold text-primary tabular-nums">{{ formatCurrency(item.total_amount) }}</p>
               <UiStatusBadge
                 :value="getStatusText(item.status)"
                 format="text"
@@ -167,7 +167,7 @@
         </template>
 
         <template #cell-total_amount="{ value }">
-          <span class="text-sm font-bold text-primary">${{ formatCurrency(value) }}</span>
+          <span class="text-sm font-bold text-primary">{{ formatCurrency(value) }}</span>
         </template>
 
         <template #cell-items_count="{ value }">
@@ -262,7 +262,7 @@ import { onMounted, onUnmounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import { useScanQuotaQuery } from '~/composables/queries/useScanQuota'
-const { t, locale } = useI18n({ useScope: 'global' })
+const { t } = useI18n({ useScope: 'global' })
 
 useHead({
   title: () => t('abastecimiento.head.comprasDirectas')
@@ -390,7 +390,7 @@ const startItem = computed(() => (currentPage.value - 1) * itemsPerPage.value + 
 const endItem = computed(() => Math.min(currentPage.value * itemsPerPage.value, purchasesData.value.total))
 
 // Methods
-const { formatDate: _fmtDate } = useFormatters()
+const { formatDate: _fmtDate, formatCurrency } = useFormatters()
 const formatDate = (date: string) => _fmtDate(date)
 
 const getPaymentDateValue = (purchase: any) => {
@@ -402,11 +402,6 @@ const getPaymentDateValue = (purchase: any) => {
 const getPaymentDateLabel = (purchase: any) => {
   const value = getPaymentDateValue(purchase)
   return value ? formatDate(value) : t('abastecimiento.common.sinPago')
-}
-
-const formatCurrency = (value: number) => {
-  if (!value) return '0'
-  return value.toLocaleString(toNumberLocaleTag(locale.value), { minimumFractionDigits: 0, maximumFractionDigits: 0 })
 }
 
 const getStatusText = (status: string) => {


### PR DESCRIPTION
## Summary
- List and purchase detail now format money via `useFormatters` (tenant currency), not `$` + bare number
- Detail unit costs keep fractional precision with Intl + tenant currency
- Create/edit input prefixes use `currencyCode` (menu pattern) instead of hardcoded `$`

Closes #1790

## Test plan
- [ ] MXN tenant: `/abastecimiento/compras-directas` totals show MXN (not `$1234`)
- [ ] Create form unit/total inputs show `MXN` prefix
- [ ] Purchase detail line costs/totals use tenant currency; tiny unit costs keep decimals
- [ ] Edit form unit-cost prefix uses tenant currency code
- [ ] COP tenant still formats correctly

## Validation evidence
```text
$ bun test utils/currencyDisplay.test.ts
bun test v1.2.21 (7c45ed97)
utils/currencyDisplay.test.ts:
(pass) normalizeCurrencyCode > defaults missing/invalid to COP
(pass) normalizeCurrencyCode > uppercases valid 3-letter codes
(pass) localeToNumberFormatTag > defaults to es-CO
(pass) localeToNumberFormatTag > maps every supported locale and regional tag
(pass) coerceMoneyNumber > accepts numbers and Decimal-like numeric strings
(pass) formatMoney > formats Decimal JSON strings like finite numbers
(pass) formatMoney > formats empty values as zero in the resolved currency
(pass) formatMoney > changes currency option without rewriting the numeric value
(pass) formatMoney > uses en-US punctuation when locale is en
(pass) formatMoney > uses authoritative minor units for zero- and two-decimal currencies
(pass) formatMoney > uses Intl compact notation without hardcoding a currency symbol
(pass) normalizeMinorUnits > accepts ISO-style units and falls back safely
 12 pass
 0 fail
Ran 12 tests across 1 file. [348.00ms]
```

## wr-context
See local `.wr/1790.yaml` (gitignored LLM contract).

Made with [Cursor](https://cursor.com)