### PR TITLE
fix(menu): unify quota create modal (Mi Plan) and cap modifier list chips

### DIFF
--- a/.wr/1812.yaml
+++ b/.wr/1812.yaml
@@ -1,0 +1,34 @@
+issue: 1812
+title: "fix(menu): unify quota create modal (Mi Plan) and cap modifier list chips"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1812-quota-modal-modifier-chips
+
+paths:
+  - composables/useMenuCatalogQuotaGate.ts
+  - pages/menu/productos/index.vue
+  - pages/menu/categorias/index.vue
+  - pages/menu/recetas/index.vue
+  - pages/menu/modificadores/index.vue
+  - i18n/locales/*/menu.json
+
+ac:
+  - "List Nuevo/Crear on Productos, Categorías, Recetas, Modificadores opens UiConfirmActionModal with Mi Plan + Cerrar when quota exhausted (not toast-only)"
+  - "Modal message shows usage; confirm navigates to /gestion/billing"
+  - "Shared handle*CreateClick helpers via useMenuCatalogQuotaGate"
+  - "Modificadores Opciones column: max 3 chips + +N more, left-aligned like Productos"
+
+out_of_scope:
+  - starter quota number changes
+  - API enforcement
+  - modifier create/edit form fields beyond list chips / list CTA gating
+
+hints:
+  entry: "useMenuCatalogQuotaGate.handleQuotaCreateClick — shared list create gate"
+  pattern: "modificadores/index.vue UiConfirmActionModal Mi Plan — mirror on other lists"
+  tests: "manual — quota-exhausted Nuevo on four list pages; opciones chips >3"
+
+skip:
+  audits: [ux, color, typography]

--- a/composables/useMenuCatalogQuotaGate.ts
+++ b/composables/useMenuCatalogQuotaGate.ts
@@ -203,13 +203,16 @@ export function useMenuCatalogQuotaGate() {
     return true
   }
 
-  /** Modificadores list Nuevo: stay clickable; open limit modal when groups cap reached. */
-  const handleModifiersCreateClick = async (navigate: () => void) => {
-    const result = await fetchQuotaStatus('modifier_groups')
+  /** List Nuevo/Crear: stay clickable; open Mi Plan modal when quota exhausted. */
+  const handleQuotaCreateClick = async (
+    resource: OperationalQuotaKey,
+    navigate: () => void,
+  ) => {
+    const result = await fetchQuotaStatus(resource)
     if (result.blocked) {
       openQuotaLimitModalWithMessage(
         result.message
-          || BILLING_QUOTA_RESOURCE_CONFIG.modifier_groups?.blockedMessage
+          || BILLING_QUOTA_RESOURCE_CONFIG[resource]?.blockedMessage
           || t('menu.common.quotaBlocked', 'Cupo del plan alcanzado'),
       )
       return false
@@ -217,6 +220,19 @@ export function useMenuCatalogQuotaGate() {
     navigate()
     return true
   }
+
+  const handleProductsCreateClick = (navigate: () => void) =>
+    handleQuotaCreateClick('menu_products', navigate)
+
+  const handleCategoriesCreateClick = (navigate: () => void) =>
+    handleQuotaCreateClick('menu_categories', navigate)
+
+  const handleRecipesCreateClick = (navigate: () => void) =>
+    handleQuotaCreateClick('recipe_bases', navigate)
+
+  /** Modificadores list Nuevo: stay clickable; open limit modal when groups cap reached. */
+  const handleModifiersCreateClick = (navigate: () => void) =>
+    handleQuotaCreateClick('modifier_groups', navigate)
 
   /**
    * Product recipe editor: stay clickable when at recipe_lines_per_product;
@@ -310,6 +326,9 @@ export function useMenuCatalogQuotaGate() {
     refreshCategoriesCreateGate,
     fetchQuotaBlocked,
     handleInlineCategoryCreate,
+    handleProductsCreateClick,
+    handleCategoriesCreateClick,
+    handleRecipesCreateClick,
     handleModifiersCreateClick,
     handleAddProductRecipeLine,
     handleAddModifierOption,

--- a/i18n/locales/ar/menu.json
+++ b/i18n/locales/ar/menu.json
@@ -303,6 +303,7 @@
       "type": "النوع",
       "all": "الكل",
       "moreProducts": "+{count} المزيد",
+      "moreOptions": "+{count} المزيد",
       "noProducts": "لا توجد منتجات",
       "noOptions": "لا توجد خيارات",
       "required": "مطلوب",

--- a/i18n/locales/de/menu.json
+++ b/i18n/locales/de/menu.json
@@ -303,6 +303,7 @@
       "type": "Typ",
       "all": "Alle",
       "moreProducts": "+{count} weitere",
+      "moreOptions": "+{count} weitere",
       "noProducts": "Keine Produkte",
       "noOptions": "Keine Optionen",
       "required": "Erforderlich",

--- a/i18n/locales/en/menu.json
+++ b/i18n/locales/en/menu.json
@@ -303,6 +303,7 @@
       "type": "Type",
       "all": "All",
       "moreProducts": "+{count} more",
+      "moreOptions": "+{count} more",
       "noProducts": "No products",
       "noOptions": "No options",
       "required": "Required",

--- a/i18n/locales/es/menu.json
+++ b/i18n/locales/es/menu.json
@@ -303,6 +303,7 @@
       "type": "Tipo",
       "all": "Todos",
       "moreProducts": "+{count} más",
+      "moreOptions": "+{count} más",
       "noProducts": "Sin productos",
       "noOptions": "Sin opciones",
       "required": "Obligatorio",

--- a/i18n/locales/fr/menu.json
+++ b/i18n/locales/fr/menu.json
@@ -303,6 +303,7 @@
       "type": "Type",
       "all": "Tous",
       "moreProducts": "+{count} de plus",
+      "moreOptions": "+{count} de plus",
       "noProducts": "Aucun produit",
       "noOptions": "Aucune option",
       "required": "Obligatoire",

--- a/i18n/locales/hi/menu.json
+++ b/i18n/locales/hi/menu.json
@@ -303,6 +303,7 @@
       "type": "प्रकार",
       "all": "सभी",
       "moreProducts": "+{count} और",
+      "moreOptions": "+{count} और",
       "noProducts": "कोई उत्पाद नहीं",
       "noOptions": "कोई विकल्प नहीं",
       "required": "अनिवार्य",

--- a/i18n/locales/pt/menu.json
+++ b/i18n/locales/pt/menu.json
@@ -303,6 +303,7 @@
       "type": "Tipo",
       "all": "Todos",
       "moreProducts": "+{count} mais",
+      "moreOptions": "+{count} mais",
       "noProducts": "Sem produtos",
       "noOptions": "Sem opções",
       "required": "Obrigatório",

--- a/i18n/locales/zh/menu.json
+++ b/i18n/locales/zh/menu.json
@@ -303,6 +303,7 @@
       "type": "类型",
       "all": "全部",
       "moreProducts": "+{count} 更多",
+      "moreOptions": "+{count} 更多",
       "noProducts": "无产品",
       "noOptions": "无选项",
       "required": "必填",

--- a/pages/menu/categorias/index.vue
+++ b/pages/menu/categorias/index.vue
@@ -34,9 +34,8 @@
           <template #trailing>
             <button
               type="button"
-              :disabled="isCategoriesCreateBlocked"
-              :title="isCategoriesCreateBlocked ? categoriesCreateBlockedMessage : t('menu.categorias.newCategory')"
-              class="inline-flex min-h-[44px] items-center rounded-lg bg-shell-cta-bg px-4 py-2 text-center text-sm font-medium text-shell-cta-text whitespace-nowrap transition-all hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring disabled:opacity-50 disabled:cursor-not-allowed"
+              :title="t('menu.categorias.newCategory')"
+              class="inline-flex min-h-[44px] items-center rounded-lg bg-shell-cta-bg px-4 py-2 text-center text-sm font-medium text-shell-cta-text whitespace-nowrap transition-all hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring"
               @click="openCreatePanel"
             >
               <span class="hidden sm:inline">{{ t('menu.categorias.newCategory') }}</span>
@@ -172,6 +171,16 @@
       :message="errorModal.message"
       :dependents="errorModal.dependents"
     />
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('shell.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>
 
@@ -179,11 +188,12 @@
 import { PencilSquareIcon, TrashIcon } from '@heroicons/vue/24/outline'
 const { t } = useI18n({ useScope: 'global' })
 const {
-  isCategoriesCreateBlocked,
-  categoriesCreateBlockedMessage,
-  showCategoriesCreateBlocked,
+  handleCategoriesCreateClick,
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
   ensureBillingOverview,
-  fetchQuotaBlocked,
 } = useMenuCatalogQuotaGate()
 
 definePageMeta({
@@ -287,13 +297,10 @@ const panelOpen = ref(false)
 const panelCategory = ref<Category | null>(null)
 
 const openCreatePanel = async () => {
-  // Fresh check: billing cache may be empty without mi_plan / overview.
-  if (isCategoriesCreateBlocked.value || await fetchQuotaBlocked('menu_categories')) {
-    showCategoriesCreateBlocked()
-    return
-  }
-  panelCategory.value = null
-  panelOpen.value = true
+  await handleCategoriesCreateClick(() => {
+    panelCategory.value = null
+    panelOpen.value = true
+  })
 }
 
 const openEditPanel = (cat: Record<string, any>) => {

--- a/pages/menu/modificadores/index.vue
+++ b/pages/menu/modificadores/index.vue
@@ -80,16 +80,26 @@
       </template>
 
       <template #cell-opciones="{ row }">
-        <div class="flex flex-wrap justify-center gap-1.5 max-w-[260px] mx-auto">
+        <div
+          v-for="chipState in [getGroupOptionChipState(row.id)]"
+          :key="row.id"
+          class="flex flex-wrap gap-1.5 max-w-[260px]"
+        >
           <span
-            v-for="option in getGroupOptionLabels(row.id)"
+            v-for="option in chipState.visible"
             :key="option"
             class="inline-flex max-w-full items-center rounded-full border border-badge-primary-border bg-badge-primary-bg px-2 py-0.5 text-[11px] font-medium leading-4 text-badge-primary-text"
             :title="option"
           >
             <span class="whitespace-normal break-words">{{ option }}</span>
           </span>
-          <span v-if="!getGroupOptionLabels(row.id).length" class="text-xs text-text-secondary">
+          <span
+            v-if="chipState.moreCount > 0"
+            class="text-xs text-text-secondary"
+          >
+            {{ t('menu.modificadores.moreOptions', { count: chipState.moreCount }) }}
+          </span>
+          <span v-if="chipState.empty" class="text-xs text-text-secondary">
             {{ t('menu.modificadores.noOptions') }}
           </span>
         </div>
@@ -499,6 +509,15 @@ function getGroupOptionLabels(grupoId: string) {
     if (type === 'PRODUCT') return m.linked_product?.name || m.name
     return m.name
   }).filter(Boolean)
+}
+
+function getGroupOptionChipState(grupoId: string) {
+  const labels = getGroupOptionLabels(grupoId)
+  return {
+    visible: labels.slice(0, 3),
+    moreCount: Math.max(labels.length - 3, 0),
+    empty: labels.length === 0,
+  }
 }
 
 const goToCreateGroup = () => {

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -66,9 +66,8 @@
               </button>
               <button
                 type="button"
-                :disabled="isProductsCreateBlocked"
-                :title="isProductsCreateBlocked ? productsCreateBlockedMessage : t('menu.productos.newProduct')"
-                class="inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-shell-cta-bg px-4 py-2 text-center text-sm font-medium text-shell-cta-text whitespace-nowrap transition-all hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring disabled:opacity-50 disabled:cursor-not-allowed"
+                :title="t('menu.productos.newProduct')"
+                class="inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-shell-cta-bg px-4 py-2 text-center text-sm font-medium text-shell-cta-text whitespace-nowrap transition-all hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring"
                 @click="onNewProduct"
               >
                 <Icon name="heroicons:plus" class="h-4 w-4 flex-shrink-0" />
@@ -874,6 +873,16 @@
         </div>
       </div>
     </UiModal>
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('shell.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>
 
@@ -899,18 +908,18 @@ definePageMeta({
 const route = useRoute()
 const router = useRouter()
 const {
-  isProductsCreateBlocked,
-  productsCreateBlockedMessage,
-  showProductsCreateBlocked,
+  handleProductsCreateClick,
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
   ensureBillingOverview,
 } = useMenuCatalogQuotaGate()
 
 const onNewProduct = () => {
-  if (isProductsCreateBlocked.value) {
-    showProductsCreateBlocked()
-    return
-  }
-  router.push('/menu/productos/crear')
+  void handleProductsCreateClick(() => {
+    router.push('/menu/productos/crear')
+  })
 }
 
 const QUERY_TO_PRODUCT_TYPE: Record<string, ProductTypeFilter> = {

--- a/pages/menu/recetas/index.vue
+++ b/pages/menu/recetas/index.vue
@@ -21,22 +21,11 @@
           @clear="onClearRecetasFilters"
         >
           <template #trailing>
-            <NuxtLink
-              v-if="!isRecipesCreateBlocked"
-              to="/menu/recetas/crear"
-              class="inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-shell-cta-bg px-4 py-2 text-center text-sm font-medium text-shell-cta-text whitespace-nowrap transition-all hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring"
-            >
-              <Icon name="heroicons:plus" class="h-4 w-4 flex-shrink-0" />
-              <span class="hidden sm:inline">{{ t('menu.recetas.newRecipe') }}</span>
-              <span class="sm:hidden">{{ t('menu.recetas.newShort') }}</span>
-            </NuxtLink>
             <button
-              v-else
               type="button"
-              disabled
-              :title="recipesCreateBlockedMessage"
-              class="inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-shell-cta-bg px-4 py-2 text-center text-sm font-medium text-shell-cta-text whitespace-nowrap opacity-50 cursor-not-allowed"
-              @click="showRecipesCreateBlocked"
+              :title="t('menu.recetas.newRecipe')"
+              class="inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-shell-cta-bg px-4 py-2 text-center text-sm font-medium text-shell-cta-text whitespace-nowrap transition-all hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring"
+              @click="onNewRecipe"
             >
               <Icon name="heroicons:plus" class="h-4 w-4 flex-shrink-0" />
               <span class="hidden sm:inline">{{ t('menu.recetas.newRecipe') }}</span>
@@ -265,6 +254,16 @@
         </div>
       </div>
     </div>
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('shell.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>
 
@@ -277,12 +276,21 @@ import { recipeIngredientLineCost } from '~/utils/recipeIngredientLineCost'
 const { t } = useI18n()
 const WAREHOUSE_COPY = useWarehouseCopy()
 const { formatCurrency } = useFormatters()
+const router = useRouter()
 const {
-  isRecipesCreateBlocked,
-  recipesCreateBlockedMessage,
-  showRecipesCreateBlocked,
+  handleRecipesCreateClick,
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
   ensureBillingOverview,
 } = useMenuCatalogQuotaGate()
+
+const onNewRecipe = () => {
+  void handleRecipesCreateClick(() => {
+    router.push('/menu/recetas/crear')
+  })
+}
 
 definePageMeta({
   // layout: 'dashboard' - Inherited from parent menu.vue


### PR DESCRIPTION
## Summary
- Productos, Categorías, Recetas, and Modificadores list **Nuevo** CTAs open a shared `UiConfirmActionModal` with **Mi Plan** + **Cerrar** when the relevant quota is exhausted (no toast-only / disabled-only path).
- Shared `handle*CreateClick` helpers in `useMenuCatalogQuotaGate` fetch fresh remaining-usage and show usage in the modal message.
- Modificadores **Opciones** column now caps at 3 chips + “+N more” and is left-aligned like **Productos**.

Closes #1812

## Test plan
- [ ] On a starter tenant at product/category/recipe/modifier-group cap, click Nuevo on each list → modal with usage + Mi Plan → `/gestion/billing`; Cerrar dismisses
- [ ] Below cap, Nuevo still navigates / opens create as before
- [ ] Modificadores list: group with >3 options shows 3 chips + “+N más”, left-aligned

## wr-context
See `.wr/1812.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)