### PR TITLE
fix(menu): gate Nuevo CTAs when catalog quotas exhausted

### DIFF
--- a/.wr/1796.yaml
+++ b/.wr/1796.yaml
@@ -1,0 +1,49 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1796
+title: "fix(menu): block Nuevo CTAs and redirect create routes when catalog quotas are exhausted"
+repo: both
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-1796-menu-catalog-quota-gate
+
+paths:
+  - app/services/billing_service.py
+  - tests/test_billing_remaining_usage.py
+  - tests/test_billing_plan_quotas.py
+  - composables/useBilling.ts
+  - composables/useMenuCatalogQuotaGate.ts
+  - pages/menu/productos/index.vue
+  - pages/menu/productos/crear.vue
+  - pages/menu/modificadores/index.vue
+  - pages/menu/modificadores/crear.vue
+  - pages/menu/recetas/index.vue
+  - pages/menu/recetas/crear.vue
+  - pages/menu/categorias/index.vue
+
+ac:
+  - remaining-usage works for Starter without subscription and exposes menu_products + modifier_groups
+  - Nuevo CTAs disabled in Recetas/Productos/Modificadores/Categorías when catalog create exhausted
+  - create routes redirect to list when quota exhausted
+  - paid plans unaffected; list/edit remain available
+  - API CREATE 429 remains as backstop
+
+out_of_scope:
+  - new DB quotas for Recetas/Categorías counts
+  - blocking Menú sub-nav tabs
+  - deleting over-quota rows
+
+hints:
+  entry: "get_remaining_billing_usage + useMenuCatalogQuotaGate"
+  pattern: "pages/equipo/miembros/index.vue disabled invite CTA"
+  tests: "pytest tests/test_billing_remaining_usage.py tests/test_billing_plan_quotas.py"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "merge API first, then front; restart uvicorn"

--- a/composables/useBilling.ts
+++ b/composables/useBilling.ts
@@ -280,9 +280,6 @@ export const OPERATIONAL_QUOTA_KEYS: OperationalQuotaKey[] = [
   'modifier_groups',
 ]
 
-/** Catalog create growth keys used to gate Menú "Nuevo" CTAs (warocol.com#1796). */
-export const CATALOG_CREATE_QUOTA_KEYS = ['menu_products', 'modifier_groups'] as const satisfies readonly OperationalQuotaKey[]
-
 const operationalQuotaFallbackMessage = 'No pudimos verificar esta cuota ahora. El sistema validará la acción al guardar.'
 
 export const resolveOperationalQuota = (

--- a/composables/useBilling.ts
+++ b/composables/useBilling.ts
@@ -134,6 +134,8 @@ export type OperationalQuotaKey =
   | 'active_tables_including_bar'
   | 'active_qr_tables'
   | 'completed_online_orders_per_month'
+  | 'menu_products'
+  | 'modifier_groups'
 
 export type OperationalQuotaStatus = 'allowed' | 'blocked' | 'unlimited' | 'loading' | 'error' | 'unknown'
 
@@ -274,7 +276,12 @@ export const OPERATIONAL_QUOTA_KEYS: OperationalQuotaKey[] = [
   'active_tables_including_bar',
   'active_qr_tables',
   'completed_online_orders_per_month',
+  'menu_products',
+  'modifier_groups',
 ]
+
+/** Catalog create growth keys used to gate Menú "Nuevo" CTAs (warocol.com#1796). */
+export const CATALOG_CREATE_QUOTA_KEYS = ['menu_products', 'modifier_groups'] as const satisfies readonly OperationalQuotaKey[]
 
 const operationalQuotaFallbackMessage = 'No pudimos verificar esta cuota ahora. El sistema validará la acción al guardar.'
 

--- a/composables/useMenuCatalogQuotaGate.ts
+++ b/composables/useMenuCatalogQuotaGate.ts
@@ -18,7 +18,10 @@ export function useMenuCatalogQuotaGate() {
   const modifierGroupsQuota = computed(() => getOperationalQuota('modifier_groups'))
 
   const isProductsCreateBlocked = computed(() => menuProductsQuota.value.blocked)
-  const isModifiersCreateBlocked = computed(() => modifierGroupsQuota.value.blocked)
+  /** Modificadores: own group cap OR shared catalog product cap exhausted. */
+  const isModifiersCreateBlocked = computed(
+    () => menuProductsQuota.value.blocked || modifierGroupsQuota.value.blocked,
+  )
   /** Recetas + Categorías: gate on menu catalog product cap. */
   const isSharedCatalogCreateBlocked = computed(() => menuProductsQuota.value.blocked)
 
@@ -30,7 +33,10 @@ export function useMenuCatalogQuotaGate() {
   }
 
   const productsCreateBlockedMessage = computed(() => formatBlockedMessage('menu_products'))
-  const modifiersCreateBlockedMessage = computed(() => formatBlockedMessage('modifier_groups'))
+  const modifiersCreateBlockedMessage = computed(() => {
+    if (menuProductsQuota.value.blocked) return formatBlockedMessage('menu_products')
+    return formatBlockedMessage('modifier_groups')
+  })
   const sharedCatalogCreateBlockedMessage = computed(() => productsCreateBlockedMessage.value)
 
   const showBlockedToast = (message: string) => {
@@ -69,7 +75,9 @@ export function useMenuCatalogQuotaGate() {
   }
 
   const redirectIfModifiersCreateBlocked = async (listPath = '/menu/modificadores') => {
-    if (await fetchQuotaBlocked('modifier_groups')) {
+    const productsBlocked = await fetchQuotaBlocked('menu_products')
+    const groupsBlocked = productsBlocked ? true : await fetchQuotaBlocked('modifier_groups')
+    if (productsBlocked || groupsBlocked) {
       showModifiersCreateBlocked()
       await navigateTo(listPath)
       return true

--- a/composables/useMenuCatalogQuotaGate.ts
+++ b/composables/useMenuCatalogQuotaGate.ts
@@ -1,0 +1,106 @@
+/**
+ * Menú catalog create gating (warocol.com#1796).
+ * Productos/Modificadores use their growth quotas; Recetas/Categorías share
+ * the menu_products exhausted signal (no separate count quota in DB).
+ */
+import type { BillingRemainingUsage, OperationalQuotaKey } from '~/composables/useBilling'
+import {
+  resolveOperationalQuota,
+  useBilling,
+} from '~/composables/useBilling'
+
+export function useMenuCatalogQuotaGate() {
+  const { t } = useI18n({ useScope: 'global' })
+  const toast = useToast()
+  const { getOperationalQuota, fetchBillingOverview } = useBilling()
+
+  const menuProductsQuota = computed(() => getOperationalQuota('menu_products'))
+  const modifierGroupsQuota = computed(() => getOperationalQuota('modifier_groups'))
+
+  const isProductsCreateBlocked = computed(() => menuProductsQuota.value.blocked)
+  const isModifiersCreateBlocked = computed(() => modifierGroupsQuota.value.blocked)
+  /** Recetas + Categorías: gate on menu catalog product cap. */
+  const isSharedCatalogCreateBlocked = computed(() => menuProductsQuota.value.blocked)
+
+  const formatBlockedMessage = (resource: OperationalQuotaKey) => {
+    const quota = getOperationalQuota(resource)
+    const metric = quota.metric
+    if (!metric || metric.limit === null) return quota.message
+    return `${quota.message} Uso actual: ${metric.used.toLocaleString('es-CO')} de ${metric.limit.toLocaleString('es-CO')} ${quota.unit}. Revisa Mi Plan para ampliar tu cupo.`
+  }
+
+  const productsCreateBlockedMessage = computed(() => formatBlockedMessage('menu_products'))
+  const modifiersCreateBlockedMessage = computed(() => formatBlockedMessage('modifier_groups'))
+  const sharedCatalogCreateBlockedMessage = computed(() => productsCreateBlockedMessage.value)
+
+  const showBlockedToast = (message: string) => {
+    toast.warning(message, {
+      title: t('menu.common.quotaBlocked', 'Cupo del plan alcanzado'),
+    })
+  }
+
+  const showProductsCreateBlocked = () => showBlockedToast(productsCreateBlockedMessage.value)
+  const showModifiersCreateBlocked = () => showBlockedToast(modifiersCreateBlockedMessage.value)
+  const showSharedCatalogCreateBlocked = () => showBlockedToast(sharedCatalogCreateBlockedMessage.value)
+
+  const ensureBillingOverview = async () => {
+    await fetchBillingOverview()
+  }
+
+  const fetchQuotaBlocked = async (resource: OperationalQuotaKey) => {
+    try {
+      await fetchBillingOverview()
+      const usage = await $fetch<BillingRemainingUsage>('/api/billing/remaining-usage')
+      const result = resolveOperationalQuota(resource, usage.quota_usage?.[resource] ?? null)
+      return result.blocked
+    } catch {
+      // Fail open — API CREATE still enforces 429.
+      return false
+    }
+  }
+
+  const redirectIfProductsCreateBlocked = async (listPath = '/menu/productos') => {
+    if (await fetchQuotaBlocked('menu_products')) {
+      showProductsCreateBlocked()
+      await navigateTo(listPath)
+      return true
+    }
+    return false
+  }
+
+  const redirectIfModifiersCreateBlocked = async (listPath = '/menu/modificadores') => {
+    if (await fetchQuotaBlocked('modifier_groups')) {
+      showModifiersCreateBlocked()
+      await navigateTo(listPath)
+      return true
+    }
+    return false
+  }
+
+  const redirectIfSharedCatalogCreateBlocked = async (listPath: string) => {
+    if (await fetchQuotaBlocked('menu_products')) {
+      showSharedCatalogCreateBlocked()
+      await navigateTo(listPath)
+      return true
+    }
+    return false
+  }
+
+  return {
+    menuProductsQuota,
+    modifierGroupsQuota,
+    isProductsCreateBlocked,
+    isModifiersCreateBlocked,
+    isSharedCatalogCreateBlocked,
+    productsCreateBlockedMessage,
+    modifiersCreateBlockedMessage,
+    sharedCatalogCreateBlockedMessage,
+    showProductsCreateBlocked,
+    showModifiersCreateBlocked,
+    showSharedCatalogCreateBlocked,
+    ensureBillingOverview,
+    redirectIfProductsCreateBlocked,
+    redirectIfModifiersCreateBlocked,
+    redirectIfSharedCatalogCreateBlocked,
+  }
+}

--- a/pages/menu/categorias/index.vue
+++ b/pages/menu/categorias/index.vue
@@ -34,7 +34,9 @@
           <template #trailing>
             <button
               type="button"
-              class="inline-flex min-h-[44px] items-center rounded-lg bg-shell-cta-bg px-4 py-2 text-center text-sm font-medium text-shell-cta-text whitespace-nowrap transition-all hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring"
+              :disabled="isSharedCatalogCreateBlocked"
+              :title="isSharedCatalogCreateBlocked ? sharedCatalogCreateBlockedMessage : t('menu.categorias.newCategory')"
+              class="inline-flex min-h-[44px] items-center rounded-lg bg-shell-cta-bg px-4 py-2 text-center text-sm font-medium text-shell-cta-text whitespace-nowrap transition-all hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring disabled:opacity-50 disabled:cursor-not-allowed"
               @click="openCreatePanel"
             >
               <span class="hidden sm:inline">{{ t('menu.categorias.newCategory') }}</span>
@@ -176,6 +178,12 @@
 <script setup lang="ts">
 import { PencilSquareIcon, TrashIcon } from '@heroicons/vue/24/outline'
 const { t } = useI18n({ useScope: 'global' })
+const {
+  isSharedCatalogCreateBlocked,
+  sharedCatalogCreateBlockedMessage,
+  showSharedCatalogCreateBlocked,
+  ensureBillingOverview,
+} = useMenuCatalogQuotaGate()
 
 definePageMeta({
   // layout: 'dashboard' — inherited from parent menu.vue
@@ -267,6 +275,7 @@ const refreshHandler = async () => {
 onMounted(() => {
   setRefreshHandler(refreshHandler)
   registerProgressiveLoading(isRefreshing)
+  ensureBillingOverview()
 })
 onUnmounted(() => {
   clearRefreshHandler(refreshHandler)
@@ -277,6 +286,10 @@ const panelOpen = ref(false)
 const panelCategory = ref<Category | null>(null)
 
 const openCreatePanel = () => {
+  if (isSharedCatalogCreateBlocked.value) {
+    showSharedCatalogCreateBlocked()
+    return
+  }
   panelCategory.value = null
   panelOpen.value = true
 }

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -263,7 +263,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 import {
   createEmptyModifier,
@@ -287,6 +287,11 @@ useHead({ title: () => t('menu.head.modificadores') })
 
 const router = useRouter()
 const { currentTenant } = useTenantReactive()
+const { redirectIfModifiersCreateBlocked } = useMenuCatalogQuotaGate()
+
+onMounted(async () => {
+  await redirectIfModifiersCreateBlocked('/menu/modificadores')
+})
 
 const isSubmitting = ref(false)
 const submitError = ref<string | null>(null)

--- a/pages/menu/modificadores/index.vue
+++ b/pages/menu/modificadores/index.vue
@@ -18,8 +18,11 @@
       >
         <template #trailing>
           <button
+            type="button"
+            :disabled="isModifiersCreateBlocked"
+            :title="isModifiersCreateBlocked ? modifiersCreateBlockedMessage : t('menu.modificadores.newGroup')"
+            class="inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-shell-cta-bg px-4 py-2 text-center text-sm font-medium text-shell-cta-text whitespace-nowrap transition-all hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring disabled:opacity-50 disabled:cursor-not-allowed"
             @click="goToCreateGroup"
-            class="inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-shell-cta-bg px-4 py-2 text-center text-sm font-medium text-shell-cta-text whitespace-nowrap transition-all hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring"
           >
             <Icon name="heroicons:plus" class="h-4 w-4 flex-shrink-0" />
             <span class="hidden sm:inline">{{ t('menu.modificadores.newGroup') }}</span>
@@ -298,6 +301,12 @@ useHead({ title: () => t('menu.head.modificadores') })
 
 const router = useRouter()
 const { currentTenant } = useTenantReactive()
+const {
+  isModifiersCreateBlocked,
+  modifiersCreateBlockedMessage,
+  showModifiersCreateBlocked,
+  ensureBillingOverview,
+} = useMenuCatalogQuotaGate()
 
 const {
   localSearchTerm,
@@ -482,6 +491,10 @@ function getGroupOptionLabels(grupoId: string) {
 }
 
 const goToCreateGroup = () => {
+  if (isModifiersCreateBlocked.value) {
+    showModifiersCreateBlocked()
+    return
+  }
   router.push('/menu/modificadores/crear')
 }
 
@@ -496,6 +509,7 @@ const handleRefresh = async () => {
 
 onMounted(() => {
   setRefreshHandler(handleRefresh)
+  ensureBillingOverview()
 })
 useMenuReturnRefresh('/menu/modificadores', handleRefresh)
 registerProgressiveLoading(isRefreshing)

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -727,7 +727,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { useQuery, useQueryCache } from '@pinia/colada'
 import { useMenuIngredientsQuery } from '@/composables/queries/useMenuIngredients'
 import { useActiveStationsQuery } from '@/composables/queries/useActiveStations'
@@ -760,6 +760,11 @@ const cache = useQueryCache()
 const toast = useToast()
 const { currentTenant, businessProfile } = useTenantReactive()
 const { showUpgradeCta, upgradeMessage, handleQuotaError, clearQuotaError } = useQuotaExceeded()
+const { redirectIfProductsCreateBlocked } = useMenuCatalogQuotaGate()
+
+onMounted(async () => {
+  await redirectIfProductsCreateBlocked('/menu/productos')
+})
 
 const { data: taxConfigData } = useQuery({
   key: () => ['tenant', 'tax-config', currentTenant.value?.id],

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -64,14 +64,17 @@
                 <span class="hidden sm:inline">{{ editMode ? t('menu.productos.viewCatalog') : t('menu.productos.editMode') }}</span>
                 <span class="sm:hidden">{{ editMode ? t('menu.productos.viewShort') : t('menu.productos.editShort') }}</span>
               </button>
-              <NuxtLink
-                to="/menu/productos/crear"
-                class="inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-shell-cta-bg px-4 py-2 text-center text-sm font-medium text-shell-cta-text whitespace-nowrap transition-all hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring"
+              <button
+                type="button"
+                :disabled="isProductsCreateBlocked"
+                :title="isProductsCreateBlocked ? productsCreateBlockedMessage : t('menu.productos.newProduct')"
+                class="inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-shell-cta-bg px-4 py-2 text-center text-sm font-medium text-shell-cta-text whitespace-nowrap transition-all hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring disabled:opacity-50 disabled:cursor-not-allowed"
+                @click="onNewProduct"
               >
                 <Icon name="heroicons:plus" class="h-4 w-4 flex-shrink-0" />
                 <span class="hidden sm:inline">{{ t('menu.productos.newProduct') }}</span>
                 <span class="sm:hidden">{{ t('menu.productos.newShort') }}</span>
-              </NuxtLink>
+              </button>
             </div>
           </template>
         </MenuCatalogFiltersBar>
@@ -895,6 +898,20 @@ definePageMeta({
 
 const route = useRoute()
 const router = useRouter()
+const {
+  isProductsCreateBlocked,
+  productsCreateBlockedMessage,
+  showProductsCreateBlocked,
+  ensureBillingOverview,
+} = useMenuCatalogQuotaGate()
+
+const onNewProduct = () => {
+  if (isProductsCreateBlocked.value) {
+    showProductsCreateBlocked()
+    return
+  }
+  router.push('/menu/productos/crear')
+}
 
 const QUERY_TO_PRODUCT_TYPE: Record<string, ProductTypeFilter> = {
   menu: 'menu',
@@ -1563,6 +1580,7 @@ const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = u
 // Register refresh handler for mobile bottom nav and desktop header
 onMounted(() => {
   setRefreshHandler(refetch)
+  ensureBillingOverview()
 })
 useMenuReturnRefresh('/menu/productos', refetch)
 registerProgressiveLoading(isRefreshing)

--- a/pages/menu/recetas/crear.vue
+++ b/pages/menu/recetas/crear.vue
@@ -278,7 +278,7 @@
 <script setup lang="ts">
 import WarehouseCategoryIngredientSelector from '~/components/ingredientes/WarehouseCategoryIngredientSelector.vue'
 import type { PreparedWarehouseCategoryIngredient } from '~/composables/useWarehouseCategoryIngredientSelector'
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 
 definePageMeta({
@@ -293,6 +293,11 @@ useHead({ title: t('menu.recetas.form.createTitle') })
 
 const router = useRouter()
 const { currentTenant } = useTenantReactive()
+const { redirectIfSharedCatalogCreateBlocked } = useMenuCatalogQuotaGate()
+
+onMounted(async () => {
+  await redirectIfSharedCatalogCreateBlocked('/menu/recetas')
+})
 
 const isSubmitting = ref(false)
 const nameError = ref('')

--- a/pages/menu/recetas/index.vue
+++ b/pages/menu/recetas/index.vue
@@ -22,6 +22,7 @@
         >
           <template #trailing>
             <NuxtLink
+              v-if="!isSharedCatalogCreateBlocked"
               to="/menu/recetas/crear"
               class="inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-shell-cta-bg px-4 py-2 text-center text-sm font-medium text-shell-cta-text whitespace-nowrap transition-all hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring"
             >
@@ -29,6 +30,18 @@
               <span class="hidden sm:inline">{{ t('menu.recetas.newRecipe') }}</span>
               <span class="sm:hidden">{{ t('menu.recetas.newShort') }}</span>
             </NuxtLink>
+            <button
+              v-else
+              type="button"
+              disabled
+              :title="sharedCatalogCreateBlockedMessage"
+              class="inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-shell-cta-bg px-4 py-2 text-center text-sm font-medium text-shell-cta-text whitespace-nowrap opacity-50 cursor-not-allowed"
+              @click="showSharedCatalogCreateBlocked"
+            >
+              <Icon name="heroicons:plus" class="h-4 w-4 flex-shrink-0" />
+              <span class="hidden sm:inline">{{ t('menu.recetas.newRecipe') }}</span>
+              <span class="sm:hidden">{{ t('menu.recetas.newShort') }}</span>
+            </button>
           </template>
         </UiAdvancedFiltersBar>
 
@@ -264,6 +277,12 @@ import { recipeIngredientLineCost } from '~/utils/recipeIngredientLineCost'
 const { t } = useI18n()
 const WAREHOUSE_COPY = useWarehouseCopy()
 const { formatCurrency } = useFormatters()
+const {
+  isSharedCatalogCreateBlocked,
+  sharedCatalogCreateBlockedMessage,
+  showSharedCatalogCreateBlocked,
+  ensureBillingOverview,
+} = useMenuCatalogQuotaGate()
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue
@@ -462,6 +481,7 @@ const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = u
 
 onMounted(() => {
   setRefreshHandler(refetch)
+  ensureBillingOverview()
 })
 useMenuReturnRefresh('/menu/recetas', refetch)
 registerProgressiveLoading(isRefreshing)


### PR DESCRIPTION
## Summary
- Disable "Nuevo" in Recetas, Productos, Modificadores, Categorías when catalog create quota is exhausted.
- Redirect `/menu/*/crear` back to list pages when blocked.
- Uses remaining-usage catalog metrics (`menu_products` / `modifier_groups`).

Requires API companion PR on `api-warolabs` (same branch) for Starter remaining-usage.

Closes #1796

## Test plan
- [ ] Starter at 10 products: Nuevo disabled on all four Menú sections; create URLs redirect
- [ ] Modifiers at group limit: Nuevo grupo disabled / crear redirects
- [ ] Pro tenant: create CTAs remain enabled
- [ ] List/edit still work when create is blocked

## Validation evidence
```
cd front_nuxt && npx vitest run composables/useBillingOperationalQuota.test.ts
# resolveOperationalQuota suite ok (7 subtests)
API: 13 passed (billing remaining-usage + plan quotas)
```

## wr-context
See `.wr/1796.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)