### PR TITLE
fix(abastecimiento): hide wallet and credit from compra directa payment methods

### DIFF
--- a/.wr/1823.yaml
+++ b/.wr/1823.yaml
@@ -1,0 +1,38 @@
+issue: 1823
+title: "fix(abastecimiento): hide wallet and credit from compra directa payment methods"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1823-hide-purchase-wallet-credit
+
+paths:
+  - pages/abastecimiento/compras-directas/crear.vue
+  - utils/paymentDefaults.ts
+  - utils/paymentDefaults.purchaseFilter.test.ts
+
+ac:
+  - "Método de pago on crear hides credit + customer_wallet"
+  - "Other catalog methods still listed; Sin pago aun + payment_type Contado/Crédito unchanged"
+  - "POS mergePosPaymentGroupsFromApi / checkout defaults unchanged"
+
+out_of_scope:
+  - edit page
+  - removing payment_type credito option
+  - API payment catalog
+  - POS wallet/credit behavior
+
+hints:
+  entry: "crear.vue paymentGroups computed — wrap mergePosPaymentGroupsFromApi with filterPurchasePaymentGroups"
+  pattern: "utils/paymentDefaults.ts WALLET_PAYMENT_SLUG + credit slug"
+  tests: "node --test --experimental-strip-types utils/paymentDefaults.purchaseFilter.test.ts"
+
+risk:
+  sensitive: false
+  areas: [purchase payment method picker only]
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "single front PR — Closes #1823"

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -716,7 +716,7 @@ import { WAREHOUSE_COPY } from '~/constants/warehouseCopy'
 import { useScanQuotaQuery } from '~/composables/queries/useScanQuota'
 import { usePaymentLabel } from '~/composables/usePaymentLabel'
 import { usePaymentSelectValue } from '~/composables/usePaymentSelectValue'
-import { mergePosPaymentGroupsFromApi } from '~/utils/paymentDefaults'
+import { filterPurchasePaymentGroups, mergePosPaymentGroupsFromApi } from '~/utils/paymentDefaults'
 import { useInlineCatalogProductLink } from '@/composables/useInlineCatalogProductLink'
 import { useFormatters } from '~/composables/useFormatters'
 import { localeToNumberFormatTag, normalizeCurrencyCode } from '~/utils/currencyDisplay'
@@ -818,7 +818,9 @@ const { data: paymentMethodsData } = useFetch<{ success: boolean; data: import('
   { server: false },
 )
 const paymentGroups = computed(() =>
-  mergePosPaymentGroupsFromApi(paymentMethodsData.value?.data ?? []),
+  filterPurchasePaymentGroups(
+    mergePosPaymentGroupsFromApi(paymentMethodsData.value?.data ?? []),
+  ),
 )
 const { resolveLabel: resolvePaymentLabel } = usePaymentLabel(paymentGroups)
 const { paymentSelectValue, hasPaymentSelected } = usePaymentSelectValue(form, paymentGroups)

--- a/utils/paymentDefaults.purchaseFilter.test.ts
+++ b/utils/paymentDefaults.purchaseFilter.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  WALLET_PAYMENT_SLUG,
+  filterPurchasePaymentGroups,
+  mergePosPaymentGroupsFromApi,
+} from './paymentDefaults.ts'
+
+describe('filterPurchasePaymentGroups', () => {
+  it('removes credit and wallet from default POS merge (#1823)', () => {
+    const groups = filterPurchasePaymentGroups(mergePosPaymentGroupsFromApi([]))
+    const slugs = groups.map(g => g.slug)
+
+    assert.ok(!slugs.includes('credit'))
+    assert.ok(!slugs.includes(WALLET_PAYMENT_SLUG))
+    assert.ok(slugs.includes('cash'))
+    assert.ok(slugs.includes('card'))
+    assert.ok(slugs.includes('digital'))
+  })
+
+  it('keeps tenant methods that are not credit/wallet', () => {
+    const groups = filterPurchasePaymentGroups(
+      mergePosPaymentGroupsFromApi([
+        { id: '1', slug: 'cash', name: 'Efectivo', methods: [{ id: 'm1', name: 'Caja' }] },
+        { id: '2', slug: 'credit', name: 'Crédito', methods: [] },
+        { id: '3', slug: WALLET_PAYMENT_SLUG, name: 'Saldo wallet', methods: [] },
+        { id: '4', slug: 'transfer', name: 'Transferencia', methods: [{ id: 'm2', name: 'Bancolombia' }] },
+      ]),
+    )
+    const slugs = groups.map(g => g.slug)
+
+    assert.deepEqual(slugs, ['cash', 'transfer'])
+  })
+})

--- a/utils/paymentDefaults.ts
+++ b/utils/paymentDefaults.ts
@@ -44,6 +44,9 @@ export const PAYMENT_DEFAULTS: PosPaymentGroup[] = [
 /** Synthetic POS groups kept client-side (not stored in payment_method_groups). */
 export const SYNTHETIC_POS_PAYMENT_SLUGS = [WALLET_PAYMENT_SLUG] as const
 
+/** POS-only tenders that must not appear on supplier purchase payment pickers (#1823). */
+export const PURCHASE_EXCLUDED_PAYMENT_SLUGS = ['credit', WALLET_PAYMENT_SLUG] as const
+
 /**
  * Merge tenant API payment groups with synthetic defaults (e.g. customer_wallet).
  * The wallet tender is handled in checkout logic but is not a DB-configured group.
@@ -67,6 +70,14 @@ export function mergePosPaymentGroupsFromApi(
     }
   }
   return merged
+}
+
+/** Drop wallet + credit groups from Compra Directa / supplier purchase UIs. POS unchanged. */
+export function filterPurchasePaymentGroups(
+  groups: PosPaymentGroup[],
+): PosPaymentGroup[] {
+  const excluded = new Set<string>(PURCHASE_EXCLUDED_PAYMENT_SLUGS)
+  return groups.filter(g => !excluded.has(g.slug))
 }
 
 /** Map a payment group slug to a Heroicon component. Falls back to CurrencyDollarIcon. */


### PR DESCRIPTION
## Summary
- Compra Directa **Método de pago** no longer lists POS-only **Crédito** or **Saldo wallet**.
- Shared `filterPurchasePaymentGroups` keeps `mergePosPaymentGroupsFromApi` / POS checkout unchanged.
- Contado/Crédito *tipo de pago* and “Sin pago aun” unchanged.

Closes #1823

## Test plan
- [ ] `/abastecimiento/compras-directas/crear` → Método de pago has no wallet/credit
- [ ] Cash/card/transfer (etc.) still appear
- [ ] Contado/Crédito tipo de pago still available
- [ ] POS payment picker still shows wallet/credit

## Validation evidence
`node --test --experimental-strip-types utils/paymentDefaults.purchaseFilter.test.ts`

```text
# tests 2
# pass 2
# fail 0
```

## wr-context
See `.wr/1823.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)