### PR TITLE
fix(ui): catalog search dropdown grow to full single-line labels

### DIFF
--- a/.wr/1832.yaml
+++ b/.wr/1832.yaml
@@ -1,0 +1,36 @@
+issue: 1832
+title: "fix(ui): catalog search dropdown grow to full single-line labels"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1832-search-dropdown-grow
+
+paths:
+  - composables/useCatalogSearchDropdownPlacement.ts
+  - components/ui/CatalogSearchCombobox.vue
+  - components/ui/IngredientSearchInput.vue
+  - components/ui/CatalogSearchCombobox.test.ts
+
+ac:
+  - "nowrap rows without truncate; full labels visible"
+  - "panel minWidth=input, width=max-content, maxWidth=viewport"
+  - "vertical scroll preserved; shared consumers benefit"
+
+out_of_scope:
+  - multi-line wraps
+  - search API
+
+hints:
+  entry: "resolveCatalogSearchPanelWidth + remove truncate"
+  tests: "npx vitest run components/ui/CatalogSearchCombobox.test.ts"
+
+risk:
+  sensitive: false
+  areas: [shared search dropdown]
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "Closes #1832"

--- a/components/ui/CatalogSearchCombobox.test.ts
+++ b/components/ui/CatalogSearchCombobox.test.ts
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils'
 import { defineComponent, h } from 'vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import CatalogSearchCombobox from './CatalogSearchCombobox.vue'
-import { resolveCatalogSearchOpenUpward } from '~/composables/useCatalogSearchDropdownPlacement'
+import { resolveCatalogSearchOpenUpward, resolveCatalogSearchPanelWidth } from '~/composables/useCatalogSearchDropdownPlacement'
 
 const options = [
   { id: 'one', label: 'Primera' },
@@ -53,6 +53,23 @@ describe('CatalogSearchCombobox', () => {
       spaceBelow: 240,
       dropdownHeight: 192,
     })).toBe(false)
+  })
+
+  it('grows panel width with content while keeping input minWidth (#1832)', () => {
+    expect(resolveCatalogSearchPanelWidth({
+      inputWidth: 280,
+      viewportWidth: 1200,
+      left: 100,
+    })).toEqual({
+      minWidth: '280px',
+      width: 'max-content',
+      maxWidth: `${1200 - 100 - 8}px`,
+    })
+    expect(resolveCatalogSearchPanelWidth({
+      inputWidth: 400,
+      viewportWidth: 420,
+      left: 40,
+    }).minWidth).toBe('400px')
   })
 
   it('creates unique combobox/listbox relationships per instance', async () => {
@@ -173,7 +190,7 @@ describe('CatalogSearchCombobox', () => {
     expect(wrapper.text()).toContain('Create "cate"')
   })
 
-  it('keeps long values available and wraps long result labels', async () => {
+  it('keeps long values available on a single nowrap line (#1832)', async () => {
     const longLabel = 'Taste Of The Wild Prey Angus Beef Feline 15 Lb Alimento Para Gatos Premium A Base De Res Angus Lenteja Y Grasa De Pollo'
     const wrapper = mountCombobox({
       modelValue: longLabel,
@@ -187,6 +204,8 @@ describe('CatalogSearchCombobox', () => {
     const option = wrapper.get('[role="option"]')
     expect(option.attributes('title')).toBe(longLabel)
     expect(option.text()).toBe(longLabel)
-    expect(option.get('span').classes()).toContain('[overflow-wrap:anywhere]')
+    expect(option.classes()).toContain('whitespace-nowrap')
+    expect(option.get('span').classes()).toContain('whitespace-nowrap')
+    expect(option.get('span').classes()).not.toContain('truncate')
   })
 })

--- a/components/ui/CatalogSearchCombobox.vue
+++ b/components/ui/CatalogSearchCombobox.vue
@@ -42,7 +42,7 @@
         :aria-label="listboxLabel"
         :aria-busy="loading"
         :style="panelStyle"
-        class="bg-surface border border-border rounded-lg shadow-lg overflow-x-hidden overflow-y-auto"
+        class="bg-surface border border-border rounded-lg shadow-lg overflow-x-auto overflow-y-auto"
       >
         <li
           v-if="loading"
@@ -71,7 +71,7 @@
               role="presentation"
               aria-hidden="true"
               :title="option.label"
-              class="min-w-0 px-3 py-1 text-xs font-semibold text-text-secondary uppercase tracking-wide bg-surface-secondary/40 select-none whitespace-nowrap truncate"
+              class="px-3 py-1 text-xs font-semibold text-text-secondary uppercase tracking-wide bg-surface-secondary/40 select-none whitespace-nowrap"
             >
               <slot name="presentation" :option="option">
                 {{ option.label }}
@@ -84,7 +84,7 @@
               :aria-selected="activeKey === option.id"
               :title="option.label"
               :class="[
-                'min-w-0 px-3 py-2 text-sm text-text-primary cursor-pointer min-h-[40px] flex items-center whitespace-nowrap',
+                'px-3 py-2 text-sm text-text-primary cursor-pointer min-h-[40px] flex items-center whitespace-nowrap',
                 activeKey === option.id ? 'bg-surface-secondary' : 'hover:bg-surface-secondary',
                 option.class,
               ]"
@@ -93,7 +93,7 @@
               @click="chooseOption(option)"
             >
               <slot name="option" :option="option" :active="activeKey === option.id">
-                <span class="min-w-0 truncate whitespace-nowrap">
+                <span class="whitespace-nowrap">
                   {{ option.label }}
                 </span>
               </slot>
@@ -124,7 +124,7 @@
             <svg class="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
             </svg>
-            <span class="min-w-0 flex-1 truncate whitespace-nowrap" :title="resolvedCreateLabel">
+            <span class="whitespace-nowrap" :title="resolvedCreateLabel">
               {{ resolvedCreateLabel }}
             </span>
           </li>
@@ -231,11 +231,21 @@ const activeDescendant = computed(
 )
 
 const preferredPlacement = computed(() => props.placement)
-const { panelStyle } = useCatalogSearchDropdownPlacement(
+const { panelStyle, updatePlacement } = useCatalogSearchDropdownPlacement(
   anchorRef,
   panelRef,
   dropdownOpen,
   preferredPlacement,
+)
+
+watch(
+  () => props.options,
+  async () => {
+    if (!dropdownOpen.value) return
+    await nextTick()
+    updatePlacement()
+  },
+  { deep: true },
 )
 
 function optionKey(option: CatalogSearchOption) {

--- a/components/ui/IngredientSearchInput.vue
+++ b/components/ui/IngredientSearchInput.vue
@@ -20,11 +20,8 @@
       {{ option.label }}
     </template>
     <template #option="{ option }">
-      <span class="min-w-0 flex-1 flex items-center gap-1.5 overflow-hidden">
-        <span
-          class="min-w-0 flex-1 truncate whitespace-nowrap"
-          :title="`${option.label} (${option.raw.unit})`"
-        >
+      <span class="flex items-center gap-1.5 whitespace-nowrap">
+        <span class="whitespace-nowrap" :title="`${option.label} (${option.raw.unit})`">
           {{ option.label }}
           <span class="text-text-secondary">({{ option.raw.unit }})</span>
         </span>

--- a/composables/useCatalogSearchDropdownPlacement.ts
+++ b/composables/useCatalogSearchDropdownPlacement.ts
@@ -26,6 +26,26 @@ export function resolveCatalogSearchOpenUpward({
   return spaceBelow < dropdownHeight && spaceAbove > spaceBelow
 }
 
+/** Grow listbox with single-line labels; never narrower than the input (#1832). */
+export function resolveCatalogSearchPanelWidth({
+  inputWidth,
+  viewportWidth,
+  left,
+  edgePad = 8,
+}: {
+  inputWidth: number
+  viewportWidth: number
+  left: number
+  edgePad?: number
+}) {
+  const maxWidth = Math.max(inputWidth, viewportWidth - left - edgePad)
+  return {
+    minWidth: `${inputWidth}px`,
+    width: 'max-content',
+    maxWidth: `${maxWidth}px`,
+  }
+}
+
 export function useCatalogSearchDropdownPlacement(
   anchorRef: Ref<HTMLElement | null>,
   panelRef: Ref<HTMLElement | null>,
@@ -62,10 +82,16 @@ export function useCatalogSearchDropdownPlacement(
       Math.max(MIN_DROPDOWN_PX, openUpward.value ? spaceAbove : spaceBelow),
     )
 
+    const widthStyle = resolveCatalogSearchPanelWidth({
+      inputWidth: rect.width,
+      viewportWidth: window.innerWidth,
+      left: rect.left,
+    })
+
     panelStyle.value = {
       position: 'fixed',
       left: `${rect.left}px`,
-      width: `${rect.width}px`,
+      ...widthStyle,
       maxHeight: `${maxH}px`,
       zIndex: '9999',
       ...(openUpward.value


### PR DESCRIPTION
## Summary
- Dropdown panel grows with content (`minWidth` = input, `width: max-content`, `maxWidth` = viewport).
- Option rows stay single-line without truncate so full labels show.
- Vitest updated for nowrap + panel width helper.

Closes #1832
Refs #1830

## Test plan
- [ ] Compra Directa search: long names fully visible on one line; panel wider than input
- [ ] Many results still scroll vertically
- [ ] Near right edge: panel capped by viewport (horizontal scroll if needed)

## Validation evidence
`npx vitest run components/ui/CatalogSearchCombobox.test.ts`
```text
✓ CatalogSearchCombobox.test.ts (10 tests)
Test Files  1 passed
Tests  10 passed
```

## wr-context
See `.wr/1832.yaml` on this branch.

Made with [Cursor](https://cursor.com)