### PR TITLE
fix(menu): independent modifiers gate and clickable quota modals

### DIFF
--- a/.wr/1808.yaml
+++ b/.wr/1808.yaml
@@ -1,0 +1,46 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1808
+title: "Menu quotas: independent modifiers gate + clickable Nuevo/add-line limit modals"
+repo: both
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-1808-menu-quota-modals
+
+paths:
+  - composables/useMenuCatalogQuotaGate.ts
+  - composables/useBilling.ts
+  - pages/menu/modificadores/index.vue
+  - pages/menu/modificadores/crear.vue
+  - pages/menu/modificadores/[id].vue
+  - pages/menu/productos/crear.vue
+  - pages/menu/productos/[id].vue
+  - ../api_warocol.com/app/services/billing_service.py
+  - ../api_warocol.com/tests/test_billing_remaining_usage.py
+
+ac:
+  - Modifiers create gated only by modifier_groups (not menu_products)
+  - Nuevo/add-line stay clickable and open UiConfirmActionModal → Mi Plan
+  - Product recipe lines use recipe_lines_per_product (local count vs plan limit)
+  - Modifier options use modifier_options_per_group the same way
+  - remaining-usage exposes scoped limits for front
+
+out_of_scope:
+  - Changing Starter numeric caps
+  - Recipe-base template line UI
+  - Mi Plan matrix redesign
+
+hints:
+  entry: "useMenuCatalogQuotaGate + remaining-usage scoped metrics"
+  pattern: "pages/menu/productos/crear.vue categoriesLimitModal (#1806)"
+  tests: "cd api_warocol.com && python -m pytest tests/test_billing_remaining_usage.py -q"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "wr-review"

--- a/composables/useBilling.ts
+++ b/composables/useBilling.ts
@@ -143,6 +143,8 @@ export type OperationalQuotaKey =
   | 'menu_categories'
   | 'modifier_groups'
   | 'recipe_bases'
+  | 'recipe_lines_per_product'
+  | 'modifier_options_per_group'
 
 export type OperationalQuotaStatus = 'allowed' | 'blocked' | 'unlimited' | 'loading' | 'error' | 'unknown'
 
@@ -305,6 +307,8 @@ export const OPERATIONAL_QUOTA_KEYS: OperationalQuotaKey[] = [
   'menu_categories',
   'modifier_groups',
   'recipe_bases',
+  'recipe_lines_per_product',
+  'modifier_options_per_group',
 ]
 
 const operationalQuotaFallbackMessage = 'No pudimos verificar esta cuota ahora. El sistema validará la acción al guardar.'

--- a/composables/useMenuCatalogQuotaGate.ts
+++ b/composables/useMenuCatalogQuotaGate.ts
@@ -1,6 +1,7 @@
 /**
- * Menú catalog create gating (warocol.com#1796 / #1798 / #1800 / #1806).
+ * Menú catalog create gating (warocol.com#1796 / #1798 / #1800 / #1806 / #1808).
  * Productos, Categorías, Modificadores, and Recetas each use their own growth quota.
+ * Scoped line/option caps compare local editor counts to plan limits.
  */
 import type {
   BillingRemainingUsage,
@@ -24,8 +25,11 @@ export function useMenuCatalogQuotaGate() {
     message: string
   } | null>(null)
 
-  const categoriesLimitModalOpen = ref(false)
-  const categoriesLimitModalMessage = ref('')
+  /** Shared limit modal (categories inline, modifiers Nuevo, product add-line). */
+  const quotaLimitModalOpen = ref(false)
+  const quotaLimitModalMessage = ref('')
+  const categoriesLimitModalOpen = quotaLimitModalOpen
+  const categoriesLimitModalMessage = quotaLimitModalMessage
 
   const menuProductsQuota = computed(() => getOperationalQuota('menu_products'))
   const menuCategoriesQuota = computed(() => getOperationalQuota('menu_categories'))
@@ -33,10 +37,8 @@ export function useMenuCatalogQuotaGate() {
   const recipeBasesQuota = computed(() => getOperationalQuota('recipe_bases'))
 
   const isProductsCreateBlocked = computed(() => menuProductsQuota.value.blocked)
-  /** Modificadores: own group cap OR shared catalog product cap exhausted. */
-  const isModifiersCreateBlocked = computed(
-    () => menuProductsQuota.value.blocked || modifierGroupsQuota.value.blocked,
-  )
+  /** Modificadores: own group cap only (independent of menu_products — #1808). */
+  const isModifiersCreateBlocked = computed(() => modifierGroupsQuota.value.blocked)
   const isRecipesCreateBlocked = computed(() => recipeBasesQuota.value.blocked)
   const isCategoriesCreateBlocked = computed(
     () => categoriesQuotaFresh.value?.blocked === true || menuCategoriesQuota.value.blocked,
@@ -59,12 +61,23 @@ export function useMenuCatalogQuotaGate() {
     return formatMetricMessage(resource, metric)
   }
 
+  const formatScopedCountMessage = (
+    resource: 'recipe_lines_per_product' | 'modifier_options_per_group',
+    currentCount: number,
+    limit: number,
+  ) => {
+    return formatMetricMessage(resource, {
+      used: currentCount,
+      limit,
+      remaining: Math.max(limit - currentCount, 0),
+      period_start: '',
+      period_end: '',
+    })
+  }
+
   const productsCreateBlockedMessage = computed(() => formatBlockedMessage('menu_products'))
   const categoriesCreateBlockedMessage = computed(() => formatBlockedMessage('menu_categories'))
-  const modifiersCreateBlockedMessage = computed(() => {
-    if (menuProductsQuota.value.blocked) return formatBlockedMessage('menu_products')
-    return formatBlockedMessage('modifier_groups')
-  })
+  const modifiersCreateBlockedMessage = computed(() => formatBlockedMessage('modifier_groups'))
   const recipesCreateBlockedMessage = computed(() => formatBlockedMessage('recipe_bases'))
   const sharedCatalogCreateBlockedMessage = computed(() => productsCreateBlockedMessage.value)
 
@@ -124,24 +137,49 @@ export function useMenuCatalogQuotaGate() {
     }
   }
 
-  const openCategoriesLimitModal = async (opts?: { skipRefresh?: boolean }) => {
-    if (!opts?.skipRefresh) {
+  const fetchScopedQuotaLimit = async (
+    resource: 'recipe_lines_per_product' | 'modifier_options_per_group',
+  ): Promise<number | null> => {
+    const cached = remainingUsage.value?.quota_usage?.[resource]?.limit
+    if (cached !== undefined) return cached
+    try {
+      const usage = await fetchRemainingUsage()
+      return usage.quota_usage?.[resource]?.limit ?? null
+    } catch {
+      return null
+    }
+  }
+
+  const openQuotaLimitModalWithMessage = (message: string) => {
+    quotaLimitModalMessage.value = message
+      || t('menu.common.quotaBlocked', 'Cupo del plan alcanzado')
+    quotaLimitModalOpen.value = true
+  }
+
+  const openQuotaLimitModal = async (resource: OperationalQuotaKey, opts?: { skipRefresh?: boolean }) => {
+    if (resource === 'menu_categories' && !opts?.skipRefresh) {
       await refreshCategoriesCreateGate()
     }
-    categoriesLimitModalMessage.value = categoriesCreateBlockedMessage.value
-      || BILLING_QUOTA_RESOURCE_CONFIG.menu_categories?.blockedMessage
+    const message = formatBlockedMessage(resource)
+      || BILLING_QUOTA_RESOURCE_CONFIG[resource]?.blockedMessage
       || t('menu.common.quotaBlocked', 'Cupo del plan alcanzado')
-    categoriesLimitModalOpen.value = true
+    openQuotaLimitModalWithMessage(message)
   }
 
-  const closeCategoriesLimitModal = () => {
-    categoriesLimitModalOpen.value = false
+  const openCategoriesLimitModal = async (opts?: { skipRefresh?: boolean }) => {
+    await openQuotaLimitModal('menu_categories', opts)
   }
 
-  const goToBillingFromCategoriesLimitModal = async () => {
-    categoriesLimitModalOpen.value = false
+  const closeQuotaLimitModal = () => {
+    quotaLimitModalOpen.value = false
+  }
+  const closeCategoriesLimitModal = closeQuotaLimitModal
+
+  const goToBillingFromQuotaLimitModal = async () => {
+    quotaLimitModalOpen.value = false
     await navigateTo('/gestion/billing')
   }
+  const goToBillingFromCategoriesLimitModal = goToBillingFromQuotaLimitModal
 
   /** Inline product flows: allow click, show modal instead of create panel when blocked. */
   const handleInlineCategoryCreate = async (typedName: string, openCreate: (name: string) => void) => {
@@ -150,6 +188,48 @@ export function useMenuCatalogQuotaGate() {
       return false
     }
     openCreate(typedName)
+    return true
+  }
+
+  /** Modificadores list Nuevo: stay clickable; open limit modal when groups cap reached. */
+  const handleModifiersCreateClick = async (navigate: () => void) => {
+    if (await fetchQuotaBlocked('modifier_groups')) {
+      await openQuotaLimitModal('modifier_groups')
+      return false
+    }
+    navigate()
+    return true
+  }
+
+  /**
+   * Product recipe editor: stay clickable when at recipe_lines_per_product;
+   * open limit modal instead of appending a line.
+   */
+  const handleAddProductRecipeLine = async (currentCount: number, add: () => void) => {
+    const limit = await fetchScopedQuotaLimit('recipe_lines_per_product')
+    if (limit !== null && currentCount >= limit) {
+      openQuotaLimitModalWithMessage(
+        formatScopedCountMessage('recipe_lines_per_product', currentCount, limit),
+      )
+      return false
+    }
+    add()
+    return true
+  }
+
+  /**
+   * Modifier option editor: stay clickable when at modifier_options_per_group;
+   * open limit modal instead of appending an option.
+   */
+  const handleAddModifierOption = async (currentCount: number, add: () => void) => {
+    const limit = await fetchScopedQuotaLimit('modifier_options_per_group')
+    if (limit !== null && currentCount >= limit) {
+      openQuotaLimitModalWithMessage(
+        formatScopedCountMessage('modifier_options_per_group', currentCount, limit),
+      )
+      return false
+    }
+    add()
     return true
   }
 
@@ -163,9 +243,7 @@ export function useMenuCatalogQuotaGate() {
   }
 
   const redirectIfModifiersCreateBlocked = async (listPath = '/menu/modificadores') => {
-    const productsBlocked = await fetchQuotaBlocked('menu_products')
-    const groupsBlocked = productsBlocked ? true : await fetchQuotaBlocked('modifier_groups')
-    if (productsBlocked || groupsBlocked) {
+    if (await fetchQuotaBlocked('modifier_groups')) {
       showModifiersCreateBlocked()
       await navigateTo(listPath)
       return true
@@ -215,10 +293,18 @@ export function useMenuCatalogQuotaGate() {
     refreshCategoriesCreateGate,
     fetchQuotaBlocked,
     handleInlineCategoryCreate,
+    handleModifiersCreateClick,
+    handleAddProductRecipeLine,
+    handleAddModifierOption,
+    quotaLimitModalOpen,
+    quotaLimitModalMessage,
     categoriesLimitModalOpen,
     categoriesLimitModalMessage,
+    openQuotaLimitModal,
     openCategoriesLimitModal,
+    closeQuotaLimitModal,
     closeCategoriesLimitModal,
+    goToBillingFromQuotaLimitModal,
     goToBillingFromCategoriesLimitModal,
     redirectIfProductsCreateBlocked,
     redirectIfModifiersCreateBlocked,

--- a/composables/useMenuCatalogQuotaGate.ts
+++ b/composables/useMenuCatalogQuotaGate.ts
@@ -119,22 +119,28 @@ export function useMenuCatalogQuotaGate() {
     await refreshCategoriesCreateGate()
   }
 
-  const fetchQuotaBlocked = async (resource: OperationalQuotaKey) => {
+  const fetchQuotaStatus = async (resource: OperationalQuotaKey) => {
     try {
       const usage = await fetchRemainingUsage()
       const metric = usage.quota_usage?.[resource] ?? null
       const blocked = resolveOperationalQuota(resource, metric).blocked
+      const message = formatMetricMessage(resource, metric)
       if (resource === 'menu_categories') {
         categoriesQuotaFresh.value = {
           blocked,
-          message: formatMetricMessage('menu_categories', metric),
+          message,
         }
       }
-      return blocked
+      return { blocked, message, metric }
     } catch {
       // Fail open — API CREATE still enforces 429.
-      return false
+      return { blocked: false, message: '', metric: null }
     }
+  }
+
+  /** Boolean helper for callers that only need blocked (categories list, redirects). */
+  const fetchQuotaBlocked = async (resource: OperationalQuotaKey) => {
+    return (await fetchQuotaStatus(resource)).blocked
   }
 
   const fetchScopedQuotaLimit = async (
@@ -183,8 +189,14 @@ export function useMenuCatalogQuotaGate() {
 
   /** Inline product flows: allow click, show modal instead of create panel when blocked. */
   const handleInlineCategoryCreate = async (typedName: string, openCreate: (name: string) => void) => {
-    if (await fetchQuotaBlocked('menu_categories')) {
-      await openCategoriesLimitModal({ skipRefresh: true })
+    const result = await fetchQuotaStatus('menu_categories')
+    if (result.blocked) {
+      openQuotaLimitModalWithMessage(
+        result.message
+          || categoriesCreateBlockedMessage.value
+          || BILLING_QUOTA_RESOURCE_CONFIG.menu_categories?.blockedMessage
+          || t('menu.common.quotaBlocked', 'Cupo del plan alcanzado'),
+      )
       return false
     }
     openCreate(typedName)
@@ -193,8 +205,13 @@ export function useMenuCatalogQuotaGate() {
 
   /** Modificadores list Nuevo: stay clickable; open limit modal when groups cap reached. */
   const handleModifiersCreateClick = async (navigate: () => void) => {
-    if (await fetchQuotaBlocked('modifier_groups')) {
-      await openQuotaLimitModal('modifier_groups')
+    const result = await fetchQuotaStatus('modifier_groups')
+    if (result.blocked) {
+      openQuotaLimitModalWithMessage(
+        result.message
+          || BILLING_QUOTA_RESOURCE_CONFIG.modifier_groups?.blockedMessage
+          || t('menu.common.quotaBlocked', 'Cupo del plan alcanzado'),
+      )
       return false
     }
     navigate()

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -246,6 +246,16 @@
       :on-ingredient-saved="onCustomIngredientCreated"
       :on-product-saved="onInlineProductCreated"
     />
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('shell.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>
 
@@ -282,6 +292,13 @@ const route = useRoute()
 const toast = useToast()
 const cache = useQueryCache()
 const { currentTenant } = useTenantReactive()
+const {
+  handleAddModifierOption,
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+} = useMenuCatalogQuotaGate()
 
 const isSubmitting = ref(false)
 const submitError = ref('')
@@ -591,7 +608,9 @@ function getSelectedProductsText() {
 }
 
 function addModifier() {
-  form.value.modifiers.push(createEmptyModifier(form.value.modifiers.length))
+  void handleAddModifierOption(form.value.modifiers.length, () => {
+    form.value.modifiers.push(createEmptyModifier(form.value.modifiers.length))
+  })
 }
 
 const warehouseCategorySelectorRef = ref<{ dismissPreparedIngredient: (id: string) => void } | null>(null)

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -259,6 +259,16 @@
       :on-ingredient-saved="onCustomIngredientCreated"
       :on-product-saved="onInlineProductCreated"
     />
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('shell.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>
 
@@ -287,7 +297,14 @@ useHead({ title: () => t('menu.head.modificadores') })
 
 const router = useRouter()
 const { currentTenant } = useTenantReactive()
-const { redirectIfModifiersCreateBlocked } = useMenuCatalogQuotaGate()
+const {
+  redirectIfModifiersCreateBlocked,
+  handleAddModifierOption,
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+} = useMenuCatalogQuotaGate()
 
 onMounted(async () => {
   await redirectIfModifiersCreateBlocked('/menu/modificadores')
@@ -325,7 +342,9 @@ watch(selectedProducts, (list) => {
 }, { deep: true })
 
 function addModifier() {
-  form.value.modifiers.push(createEmptyModifier(form.value.modifiers.length))
+  void handleAddModifierOption(form.value.modifiers.length, () => {
+    form.value.modifiers.push(createEmptyModifier(form.value.modifiers.length))
+  })
 }
 
 const ingredientCache = ref<Record<string, any>>({})

--- a/pages/menu/modificadores/index.vue
+++ b/pages/menu/modificadores/index.vue
@@ -19,9 +19,8 @@
         <template #trailing>
           <button
             type="button"
-            :disabled="isModifiersCreateBlocked"
-            :title="isModifiersCreateBlocked ? modifiersCreateBlockedMessage : t('menu.modificadores.newGroup')"
-            class="inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-shell-cta-bg px-4 py-2 text-center text-sm font-medium text-shell-cta-text whitespace-nowrap transition-all hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring disabled:opacity-50 disabled:cursor-not-allowed"
+            :title="t('menu.modificadores.newGroup')"
+            class="inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-shell-cta-bg px-4 py-2 text-center text-sm font-medium text-shell-cta-text whitespace-nowrap transition-all hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring"
             @click="goToCreateGroup"
           >
             <Icon name="heroicons:plus" class="h-4 w-4 flex-shrink-0" />
@@ -282,6 +281,16 @@
       </div>
     </div>
     </div>
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('shell.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>
 
@@ -302,9 +311,11 @@ useHead({ title: () => t('menu.head.modificadores') })
 const router = useRouter()
 const { currentTenant } = useTenantReactive()
 const {
-  isModifiersCreateBlocked,
-  modifiersCreateBlockedMessage,
-  showModifiersCreateBlocked,
+  handleModifiersCreateClick,
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
   ensureBillingOverview,
 } = useMenuCatalogQuotaGate()
 
@@ -491,11 +502,9 @@ function getGroupOptionLabels(grupoId: string) {
 }
 
 const goToCreateGroup = () => {
-  if (isModifiersCreateBlocked.value) {
-    showModifiersCreateBlocked()
-    return
-  }
-  router.push('/menu/modificadores/crear')
+  void handleModifiersCreateClick(() => {
+    router.push('/menu/modificadores/crear')
+  })
 }
 
 const goToEditGroup = (groupId: string) => {

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -929,6 +929,7 @@ const WAREHOUSE_COPY = useWarehouseCopy()
 const { currentTenant, businessProfile } = useTenantReactive()
 const {
   handleInlineCategoryCreate,
+  handleAddProductRecipeLine,
   categoriesLimitModalOpen,
   categoriesLimitModalMessage,
   closeCategoriesLimitModal,
@@ -1534,13 +1535,15 @@ const onRecipeBaseChange = () => {
 }
 
 const addIngredient = () => {
-  // Adding an ingredient implies the product tracks inventory.
-  tracksInventory.value = true
-  form.value.ingredients.push({
-    ingredient_id: '',
-    ingredient_name: '',
-    quantity: 0,
-    unit: 'g'
+  void handleAddProductRecipeLine(form.value.ingredients.length, () => {
+    // Adding an ingredient implies the product tracks inventory.
+    tracksInventory.value = true
+    form.value.ingredients.push({
+      ingredient_id: '',
+      ingredient_name: '',
+      quantity: 0,
+      unit: 'g'
+    })
   })
 }
 

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -770,7 +770,7 @@ const cache = useQueryCache()
 const toast = useToast()
 const { currentTenant, businessProfile } = useTenantReactive()
 const { showUpgradeCta, upgradeMessage, handleQuotaError, clearQuotaError } = useQuotaExceeded()
-const { redirectIfProductsCreateBlocked, handleInlineCategoryCreate, categoriesLimitModalOpen, categoriesLimitModalMessage, closeCategoriesLimitModal, goToBillingFromCategoriesLimitModal } = useMenuCatalogQuotaGate()
+const { redirectIfProductsCreateBlocked, handleInlineCategoryCreate, handleAddProductRecipeLine, categoriesLimitModalOpen, categoriesLimitModalMessage, closeCategoriesLimitModal, goToBillingFromCategoriesLimitModal } = useMenuCatalogQuotaGate()
 
 onMounted(async () => {
   await redirectIfProductsCreateBlocked('/menu/productos')
@@ -1270,11 +1270,13 @@ function getCategoryName(categoryId: string) {
 }
 
 function addIngredient() {
-  form.value.ingredients.push({
-    ingredient_id: '',
-    ingredient_name: '',
-    quantity: 0,
-    unit: 'g',
+  void handleAddProductRecipeLine(form.value.ingredients.length, () => {
+    form.value.ingredients.push({
+      ingredient_id: '',
+      ingredient_name: '',
+      quantity: 0,
+      unit: 'g',
+    })
   })
 }
 


### PR DESCRIPTION
## Summary
- Modificadores create is gated only by `modifier_groups` (no longer by `menu_products`).
- Nuevo / Agregar línea / Agregar opción stay clickable and open `UiConfirmActionModal` → Mi Plan when the cap is reached (same pattern as categories #1806).
- Product recipe lines use `recipe_lines_per_product`; modifier options use `modifier_options_per_group`.

Closes #1808

Companion API PR: exposes scoped limits in remaining-usage (deploy API first).

## Test plan
- [ ] Starter tenant: with products at cap, Modificadores Nuevo still works if groups remaining
- [ ] At modifier_groups cap: Nuevo opens limit modal (not disabled)
- [ ] Product create/edit: at 4 ingredient lines, Agregar línea opens modal
- [ ] Modifier create/edit: at 6 options, Agregar opción opens modal
- [ ] Modal CTA navigates to Mi Plan

## Validation evidence
API companion (scoped remaining-usage keys):
```
./venv/bin/python -m pytest tests/test_billing_remaining_usage.py -q
7 passed in 0.04s
```
Front: no unit test suite for this gate; manual QA above.

## wr-context
See `.wr/1808.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)