### PR TITLE
fix(i18n): use nav.miPlan for quota modal confirm label

### DIFF
--- a/components/menu/ProductQuickCreatePanel.vue
+++ b/components/menu/ProductQuickCreatePanel.vue
@@ -184,7 +184,7 @@
       v-model="categoriesLimitModalOpen"
       :title="t('billing.upgrade.quotaBlocked')"
       :message="categoriesLimitModalMessage"
-      :confirm-label="t('shell.miPlan')"
+      :confirm-label="t('nav.miPlan')"
       :cancel-label="t('billing.close')"
       @confirm="goToBillingFromCategoriesLimitModal"
       @cancel="closeCategoriesLimitModal"

--- a/pages/abastecimiento/compras-directas/index.vue
+++ b/pages/abastecimiento/compras-directas/index.vue
@@ -261,7 +261,7 @@
       v-model="quotaLimitModalOpen"
       :title="t('billing.upgrade.quotaBlocked')"
       :message="quotaLimitModalMessage"
-      :confirm-label="t('shell.miPlan')"
+      :confirm-label="t('nav.miPlan')"
       :cancel-label="t('billing.close')"
       @confirm="goToBillingFromQuotaLimitModal"
       @cancel="closeQuotaLimitModal"

--- a/pages/abastecimiento/ingredientes-propios.vue
+++ b/pages/abastecimiento/ingredientes-propios.vue
@@ -472,7 +472,7 @@
       v-model="quotaLimitModalOpen"
       :title="t('billing.upgrade.quotaBlocked')"
       :message="quotaLimitModalMessage"
-      :confirm-label="t('shell.miPlan')"
+      :confirm-label="t('nav.miPlan')"
       :cancel-label="t('billing.close')"
       @confirm="goToBillingFromQuotaLimitModal"
       @cancel="closeQuotaLimitModal"

--- a/pages/abastecimiento/proveedores.vue
+++ b/pages/abastecimiento/proveedores.vue
@@ -207,7 +207,7 @@
       v-model="quotaLimitModalOpen"
       :title="t('billing.upgrade.quotaBlocked')"
       :message="quotaLimitModalMessage"
-      :confirm-label="t('shell.miPlan')"
+      :confirm-label="t('nav.miPlan')"
       :cancel-label="t('billing.close')"
       @confirm="goToBillingFromQuotaLimitModal"
       @cancel="closeQuotaLimitModal"

--- a/pages/abastecimiento/stock.vue
+++ b/pages/abastecimiento/stock.vue
@@ -51,7 +51,7 @@
       v-model="quotaLimitModalOpen"
       :title="t('billing.upgrade.quotaBlocked')"
       :message="quotaLimitModalMessage"
-      :confirm-label="t('shell.miPlan')"
+      :confirm-label="t('nav.miPlan')"
       :cancel-label="t('billing.close')"
       @confirm="goToBillingFromQuotaLimitModal"
       @cancel="closeQuotaLimitModal"

--- a/pages/menu/categorias/index.vue
+++ b/pages/menu/categorias/index.vue
@@ -176,7 +176,7 @@
       v-model="quotaLimitModalOpen"
       :title="t('billing.upgrade.quotaBlocked')"
       :message="quotaLimitModalMessage"
-      :confirm-label="t('shell.miPlan')"
+      :confirm-label="t('nav.miPlan')"
       :cancel-label="t('billing.close')"
       @confirm="goToBillingFromQuotaLimitModal"
       @cancel="closeQuotaLimitModal"

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -251,7 +251,7 @@
       v-model="quotaLimitModalOpen"
       :title="t('billing.upgrade.quotaBlocked')"
       :message="quotaLimitModalMessage"
-      :confirm-label="t('shell.miPlan')"
+      :confirm-label="t('nav.miPlan')"
       :cancel-label="t('billing.close')"
       @confirm="goToBillingFromQuotaLimitModal"
       @cancel="closeQuotaLimitModal"

--- a/pages/menu/modificadores/crear.vue
+++ b/pages/menu/modificadores/crear.vue
@@ -264,7 +264,7 @@
       v-model="quotaLimitModalOpen"
       :title="t('billing.upgrade.quotaBlocked')"
       :message="quotaLimitModalMessage"
-      :confirm-label="t('shell.miPlan')"
+      :confirm-label="t('nav.miPlan')"
       :cancel-label="t('billing.close')"
       @confirm="goToBillingFromQuotaLimitModal"
       @cancel="closeQuotaLimitModal"

--- a/pages/menu/modificadores/index.vue
+++ b/pages/menu/modificadores/index.vue
@@ -296,7 +296,7 @@
       v-model="quotaLimitModalOpen"
       :title="t('billing.upgrade.quotaBlocked')"
       :message="quotaLimitModalMessage"
-      :confirm-label="t('shell.miPlan')"
+      :confirm-label="t('nav.miPlan')"
       :cancel-label="t('billing.close')"
       @confirm="goToBillingFromQuotaLimitModal"
       @cancel="closeQuotaLimitModal"

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -858,7 +858,7 @@
       v-model="categoriesLimitModalOpen"
       :title="t('billing.upgrade.quotaBlocked')"
       :message="categoriesLimitModalMessage"
-      :confirm-label="t('shell.miPlan')"
+      :confirm-label="t('nav.miPlan')"
       :cancel-label="t('billing.close')"
       @confirm="goToBillingFromCategoriesLimitModal"
       @cancel="closeCategoriesLimitModal"

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -715,7 +715,7 @@
       v-model="categoriesLimitModalOpen"
       :title="t('billing.upgrade.quotaBlocked')"
       :message="categoriesLimitModalMessage"
-      :confirm-label="t('shell.miPlan')"
+      :confirm-label="t('nav.miPlan')"
       :cancel-label="t('billing.close')"
       @confirm="goToBillingFromCategoriesLimitModal"
       @cancel="closeCategoriesLimitModal"

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -878,7 +878,7 @@
       v-model="quotaLimitModalOpen"
       :title="t('billing.upgrade.quotaBlocked')"
       :message="quotaLimitModalMessage"
-      :confirm-label="t('shell.miPlan')"
+      :confirm-label="t('nav.miPlan')"
       :cancel-label="t('billing.close')"
       @confirm="goToBillingFromQuotaLimitModal"
       @cancel="closeQuotaLimitModal"

--- a/pages/menu/recetas/index.vue
+++ b/pages/menu/recetas/index.vue
@@ -259,7 +259,7 @@
       v-model="quotaLimitModalOpen"
       :title="t('billing.upgrade.quotaBlocked')"
       :message="quotaLimitModalMessage"
-      :confirm-label="t('shell.miPlan')"
+      :confirm-label="t('nav.miPlan')"
       :cancel-label="t('billing.close')"
       @confirm="goToBillingFromQuotaLimitModal"
       @cancel="closeQuotaLimitModal"


### PR DESCRIPTION
## Summary
- Quota modals used `t('shell.miPlan')`, which is missing; the real key is `nav.miPlan` (`i18n/locales/*/shell.json`).
- Confirm CTA showed the raw key `shell.miPlan` instead of **Mi Plan**.
- Updated all quota-modal usages (menu + abastecimiento).

## Test plan
- [ ] Proveedores at supplier cap: confirm button shows **Mi Plan** (not `shell.miPlan`)
- [ ] Same on Compra Directa / Stock / Catálogo / Menú quota modals
- [ ] Confirm still navigates to `/gestion/billing`


Made with [Cursor](https://cursor.com)