### PR TITLE
fix(abastecimiento): refetch stock cache on adjust panel cancel/close

### DIFF
--- a/.wr/1828.yaml
+++ b/.wr/1828.yaml
@@ -1,0 +1,35 @@
+issue: 1828
+title: "fix(abastecimiento): refetch stock cache on adjust panel cancel/close"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1828-stock-panel-close-refetch
+
+paths:
+  - components/abastecimiento/StockAdjustmentPanel.vue
+  - pages/abastecimiento/stock.vue
+
+ac:
+  - "Cancelar / X / backdrop / Esc close emits closed → inventory refetch"
+  - "saved still refetches; close after save skips one refetch to avoid double-fetch"
+  - "Quota modal / filters unchanged"
+
+out_of_scope:
+  - adjustment API
+  - other panels
+
+hints:
+  entry: "StockAdjustmentPanel.close — emit closed; stock.vue onAdjustmentClosed"
+  pattern: "existing @saved=refetch"
+  tests: "node static assert emit closed + parent handlers"
+
+risk:
+  sensitive: false
+  areas: [stock list cache]
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "Closes #1828"

--- a/components/abastecimiento/StockAdjustmentPanel.vue
+++ b/components/abastecimiento/StockAdjustmentPanel.vue
@@ -420,6 +420,7 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
   (e: 'update:modelValue', value: boolean): void
   (e: 'saved'): void
+  (e: 'closed'): void
 }>()
 
 const uid = useId()
@@ -607,6 +608,7 @@ const resetForAnother = async () => {
 const close = () => {
   if (isSubmitting.value) return
   emit('update:modelValue', false)
+  emit('closed')
 }
 
 const formatNumber = (value: number | null | undefined) => {

--- a/pages/abastecimiento/stock.vue
+++ b/pages/abastecimiento/stock.vue
@@ -44,7 +44,8 @@
     <AbastecimientoStockAdjustmentPanel
       v-model="adjustmentOpen"
       :preselect="adjustmentPreselect"
-      @saved="refetch"
+      @saved="onAdjustmentSaved"
+      @closed="onAdjustmentClosed"
     />
 
     <UiConfirmActionModal
@@ -91,6 +92,21 @@ const itemsPerPage = ref(20)
 
 const adjustmentOpen = ref(false)
 const adjustmentPreselect = ref<StockAdjustmentPreselect | null>(null)
+/** After a successful save, list already refetched — skip one close refetch (#1828). */
+const skipCloseRefetch = ref(false)
+
+const onAdjustmentSaved = () => {
+  skipCloseRefetch.value = true
+  void refetch()
+}
+
+const onAdjustmentClosed = () => {
+  if (skipCloseRefetch.value) {
+    skipCloseRefetch.value = false
+    return
+  }
+  void refetch()
+}
 
 const openAdjustment = (item: {
   ingredient_id: string
@@ -100,6 +116,7 @@ const openAdjustment = (item: {
   maximum_stock?: number | null
 }) => {
   void handleCreateClick(() => {
+    skipCloseRefetch.value = false
     adjustmentPreselect.value = {
       id: item.ingredient_id,
       name: item.ingredient_name,


### PR DESCRIPTION
## Summary
- Stock adjustment panel emits `closed` on Cancelar / X / backdrop / Esc.
- Parent refetches inventory on close; after a successful `@saved` refetch, the immediate close skips a second fetch.
- “Ajustar otro” still gets a list refresh via `@saved`.

Closes #1828

## Test plan
- [ ] Open Ajustar → Cancelar → list refreshes (network/refetch)
- [ ] Save → Close → list updated, no obvious double-fetch storm
- [ ] Save → Ajustar otro → list already refreshed

## Validation evidence
```text
node (static assert)
ok: closed emit + parent skip-after-save refetch wiring
```

## wr-context
See `.wr/1828.yaml` on this branch.

Made with [Cursor](https://cursor.com)