### PR TITLE
fix(abastecimiento): Mi Plan quota gates for proveedores and compra directa

### DIFF
--- a/.wr/1818.yaml
+++ b/.wr/1818.yaml
@@ -1,0 +1,58 @@
+issue: 1818
+title: "fix(abastecimiento): Mi Plan quota gates for proveedores and compra directa"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1818-abastecimiento-quota-gates
+base_branch: main  # PREREQUISITE: merge #1815 (issue #1814) first, then pull main
+epic: 1816
+
+paths:
+  - composables/useBilling.ts
+  - composables/useOperationalQuotaGate.ts        # new — generic sibling of useWarehouseCatalogQuotaGate
+  - composables/useBillingOperationalQuota.test.ts
+  - pages/abastecimiento/proveedores.vue
+  - pages/abastecimiento/compras-directas/index.vue
+
+ac:
+  - "tenant_suppliers + direct_purchases_per_period added to BillingQuotaKey (:15), OperationalQuotaKey (:136), BILLING_QUOTA_RESOURCE_CONFIG (after :249), OPERATIONAL_QUOTA_KEYS (:301)"
+  - "Proveedores Nuevo stays clickable; at tenant_suppliers cap opens UiConfirmActionModal (Mi Plan -> /gestion/billing, Cerrar) with usage message"
+  - "Compra Directa Nuevo same UX for direct_purchases_per_period"
+  - "Below cap both CTAs navigate to their crear route exactly as today"
+  - "Edit existing suppliers/purchases unaffected; no changes to Movimientos / Calidad / Stock"
+  - "Gate fails open when remaining-usage lacks the key (API batch 1 not deployed yet)"
+
+out_of_scope:
+  - stock adjustment gate (batch 3, #1819)
+  - API key definition / enforcement (batch 1, api-warolabs#723)
+  - migrating menu + warehouse gates onto the generic helper (follow-up)
+  - adding the two keys to STARTER_DISPLAY_QUOTA_KEYS (:291)
+  - inventing additional quota keys
+
+hints:
+  entry: "proveedores.vue:47-51 and compras-directas/index.vue:56-60 are <NuxtLink to=...> — swap to <button @click> + gate, same swap as recetas in #1812"
+  pattern: "composables/useWarehouseCatalogQuotaGate.ts — copy with resource as a param; only :18 (const resource) is resource-specific"
+  callback: "handleCreateClick(open) — here open = () => navigateTo(route), not openPanel"
+  modal: "pages/abastecimiento/ingredientes-propios.vue:471-479 — exact UiConfirmActionModal props/events to mirror"
+  period_copy: "direct_purchases_per_period is a period quota: unit 'compras en el periodo', blockedMessage should say it resets with the billing period"
+  tests: "node --test --experimental-strip-types composables/useBillingOperationalQuota.test.ts"
+
+risk:
+  sensitive: false
+  areas: [billing quota unions, abastecimiento create navigation]
+  blockers:
+    - "api-warolabs#723 (batch 1) still OPEN — remaining-usage has no tenant_suppliers / direct_purchases_per_period yet, so the at-cap path cannot be verified end-to-end until it merges + deploys. Gate fails open meanwhile (allowed by AC)."
+  prerequisite:
+    - "Merge #1815 (issue #1814) to main BEFORE starting #1818, then git pull origin main. #1815 adds useWarehouseCatalogQuotaGate.ts and tenant_ingredients to the same four useBilling.ts unions; starting before it merges guarantees conflicts."
+
+validation:
+  - "node --test --experimental-strip-types composables/useBillingOperationalQuota.test.ts"
+  - "manual: both Nuevo CTAs navigate normally below cap (fail-open today)"
+  - "no build / no lint without explicit approval (front_nuxt cursor rule)"
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "single front PR — Closes #1818, Refs #1816. Stack on #1815; rebase to main once #1815 merges."

--- a/composables/useBilling.ts
+++ b/composables/useBilling.ts
@@ -23,6 +23,8 @@ export type BillingQuotaKey =
   | 'menu_products'
   | 'menu_categories'
   | 'tenant_ingredients'
+  | 'tenant_suppliers'
+  | 'direct_purchases_per_period'
   | 'modifier_groups'
   | 'recipe_bases'
   | 'recipe_lines_per_product'
@@ -142,6 +144,8 @@ export type OperationalQuotaKey =
   | 'menu_products'
   | 'menu_categories'
   | 'tenant_ingredients'
+  | 'tenant_suppliers'
+  | 'direct_purchases_per_period'
   | 'modifier_groups'
   | 'recipe_bases'
   | 'recipe_lines_per_product'
@@ -254,6 +258,22 @@ export const BILLING_QUOTA_RESOURCE_CONFIG: Record<BillingQuotaKey, BillingQuota
     blockedMessage: 'Alcanzaste el límite de ingredientes de tu plan.',
     unlimitedMessage: 'Puedes crear ingredientes sin límite por override.',
   },
+  tenant_suppliers: {
+    key: 'tenant_suppliers',
+    label: 'Proveedores',
+    description: 'Proveedores activos del establecimiento',
+    unit: 'proveedores',
+    blockedMessage: 'Alcanzaste el límite de proveedores de tu plan.',
+    unlimitedMessage: 'Puedes crear proveedores sin límite por override.',
+  },
+  direct_purchases_per_period: {
+    key: 'direct_purchases_per_period',
+    label: 'Compras directas por periodo',
+    description: 'Compras directas registradas en el periodo de facturación',
+    unit: 'compras en el periodo',
+    blockedMessage: 'Alcanzaste el límite de compras directas de tu plan para este periodo. El cupo se reinicia con tu periodo de facturación.',
+    unlimitedMessage: 'Puedes registrar compras directas sin límite por override.',
+  },
   modifier_groups: {
     key: 'modifier_groups',
     label: 'Grupos de modificadores',
@@ -307,6 +327,8 @@ export const OPERATIONAL_QUOTA_KEYS: OperationalQuotaKey[] = [
   'menu_products',
   'menu_categories',
   'tenant_ingredients',
+  'tenant_suppliers',
+  'direct_purchases_per_period',
   'modifier_groups',
   'recipe_bases',
   'recipe_lines_per_product',

--- a/composables/useBillingOperationalQuota.test.ts
+++ b/composables/useBillingOperationalQuota.test.ts
@@ -74,6 +74,33 @@ describe('resolveOperationalQuota', () => {
     assert.equal(result.blocked, false)
   })
 
+  it('gates tenant_suppliers like other growth quotas (#1818)', () => {
+    assert.ok(OPERATIONAL_QUOTA_KEYS.includes('tenant_suppliers'))
+
+    const allowed = resolveOperationalQuota('tenant_suppliers', metric({ used: 2, limit: 3, remaining: 1 }))
+    const blocked = resolveOperationalQuota('tenant_suppliers', metric({ used: 3, limit: 3, remaining: 0 }))
+    const missing = resolveOperationalQuota('tenant_suppliers')
+
+    assert.equal(allowed.blocked, false)
+    assert.equal(blocked.blocked, true)
+    assert.equal(blocked.message, BILLING_QUOTA_RESOURCE_CONFIG.tenant_suppliers.blockedMessage)
+    // Fail open until the API metric ships (batch 1)
+    assert.equal(missing.blocked, false)
+  })
+
+  it('gates direct_purchases_per_period as a period quota (#1818)', () => {
+    assert.ok(OPERATIONAL_QUOTA_KEYS.includes('direct_purchases_per_period'))
+
+    const allowed = resolveOperationalQuota('direct_purchases_per_period', metric({ used: 14, limit: 15, remaining: 1 }))
+    const blocked = resolveOperationalQuota('direct_purchases_per_period', metric({ used: 15, limit: 15, remaining: 0 }))
+    const missing = resolveOperationalQuota('direct_purchases_per_period')
+
+    assert.equal(allowed.blocked, false)
+    assert.equal(blocked.blocked, true)
+    assert.match(blocked.message, /periodo/)
+    assert.equal(missing.blocked, false)
+  })
+
   it('defines reusable messages for every operational resource', () => {
     for (const resource of OPERATIONAL_QUOTA_KEYS) {
       const config = BILLING_QUOTA_RESOURCE_CONFIG[resource]

--- a/composables/useOperationalQuotaGate.ts
+++ b/composables/useOperationalQuotaGate.ts
@@ -1,0 +1,92 @@
+/**
+ * Generic operational quota gate (warocol.com#1818).
+ * Parameterized sibling of `useMenuCatalogQuotaGate` / `useWarehouseCatalogQuotaGate`:
+ * keeps the create CTA clickable and opens the Mi Plan modal before the action
+ * when the plan cap for `resource` is reached. Fails open when remaining-usage
+ * lacks the metric — the API stays the source of truth (429 quota_exceeded on
+ * create). Migrating the menu/warehouse gates onto this helper is a follow-up.
+ */
+import type {
+  BillingRemainingUsage,
+  BillingUsageMetric,
+  OperationalQuotaKey,
+} from '~/composables/useBilling'
+import {
+  BILLING_QUOTA_RESOURCE_CONFIG,
+  resolveOperationalQuota,
+  useBilling,
+} from '~/composables/useBilling'
+
+export function useOperationalQuotaGate(resource: OperationalQuotaKey) {
+  const { t } = useI18n({ useScope: 'global' })
+  const { fetchBillingOverview } = useBilling()
+
+  const quotaLimitModalOpen = ref(false)
+  const quotaLimitModalMessage = ref('')
+
+  const formatMetricMessage = (metric: BillingUsageMetric | null | undefined) => {
+    const result = resolveOperationalQuota(resource, metric ?? null)
+    if (!metric || metric.limit === null) return result.message
+    return `${result.message} Uso actual: ${metric.used.toLocaleString('es-CO')} de ${metric.limit.toLocaleString('es-CO')} ${result.unit}. Revisa Mi Plan para ampliar tu cupo.`
+  }
+
+  const fetchRemainingUsage = async () => {
+    return await $fetch<BillingRemainingUsage>('/api/billing/remaining-usage')
+  }
+
+  const fetchQuotaStatus = async () => {
+    try {
+      const usage = await fetchRemainingUsage()
+      const metric = usage.quota_usage?.[resource] ?? null
+      const blocked = resolveOperationalQuota(resource, metric).blocked
+      return { blocked, message: formatMetricMessage(metric) }
+    } catch {
+      // Fail open — API create still enforces 429.
+      return { blocked: false, message: '' }
+    }
+  }
+
+  const openQuotaLimitModalWithMessage = (message: string) => {
+    quotaLimitModalMessage.value = message
+      || BILLING_QUOTA_RESOURCE_CONFIG[resource]?.blockedMessage
+      || t('menu.common.quotaBlocked', 'Cupo del plan alcanzado')
+    quotaLimitModalOpen.value = true
+  }
+
+  const closeQuotaLimitModal = () => {
+    quotaLimitModalOpen.value = false
+  }
+
+  const goToBillingFromQuotaLimitModal = async () => {
+    quotaLimitModalOpen.value = false
+    await navigateTo('/gestion/billing')
+  }
+
+  /** Create CTA: stay clickable; open Mi Plan modal instead of `open()` at cap. */
+  const handleCreateClick = async (open: () => void) => {
+    const result = await fetchQuotaStatus()
+    if (result.blocked) {
+      openQuotaLimitModalWithMessage(
+        result.message
+          || BILLING_QUOTA_RESOURCE_CONFIG[resource]?.blockedMessage
+          || t('menu.common.quotaBlocked', 'Cupo del plan alcanzado'),
+      )
+      return false
+    }
+    open()
+    return true
+  }
+
+  const ensureBillingOverview = async () => {
+    await fetchBillingOverview()
+  }
+
+  return {
+    quotaLimitModalOpen,
+    quotaLimitModalMessage,
+    closeQuotaLimitModal,
+    goToBillingFromQuotaLimitModal,
+    handleCreateClick,
+    ensureBillingOverview,
+  }
+}

--- a/pages/abastecimiento/compras-directas/index.vue
+++ b/pages/abastecimiento/compras-directas/index.vue
@@ -53,11 +53,14 @@
         </template>
 
         <template #trailing>
-          <NuxtLink to="/abastecimiento/compras-directas/crear"
-            class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap">
+          <button
+            type="button"
+            class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap"
+            @click="handleNewPurchaseClick"
+          >
             <span class="hidden sm:inline">{{ t('abastecimiento.comprasDirectas.newPurchase') }}</span>
             <span class="sm:hidden">{{ t('abastecimiento.comprasDirectas.newShort') }}</span>
-          </NuxtLink>
+          </button>
         </template>
       </UiAdvancedFiltersBar>
 
@@ -253,6 +256,16 @@
         </div>
       </div>
     </div>
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('shell.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>
 
@@ -262,6 +275,7 @@ import { onMounted, onUnmounted } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import { useScanQuotaQuery } from '~/composables/queries/useScanQuota'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
 const { t } = useI18n({ useScope: 'global' })
 
 useHead({
@@ -270,6 +284,20 @@ useHead({
 
 // Scan quota
 const { quota, warningLevel, scansRemaining } = useScanQuotaQuery()
+
+// Plan quota gate: Nuevo stays clickable; Mi Plan modal at direct_purchases_per_period cap (#1818)
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+  ensureBillingOverview,
+} = useOperationalQuotaGate('direct_purchases_per_period')
+
+const handleNewPurchaseClick = () => {
+  void handleCreateClick(() => navigateTo('/abastecimiento/compras-directas/crear'))
+}
 
 // State
 const currentPage = ref(1)
@@ -484,6 +512,7 @@ const handleRefresh = async () => {
 
 onMounted(() => {
   setRefreshHandler(handleRefresh)
+  ensureBillingOverview()
 })
 useMenuReturnRefresh(
   '/abastecimiento/compras-directas',

--- a/pages/abastecimiento/proveedores.vue
+++ b/pages/abastecimiento/proveedores.vue
@@ -44,11 +44,14 @@
         </template>
 
         <template #trailing>
-          <NuxtLink to="/abastecimiento/proveedor/crear"
-            class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap">
+          <button
+            type="button"
+            class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap"
+            @click="handleNewSupplierClick"
+          >
             <span class="hidden sm:inline">{{ t('abastecimiento.proveedores.newSupplier') }}</span>
             <span class="sm:hidden">{{ t('abastecimiento.proveedores.newShort') }}</span>
-          </NuxtLink>
+          </button>
         </template>
       </UiAdvancedFiltersBar>
 
@@ -199,6 +202,16 @@
       </div>
 
     </div>
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('shell.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>
 
@@ -217,9 +230,24 @@ import {
 import { ref, computed, watch, inject, onMounted } from 'vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import { useSupplierTaxIdLabel } from '~/composables/useSupplierTaxIdLabel'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
 
 const { t } = useI18n({ useScope: 'global' })
 const { taxIdLabel } = useSupplierTaxIdLabel()
+
+// Plan quota gate: Nuevo stays clickable; Mi Plan modal at tenant_suppliers cap (#1818)
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+  ensureBillingOverview,
+} = useOperationalQuotaGate('tenant_suppliers')
+
+const handleNewSupplierClick = () => {
+  void handleCreateClick(() => navigateTo('/abastecimiento/proveedor/crear'))
+}
 
 // Tenant reactivity
 const { currentTenant } = useTenantReactive()
@@ -352,6 +380,7 @@ const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = u
 
 onMounted(() => {
   setRefreshHandler(refetch)
+  ensureBillingOverview()
 })
 useMenuReturnRefresh(
   '/abastecimiento/proveedores',


### PR DESCRIPTION
## Summary

- Adds `tenant_suppliers` and `direct_purchases_per_period` to the front billing quota unions, resource config (labels/messages), and `OPERATIONAL_QUOTA_KEYS`.
- New generic `useOperationalQuotaGate(resource)` composable — parameterized sibling of `useMenuCatalogQuotaGate` / `useWarehouseCatalogQuotaGate` (migrating those two is a follow-up).
- Proveedores and Compra Directa **Nuevo** CTAs stay clickable: at cap they open `UiConfirmActionModal` (Mi Plan → `/gestion/billing`, Cerrar); below cap they navigate to the crear routes as before.
- Fails open while `remaining-usage` lacks the new metrics (API batch 1, api-warolabs#723, not deployed yet) — API remains the source of truth via 429 `quota_exceeded`.

Edit flows, Movimientos, Calidad and Stock are untouched (stock gate is batch 3, #1819).

## Validation evidence

`node --test --experimental-strip-types composables/useBillingOperationalQuota.test.ts`

```text
# Subtest: gates tenant_suppliers like other growth quotas (#1818)
ok 7 - gates tenant_suppliers like other growth quotas (#1818)
# Subtest: gates direct_purchases_per_period as a period quota (#1818)
ok 8 - gates direct_purchases_per_period as a period quota (#1818)
# Subtest: defines reusable messages for every operational resource
ok 9 - defines reusable messages for every operational resource
1..1
# tests 9
# pass 9
# fail 0
```

Closes #1818
Refs #1816

Made with [Cursor](https://cursor.com)