### PR TITLE
fix(ui): single-line rows in ingredient catalog search results

### DIFF
--- a/.wr/1830.yaml
+++ b/.wr/1830.yaml
@@ -1,0 +1,35 @@
+issue: 1830
+title: "fix(ui): single-line rows in ingredient catalog search results"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1830-search-results-nowrap
+
+paths:
+  - components/ui/CatalogSearchCombobox.vue
+  - components/ui/IngredientSearchInput.vue
+
+ac:
+  - "Option rows single-line truncate + nowrap; title tooltip"
+  - "Badges same row; Compra Directa + other IngredientSearchInput consumers denser"
+  - "Create option / headers compact; no per-page forks"
+
+out_of_scope:
+  - search API
+  - stock table
+
+hints:
+  entry: "IngredientSearchInput #option slot + CatalogSearchCombobox option li classes"
+  pattern: "replace whitespace-normal/break-words with truncate whitespace-nowrap items-center"
+  tests: "node static assert no break-words on option rows"
+
+risk:
+  sensitive: false
+  areas: [shared search UI]
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "Closes #1830"

--- a/components/ui/CatalogSearchCombobox.vue
+++ b/components/ui/CatalogSearchCombobox.vue
@@ -70,7 +70,7 @@
               v-if="option.kind === 'presentation'"
               role="presentation"
               aria-hidden="true"
-              class="min-w-0 px-3 py-1 text-xs font-semibold text-text-secondary uppercase tracking-wide bg-surface-secondary/40 select-none whitespace-normal break-words [overflow-wrap:anywhere] leading-snug"
+              class="min-w-0 px-3 py-1 text-xs font-semibold text-text-secondary uppercase tracking-wide bg-surface-secondary/40 select-none whitespace-nowrap truncate"
             >
               <slot name="presentation" :option="option">
                 {{ option.label }}
@@ -83,7 +83,7 @@
               :aria-selected="activeKey === option.id"
               :title="option.label"
               :class="[
-                'min-w-0 px-3 py-2 text-sm text-text-primary cursor-pointer min-h-[40px] whitespace-normal',
+                'min-w-0 px-3 py-2 text-sm text-text-primary cursor-pointer min-h-[40px] flex items-center whitespace-nowrap',
                 activeKey === option.id ? 'bg-surface-secondary' : 'hover:bg-surface-secondary',
                 option.class,
               ]"
@@ -92,7 +92,7 @@
               @click="chooseOption(option)"
             >
               <slot name="option" :option="option" :active="activeKey === option.id">
-                <span class="min-w-0 whitespace-normal break-words [overflow-wrap:anywhere] leading-snug">
+                <span class="min-w-0 truncate whitespace-nowrap">
                   {{ option.label }}
                 </span>
               </slot>
@@ -113,17 +113,17 @@
             role="option"
             :aria-selected="activeKey === CREATE_KEY"
             :class="[
-              'px-3 py-2 text-sm text-primary border-t border-border cursor-pointer flex items-start gap-1.5 min-h-[40px]',
+              'px-3 py-2 text-sm text-primary border-t border-border cursor-pointer flex items-center gap-1.5 min-h-[40px] whitespace-nowrap',
               activeKey === CREATE_KEY ? 'bg-surface-secondary' : 'hover:bg-surface-secondary',
             ]"
             @mouseenter="activeKey = CREATE_KEY"
             @mousedown.prevent
             @click="chooseCreate"
           >
-            <svg class="w-3.5 h-3.5 flex-shrink-0 mt-0.5" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
             </svg>
-            <span class="min-w-0 flex-1 whitespace-normal break-words [overflow-wrap:anywhere] leading-snug">
+            <span class="min-w-0 flex-1 truncate whitespace-nowrap" :title="resolvedCreateLabel">
               {{ resolvedCreateLabel }}
             </span>
           </li>

--- a/components/ui/CatalogSearchCombobox.vue
+++ b/components/ui/CatalogSearchCombobox.vue
@@ -70,6 +70,7 @@
               v-if="option.kind === 'presentation'"
               role="presentation"
               aria-hidden="true"
+              :title="option.label"
               class="min-w-0 px-3 py-1 text-xs font-semibold text-text-secondary uppercase tracking-wide bg-surface-secondary/40 select-none whitespace-nowrap truncate"
             >
               <slot name="presentation" :option="option">

--- a/components/ui/IngredientSearchInput.vue
+++ b/components/ui/IngredientSearchInput.vue
@@ -20,26 +20,26 @@
       {{ option.label }}
     </template>
     <template #option="{ option }">
-      <span class="min-w-0 flex-1 flex items-start gap-1.5">
+      <span class="min-w-0 flex-1 flex items-center gap-1.5 overflow-hidden">
         <span
-          class="min-w-0 flex-1 break-words whitespace-normal [overflow-wrap:anywhere] leading-snug"
-          :title="option.label"
+          class="min-w-0 flex-1 truncate whitespace-nowrap"
+          :title="`${option.label} (${option.raw.unit})`"
         >
           {{ option.label }}
           <span class="text-text-secondary">({{ option.raw.unit }})</span>
         </span>
         <span
           v-if="showTypeLabel && typeBadgeLabel(option.raw?.type)"
-          class="mt-0.5 text-[10px] font-medium px-1.5 py-0.5 rounded-full flex-shrink-0"
+          class="text-[10px] font-medium px-1.5 py-0.5 rounded-full flex-shrink-0 whitespace-nowrap"
           :class="typeBadgeClass(option.raw?.type)"
         >{{ typeBadgeLabel(option.raw?.type) }}</span>
         <span
           v-if="option.raw.is_resale"
-          class="mt-0.5 text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-primary/10 text-primary flex-shrink-0"
+          class="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-primary/10 text-primary flex-shrink-0 whitespace-nowrap"
         >{{ t('menu.common.reventa') }}</span>
         <span
           v-else-if="option.raw.is_custom"
-          class="mt-0.5 text-xs bg-surface-secondary text-text-secondary rounded px-1 flex-shrink-0"
+          class="text-xs bg-surface-secondary text-text-secondary rounded px-1 flex-shrink-0 whitespace-nowrap"
         >{{ t('abastecimiento.glossary.customLabel') }}</span>
       </span>
     </template>
@@ -112,7 +112,7 @@ const options = computed(() => groupedResults.value.map((row: Ingredient & { _is
   id: row._isHeader ? `header-${row.id}` : row.id,
   label: row.name,
   kind: row._isHeader ? 'presentation' as const : 'option' as const,
-  class: row.parent_id ? 'ps-6 flex items-start gap-1.5' : 'flex items-start gap-1.5',
+  class: row.parent_id ? 'ps-6 flex items-center gap-1.5' : 'flex items-center gap-1.5',
   raw: row,
 })))
 


### PR DESCRIPTION
## Summary
- Catalog search option/create rows use `whitespace-nowrap` + truncate (no break-words wraps).
- Ingredient search keeps label, unit, and Reventa/Personalizado badges on one dense row.
- Shared fix covers Compra Directa and other `UiIngredientSearchInput` call sites.

Closes #1830

## Test plan
- [ ] Compra Directa create → search dropdown rows are single-line / compact
- [ ] Long names truncate; hover title shows full name
- [ ] Menu/receta ingredient search still works

## Validation evidence
```text
node (static assert)
ok: search option rows nowrap/truncate; badges items-center
```

## wr-context
See `.wr/1830.yaml` on this branch.

Made with [Cursor](https://cursor.com)