### PR TITLE
fix(abastecimiento): Mi Plan quota gate for stock adjustments

### DIFF
--- a/.wr/1819.yaml
+++ b/.wr/1819.yaml
@@ -1,0 +1,58 @@
+issue: 1819
+title: "fix(abastecimiento): Mi Plan quota gate for stock adjustments"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1819-stock-adjustment-quota-gate
+base_branch: main  # PREREQUISITE: merge #1820 (issue #1818) first, then pull main
+epic: 1816
+
+paths:
+  - composables/useBilling.ts
+  - composables/useBillingOperationalQuota.test.ts
+  - pages/abastecimiento/stock.vue
+  # reuse only (must already be on main after #1820):
+  # composables/useOperationalQuotaGate.ts
+
+ac:
+  - "stock_adjustments_per_period added to BillingQuotaKey, OperationalQuotaKey, BILLING_QUOTA_RESOURCE_CONFIG, OPERATIONAL_QUOTA_KEYS (period copy: resets with billing period)"
+  - "Per-row Ajustar / openAdjustment at period cap opens UiConfirmActionModal (Mi Plan -> /gestion/billing, Cerrar) with usage message"
+  - "Below cap AbastecimientoStockAdjustmentPanel opens as today"
+  - "Viewing stock and movimientos-path link unchanged; no Movimientos / Calidad / Proveedores / Compra Directa edits"
+  - "Does not invent a stock catalog-create quota (tenant_ingredients stays warehouse catalog)"
+  - "Gate fails open when remaining-usage lacks the key (API batch 1 not deployed yet)"
+
+out_of_scope:
+  - API keys / enforce (batch 1, api-warolabs#723)
+  - proveedores / compra directa gates (batch 2, #1818)
+  - cloning a new gate composable (reuse useOperationalQuotaGate)
+  - migrating menu/warehouse gates onto the generic helper
+  - adding the key to STARTER_DISPLAY_QUOTA_KEYS
+
+hints:
+  entry: "pages/abastecimiento/stock.vue:74-89 openAdjustment — wrap panel-open body in handleCreateClick(() => { set preselect; adjustmentOpen = true })"
+  event: "stock.vue:41 @adjust from InventarioStockInventoryView — keep wiring; gate inside openAdjustment only"
+  pattern: "useOperationalQuotaGate('stock_adjustments_per_period') from #1818; modal props mirror ingredientes-propios / proveedores"
+  billing: "add only stock_adjustments_per_period to the four useBilling unions/config; unit 'ajustes en el periodo'"
+  mount: "ensureBillingOverview() in existing onMounted (stock.vue:219)"
+  tests: "node --test --experimental-strip-types composables/useBillingOperationalQuota.test.ts"
+
+risk:
+  sensitive: false
+  areas: [billing quota unions, stock adjustment panel open]
+  prerequisite:
+    - "Merge warocol.com#1820 (issue #1818) BEFORE starting — delivers useOperationalQuotaGate.ts + sibling billing keys. Branching off main without it means re-implementing the helper or stacking on wr-1818-*."
+  blockers:
+    - "api-warolabs#723 still OPEN — remaining-usage has no stock_adjustments_per_period yet; at-cap path unverifiable E2E until merge+deploy. Fail open allowed by AC."
+
+validation:
+  - "node --test --experimental-strip-types composables/useBillingOperationalQuota.test.ts"
+  - "manual: Ajustar opens panel below cap (fail-open today)"
+  - "no build / no lint without explicit approval"
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "single front PR — Closes #1819, Refs #1816. After #1820 on main."

--- a/composables/useBilling.ts
+++ b/composables/useBilling.ts
@@ -25,6 +25,7 @@ export type BillingQuotaKey =
   | 'tenant_ingredients'
   | 'tenant_suppliers'
   | 'direct_purchases_per_period'
+  | 'stock_adjustments_per_period'
   | 'modifier_groups'
   | 'recipe_bases'
   | 'recipe_lines_per_product'
@@ -146,6 +147,7 @@ export type OperationalQuotaKey =
   | 'tenant_ingredients'
   | 'tenant_suppliers'
   | 'direct_purchases_per_period'
+  | 'stock_adjustments_per_period'
   | 'modifier_groups'
   | 'recipe_bases'
   | 'recipe_lines_per_product'
@@ -274,6 +276,14 @@ export const BILLING_QUOTA_RESOURCE_CONFIG: Record<BillingQuotaKey, BillingQuota
     blockedMessage: 'Alcanzaste el límite de compras directas de tu plan para este periodo. El cupo se reinicia con tu periodo de facturación.',
     unlimitedMessage: 'Puedes registrar compras directas sin límite por override.',
   },
+  stock_adjustments_per_period: {
+    key: 'stock_adjustments_per_period',
+    label: 'Ajustes de stock por periodo',
+    description: 'Ajustes de inventario registrados en el periodo de facturación',
+    unit: 'ajustes en el periodo',
+    blockedMessage: 'Alcanzaste el límite de ajustes de stock de tu plan para este periodo. El cupo se reinicia con tu periodo de facturación.',
+    unlimitedMessage: 'Puedes registrar ajustes de stock sin límite por override.',
+  },
   modifier_groups: {
     key: 'modifier_groups',
     label: 'Grupos de modificadores',
@@ -329,6 +339,7 @@ export const OPERATIONAL_QUOTA_KEYS: OperationalQuotaKey[] = [
   'tenant_ingredients',
   'tenant_suppliers',
   'direct_purchases_per_period',
+  'stock_adjustments_per_period',
   'modifier_groups',
   'recipe_bases',
   'recipe_lines_per_product',

--- a/composables/useBillingOperationalQuota.test.ts
+++ b/composables/useBillingOperationalQuota.test.ts
@@ -101,6 +101,21 @@ describe('resolveOperationalQuota', () => {
     assert.equal(missing.blocked, false)
   })
 
+  it('gates stock_adjustments_per_period as a period quota (#1819)', () => {
+    assert.ok(OPERATIONAL_QUOTA_KEYS.includes('stock_adjustments_per_period'))
+
+    const allowed = resolveOperationalQuota('stock_adjustments_per_period', metric({ used: 19, limit: 20, remaining: 1 }))
+    const blocked = resolveOperationalQuota('stock_adjustments_per_period', metric({ used: 20, limit: 20, remaining: 0 }))
+    const missing = resolveOperationalQuota('stock_adjustments_per_period')
+
+    assert.equal(allowed.blocked, false)
+    assert.equal(blocked.blocked, true)
+    assert.match(blocked.message, /periodo/)
+    assert.equal(BILLING_QUOTA_RESOURCE_CONFIG.stock_adjustments_per_period.unit, 'ajustes en el periodo')
+    // Fail open until the API metric ships (batch 1)
+    assert.equal(missing.blocked, false)
+  })
+
   it('defines reusable messages for every operational resource', () => {
     for (const resource of OPERATIONAL_QUOTA_KEYS) {
       const config = BILLING_QUOTA_RESOURCE_CONFIG[resource]

--- a/pages/abastecimiento/stock.vue
+++ b/pages/abastecimiento/stock.vue
@@ -46,17 +46,38 @@
       :preselect="adjustmentPreselect"
       @saved="refetch"
     />
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('shell.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
 import type { StockAdjustmentPreselect } from '@/components/abastecimiento/StockAdjustmentPanel.vue'
 
 const { t } = useI18n()
 const WAREHOUSE_COPY = useWarehouseCopy()
 useHead({ title: () => t('abastecimiento.head.stock') })
+
+// Plan quota gate: Ajustar stays clickable; Mi Plan modal at stock_adjustments_per_period cap (#1819)
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+  ensureBillingOverview,
+} = useOperationalQuotaGate('stock_adjustments_per_period')
 
 // Tenant reactivity
 const { currentTenant } = useTenantReactive()
@@ -78,14 +99,16 @@ const openAdjustment = (item: {
   minimum_stock: number
   maximum_stock?: number | null
 }) => {
-  adjustmentPreselect.value = {
-    id: item.ingredient_id,
-    name: item.ingredient_name,
-    unit: item.unit,
-    minimum_stock: item.minimum_stock,
-    maximum_stock: item.maximum_stock ?? null,
-  }
-  adjustmentOpen.value = true
+  void handleCreateClick(() => {
+    adjustmentPreselect.value = {
+      id: item.ingredient_id,
+      name: item.ingredient_name,
+      unit: item.unit,
+      minimum_stock: item.minimum_stock,
+      maximum_stock: item.maximum_stock ?? null,
+    }
+    adjustmentOpen.value = true
+  })
 }
 
 const currentOffset = computed(() => (currentPage.value - 1) * itemsPerPage.value)
@@ -218,6 +241,7 @@ const clearFilters = () => {
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 onMounted(() => {
   setRefreshHandler(refetch)
+  ensureBillingOverview()
 })
 useMenuReturnRefresh(
   '/abastecimiento/stock',


### PR DESCRIPTION
## Summary

- Adds `stock_adjustments_per_period` to front billing quota unions, resource config (period copy), and `OPERATIONAL_QUOTA_KEYS`.
- Reuses `useOperationalQuotaGate` from #1818: Stock **Ajustar** (`openAdjustment`) stays clickable; at period cap opens `UiConfirmActionModal` (Mi Plan → `/gestion/billing`, Cerrar); below cap opens `AbastecimientoStockAdjustmentPanel` as before.
- Viewing stock and the movimientos link are untouched. No catalog-create quota invented on stock.
- Fails open while `remaining-usage` lacks the metric (API batch 1, api-warolabs#723, still open/conflicting) — API remains source of truth via 429.

## Validation evidence

`node --test --experimental-strip-types composables/useBillingOperationalQuota.test.ts`

```text
# Subtest: gates stock_adjustments_per_period as a period quota (#1819)
ok 9 - gates stock_adjustments_per_period as a period quota (#1819)
# Subtest: defines reusable messages for every operational resource
ok 10 - defines reusable messages for every operational resource
1..1
# tests 10
# pass 10
# fail 0
```

Closes #1819
Refs #1816

Made with [Cursor](https://cursor.com)