### PR TITLE
fix(public): restore lead modal CTAs and improve blog masthead

### DIFF
--- a/components/blog/BlogArticleCTA.vue
+++ b/components/blog/BlogArticleCTA.vue
@@ -1,36 +1,25 @@
 <script setup lang="ts">
-import { activatePublicCta } from '~/utils/publicCta'
+import { blogLeadSource } from '~/utils/blogLeadCta'
 
 const props = defineProps<{ slug: string }>()
-const router = useRouter()
+const leadModal = useLeadModal()
 const ctaContent = computed(() => useBlogCta(props.slug))
-const startRegistration = () => router.push(activatePublicCta(
-  ctaContent.value,
-  { source: 'blog_article', content: `${props.slug}_final` },
-  undefined,
-  import.meta.client ? window.sessionStorage : null,
-))
+const openLeadModal = () => leadModal.open(blogLeadSource(props.slug))
 </script>
 
 <template>
   <div class="blog-cta-banner">
     <div class="blog-cta-inner">
       <div class="blog-cta-text">
-        <p class="blog-cta-eyebrow">{{ ctaContent.eyebrow }}</p>
         <p class="blog-cta-headline">{{ ctaContent.headline }}</p>
         <p class="blog-cta-body">{{ ctaContent.body }}</p>
         <p class="blog-cta-microcopy">{{ ctaContent.microcopy }}</p>
-        <p v-if="ctaContent.comparison" class="blog-cta-disclosure">
-          {{ ctaContent.comparison.scope }} {{ ctaContent.comparison.disclosure }}
-          <a :href="ctaContent.comparison.url" target="_blank" rel="noopener noreferrer">
-            {{ ctaContent.comparison.source }} · {{ ctaContent.comparison.asOf }}
-          </a>
-        </p>
       </div>
       <button
         class="blog-cta-button"
         type="button"
-        @click="startRegistration"
+        aria-haspopup="dialog"
+        @click="openLeadModal"
       >
         {{ ctaContent.button }}
       </button>
@@ -70,15 +59,6 @@ const startRegistration = () => router.push(activatePublicCta(
   flex: 1;
 }
 
-.blog-cta-eyebrow {
-  margin: 0;
-  color: hsl(var(--badge-primary-hover-bg));
-  font-size: 0.6875rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
 .blog-cta-headline {
   font-size: 1rem;
   font-weight: 700;
@@ -100,19 +80,11 @@ const startRegistration = () => router.push(activatePublicCta(
   margin: 0;
 }
 
-.blog-cta-microcopy,
-.blog-cta-disclosure {
+.blog-cta-microcopy {
   margin: 0.125rem 0 0;
   color: hsl(var(--badge-primary-hover-bg));
   font-size: 0.75rem;
   line-height: 1.5;
-}
-
-.blog-cta-disclosure a {
-  color: inherit;
-  font-weight: 700;
-  text-decoration: underline;
-  text-underline-offset: 2px;
 }
 
 .blog-cta-button {

--- a/components/blog/BlogArticleContent.vue
+++ b/components/blog/BlogArticleContent.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, ref, onMounted, onUnmounted, nextTick } from 'vue'
 import MarkdownIt from 'markdown-it'
-import { activatePublicCta, type PublicCta } from '~/utils/publicCta'
+import { blogLeadSource } from '~/utils/blogLeadCta'
+import type { BlogLeadCtaContent } from '~/utils/blogLeadCta'
 
 interface Props {
   content: string
@@ -14,27 +15,20 @@ const props = withDefaults(defineProps<Props>(), {
   slug: '',
 })
 
-// Markdown renderer
 const md = new MarkdownIt({ html: true, linkify: true, typographer: true })
 const renderedContent = computed(() => md.render(props.content))
 
-// Barra de progreso de lectura
 const readingProgress = ref(0)
-
 const articleRef = ref<HTMLElement | null>(null)
-const router = useRouter()
+const leadModal = useLeadModal()
 const insertedCtas: HTMLElement[] = []
 
-function buildMidCta(cta: PublicCta, index: number): HTMLElement {
+function buildMidCta(cta: BlogLeadCtaContent, index: number, source: string): HTMLElement {
   const wrap = document.createElement('div')
   wrap.setAttribute('data-mid-cta', '')
 
   const content = document.createElement('div')
   content.setAttribute('data-mid-cta-content', '')
-
-  const eyebrow = document.createElement('span')
-  eyebrow.setAttribute('data-mid-cta-eyebrow', '')
-  eyebrow.textContent = cta.eyebrow
 
   const headline = document.createElement('p')
   headline.setAttribute('data-mid-cta-headline', '')
@@ -51,31 +45,13 @@ function buildMidCta(cta: PublicCta, index: number): HTMLElement {
   const btn = document.createElement('button')
   btn.setAttribute('data-blog-cta-btn', '')
   btn.textContent = cta.button
-
   btn.type = 'button'
-  btn.addEventListener('click', () => router.push(activatePublicCta(
-    cta,
-    { source: 'blog_article', content: `${props.slug}_${cta.placement}` },
-    undefined,
-    window.sessionStorage,
-  )))
+  btn.setAttribute('aria-haspopup', 'dialog')
+  btn.addEventListener('click', () => leadModal.open(source))
 
-  content.appendChild(eyebrow)
   content.appendChild(headline)
   content.appendChild(text)
   content.appendChild(microcopy)
-  if (cta.comparison) {
-    const disclosure = document.createElement('p')
-    disclosure.setAttribute('data-mid-cta-disclosure', '')
-    disclosure.append(document.createTextNode(`${cta.comparison.scope} ${cta.comparison.disclosure} `))
-    const source = document.createElement('a')
-    source.href = cta.comparison.url
-    source.target = '_blank'
-    source.rel = 'noopener noreferrer'
-    source.textContent = `${cta.comparison.source} · ${cta.comparison.asOf}`
-    disclosure.appendChild(source)
-    content.appendChild(disclosure)
-  }
   wrap.appendChild(content)
   wrap.appendChild(btn)
   wrap.setAttribute('data-mid-cta-position', String(index + 1))
@@ -114,9 +90,10 @@ onMounted(() => {
 
     // Inject contextual CTA banners at natural reading breaks.
     if (props.slug) {
+      const source = blogLeadSource(props.slug)
       getMidCtaTargets(articleRef.value).forEach((h2, index) => {
         const cta = useBlogCta(props.slug, index === 0 ? 'benefit' : 'price')
-        const banner = buildMidCta(cta, index)
+        const banner = buildMidCta(cta, index, source)
         h2.parentNode!.insertBefore(banner, h2)
         insertedCtas.push(banner)
       })

--- a/components/blog/BlogFeaturedArticleCard.vue
+++ b/components/blog/BlogFeaturedArticleCard.vue
@@ -20,9 +20,11 @@ withDefaults(defineProps<{
   gradientClass: string
   embedded?: boolean
   compact?: boolean
+  stacked?: boolean
 }>(), {
   embedded: false,
   compact: false,
+  stacked: false,
 })
 
 const formatDate = (dateString: string) => {
@@ -49,13 +51,17 @@ const getReadingTime = (description: string) => {
     </div>
 
     <article
-      class="group relative bg-surface rounded-2xl overflow-hidden border border-border hover:border-badge-primary-border transition-colors duration-300 grid"
-      :class="compact ? 'lg:grid-cols-[1.15fr_1fr]' : 'lg:grid-cols-[1.1fr_1fr]'"
+      class="group relative bg-surface rounded-2xl overflow-hidden border border-border hover:border-badge-primary-border transition-colors duration-300"
+      :class="stacked ? 'flex flex-col' : ['grid', compact ? 'lg:grid-cols-[1.15fr_1fr]' : 'lg:grid-cols-[1.1fr_1fr]']"
     >
       <NuxtLink
         :to="`/blog/${article.slug}`"
-        class="relative overflow-hidden"
-        :class="compact ? 'min-h-[12rem] sm:min-h-[14rem] lg:min-h-[16rem]' : 'min-h-[13rem] sm:min-h-[18rem] lg:min-h-[26rem]'"
+        class="relative overflow-hidden block"
+        :class="stacked
+          ? 'aspect-[16/10] sm:aspect-[16/9] shrink-0'
+          : compact
+            ? 'min-h-[12rem] sm:min-h-[14rem] lg:min-h-[16rem]'
+            : 'min-h-[13rem] sm:min-h-[18rem] lg:min-h-[20rem]'"
       >
         <img
           v-if="article.cover"
@@ -67,7 +73,14 @@ const getReadingTime = (description: string) => {
         <div class="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent lg:bg-gradient-to-r lg:from-transparent lg:to-black/10"></div>
       </NuxtLink>
 
-      <div class="p-5 sm:p-8 lg:p-12 xl:p-14 flex flex-col justify-center">
+      <div
+        class="flex flex-col justify-center"
+        :class="stacked
+          ? 'p-4 sm:p-5 lg:p-6'
+          : compact
+            ? 'p-5 sm:p-6 lg:p-8'
+            : 'p-5 sm:p-8 lg:p-12 xl:p-14'"
+      >
         <div class="flex items-center gap-2 mb-3 sm:mb-5 text-xs text-text-tertiary font-medium">
           <svg class="w-3.5 h-3.5 text-badge-primary-text" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
@@ -76,18 +89,29 @@ const getReadingTime = (description: string) => {
         </div>
 
         <NuxtLink :to="`/blog/${article.slug}`">
-          <h2 class="text-xl sm:text-2xl lg:text-3xl xl:text-4xl font-bold mb-3 sm:mb-5 text-text-primary leading-tight group-hover:text-badge-primary-text transition-colors duration-300">
+          <h2
+            class="font-bold text-text-primary leading-tight group-hover:text-badge-primary-text transition-colors duration-300"
+            :class="stacked
+              ? 'text-lg sm:text-xl mb-2 sm:mb-3 line-clamp-2'
+              : compact
+                ? 'text-xl sm:text-2xl lg:text-2xl mb-3 sm:mb-4 line-clamp-3'
+                : 'text-xl sm:text-2xl lg:text-3xl xl:text-4xl mb-3 sm:mb-5'"
+          >
             {{ article.title }}
           </h2>
         </NuxtLink>
 
-        <p class="text-text-secondary text-sm sm:text-base lg:text-lg leading-relaxed mb-5 sm:mb-8 line-clamp-2 sm:line-clamp-3">
+        <p
+          class="text-text-secondary leading-relaxed line-clamp-2 sm:line-clamp-3"
+          :class="stacked || compact ? 'text-sm sm:text-base mb-4 sm:mb-5' : 'text-sm sm:text-base lg:text-lg mb-5 sm:mb-8'"
+        >
           {{ article.description }}
         </p>
 
         <NuxtLink
           :to="`/blog/${article.slug}`"
-          class="inline-flex items-center gap-2 self-start px-5 py-2.5 bg-action-primary-bg hover:bg-action-primary-hover-bg text-action-primary-text text-sm font-semibold rounded-full transition-all duration-200 hover:gap-3 mb-4 sm:mb-8"
+          class="inline-flex items-center gap-2 self-start px-5 py-2.5 bg-action-primary-bg hover:bg-action-primary-hover-bg text-action-primary-text text-sm font-semibold rounded-full transition-all duration-200 hover:gap-3"
+          :class="stacked || compact ? 'mb-4' : 'mb-4 sm:mb-8'"
         >
           Leer artículo
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -95,7 +119,7 @@ const getReadingTime = (description: string) => {
           </svg>
         </NuxtLink>
 
-        <div class="flex items-center gap-3 pt-6 border-t border-border">
+        <div class="flex items-center gap-3 border-t border-border" :class="stacked ? 'pt-4 mt-auto' : 'pt-6'">
           <img
             v-if="article.author_avatar"
             :src="article.author_avatar"

--- a/components/blog/BlogMasthead.vue
+++ b/components/blog/BlogMasthead.vue
@@ -20,15 +20,14 @@ const props = defineProps<{
   gradientClasses: string[]
 }>()
 
-const leftArticle = computed(() => props.articles[0] ?? null)
-const rightArticle = computed(() => props.articles[1] ?? null)
+const featuredArticle = computed(() => props.articles[0] ?? null)
 
 const getGradientClass = (index: number) =>
   props.gradientClasses[index % props.gradientClasses.length]
 </script>
 
 <template>
-  <section v-if="leftArticle" class="mb-12 sm:mb-16 lg:mb-20">
+  <section v-if="featuredArticle" class="mb-12 sm:mb-16 lg:mb-20">
     <div class="flex items-center gap-3 mb-5 sm:mb-6">
       <div class="w-1 h-6 bg-action-primary-bg rounded-full" />
       <h2 class="text-sm sm:text-base font-bold uppercase tracking-[0.15em] text-text-primary">
@@ -36,25 +35,10 @@ const getGradientClass = (index: number) =>
       </h2>
     </div>
 
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6 lg:gap-7 items-stretch auto-rows-fr">
-      <BlogFeaturedArticleCard
-        class="h-full min-h-0"
-        :article="leftArticle"
-        :gradient-class="getGradientClass(0)"
-        embedded
-        compact
-        stacked
-      />
-
-      <BlogFeaturedArticleCard
-        v-if="rightArticle"
-        class="h-full min-h-0"
-        :article="rightArticle"
-        :gradient-class="getGradientClass(1)"
-        embedded
-        compact
-        stacked
-      />
-    </div>
+    <BlogFeaturedArticleCard
+      :article="featuredArticle"
+      :gradient-class="getGradientClass(0)"
+      embedded
+    />
   </section>
 </template>

--- a/components/layout/PublicShell.vue
+++ b/components/layout/PublicShell.vue
@@ -7,6 +7,7 @@
     </main>
     <LayoutFooter v-if="showFooter" :class="footerClass" />
     <LayoutBottomNav v-if="showBottomNav" />
+    <ModalsLeadModal />
   </div>
 </template>
 

--- a/components/modals/LeadModal.vue
+++ b/components/modals/LeadModal.vue
@@ -1,0 +1,19 @@
+<template>
+  <!-- Desktop -->
+  <Modal :model-value="isOpen" title="¡Hablemos!" @update:model-value="close">
+    <LeadModalForm :button-source="buttonSource" @close="close" />
+  </Modal>
+
+  <!-- Mobile -->
+  <BottomSheetModal :model-value="isOpen" title="¡Hablemos!" @update:model-value="close">
+    <LeadModalForm :button-source="buttonSource" @close="close" />
+  </BottomSheetModal>
+</template>
+
+<script setup lang="ts">
+import Modal from '~/components/ui/Modal.vue'
+import BottomSheetModal from '~/components/ui/BottomSheetModal.vue'
+import LeadModalForm from '~/components/modals/LeadModalForm.vue'
+
+const { isOpen, buttonSource, close } = useLeadModal()
+</script>

--- a/components/modals/LeadModalForm.vue
+++ b/components/modals/LeadModalForm.vue
@@ -1,0 +1,177 @@
+<template>
+  <div class="px-6 py-6">
+
+    <!-- Success state: new lead -->
+    <div v-if="isSuccess && !isAlreadyRegistered" class="flex flex-col items-center gap-6 py-8 text-center">
+      <div class="w-16 h-16 rounded-full bg-status-success-bg flex items-center justify-center ring-8 ring-status-success-bg/40">
+        <Icon name="heroicons:check-circle" class="w-9 h-9 text-status-success-text" aria-hidden="true" />
+      </div>
+      <div class="flex flex-col gap-2">
+        <p class="text-lg font-bold leading-tight text-ebony-900">¡Gracias por escribirnos!</p>
+        <p class="text-sm leading-relaxed text-ebony-500 max-w-[240px] mx-auto">
+          Recibimos tu mensaje. Nos pondremos en contacto contigo muy pronto.
+        </p>
+      </div>
+      <button
+        class="min-h-[44px] px-8 rounded-lg text-sm font-semibold text-crocus-700 bg-crocus-50
+               hover:bg-crocus-100 focus:outline-none focus:ring-2 focus:ring-crocus-500
+               transition-colors"
+        @click="emit('close')"
+      >
+        Cerrar
+      </button>
+    </div>
+
+    <!-- Success state: already registered -->
+    <div v-else-if="isSuccess && isAlreadyRegistered" class="flex flex-col items-center gap-6 py-8 text-center">
+      <div class="w-16 h-16 rounded-full bg-crocus-100 flex items-center justify-center ring-8 ring-crocus-100/40">
+        <Icon name="heroicons:clock" class="w-9 h-9 text-crocus-600" aria-hidden="true" />
+      </div>
+      <div class="flex flex-col gap-2">
+        <p class="text-lg font-bold leading-tight text-ebony-900">Ya tenemos tu solicitud</p>
+        <p class="text-sm leading-relaxed text-ebony-500 max-w-[240px] mx-auto">
+          Disculpa si enviaste el formulario más de una vez. Ya estás en nuestra lista y pronto te contactamos.
+        </p>
+      </div>
+      <button
+        class="min-h-[44px] px-8 rounded-lg text-sm font-semibold text-crocus-700 bg-crocus-50
+               hover:bg-crocus-100 focus:outline-none focus:ring-2 focus:ring-crocus-500
+               transition-colors"
+        @click="emit('close')"
+      >
+        Entendido
+      </button>
+    </div>
+
+    <!-- Form state -->
+    <form v-else class="flex flex-col gap-5" @submit.prevent="handleSubmit">
+
+      <!-- Email -->
+      <div class="flex flex-col gap-1">
+        <label for="lead-email" class="text-sm font-medium text-ebony-700">
+          Correo electrónico <span class="text-destructive" aria-hidden="true">*</span>
+        </label>
+        <input
+          id="lead-email"
+          v-model="form.email"
+          type="email"
+          required
+          autocomplete="email"
+          placeholder="tu@correo.com"
+          class="w-full px-3 py-2.5 text-base border border-titan-300 rounded-lg bg-white text-ebony-900
+                 placeholder:text-titan-400 focus:outline-none focus:ring-2 focus:ring-crocus-500
+                 disabled:opacity-50 disabled:cursor-not-allowed"
+          :disabled="isSubmitting"
+        />
+        <p v-if="errors.email" class="flex items-center gap-1 text-sm leading-normal text-destructive" role="alert">
+          <Icon name="heroicons:exclamation-circle" class="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+          {{ errors.email }}
+        </p>
+      </div>
+
+      <!-- Phone -->
+      <div class="flex flex-col gap-1">
+        <label for="lead-phone" class="text-sm font-medium text-ebony-700">
+          Teléfono <span class="text-destructive" aria-hidden="true">*</span>
+        </label>
+        <div class="flex">
+          <span
+            class="inline-flex items-center px-3 border border-e-0 border-titan-300 rounded-s-lg bg-titan-50
+                   text-ebony-500 text-sm select-none"
+            aria-label="Código de país Colombia"
+          >
+            🇨🇴 +57
+          </span>
+          <input
+            id="lead-phone"
+            v-model="form.phone"
+            type="tel"
+            required
+            autocomplete="tel-national"
+            placeholder="300 123 4567"
+            inputmode="numeric"
+            class="flex-1 px-3 py-2.5 text-base border border-titan-300 rounded-e-lg bg-white text-ebony-900
+                   placeholder:text-titan-400 focus:outline-none focus:ring-2 focus:ring-crocus-500
+                   disabled:opacity-50 disabled:cursor-not-allowed"
+            :disabled="isSubmitting"
+          />
+        </div>
+        <p v-if="errors.phone" class="flex items-center gap-1 text-sm leading-normal text-destructive" role="alert">
+          <Icon name="heroicons:exclamation-circle" class="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+          {{ errors.phone }}
+        </p>
+      </div>
+
+      <!-- Submit -->
+      <button
+        type="submit"
+        :disabled="isSubmitting"
+        class="w-full min-h-[44px] py-2.5 px-4 rounded-lg font-semibold text-base text-white
+               bg-crocus-600 hover:bg-crocus-700 active:scale-[0.98]
+               focus:outline-none focus:ring-2 focus:ring-crocus-500 focus:ring-offset-2
+               disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+      >
+        <UiLoadingDots v-if="isSubmitting" color="currentColor" size="14px" aria-label="Enviando..." />
+        <span v-else>Quiero saber más</span>
+      </button>
+
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  buttonSource: string
+}>()
+
+const emit = defineEmits<{ close: [] }>()
+
+const { error } = useToast()
+
+const form = ref({ email: '', phone: '' })
+const errors = ref({ email: '', phone: '' })
+const isSubmitting = ref(false)
+const isSuccess = ref(false)
+const isAlreadyRegistered = ref(false)
+
+function validate(): boolean {
+  errors.value = { email: '', phone: '' }
+  let valid = true
+
+  if (!form.value.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.value.email)) {
+    errors.value.email = 'Ingresa un correo electrónico válido'
+    valid = false
+  }
+
+  const digits = form.value.phone.replace(/\D/g, '')
+  if (digits.length < 7 || digits.length > 10) {
+    errors.value.phone = 'Ingresa un número de teléfono válido (7-10 dígitos)'
+    valid = false
+  }
+
+  return valid
+}
+
+async function handleSubmit() {
+  if (!validate()) return
+
+  isSubmitting.value = true
+  try {
+    const res = await $fetch<{ success: boolean; already_registered: boolean }>('/api/leads/capture', {
+      method: 'POST',
+      body: {
+        email: form.value.email.trim().toLowerCase(),
+        phone: form.value.phone.replace(/\D/g, ''),
+        button_source: props.buttonSource,
+      },
+    })
+
+    isAlreadyRegistered.value = res.already_registered
+    isSuccess.value = true
+  } catch {
+    error('Ocurrió un error. Por favor intenta de nuevo.')
+  } finally {
+    isSubmitting.value = false
+  }
+}
+</script>

--- a/components/public/HomeHero.vue
+++ b/components/public/HomeHero.vue
@@ -1,14 +1,7 @@
 <script setup lang="ts">
-import { activatePublicCta, getPublicCta } from '~/utils/publicCta'
+const leadModal = useLeadModal()
 
-const router = useRouter()
-const heroCta = getPublicCta('management', 'hero')
-const startRegistration = () => router.push(activatePublicCta(
-  heroCta,
-  { source: 'home_hero', content: 'primary' },
-  undefined,
-  import.meta.client ? window.sessionStorage : null,
-))
+const openLeadModal = () => leadModal.open('habla_con_nosotros')
 </script>
 
 <template>
@@ -21,13 +14,14 @@ const startRegistration = () => router.push(activatePublicCta(
 
     <div class="cta-buttons">
       <button
-        class="btn btn-secondary"
+        class="btn btn-primary"
         type="button"
-        @click="startRegistration"
+        aria-haspopup="dialog"
+        @click="openLeadModal"
       >
-        {{ heroCta.button }}
+        HABLA CON NOSOTROS
       </button>
-      <p class="cta-microcopy">{{ heroCta.microcopy }}</p>
+      <p class="cta-microcopy">2 minutos. Sin tarjeta. Un asesor te contacta.</p>
     </div>
   </section>
 </template>
@@ -100,15 +94,15 @@ h1 {
   min-width: 160px;
 }
 
-.btn-secondary {
-  background: transparent;
-  color: hsl(262, 83%, 58%);
+.btn-primary {
+  background: hsl(262, 83%, 58%);
+  color: white;
   border: 2px solid hsl(262, 83%, 58%);
 }
 
-.btn-secondary:hover {
-  background: hsl(262, 83%, 58%);
-  color: white;
+.btn-primary:hover {
+  background: hsl(262, 83%, 52%);
+  border-color: hsl(262, 83%, 52%);
   transform: translateY(-2px);
   box-shadow: 0 6px 20px hsl(var(--action-primary-bg) / 0.2);
 }
@@ -125,6 +119,8 @@ h1 {
   .btn {
     padding: 12px 24px;
     min-width: 140px;
+    width: 100%;
+    max-width: 280px;
   }
 }
 </style>

--- a/composables/useBlogCta.ts
+++ b/composables/useBlogCta.ts
@@ -1,14 +1,14 @@
 import {
-  getBlogPublicCta,
-  type PublicCta,
-  type PublicCtaPlacement,
-} from '~/utils/publicCta'
+  getBlogLeadCta,
+  type BlogLeadCtaContent,
+  type BlogLeadCtaPlacement,
+} from '~/utils/blogLeadCta'
 
-export type BlogCtaContent = PublicCta
+export type BlogCtaContent = BlogLeadCtaContent
 
 export function useBlogCta(
   slug: string,
-  placement: Extract<PublicCtaPlacement, 'benefit' | 'price' | 'final'> = 'final',
+  placement: BlogLeadCtaPlacement = 'final',
 ): BlogCtaContent {
-  return getBlogPublicCta(slug, placement)
+  return getBlogLeadCta(slug, placement)
 }

--- a/composables/useLeadModal.ts
+++ b/composables/useLeadModal.ts
@@ -1,0 +1,15 @@
+export function useLeadModal() {
+  const isOpen = useState('lead-modal-open', () => false)
+  const buttonSource = useState<string>('lead-modal-source', () => 'comenzar')
+
+  function open(source: string = 'comenzar') {
+    buttonSource.value = source
+    isOpen.value = true
+  }
+
+  function close() {
+    isOpen.value = false
+  }
+
+  return { isOpen, buttonSource, open, close }
+}

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -60,7 +60,7 @@ const isFilteredMode = computed(() => activePillar.value !== null)
 
 const currentPage = ref(1)
 const articlesPerPage = 9
-const magazineLimit = 60
+const magazineLimit = 50
 
 watch(() => route.query.pillar, () => {
   currentPage.value = 1

--- a/utils/blogLeadCta.test.ts
+++ b/utils/blogLeadCta.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  blogLeadSource,
+  getBlogLeadCta,
+} from './blogLeadCta.ts'
+
+test('maps blog slugs to pain-first lead copy', () => {
+  const gastrobar = getBlogLeadCta('gastrobar-que-es', 'final')
+  assert.match(gastrobar.headline, /restaurante/i)
+  assert.equal(gastrobar.button, 'Quiero mi demo gratis')
+  assert.match(gastrobar.microcopy, /Sin tarjeta/)
+
+  const pos = getBlogLeadCta('software-pos-restaurantes-colombia', 'final')
+  assert.match(pos.button, /demostración/i)
+})
+
+test('shows price placement only on commercial slugs', () => {
+  const commercial = getBlogLeadCta('software-para-restaurantes-precio', 'price')
+  assert.match(commercial.headline, /95\.900/)
+
+  const informational = getBlogLeadCta('inventario-restaurante', 'price')
+  assert.doesNotMatch(informational.headline, /activa después del pago/)
+  assert.equal(informational.button, 'Quiero ver cómo funciona')
+})
+
+test('builds stable blog lead attribution sources', () => {
+  assert.equal(blogLeadSource('gastrobar-que-es'), 'blog:gastrobar-que-es')
+})

--- a/utils/blogLeadCta.ts
+++ b/utils/blogLeadCta.ts
@@ -1,0 +1,93 @@
+import { resolveBlogCtaIntent } from './publicCta.ts'
+
+export type BlogLeadCtaPlacement = 'benefit' | 'price' | 'final'
+
+export interface BlogLeadCtaContent {
+  headline: string
+  body: string
+  button: string
+  microcopy: string
+}
+
+const LEAD_MICROCOPY = '2 minutos. Sin tarjeta. Un asesor te contacta.'
+
+const COMMERCIAL_PRICE = {
+  headline: 'Plan Pro anual desde COP 95.900.',
+  body: 'POS, inventario, costos por plato y escaneo inteligente de facturas. Sin permanencia.',
+  button: 'Ver mis opciones',
+}
+
+function isCommercialSlug(slug: string): boolean {
+  const intent = resolveBlogCtaIntent(slug)
+  return intent === 'pos' || intent === 'pricing'
+}
+
+function copyForSlug(slug: string): Pick<BlogLeadCtaContent, 'headline' | 'body' | 'button'> {
+  const s = slug.toLocaleLowerCase()
+
+  if (/nomina|liquidacion|desprendible|prima-de-servicios|mesero|brigada/.test(s)) {
+    return {
+      headline: 'Evita errores de nómina antes de que cuesten plata.',
+      body: 'WARO conecta turnos, ventas, propinas e inventario para que controles la operación completa del restaurante desde un solo lugar.',
+      button: 'Ver cómo funciona',
+    }
+  }
+
+  if (/precio|gratis|free|full|open-source|comparativa/.test(s)) {
+    return {
+      headline: COMMERCIAL_PRICE.headline,
+      body: COMMERCIAL_PRICE.body,
+      button: 'Ver mis opciones',
+    }
+  }
+
+  if (/food-cost|punto-de-equilibrio|arqueo|inventario|mise-en-place|costos/.test(s)) {
+    return {
+      headline: 'Deja de perder plata calculando en Excel.',
+      body: 'WARO te muestra costos, inventario y rentabilidad por plato en tiempo real para decidir con datos, no con intuición.',
+      button: 'Quiero ver cómo funciona',
+    }
+  }
+
+  if (/software|pos|pdv|tpv|sistema-pos|contable/.test(s)) {
+    return {
+      headline: 'POS para restaurantes desde COP 95.900 al año.',
+      body: 'Vende, controla mesas, inventario, costos y facturas de proveedores con IA. Hecho en Colombia para restaurantes colombianos.',
+      button: 'Ver demostración',
+    }
+  }
+
+  if (/administrar|ingenieria-de-menu|cocinas|corrientazo|gastrobar|nombres/.test(s)) {
+    return {
+      headline: 'Ordena tu restaurante sin llenar más hojas de cálculo.',
+      body: 'WARO conecta caja, inventario, costos, mesas y domicilios en un panel simple para operar con más control.',
+      button: 'Quiero mi demo gratis',
+    }
+  }
+
+  return {
+    headline: 'Controla tu restaurante con WARO.',
+    body: 'POS, inventario, costos por plato y escaneo inteligente de facturas desde COP 95.900 al año.',
+    button: 'Comenzar gratis',
+  }
+}
+
+export function getBlogLeadCta(slug: string, placement: BlogLeadCtaPlacement = 'final'): BlogLeadCtaContent {
+  const base = copyForSlug(slug)
+
+  if (placement === 'price' && isCommercialSlug(slug)) {
+    return {
+      ...COMMERCIAL_PRICE,
+      microcopy: LEAD_MICROCOPY,
+    }
+  }
+
+  return {
+    ...base,
+    microcopy: LEAD_MICROCOPY,
+  }
+}
+
+export function blogLeadSource(slug: string): string {
+  return `blog:${slug}`
+}

--- a/utils/publicCta.test.ts
+++ b/utils/publicCta.test.ts
@@ -6,7 +6,6 @@ import {
   PUBLIC_CTA_COMPARISON,
   activatePublicCta,
   buildPublicCtaRegistrationRoute,
-  getBlogPublicCta,
   getPublicCta,
   readPublicCtaAttribution,
   resolveBlogCtaIntent,
@@ -21,21 +20,13 @@ test('maps blog slugs to the five commercial intents', () => {
   assert.equal(resolveBlogCtaIntent('liquidacion-de-nomina'), 'team')
 })
 
-test('keeps offer and article progression centralized and honest', () => {
-  const benefit = getBlogPublicCta('inventario-restaurante', 'benefit')
-  const price = getBlogPublicCta('inventario-restaurante', 'price')
-  const final = getBlogPublicCta('inventario-restaurante', 'final')
-  assert.equal(benefit.variant, 'costs_benefit_v1')
-  assert.match(price.headline, /COP 95\.900\/año/)
-  assert.match(price.microcopy, /activa después del pago/)
-  assert.equal(final.button, 'Crear cuenta y elegir plan')
-  assert.equal(JSON.stringify([benefit, price, final]).toLocaleLowerCase().includes('demostración'), false)
-  assert.equal(PUBLIC_CTA_COMPARISON, null)
-
+test('keeps self-service registration copy centralized', () => {
   const posFinal = getPublicCta('pos', 'final')
   assert.match(`${posFinal.eyebrow} ${posFinal.headline}`, /POS/)
   assert.match(posFinal.body, /COP 95\.900\/año/)
   assert.match(posFinal.microcopy, /activa después del pago/)
+  assert.equal(posFinal.button, 'Crear cuenta y elegir plan')
+  assert.equal(PUBLIC_CTA_COMPARISON, null)
 })
 
 test('builds a complete allow-listed registration route from arbitrary content', () => {


### PR DESCRIPTION
## Summary
- Restore `LeadModal` on public surfaces: hero "HABLA CON NOSOTROS", blog mid/end CTAs with `blog:<slug>` attribution
- Keep self-service registration on header "Crear cuenta" → `/registro` (separate SRC metric)
- Fix blog index 422 (`limit=50`) and masthead layout (single full-width featured article)
- Add pain-first blog CTA copy via `blogLeadCta.ts`

## Test plan
- [ ] Homepage hero opens lead modal; header "Crear cuenta" goes to `/registro`
- [ ] Blog article CTAs open lead modal and post to `/api/leads/capture`
- [ ] `/blog` loads without 422; masthead shows one featured article; pillar sections render
- [ ] Lead submission records `interaction_type = homepage_cta`

Closes #1810

Made with [Cursor](https://cursor.com)