### PR TITLE
feat(stock): open adjust slide-over from row action

### DIFF
--- a/components/abastecimiento/StockAdjustmentPanel.vue
+++ b/components/abastecimiento/StockAdjustmentPanel.vue
@@ -461,6 +461,7 @@ const {
 type State = 'idle' | 'success'
 const state = ref<State>('idle')
 const successMessage = ref('')
+let openGeneration = 0
 
 const purchaseUnitOptions = computed(() =>
   form.ingredientId ? purchaseUnitsApi.options(form.ingredientId) : [],
@@ -532,12 +533,18 @@ const onIngredientSelect = async (ingredient: { id: string; name: string; unit: 
 }
 
 watch(() => props.modelValue, async (open) => {
-  if (!open) return
+  if (!open) {
+    openGeneration += 1
+    return
+  }
+  const generation = ++openGeneration
   state.value = 'idle'
   successMessage.value = ''
   reset()
-  if (props.preselect?.id) {
-    await onIngredientSelect(props.preselect)
+  if (!props.preselect?.id) return
+  await onIngredientSelect(props.preselect)
+  if (generation !== openGeneration) {
+    reset()
   }
 })
 

--- a/components/abastecimiento/StockAdjustmentPanel.vue
+++ b/components/abastecimiento/StockAdjustmentPanel.vue
@@ -55,9 +55,7 @@
               class="flex-shrink-0 min-h-[44px] min-w-[44px] inline-flex items-center justify-center rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 disabled:opacity-50 transition-colors"
               @click="close"
             >
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-              </svg>
+              <XMarkIcon class="w-5 h-5" aria-hidden="true" />
             </button>
           </div>
         </div>
@@ -384,6 +382,7 @@ import {
   ArrowsRightLeftIcon,
   CheckCircleIcon,
   ExclamationTriangleIcon,
+  XMarkIcon,
 } from '@heroicons/vue/24/outline'
 import {
   useIngredientPurchaseUnits,
@@ -400,11 +399,23 @@ import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 const { t, locale } = useI18n({ useScope: 'global' })
 const WAREHOUSE_COPY = useWarehouseCopy()
 
-interface Props {
-  modelValue: boolean
+export interface StockAdjustmentPreselect {
+  id: string
+  name: string
+  unit: string
+  minimum_stock?: number | null
+  maximum_stock?: number | null
 }
 
-const props = defineProps<Props>()
+interface Props {
+  modelValue: boolean
+  /** When set, opens with this ingredient already selected (row adjust). */
+  preselect?: StockAdjustmentPreselect | null
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  preselect: null,
+})
 const emit = defineEmits<{
   (e: 'update:modelValue', value: boolean): void
   (e: 'saved'): void
@@ -450,14 +461,6 @@ const {
 type State = 'idle' | 'success'
 const state = ref<State>('idle')
 const successMessage = ref('')
-
-watch(() => props.modelValue, (open) => {
-  if (open) {
-    state.value = 'idle'
-    successMessage.value = ''
-    reset()
-  }
-})
 
 const purchaseUnitOptions = computed(() =>
   form.ingredientId ? purchaseUnitsApi.options(form.ingredientId) : [],
@@ -527,6 +530,16 @@ const onIngredientSelect = async (ingredient: { id: string; name: string; unit: 
   const def = purchaseUnitsApi.defaultFor(ingredient.id)
   form.unit = def ? def.value : ingredient.unit
 }
+
+watch(() => props.modelValue, async (open) => {
+  if (!open) return
+  state.value = 'idle'
+  successMessage.value = ''
+  reset()
+  if (props.preselect?.id) {
+    await onIngredientSelect(props.preselect)
+  }
+})
 
 const retryStockFetch = async () => {
   if (!form.ingredientId) return

--- a/components/inventario/StockInventoryView.vue
+++ b/components/inventario/StockInventoryView.vue
@@ -153,6 +153,7 @@
               <button
                 type="button"
                 :title="t('abastecimiento.stock.adjustAction')"
+                :aria-label="t('abastecimiento.stock.adjustAction')"
                 class="w-7 h-7 flex items-center justify-center rounded bg-surface-secondary border border-border text-text-secondary hover:text-primary transition-colors"
                 @click.stop="emitAdjust(item)"
               >
@@ -258,7 +259,7 @@
               type="button"
               :title="t('abastecimiento.stock.viewMovements')"
               :aria-label="t('abastecimiento.stock.viewMovements')"
-              class="text-text-secondary hover:text-primary transition-colors"
+              class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-md text-text-secondary hover:text-primary hover:bg-surface-secondary transition-colors"
               @click="navigateTo(`${movementsPath}?ingredient_id=${row.ingredient_id}`)"
             >
               <ClipboardDocumentListIcon class="h-4 w-4" />
@@ -267,7 +268,7 @@
               type="button"
               :title="t('abastecimiento.stock.adjustAction')"
               :aria-label="t('abastecimiento.stock.adjustAction')"
-              class="text-text-secondary hover:text-primary transition-colors"
+              class="min-h-[36px] min-w-[36px] inline-flex items-center justify-center rounded-md text-text-secondary hover:text-primary hover:bg-surface-secondary transition-colors"
               @click="emitAdjust(row)"
             >
               <AdjustmentsHorizontalIcon class="h-4 w-4" />

--- a/components/inventario/StockInventoryView.vue
+++ b/components/inventario/StockInventoryView.vue
@@ -154,11 +154,9 @@
                 type="button"
                 :title="t('abastecimiento.stock.adjustAction')"
                 class="w-7 h-7 flex items-center justify-center rounded bg-surface-secondary border border-border text-text-secondary hover:text-primary transition-colors"
-                @click.stop="navigateToAdjustment(item.ingredient_id)"
+                @click.stop="emitAdjust(item)"
               >
-                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
-                </svg>
+                <AdjustmentsHorizontalIcon class="h-4 w-4" />
               </button>
             </div>
           </div>
@@ -254,29 +252,25 @@
         </template>
 
         <template #cell-actions="{ row }">
-          <div class="flex justify-center gap-1">
+          <div class="flex justify-center space-x-2">
             <button
               v-if="movementsPath"
               type="button"
               :title="t('abastecimiento.stock.viewMovements')"
               :aria-label="t('abastecimiento.stock.viewMovements')"
-              class="p-1.5 rounded-md hover:bg-surface-secondary transition-colors text-text-secondary hover:text-primary"
+              class="text-text-secondary hover:text-primary transition-colors"
               @click="navigateTo(`${movementsPath}?ingredient_id=${row.ingredient_id}`)"
             >
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-              </svg>
+              <ClipboardDocumentListIcon class="h-4 w-4" />
             </button>
             <button
               type="button"
               :title="t('abastecimiento.stock.adjustAction')"
               :aria-label="t('abastecimiento.stock.adjustAction')"
-              class="p-1.5 rounded-md hover:bg-surface-secondary transition-colors text-primary"
-              @click="navigateToAdjustment(row.ingredient_id)"
+              class="text-text-secondary hover:text-primary transition-colors"
+              @click="emitAdjust(row)"
             >
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
-              </svg>
+              <AdjustmentsHorizontalIcon class="h-4 w-4" />
             </button>
           </div>
         </template>
@@ -297,7 +291,7 @@
           :aria-label="t('ventas.common.primeraPagina')"
           @click="$emit('go-to-page', 1)"
         >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" /></svg>
+          <ChevronDoubleLeftIcon class="h-4 w-4" />
         </button>
         <button
           type="button"
@@ -306,7 +300,7 @@
           :aria-label="t('ventas.common.paginaAnterior')"
           @click="$emit('previous-page')"
         >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" /></svg>
+          <ChevronLeftIcon class="h-4 w-4" />
         </button>
         <span class="px-3 py-1 text-sm font-medium text-text-primary">{{ currentPage }}</span>
         <button
@@ -316,7 +310,7 @@
           :aria-label="t('ventas.common.paginaSiguiente')"
           @click="$emit('next-page')"
         >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+          <ChevronRightIcon class="h-4 w-4" />
         </button>
         <button
           type="button"
@@ -325,7 +319,7 @@
           :aria-label="t('ventas.common.ultimaPagina')"
           @click="$emit('go-to-page', totalPages)"
         >
-          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7" /></svg>
+          <ChevronDoubleRightIcon class="h-4 w-4" />
         </button>
       </div>
     </div>
@@ -333,6 +327,14 @@
 </template>
 
 <script setup lang="ts">
+import {
+  AdjustmentsHorizontalIcon,
+  ChevronDoubleLeftIcon,
+  ChevronDoubleRightIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ClipboardDocumentListIcon,
+} from '@heroicons/vue/24/outline'
 import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 import { useFormatters } from '~/composables/useFormatters'
 import { localeToNumberFormatTag, normalizeCurrencyCode } from '~/utils/currencyDisplay'
@@ -394,7 +396,6 @@ const props = withDefaults(defineProps<{
   unitFilter: string
   sortField: string
   sortDirection: 'asc' | 'desc'
-  adjustmentPath: string
   movementsPath?: string
   copy: StockCopy
   statusOptions: StockStatusOption[]
@@ -417,6 +418,7 @@ const emit = defineEmits<{
   'previous-page': []
   'next-page': []
   'go-to-page': [page: number]
+  adjust: [item: StockItem]
 }>()
 
 const filterSelectClass = 'h-10 min-h-[44px] px-3 rounded-lg border border-border bg-surface text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary/30 flex-shrink-0'
@@ -562,8 +564,8 @@ const mobileSubtitle = (item: StockItem) => {
   return `${item.unit} · ${t('abastecimiento.stock.minShort')} ${formatNumber(item.minimum_stock)}${maxLabel}`
 }
 
-const navigateToAdjustment = (ingredientId: string) => {
-  navigateTo(`${props.adjustmentPath}?ingredientId=${ingredientId}`)
+const emitAdjust = (item: StockItem) => {
+  emit('adjust', item)
 }
 
 const formatNumber = (value: number) => {

--- a/pages/abastecimiento/ajustes/crear.vue
+++ b/pages/abastecimiento/ajustes/crear.vue
@@ -1,6 +1,4 @@
-<template>
-  <AbastecimientoStockAdjustmentFullForm
-    cancel-redirect-url="/abastecimiento/stock"
-    success-redirect-url="/abastecimiento/ajustes"
-  />
-</template>
+<script setup lang="ts">
+// Standalone adjust path disabled — use row action slide-over on stock list (#1792).
+await navigateTo('/abastecimiento/stock', { replace: true })
+</script>

--- a/pages/abastecimiento/stock.vue
+++ b/pages/abastecimiento/stock.vue
@@ -25,7 +25,6 @@
       :units="units"
       :sort-field="sortField"
       :sort-direction="sortDirection"
-      adjustment-path="/abastecimiento/ajustes/crear"
       movements-path="/abastecimiento/movimientos"
       :copy="stockCopy"
       :status-options="stockStatusOptions"
@@ -39,6 +38,13 @@
       @previous-page="previousPage"
       @next-page="nextPage"
       @go-to-page="goToPage"
+      @adjust="openAdjustment"
+    />
+
+    <AbastecimientoStockAdjustmentPanel
+      v-model="adjustmentOpen"
+      :preselect="adjustmentPreselect"
+      @saved="refetch"
     />
   </div>
 </template>
@@ -46,6 +52,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
+import type { StockAdjustmentPreselect } from '@/components/abastecimiento/StockAdjustmentPanel.vue'
 
 const { t } = useI18n()
 const WAREHOUSE_COPY = useWarehouseCopy()
@@ -60,6 +67,26 @@ const statusFilter = ref('all')
 const unitFilter = ref('')
 const currentPage = ref(1)
 const itemsPerPage = ref(50)
+
+const adjustmentOpen = ref(false)
+const adjustmentPreselect = ref<StockAdjustmentPreselect | null>(null)
+
+const openAdjustment = (item: {
+  ingredient_id: string
+  ingredient_name: string
+  unit: string
+  minimum_stock: number
+  maximum_stock?: number | null
+}) => {
+  adjustmentPreselect.value = {
+    id: item.ingredient_id,
+    name: item.ingredient_name,
+    unit: item.unit,
+    minimum_stock: item.minimum_stock,
+    maximum_stock: item.maximum_stock ?? null,
+  }
+  adjustmentOpen.value = true
+}
 
 const currentOffset = computed(() => (currentPage.value - 1) * itemsPerPage.value)
 

--- a/pages/inventario/stock.vue
+++ b/pages/inventario/stock.vue
@@ -25,7 +25,6 @@
       :units="units"
       :sort-field="sortField"
       :sort-direction="sortDirection"
-      adjustment-path="/inventario/ajustes/crear"
       :copy="stockCopy"
       :status-options="stockStatusOptions"
       show-mobile-stock-limits
@@ -36,12 +35,20 @@
       @previous-page="previousPage"
       @next-page="nextPage"
       @go-to-page="goToPage"
+      @adjust="openAdjustment"
+    />
+
+    <AbastecimientoStockAdjustmentPanel
+      v-model="adjustmentOpen"
+      :preselect="adjustmentPreselect"
+      @saved="refetch"
     />
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import type { StockAdjustmentPreselect } from '@/components/abastecimiento/StockAdjustmentPanel.vue'
 
 const { t } = useI18n()
 useHead({ title: () => t('abastecimiento.head.stock') })
@@ -55,6 +62,26 @@ const statusFilter = ref('all')
 const unitFilter = ref('')
 const currentPage = ref(1)
 const itemsPerPage = ref(50)
+
+const adjustmentOpen = ref(false)
+const adjustmentPreselect = ref<StockAdjustmentPreselect | null>(null)
+
+const openAdjustment = (item: {
+  ingredient_id: string
+  ingredient_name: string
+  unit: string
+  minimum_stock: number
+  maximum_stock?: number | null
+}) => {
+  adjustmentPreselect.value = {
+    id: item.ingredient_id,
+    name: item.ingredient_name,
+    unit: item.unit,
+    minimum_stock: item.minimum_stock,
+    maximum_stock: item.maximum_stock ?? null,
+  }
+  adjustmentOpen.value = true
+}
 
 const currentOffset = computed(() => (currentPage.value - 1) * itemsPerPage.value)
 


### PR DESCRIPTION
## Summary
- Row adjust opens `StockAdjustmentPanel` with the ingredient preselected (no page navigation)
- Shared list works on `/abastecimiento/stock` and `/inventario/stock`; success refreshes stock
- `/abastecimiento/ajustes/crear` redirects to stock (standalone adjust path disabled); ajustes history stays action-free
- Stock action/pagination icons use Heroicons outline `h-4 w-4`

Closes #1792

## Test plan
- [ ] Stock list: click adjust icon → slide-over opens with that ingredient selected
- [ ] Submit adjust → panel success + list refreshes
- [ ] Movements icon still goes to movimientos with ingredient filter
- [ ] `/abastecimiento/ajustes/crear` redirects to `/abastecimiento/stock`
- [ ] `/abastecimiento/ajustes` history has no create/adjust actions
- [ ] `/inventario/stock` adjust also opens the same panel

## Validation evidence
```text
$ rg -n "ajustes/crear|emit\('adjust'|preselect|navigateTo\('/abastecimiento/stock" \
  pages/abastecimiento/stock.vue pages/inventario/stock.vue \
  pages/abastecimiento/ajustes/crear.vue \
  components/inventario/StockInventoryView.vue \
  components/abastecimiento/StockAdjustmentPanel.vue
pages/abastecimiento/ajustes/crear.vue:3:await navigateTo('/abastecimiento/stock', { replace: true })
pages/abastecimiento/stock.vue:46:      :preselect="adjustmentPreselect"
components/inventario/StockInventoryView.vue:568:  emit('adjust', item)
components/abastecimiento/StockAdjustmentPanel.vue:413:  preselect?: StockAdjustmentPreselect | null
pages/inventario/stock.vue:43:      :preselect="adjustmentPreselect"
```
No targeted automated tests for this UI wiring (`hints.tests: none`).

## wr-context
See local `.wr/1792.yaml` (gitignored LLM contract).

Made with [Cursor](https://cursor.com)