### PR TITLE
fix(menu): category create UX when quota exhausted (#1806)

### DIFF
--- a/.wr/1806.yaml
+++ b/.wr/1806.yaml
@@ -1,0 +1,42 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1806
+title: "fix(menu): category create UX when menu_categories quota exhausted"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1806-category-quota-ux
+
+paths:
+  - composables/useMenuCatalogQuotaGate.ts
+  - pages/menu/categorias/index.vue
+  - pages/menu/productos/crear.vue
+  - pages/menu/productos/[id].vue
+  - components/menu/ProductQuickCreatePanel.vue
+  - .wr/1806.yaml
+
+ac:
+  - Inline create stays clickable; when blocked opens limit modal (not CategoriaPanel) with Mi Plan CTA
+  - /menu/categorias Nuevo disabled when blocked; openCreatePanel awaits fresh remaining-usage check
+  - Gate refresh works without mi_plan billing overview cache
+  - No API changes
+
+out_of_scope:
+  - Warehouse categories
+  - Disabling inline Crear option itself
+  - API quota changes
+
+hints:
+  entry: "useMenuCatalogQuotaGate + categorias openCreatePanel + product onCategoryCreateRequested"
+  pattern: "fetchQuotaBlocked / UiConfirmActionModal; remaining-usage fail-open was enabling Nuevo"
+  tests: "none targeted; node compile sanity optional"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "ready-for-review + wr-review"

--- a/components/menu/ProductQuickCreatePanel.vue
+++ b/components/menu/ProductQuickCreatePanel.vue
@@ -179,6 +179,16 @@
       :initial-name="newCategoryName"
       @saved="onCategoryCreated"
     />
+
+    <UiConfirmActionModal
+      v-model="categoriesLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="categoriesLimitModalMessage"
+      :confirm-label="t('shell.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromCategoriesLimitModal"
+      @cancel="closeCategoriesLimitModal"
+    />
   </Teleport>
 </template>
 
@@ -214,8 +224,16 @@ const emit = defineEmits<Emits>()
 
 const cache = useQueryCache()
 const toast = useToast()
+const { t } = useI18n({ useScope: 'global' })
 const { currentTenant } = useTenantReactive()
 const { currencyCode, currencyMinorUnits } = useFormatters()
+const {
+  handleInlineCategoryCreate,
+  categoriesLimitModalOpen,
+  categoriesLimitModalMessage,
+  closeCategoriesLimitModal,
+  goToBillingFromCategoriesLimitModal,
+} = useMenuCatalogQuotaGate()
 
 const inputClass = 'h-10 w-full rounded-lg border-2 border-border bg-background px-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 transition-colors'
 
@@ -272,8 +290,10 @@ function onCategorySelected(cat: { id: string; name: string }) {
 }
 
 function onCategoryCreateRequested(typedName: string) {
-  newCategoryName.value = typedName
-  showNewCategoryModal.value = true
+  void handleInlineCategoryCreate(typedName, (name) => {
+    newCategoryName.value = name
+    showNewCategoryModal.value = true
+  })
 }
 
 function onCategoryCreated(cat: { id: string; name: string }) {

--- a/composables/useMenuCatalogQuotaGate.ts
+++ b/composables/useMenuCatalogQuotaGate.ts
@@ -124,8 +124,10 @@ export function useMenuCatalogQuotaGate() {
     }
   }
 
-  const openCategoriesLimitModal = async () => {
-    await refreshCategoriesCreateGate()
+  const openCategoriesLimitModal = async (opts?: { skipRefresh?: boolean }) => {
+    if (!opts?.skipRefresh) {
+      await refreshCategoriesCreateGate()
+    }
     categoriesLimitModalMessage.value = categoriesCreateBlockedMessage.value
       || BILLING_QUOTA_RESOURCE_CONFIG.menu_categories?.blockedMessage
       || t('menu.common.quotaBlocked', 'Cupo del plan alcanzado')
@@ -144,7 +146,7 @@ export function useMenuCatalogQuotaGate() {
   /** Inline product flows: allow click, show modal instead of create panel when blocked. */
   const handleInlineCategoryCreate = async (typedName: string, openCreate: (name: string) => void) => {
     if (await fetchQuotaBlocked('menu_categories')) {
-      await openCategoriesLimitModal()
+      await openCategoriesLimitModal({ skipRefresh: true })
       return false
     }
     openCreate(typedName)

--- a/composables/useMenuCatalogQuotaGate.ts
+++ b/composables/useMenuCatalogQuotaGate.ts
@@ -1,9 +1,14 @@
 /**
- * Menú catalog create gating (warocol.com#1796 / #1798 / #1800).
+ * Menú catalog create gating (warocol.com#1796 / #1798 / #1800 / #1806).
  * Productos, Categorías, Modificadores, and Recetas each use their own growth quota.
  */
-import type { BillingRemainingUsage, OperationalQuotaKey } from '~/composables/useBilling'
+import type {
+  BillingRemainingUsage,
+  BillingUsageMetric,
+  OperationalQuotaKey,
+} from '~/composables/useBilling'
 import {
+  BILLING_QUOTA_RESOURCE_CONFIG,
   resolveOperationalQuota,
   useBilling,
 } from '~/composables/useBilling'
@@ -11,7 +16,16 @@ import {
 export function useMenuCatalogQuotaGate() {
   const { t } = useI18n({ useScope: 'global' })
   const toast = useToast()
-  const { getOperationalQuota, fetchBillingOverview } = useBilling()
+  const { getOperationalQuota, fetchBillingOverview, remainingUsage } = useBilling()
+
+  /** Fresh remaining-usage snapshot for menu pages that may lack `mi_plan` billing cache. */
+  const categoriesQuotaFresh = ref<{
+    blocked: boolean
+    message: string
+  } | null>(null)
+
+  const categoriesLimitModalOpen = ref(false)
+  const categoriesLimitModalMessage = ref('')
 
   const menuProductsQuota = computed(() => getOperationalQuota('menu_products'))
   const menuCategoriesQuota = computed(() => getOperationalQuota('menu_categories'))
@@ -24,15 +38,25 @@ export function useMenuCatalogQuotaGate() {
     () => menuProductsQuota.value.blocked || modifierGroupsQuota.value.blocked,
   )
   const isRecipesCreateBlocked = computed(() => recipeBasesQuota.value.blocked)
-  const isCategoriesCreateBlocked = computed(() => menuCategoriesQuota.value.blocked)
+  const isCategoriesCreateBlocked = computed(
+    () => categoriesQuotaFresh.value?.blocked === true || menuCategoriesQuota.value.blocked,
+  )
   /** Legacy shared gate: menu catalog product cap. */
   const isSharedCatalogCreateBlocked = computed(() => menuProductsQuota.value.blocked)
 
+  const formatMetricMessage = (resource: OperationalQuotaKey, metric: BillingUsageMetric | null | undefined) => {
+    const result = resolveOperationalQuota(resource, metric ?? null)
+    if (!metric || metric.limit === null) return result.message
+    return `${result.message} Uso actual: ${metric.used.toLocaleString('es-CO')} de ${metric.limit.toLocaleString('es-CO')} ${result.unit}. Revisa Mi Plan para ampliar tu cupo.`
+  }
+
   const formatBlockedMessage = (resource: OperationalQuotaKey) => {
+    if (resource === 'menu_categories' && categoriesQuotaFresh.value?.message) {
+      return categoriesQuotaFresh.value.message
+    }
     const quota = getOperationalQuota(resource)
-    const metric = quota.metric
-    if (!metric || metric.limit === null) return quota.message
-    return `${quota.message} Uso actual: ${metric.used.toLocaleString('es-CO')} de ${metric.limit.toLocaleString('es-CO')} ${quota.unit}. Revisa Mi Plan para ampliar tu cupo.`
+    const metric = quota.metric ?? remainingUsage.value?.quota_usage?.[resource] ?? null
+    return formatMetricMessage(resource, metric)
   }
 
   const productsCreateBlockedMessage = computed(() => formatBlockedMessage('menu_products'))
@@ -56,20 +80,75 @@ export function useMenuCatalogQuotaGate() {
   const showRecipesCreateBlocked = () => showBlockedToast(recipesCreateBlockedMessage.value)
   const showSharedCatalogCreateBlocked = () => showBlockedToast(sharedCatalogCreateBlockedMessage.value)
 
+  const fetchRemainingUsage = async () => {
+    return await $fetch<BillingRemainingUsage>('/api/billing/remaining-usage')
+  }
+
+  /** Refresh categories gate from remaining-usage (works without mi_plan billing overview). */
+  const refreshCategoriesCreateGate = async () => {
+    try {
+      const usage = await fetchRemainingUsage()
+      const metric = usage.quota_usage?.menu_categories ?? null
+      const blocked = resolveOperationalQuota('menu_categories', metric).blocked
+      categoriesQuotaFresh.value = {
+        blocked,
+        message: formatMetricMessage('menu_categories', metric),
+      }
+      return blocked
+    } catch {
+      // Keep last known; API CREATE still enforces 429.
+      return categoriesQuotaFresh.value?.blocked === true
+    }
+  }
+
   const ensureBillingOverview = async () => {
     await fetchBillingOverview()
+    await refreshCategoriesCreateGate()
   }
 
   const fetchQuotaBlocked = async (resource: OperationalQuotaKey) => {
     try {
-      await fetchBillingOverview()
-      const usage = await $fetch<BillingRemainingUsage>('/api/billing/remaining-usage')
-      const result = resolveOperationalQuota(resource, usage.quota_usage?.[resource] ?? null)
-      return result.blocked
+      const usage = await fetchRemainingUsage()
+      const metric = usage.quota_usage?.[resource] ?? null
+      const blocked = resolveOperationalQuota(resource, metric).blocked
+      if (resource === 'menu_categories') {
+        categoriesQuotaFresh.value = {
+          blocked,
+          message: formatMetricMessage('menu_categories', metric),
+        }
+      }
+      return blocked
     } catch {
       // Fail open — API CREATE still enforces 429.
       return false
     }
+  }
+
+  const openCategoriesLimitModal = async () => {
+    await refreshCategoriesCreateGate()
+    categoriesLimitModalMessage.value = categoriesCreateBlockedMessage.value
+      || BILLING_QUOTA_RESOURCE_CONFIG.menu_categories?.blockedMessage
+      || t('menu.common.quotaBlocked', 'Cupo del plan alcanzado')
+    categoriesLimitModalOpen.value = true
+  }
+
+  const closeCategoriesLimitModal = () => {
+    categoriesLimitModalOpen.value = false
+  }
+
+  const goToBillingFromCategoriesLimitModal = async () => {
+    categoriesLimitModalOpen.value = false
+    await navigateTo('/gestion/billing')
+  }
+
+  /** Inline product flows: allow click, show modal instead of create panel when blocked. */
+  const handleInlineCategoryCreate = async (typedName: string, openCreate: (name: string) => void) => {
+    if (await fetchQuotaBlocked('menu_categories')) {
+      await openCategoriesLimitModal()
+      return false
+    }
+    openCreate(typedName)
+    return true
   }
 
   const redirectIfProductsCreateBlocked = async (listPath = '/menu/productos') => {
@@ -131,6 +210,14 @@ export function useMenuCatalogQuotaGate() {
     showRecipesCreateBlocked,
     showSharedCatalogCreateBlocked,
     ensureBillingOverview,
+    refreshCategoriesCreateGate,
+    fetchQuotaBlocked,
+    handleInlineCategoryCreate,
+    categoriesLimitModalOpen,
+    categoriesLimitModalMessage,
+    openCategoriesLimitModal,
+    closeCategoriesLimitModal,
+    goToBillingFromCategoriesLimitModal,
     redirectIfProductsCreateBlocked,
     redirectIfModifiersCreateBlocked,
     redirectIfRecipesCreateBlocked,

--- a/pages/menu/categorias/index.vue
+++ b/pages/menu/categorias/index.vue
@@ -183,6 +183,7 @@ const {
   categoriesCreateBlockedMessage,
   showCategoriesCreateBlocked,
   ensureBillingOverview,
+  fetchQuotaBlocked,
 } = useMenuCatalogQuotaGate()
 
 definePageMeta({
@@ -285,8 +286,9 @@ onUnmounted(() => {
 const panelOpen = ref(false)
 const panelCategory = ref<Category | null>(null)
 
-const openCreatePanel = () => {
-  if (isCategoriesCreateBlocked.value) {
+const openCreatePanel = async () => {
+  // Fresh check: billing cache may be empty without mi_plan / overview.
+  if (isCategoriesCreateBlocked.value || await fetchQuotaBlocked('menu_categories')) {
     showCategoriesCreateBlocked()
     return
   }

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -854,6 +854,16 @@
       @saved="onCategoryCreated"
     />
 
+    <UiConfirmActionModal
+      v-model="categoriesLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="categoriesLimitModalMessage"
+      :confirm-label="t('shell.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromCategoriesLimitModal"
+      @cancel="closeCategoriesLimitModal"
+    />
+
     <CocinaStationPanel
       v-model="showNewStationModal"
       @saved="onStationCreated"
@@ -917,6 +927,13 @@ const { t } = useI18n({ useScope: 'global' })
 const { formatCurrency, currencyCode, currencyMinorUnits } = useFormatters()
 const WAREHOUSE_COPY = useWarehouseCopy()
 const { currentTenant, businessProfile } = useTenantReactive()
+const {
+  handleInlineCategoryCreate,
+  categoriesLimitModalOpen,
+  categoriesLimitModalMessage,
+  closeCategoriesLimitModal,
+  goToBillingFromCategoriesLimitModal,
+} = useMenuCatalogQuotaGate()
 
 // Tax config — only show selector when tenant has taxes enabled
 const { data: taxConfigData } = useQuery({
@@ -1192,8 +1209,10 @@ function onCategorySelected(cat: { id: string; name: string }) {
 }
 
 function onCategoryCreateRequested(typedName: string) {
-  newCategoryName.value = typedName
-  showNewCategoryModal.value = true
+  void handleInlineCategoryCreate(typedName, (name) => {
+    newCategoryName.value = name
+    showNewCategoryModal.value = true
+  })
 }
 
 function onCategoryCreated(cat: { id: string; name: string }) {

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -711,6 +711,16 @@
       @saved="onCategoryCreated"
     />
 
+    <UiConfirmActionModal
+      v-model="categoriesLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="categoriesLimitModalMessage"
+      :confirm-label="t('shell.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromCategoriesLimitModal"
+      @cancel="closeCategoriesLimitModal"
+    />
+
     <CocinaStationPanel
       v-model="showNewStationModal"
       @saved="onStationCreated"
@@ -760,7 +770,7 @@ const cache = useQueryCache()
 const toast = useToast()
 const { currentTenant, businessProfile } = useTenantReactive()
 const { showUpgradeCta, upgradeMessage, handleQuotaError, clearQuotaError } = useQuotaExceeded()
-const { redirectIfProductsCreateBlocked } = useMenuCatalogQuotaGate()
+const { redirectIfProductsCreateBlocked, handleInlineCategoryCreate, categoriesLimitModalOpen, categoriesLimitModalMessage, closeCategoriesLimitModal, goToBillingFromCategoriesLimitModal } = useMenuCatalogQuotaGate()
 
 onMounted(async () => {
   await redirectIfProductsCreateBlocked('/menu/productos')
@@ -1195,8 +1205,10 @@ function onCategorySelected(cat: { id: string; name: string }) {
 }
 
 function onCategoryCreateRequested(typedName: string) {
-  newCategoryName.value = typedName
-  showNewCategoryModal.value = true
+  void handleInlineCategoryCreate(typedName, (name) => {
+    newCategoryName.value = name
+    showNewCategoryModal.value = true
+  })
 }
 
 function onCategoryCreated(cat: { id: string; name: string }) {


### PR DESCRIPTION
## Summary
- `/menu/categorias`: “Nuevo” stays disabled when `menu_categories` is exhausted; `openCreatePanel` awaits a fresh `/api/billing/remaining-usage` check so the button cannot open create and fail only on 429.
- Product create/edit/quick-create: inline “Crear …” stays clickable but opens a limit modal (message + Mi Plan CTA) instead of `CategoriaPanel` when blocked.
- `useMenuCatalogQuotaGate` refreshes category quota without depending on `mi_plan` overview cache alone.

Closes #1806

## Test plan
- [ ] Starter tenant at 5/5 categories: `/menu/categorias` Nuevo disabled; click does not open panel
- [ ] Same tenant on `/menu/productos/crear`: search → Crear … opens limit modal, not create panel; Mi Plan CTA works
- [ ] Below limit: create panel still opens as before

## Validation evidence
```text
$ node -e "parse SFC for crear/[id]/categorias/ProductQuickCreatePanel"
parseErrors 0 (all four files)

$ rg -n "handleInlineCategoryCreate|fetchQuotaBlocked|refreshCategoriesCreateGate" composables/useMenuCatalogQuotaGate.ts pages/menu components/menu
# gate + categorias + product flows wired
```
No front unit test target for this gate; no build/lint per WR policy.

## wr-context
See `.wr/1806.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)