### PR TITLE
fix(abastecimiento): warehouse catalog create quota modal (Mi Plan) like menu

### DIFF
--- a/.wr/1814.yaml
+++ b/.wr/1814.yaml
@@ -1,0 +1,42 @@
+issue: 1814
+title: "fix(abastecimiento): warehouse catalog create quota modal (Mi Plan) like menu"
+repo: both
+repo_remote: uno0uno/warocol.com  # + uno0uno/api-warolabs
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-1814-warehouse-catalog-quota-modal
+
+paths:
+  - composables/useBilling.ts
+  - composables/useWarehouseCatalogQuotaGate.ts
+  - pages/abastecimiento/ingredientes-propios.vue
+  - api_warocol.com/app/services/billing_service.py
+  - api_warocol.com/tests/test_billing_remaining_usage.py
+
+ac:
+  - "tenant_ingredients added to front OperationalQuotaKey + OPERATIONAL_QUOTA_KEYS"
+  - "remaining-usage payload now emits tenant_ingredients metric (API) so pre-click gate works"
+  - "Catálogo de bodega Nuevo stays clickable; quota exhausted opens UiConfirmActionModal (Mi Plan + Cerrar), navigates /gestion/billing"
+  - "Below cap Nuevo opens create panel as before; edit/archive/restore unaffected"
+  - "Panel post-save useQuotaExceeded kept as API 429 fallback"
+
+out_of_scope:
+  - new quota keys for suppliers/purchases/stock/movements/data-quality
+  - changing starter limit numbers
+  - OCR scan quota UX
+  - menu catalog changes
+
+hints:
+  entry: "useWarehouseCatalogQuotaGate.handleWarehouseCreateClick — mirrors useMenuCatalogQuotaGate"
+  pattern: "pages/menu/*/index.vue UiConfirmActionModal Mi Plan — mirror on abastecimiento"
+  tests: "pytest tests/test_billing_remaining_usage.py -q ; node --test --experimental-strip-types composables/useBillingOperationalQuota.test.ts"
+
+risk:
+  sensitive: false
+  areas: [billing remaining-usage payload]
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "dual PR — front (warocol.com) + api (api-warolabs)"

--- a/composables/useBilling.ts
+++ b/composables/useBilling.ts
@@ -141,6 +141,7 @@ export type OperationalQuotaKey =
   | 'completed_online_orders_per_month'
   | 'menu_products'
   | 'menu_categories'
+  | 'tenant_ingredients'
   | 'modifier_groups'
   | 'recipe_bases'
   | 'recipe_lines_per_product'
@@ -305,6 +306,7 @@ export const OPERATIONAL_QUOTA_KEYS: OperationalQuotaKey[] = [
   'completed_online_orders_per_month',
   'menu_products',
   'menu_categories',
+  'tenant_ingredients',
   'modifier_groups',
   'recipe_bases',
   'recipe_lines_per_product',

--- a/composables/useWarehouseCatalogQuotaGate.ts
+++ b/composables/useWarehouseCatalogQuotaGate.ts
@@ -1,0 +1,92 @@
+/**
+ * Warehouse catalog create gating (warocol.com#1814).
+ * Mirrors `useMenuCatalogQuotaGate` for the `tenant_ingredients` growth quota
+ * so Catálogo de bodega opens the Mi Plan modal before create when the plan
+ * cap is reached (parity with menu catalog lists). API remains the source of
+ * truth (create still enforces 429 via check_plan_quota_growth).
+ */
+import type {
+  BillingRemainingUsage,
+  BillingUsageMetric,
+} from '~/composables/useBilling'
+import {
+  BILLING_QUOTA_RESOURCE_CONFIG,
+  resolveOperationalQuota,
+  useBilling,
+} from '~/composables/useBilling'
+
+const WAREHOUSE_QUOTA_RESOURCE = 'tenant_ingredients' as const
+
+export function useWarehouseCatalogQuotaGate() {
+  const { t } = useI18n({ useScope: 'global' })
+  const { fetchBillingOverview } = useBilling()
+
+  const quotaLimitModalOpen = ref(false)
+  const quotaLimitModalMessage = ref('')
+
+  const formatMetricMessage = (metric: BillingUsageMetric | null | undefined) => {
+    const result = resolveOperationalQuota(WAREHOUSE_QUOTA_RESOURCE, metric ?? null)
+    if (!metric || metric.limit === null) return result.message
+    return `${result.message} Uso actual: ${metric.used.toLocaleString('es-CO')} de ${metric.limit.toLocaleString('es-CO')} ${result.unit}. Revisa Mi Plan para ampliar tu cupo.`
+  }
+
+  const fetchRemainingUsage = async () => {
+    return await $fetch<BillingRemainingUsage>('/api/billing/remaining-usage')
+  }
+
+  const fetchQuotaStatus = async () => {
+    try {
+      const usage = await fetchRemainingUsage()
+      const metric = usage.quota_usage?.[WAREHOUSE_QUOTA_RESOURCE] ?? null
+      const blocked = resolveOperationalQuota(WAREHOUSE_QUOTA_RESOURCE, metric).blocked
+      return { blocked, message: formatMetricMessage(metric) }
+    } catch {
+      // Fail open — API CREATE still enforces 429.
+      return { blocked: false, message: '' }
+    }
+  }
+
+  const openQuotaLimitModalWithMessage = (message: string) => {
+    quotaLimitModalMessage.value = message
+      || BILLING_QUOTA_RESOURCE_CONFIG[WAREHOUSE_QUOTA_RESOURCE]?.blockedMessage
+      || t('menu.common.quotaBlocked', 'Cupo del plan alcanzado')
+    quotaLimitModalOpen.value = true
+  }
+
+  const closeQuotaLimitModal = () => {
+    quotaLimitModalOpen.value = false
+  }
+
+  const goToBillingFromQuotaLimitModal = async () => {
+    quotaLimitModalOpen.value = false
+    await navigateTo('/gestion/billing')
+  }
+
+  /** Warehouse catalog Nuevo: stay clickable; open Mi Plan modal when cap reached. */
+  const handleWarehouseCreateClick = async (open: () => void) => {
+    const result = await fetchQuotaStatus()
+    if (result.blocked) {
+      openQuotaLimitModalWithMessage(
+        result.message
+          || BILLING_QUOTA_RESOURCE_CONFIG[WAREHOUSE_QUOTA_RESOURCE]?.blockedMessage
+          || t('menu.common.quotaBlocked', 'Cupo del plan alcanzado'),
+      )
+      return false
+    }
+    open()
+    return true
+  }
+
+  const ensureBillingOverview = async () => {
+    await fetchBillingOverview()
+  }
+
+  return {
+    quotaLimitModalOpen,
+    quotaLimitModalMessage,
+    closeQuotaLimitModal,
+    goToBillingFromQuotaLimitModal,
+    handleWarehouseCreateClick,
+    ensureBillingOverview,
+  }
+}

--- a/pages/abastecimiento/ingredientes-propios.vue
+++ b/pages/abastecimiento/ingredientes-propios.vue
@@ -66,7 +66,7 @@
                 : t('abastecimiento.glossary.catalogEditMode') }}
             </button>
             <button
-              @click="openPanel(null)"
+              @click="openCreatePanel"
               class="btn-primary min-h-[40px] rounded-lg px-4 py-2 text-sm font-medium whitespace-nowrap"
             >
               {{ nuevoButtonLabel }}
@@ -467,6 +467,16 @@
         </div>
       </Transition>
     </Teleport>
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('shell.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>
 
@@ -475,6 +485,14 @@ import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 const { t, locale } = useI18n({ useScope: 'global' })
 const WAREHOUSE_COPY = useWarehouseCopy()
 const toast = useToast()
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleWarehouseCreateClick,
+  ensureBillingOverview,
+} = useWarehouseCatalogQuotaGate()
 
 useHead({ title: () => WAREHOUSE_COPY.warehouseCatalog })
 
@@ -739,6 +757,10 @@ const openPanel = (ingredient: any) => {
   showPanel.value = true
 }
 
+const openCreatePanel = () => {
+  void handleWarehouseCreateClick(() => openPanel(null))
+}
+
 const onSaved = () => {
   refetch()
 }
@@ -814,7 +836,10 @@ const tableColumns = computed(() => [
 
 // Layout integration
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
-onMounted(() => setRefreshHandler(refetch))
+onMounted(() => {
+  setRefreshHandler(refetch)
+  ensureBillingOverview()
+})
 registerProgressiveLoading(isRefreshing)
 onUnmounted(() => clearRefreshHandler(refetch))
 </script>


### PR DESCRIPTION
## Summary
- Add `tenant_ingredients` to front operational quota keys.
- New `useWarehouseCatalogQuotaGate` mirrors the menu gate: Catálogo de bodega **Nuevo** stays clickable and opens `UiConfirmActionModal` (**Mi Plan** → `/gestion/billing`, **Cerrar**) with usage message when the plan cap is reached.
- Below cap, Nuevo opens the create panel as before; edit/archive/restore untouched. Panel post-save `useQuotaExceeded` kept as API 429 fallback.

Requires companion API PR uno0uno/api-warolabs#722 (emits `tenant_ingredients` in remaining-usage).

Closes #1814

## Test plan
- [x] `node --test` operational quota config
- [ ] Manual: starter tenant at 5/5 ingredients → Nuevo → modal; below cap → panel opens

## Validation evidence
```
$ node --test --experimental-strip-types composables/useBillingOperationalQuota.test.ts
# tests 7
# pass 7
# fail 0
```

## wr-context
See `.wr/1814.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)