### PR TITLE
feat(finanzas): Arqueo operational quota gates (Trial)

### DIFF
--- a/composables/useBilling.ts
+++ b/composables/useBilling.ts
@@ -26,6 +26,13 @@ export type BillingQuotaKey =
   | 'tenant_suppliers'
   | 'direct_purchases_per_period'
   | 'stock_adjustments_per_period'
+  | 'cash_closes_per_period'
+  | 'active_open_cash_shifts'
+  | 'expenses_per_period'
+  | 'supplier_payments_per_period'
+  | 'payment_methods'
+  | 'accounting_period_closes_per_period'
+  | 'manual_journal_entries_per_period'
   | 'modifier_groups'
   | 'recipe_bases'
   | 'recipe_lines_per_product'
@@ -148,6 +155,13 @@ export type OperationalQuotaKey =
   | 'tenant_suppliers'
   | 'direct_purchases_per_period'
   | 'stock_adjustments_per_period'
+  | 'cash_closes_per_period'
+  | 'active_open_cash_shifts'
+  | 'expenses_per_period'
+  | 'supplier_payments_per_period'
+  | 'payment_methods'
+  | 'accounting_period_closes_per_period'
+  | 'manual_journal_entries_per_period'
   | 'modifier_groups'
   | 'recipe_bases'
   | 'recipe_lines_per_product'
@@ -284,6 +298,62 @@ export const BILLING_QUOTA_RESOURCE_CONFIG: Record<BillingQuotaKey, BillingQuota
     blockedMessage: 'Alcanzaste el límite de ajustes de stock de tu plan para este periodo. El cupo se reinicia con tu periodo de facturación.',
     unlimitedMessage: 'Puedes registrar ajustes de stock sin límite por override.',
   },
+  cash_closes_per_period: {
+    key: 'cash_closes_per_period',
+    label: 'Cierres de caja por periodo',
+    description: 'Arqueos / cierres Z registrados en el periodo de facturación',
+    unit: 'cierres en el periodo',
+    blockedMessage: 'Alcanzaste el límite de cierres de caja de tu plan para este periodo. El cupo se reinicia con tu periodo de facturación.',
+    unlimitedMessage: 'Puedes registrar cierres de caja sin límite por override.',
+  },
+  active_open_cash_shifts: {
+    key: 'active_open_cash_shifts',
+    label: 'Turnos de caja abiertos',
+    description: 'Turnos de caja abiertos al mismo tiempo',
+    unit: 'turnos abiertos',
+    blockedMessage: 'Alcanzaste el límite de turnos de caja abiertos de tu plan.',
+    unlimitedMessage: 'Puedes abrir turnos de caja sin límite por override.',
+  },
+  expenses_per_period: {
+    key: 'expenses_per_period',
+    label: 'Gastos por periodo',
+    description: 'Gastos e instancias registrados en el periodo de facturación',
+    unit: 'gastos en el periodo',
+    blockedMessage: 'Alcanzaste el límite de gastos de tu plan para este periodo. El cupo se reinicia con tu periodo de facturación.',
+    unlimitedMessage: 'Puedes registrar gastos sin límite por override.',
+  },
+  supplier_payments_per_period: {
+    key: 'supplier_payments_per_period',
+    label: 'Pagos a proveedores por periodo',
+    description: 'Pagos de compras registrados en el periodo de facturación',
+    unit: 'pagos en el periodo',
+    blockedMessage: 'Alcanzaste el límite de pagos a proveedores de tu plan para este periodo. El cupo se reinicia con tu periodo de facturación.',
+    unlimitedMessage: 'Puedes registrar pagos a proveedores sin límite por override.',
+  },
+  payment_methods: {
+    key: 'payment_methods',
+    label: 'Métodos de pago',
+    description: 'Métodos de pago activos del establecimiento',
+    unit: 'métodos',
+    blockedMessage: 'Alcanzaste el límite de métodos de pago de tu plan.',
+    unlimitedMessage: 'Puedes crear métodos de pago sin límite por override.',
+  },
+  accounting_period_closes_per_period: {
+    key: 'accounting_period_closes_per_period',
+    label: 'Cierres contables mensuales por periodo',
+    description: 'Cierres de mes contable en el periodo de facturación',
+    unit: 'cierres mensuales',
+    blockedMessage: 'Alcanzaste el límite de cierres contables mensuales de tu plan para este periodo.',
+    unlimitedMessage: 'Puedes cerrar periodos contables sin límite por override.',
+  },
+  manual_journal_entries_per_period: {
+    key: 'manual_journal_entries_per_period',
+    label: 'Asientos manuales por periodo',
+    description: 'Asientos de diario creados manualmente en el periodo',
+    unit: 'asientos manuales',
+    blockedMessage: 'Alcanzaste el límite de asientos manuales de tu plan para este periodo. El cupo se reinicia con tu periodo de facturación.',
+    unlimitedMessage: 'Puedes crear asientos manuales sin límite por override.',
+  },
   modifier_groups: {
     key: 'modifier_groups',
     label: 'Grupos de modificadores',
@@ -340,6 +410,13 @@ export const OPERATIONAL_QUOTA_KEYS: OperationalQuotaKey[] = [
   'tenant_suppliers',
   'direct_purchases_per_period',
   'stock_adjustments_per_period',
+  'cash_closes_per_period',
+  'active_open_cash_shifts',
+  'expenses_per_period',
+  'supplier_payments_per_period',
+  'payment_methods',
+  'accounting_period_closes_per_period',
+  'manual_journal_entries_per_period',
   'modifier_groups',
   'recipe_bases',
   'recipe_lines_per_product',

--- a/composables/useBillingOperationalQuota.test.ts
+++ b/composables/useBillingOperationalQuota.test.ts
@@ -116,6 +116,26 @@ describe('resolveOperationalQuota', () => {
     assert.equal(missing.blocked, false)
   })
 
+  it('gates Finanzas arqueo quotas (#1836)', () => {
+    assert.ok(OPERATIONAL_QUOTA_KEYS.includes('cash_closes_per_period'))
+    assert.ok(OPERATIONAL_QUOTA_KEYS.includes('active_open_cash_shifts'))
+
+    const closeBlocked = resolveOperationalQuota(
+      'cash_closes_per_period',
+      metric({ used: 30, limit: 30, remaining: 0 }),
+    )
+    const shiftBlocked = resolveOperationalQuota(
+      'active_open_cash_shifts',
+      metric({ used: 1, limit: 1, remaining: 0 }),
+    )
+    const closeMissing = resolveOperationalQuota('cash_closes_per_period')
+
+    assert.equal(closeBlocked.blocked, true)
+    assert.equal(shiftBlocked.blocked, true)
+    assert.equal(closeMissing.blocked, false)
+    assert.match(BILLING_QUOTA_RESOURCE_CONFIG.cash_closes_per_period.blockedMessage, /cierres/)
+  })
+
   it('defines reusable messages for every operational resource', () => {
     for (const resource of OPERATIONAL_QUOTA_KEYS) {
       const config = BILLING_QUOTA_RESOURCE_CONFIG[resource]

--- a/pages/finanzas/arqueo/apertura.vue
+++ b/pages/finanzas/arqueo/apertura.vue
@@ -265,7 +265,7 @@
                 type="button"
                 class="min-h-[44px] flex-1 px-6 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 disabled:opacity-50"
                 :disabled="isSubmitting || !canSubmitOpening"
-                @click="submitOpening"
+                @click="onSubmitOpeningClick"
               >
                 {{ t('finanzas.arqueo.openShift') }}
               </button>
@@ -274,6 +274,16 @@
         </div>
       </div>
   </div>
+
+  <UiConfirmActionModal
+    v-model="quotaLimitModalOpen"
+    :title="t('billing.upgrade.quotaBlocked')"
+    :message="quotaLimitModalMessage"
+    :confirm-label="t('nav.miPlan')"
+    :cancel-label="t('billing.close')"
+    @confirm="goToBillingFromQuotaLimitModal"
+    @cancel="closeQuotaLimitModal"
+  />
 </template>
 
 <script setup lang="ts">
@@ -282,11 +292,21 @@ import { useFormatters } from '~/composables/useFormatters'
 import { useCashDenominationCount } from '~/composables/useCashDenominationCount'
 import { useQueryCache } from '@pinia/colada'
 import { buildCierreWindowParams, isShiftOpen } from '~/composables/useCierreShiftWindow'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
+import { useQuotaExceeded } from '~/composables/useQuotaExceeded'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 const { t, locale } = useI18n({ useScope: 'global' })
 useHead({ title: () => t('finanzas.head.apertura') })
 
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+} = useOperationalQuotaGate('active_open_cash_shifts')
+const { handleQuotaError } = useQuotaExceeded()
 type AperturaMode = 'template' | 'day' | 'custom'
 
 const DAY_SHIFT_KEY = '__day__'
@@ -561,9 +581,20 @@ const submitOpening = async () => {
     cache.invalidateQueries({ key: ['cierre', 'preview'] })
     cache.invalidateQueries({ key: ['cierre', 'list'] })
   } catch (err: any) {
-    submitError.value = err?.data?.detail ?? err?.data?.message ?? t('finanzas.arqueo.openFailed')
+    if (handleQuotaError(err, { resource: 'active_open_cash_shifts' })) {
+      submitError.value = null
+      return
+    }
+    const detail = err?.data?.detail
+    submitError.value = (typeof detail === 'string' ? detail : null)
+      ?? err?.data?.message
+      ?? t('finanzas.arqueo.openFailed')
   } finally {
     isSubmitting.value = false
   }
+}
+
+const onSubmitOpeningClick = () => {
+  void handleCreateClick(() => { void submitOpening() })
 }
 </script>

--- a/pages/finanzas/arqueo/apertura.vue
+++ b/pages/finanzas/arqueo/apertura.vue
@@ -54,13 +54,14 @@
                 >
                   {{ t('finanzas.arqueo.backToArqueo') }}
                 </NuxtLink>
-                <NuxtLink
+                <button
                   v-if="closeLink"
-                  :to="closeLink"
+                  type="button"
                   class="min-h-[44px] flex-1 rounded-lg bg-primary px-5 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                  @click="onGoToCloseClick"
                 >
                   {{ closeLinkLabel }}
-                </NuxtLink>
+                </button>
               </div>
             </div>
           </Transition>
@@ -284,6 +285,15 @@
     @confirm="goToBillingFromQuotaLimitModal"
     @cancel="closeQuotaLimitModal"
   />
+  <UiConfirmActionModal
+    v-model="cashCloseQuotaModalOpen"
+    :title="t('billing.upgrade.quotaBlocked')"
+    :message="cashCloseQuotaModalMessage"
+    :confirm-label="t('nav.miPlan')"
+    :cancel-label="t('billing.close')"
+    @confirm="goToBillingFromCashCloseQuota"
+    @cancel="closeCashCloseQuotaModal"
+  />
 </template>
 
 <script setup lang="ts">
@@ -306,7 +316,16 @@ const {
   goToBillingFromQuotaLimitModal,
   handleCreateClick,
 } = useOperationalQuotaGate('active_open_cash_shifts')
-const { handleQuotaError } = useQuotaExceeded()
+
+const {
+  quotaLimitModalOpen: cashCloseQuotaModalOpen,
+  quotaLimitModalMessage: cashCloseQuotaModalMessage,
+  closeQuotaLimitModal: closeCashCloseQuotaModal,
+  goToBillingFromQuotaLimitModal: goToBillingFromCashCloseQuota,
+  handleCreateClick: handleCashCloseClick,
+} = useOperationalQuotaGate('cash_closes_per_period')
+
+const { handleQuotaError, getQuotaMessage } = useQuotaExceeded()
 type AperturaMode = 'template' | 'day' | 'custom'
 
 const DAY_SHIFT_KEY = '__day__'
@@ -581,7 +600,9 @@ const submitOpening = async () => {
     cache.invalidateQueries({ key: ['cierre', 'preview'] })
     cache.invalidateQueries({ key: ['cierre', 'list'] })
   } catch (err: any) {
-    if (handleQuotaError(err, { resource: 'active_open_cash_shifts' })) {
+    if (handleQuotaError(err, { resource: 'active_open_cash_shifts', showInline: false })) {
+      quotaLimitModalMessage.value = getQuotaMessage(err, 'active_open_cash_shifts')
+      quotaLimitModalOpen.value = true
       submitError.value = null
       return
     }
@@ -596,5 +617,10 @@ const submitOpening = async () => {
 
 const onSubmitOpeningClick = () => {
   void handleCreateClick(() => { void submitOpening() })
+}
+
+const onGoToCloseClick = () => {
+  if (!closeLink.value) return
+  void handleCashCloseClick(() => { void navigateTo(closeLink.value!) })
 }
 </script>

--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -84,12 +84,13 @@
             {{ t('finanzas.common.currentMonth') }}
           </button>
 
-          <NuxtLink
-            to="/finanzas/arqueo/apertura"
+          <button
+            type="button"
             class="h-10 px-4 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors flex items-center flex-shrink-0"
+            @click="onOpenShiftClick('/finanzas/arqueo/apertura')"
           >
             {{ t('finanzas.arqueo.openShift') }}
-          </NuxtLink>
+          </button>
 
           <NuxtLink
             :to="`/finanzas/arqueo/x?start=${periodStart}&end=${periodEnd}`"
@@ -114,9 +115,10 @@
           <div class="px-4 pb-4 pt-1">
             <p class="text-xs text-text-secondary mb-3">{{ t('finanzas.arqueo.otherPeriodHint') }}</p>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <NuxtLink
-                :to="`/finanzas/arqueo/apertura?mode=day&start=${today}&end=${today}`"
-                class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/30 bg-primary/5 hover:bg-primary/10 transition-colors min-h-[44px]"
+              <button
+                type="button"
+                class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/30 bg-primary/5 hover:bg-primary/10 transition-colors min-h-[44px] text-start"
+                @click="onOpenShiftClick(`/finanzas/arqueo/apertura?mode=day&start=${today}&end=${today}`)"
               >
                 <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-primary/15 flex items-center justify-center text-primary" aria-hidden="true">
                   <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -127,10 +129,11 @@
                   <p class="text-sm font-semibold text-text-primary">{{ t('finanzas.common.fullDay') }}</p>
                   <p class="text-xs text-text-secondary mt-0.5">{{ t('finanzas.arqueo.fullDayMode') }}</p>
                 </div>
-              </NuxtLink>
-              <NuxtLink
-                :to="`/finanzas/arqueo/z?mode=template&start=${today}`"
-                class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/20 bg-surface hover:border-primary/40 hover:bg-primary/5 transition-colors min-h-[44px]"
+              </button>
+              <button
+                type="button"
+                class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/20 bg-surface hover:border-primary/40 hover:bg-primary/5 transition-colors min-h-[44px] text-start"
+                @click="onCashCloseClick(`/finanzas/arqueo/z?mode=template&start=${today}`)"
               >
                 <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
                   <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -141,14 +144,15 @@
                   <p class="text-sm font-semibold text-text-primary">{{ t('finanzas.arqueo.templateMode') }}</p>
                   <p class="text-xs text-text-secondary mt-0.5">{{ t('finanzas.arqueo.fixedShiftConfigured') }}</p>
                 </div>
-              </NuxtLink>
+              </button>
             </div>
           </div>
         </details>
         <div v-if="!hasOpenShift" class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <NuxtLink
-            :to="`/finanzas/arqueo/apertura?mode=day&start=${today}&end=${today}`"
-            class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/30 bg-primary/5 hover:bg-primary/10 transition-colors min-h-[44px]"
+          <button
+            type="button"
+            class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/30 bg-primary/5 hover:bg-primary/10 transition-colors min-h-[44px] text-start"
+            @click="onOpenShiftClick(`/finanzas/arqueo/apertura?mode=day&start=${today}&end=${today}`)"
           >
             <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-primary/15 flex items-center justify-center text-primary" aria-hidden="true">
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -159,10 +163,11 @@
               <p class="text-sm font-semibold text-text-primary">{{ t('finanzas.common.fullDay') }}</p>
               <p class="text-xs text-text-secondary mt-0.5">{{ t('finanzas.arqueo.fullDayModeLong') }}</p>
             </div>
-          </NuxtLink>
-          <NuxtLink
-            :to="`/finanzas/arqueo/z?mode=template&start=${today}`"
-            class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/20 bg-surface hover:border-primary/40 hover:bg-primary/5 transition-colors min-h-[44px]"
+          </button>
+          <button
+            type="button"
+            class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/20 bg-surface hover:border-primary/40 hover:bg-primary/5 transition-colors min-h-[44px] text-start"
+            @click="onCashCloseClick(`/finanzas/arqueo/z?mode=template&start=${today}`)"
           >
             <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -173,7 +178,7 @@
               <p class="text-sm font-semibold text-text-primary">{{ t('finanzas.arqueo.templateMode') }}</p>
               <p class="text-xs text-text-secondary mt-0.5">{{ t('finanzas.arqueo.fixedShiftConfiguredLong') }}</p>
             </div>
-          </NuxtLink>
+          </button>
         </div>
       </div>
 
@@ -391,6 +396,25 @@
     </div>
   </Teleport>
 
+  <UiConfirmActionModal
+    v-model="openShiftQuotaModalOpen"
+    :title="t('billing.upgrade.quotaBlocked')"
+    :message="openShiftQuotaModalMessage"
+    :confirm-label="t('nav.miPlan')"
+    :cancel-label="t('billing.close')"
+    @confirm="goToBillingFromOpenShiftQuota"
+    @cancel="closeOpenShiftQuotaModal"
+  />
+  <UiConfirmActionModal
+    v-model="cashCloseQuotaModalOpen"
+    :title="t('billing.upgrade.quotaBlocked')"
+    :message="cashCloseQuotaModalMessage"
+    :confirm-label="t('nav.miPlan')"
+    :cancel-label="t('billing.close')"
+    @confirm="goToBillingFromCashCloseQuota"
+    @cancel="closeCashCloseQuotaModal"
+  />
+
   </div>
 </template>
 
@@ -400,11 +424,36 @@ import { useQueryCache } from '@pinia/colada'
 import { useFormatters } from '~/composables/useFormatters'
 import MetricCard from '~/components/shared/MetricCard.vue'
 import { buildCierreCloseRoute, isCierreOpen } from '~/composables/useCierreShiftWindow'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 const { t, locale } = useI18n({ useScope: 'global' })
 useHead({ title: () => t('finanzas.head.arqueo') })
 
+const {
+  quotaLimitModalOpen: openShiftQuotaModalOpen,
+  quotaLimitModalMessage: openShiftQuotaModalMessage,
+  closeQuotaLimitModal: closeOpenShiftQuotaModal,
+  goToBillingFromQuotaLimitModal: goToBillingFromOpenShiftQuota,
+  handleCreateClick: handleOpenShiftClick,
+  ensureBillingOverview: ensureOpenShiftBilling,
+} = useOperationalQuotaGate('active_open_cash_shifts')
+
+const {
+  quotaLimitModalOpen: cashCloseQuotaModalOpen,
+  quotaLimitModalMessage: cashCloseQuotaModalMessage,
+  closeQuotaLimitModal: closeCashCloseQuotaModal,
+  goToBillingFromQuotaLimitModal: goToBillingFromCashCloseQuota,
+  handleCreateClick: handleCashCloseClick,
+  ensureBillingOverview: ensureCashCloseBilling,
+} = useOperationalQuotaGate('cash_closes_per_period')
+
+const onOpenShiftClick = (to: string) => {
+  void handleOpenShiftClick(() => { void navigateTo(to) })
+}
+const onCashCloseClick = (to: string) => {
+  void handleCashCloseClick(() => { void navigateTo(to) })
+}
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 const { currentTenant } = useTenantReactive()
 const { todayISO, addDaysISO, dateAtNoon, isoFromDate, monthBounds, timezone } = useTenantTimezone()
@@ -533,7 +582,9 @@ const selectedCierreId = ref<string | null>(null)
 
 const onRowClick = (item: any) => {
   if (isCierreOpen(item)) {
-    navigateTo(buildCierreCloseRoute(item, timezone.value))
+    void handleCashCloseClick(() => {
+      void navigateTo(buildCierreCloseRoute(item, timezone.value))
+    })
     return
   }
   openPanel(item.id)
@@ -592,7 +643,11 @@ const handleDelete = async () => {
 }
 
 registerProgressiveLoading(isRefreshing)
-onMounted(() => { setRefreshHandler(refetch) })
+onMounted(() => {
+  setRefreshHandler(refetch)
+  void ensureOpenShiftBilling()
+  void ensureCashCloseBilling()
+})
 onUnmounted(() => { clearRefreshHandler(refetch) })
 
 </script>

--- a/pages/finanzas/arqueo/nuevo.vue
+++ b/pages/finanzas/arqueo/nuevo.vue
@@ -1380,7 +1380,9 @@ const submitCierre = async () => {
     clearStorage()
     cache.invalidateQueries({ key: ['cierre', 'list'] })
   } catch (err: any) {
-    if (handleQuotaError(err, { resource: 'cash_closes_per_period' })) {
+    if (handleQuotaError(err, { resource: 'cash_closes_per_period', showInline: false })) {
+      quotaLimitModalMessage.value = getQuotaMessage(err, 'cash_closes_per_period')
+      quotaLimitModalOpen.value = true
       submitError.value = null
       confirmArmed.value = false
       return

--- a/pages/finanzas/arqueo/nuevo.vue
+++ b/pages/finanzas/arqueo/nuevo.vue
@@ -935,7 +935,7 @@ const {
   goToBillingFromQuotaLimitModal,
   handleCreateClick,
 } = useOperationalQuotaGate('cash_closes_per_period')
-const { handleQuotaError } = useQuotaExceeded()
+const { handleQuotaError, getQuotaMessage } = useQuotaExceeded()
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 const { currentTenant } = useTenantReactive()

--- a/pages/finanzas/arqueo/nuevo.vue
+++ b/pages/finanzas/arqueo/nuevo.vue
@@ -904,6 +904,16 @@
     </template>
 
   </div>
+
+  <UiConfirmActionModal
+    v-model="quotaLimitModalOpen"
+    :title="t('billing.upgrade.quotaBlocked')"
+    :message="quotaLimitModalMessage"
+    :confirm-label="t('nav.miPlan')"
+    :cancel-label="t('billing.close')"
+    @confirm="goToBillingFromQuotaLimitModal"
+    @cancel="closeQuotaLimitModal"
+  />
 </template>
 
 <script setup lang="ts">
@@ -911,10 +921,21 @@ import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
 import { useQueryCache } from '@pinia/colada'
 import { buildCierreWindowBody, buildCierreWindowParams, cierrePreviewShiftCacheKey, isShiftOpen } from '~/composables/useCierreShiftWindow'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
+import { useQuotaExceeded } from '~/composables/useQuotaExceeded'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 const { t, locale } = useI18n({ useScope: 'global' })
 useHead({ title: () => t('finanzas.head.z') })
+
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+} = useOperationalQuotaGate('cash_closes_per_period')
+const { handleQuotaError } = useQuotaExceeded()
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 const { currentTenant } = useTenantReactive()
@@ -1337,7 +1358,7 @@ const handleConfirmButton = async () => {
     armTimeout = setTimeout(() => { confirmArmed.value = true }, 500)
     return
   }
-  await submitCierre()
+  void handleCreateClick(() => { void submitCierre() })
 }
 
 // ── Submit ────────────────────────────────────────────────────────────────
@@ -1359,10 +1380,19 @@ const submitCierre = async () => {
     clearStorage()
     cache.invalidateQueries({ key: ['cierre', 'list'] })
   } catch (err: any) {
-    const msg = err?.data?.message ?? err?.data?.detail ?? err?.message ?? t('finanzas.arqueo.registerError')
-    submitError.value = msg.includes('superpone')
+    if (handleQuotaError(err, { resource: 'cash_closes_per_period' })) {
+      submitError.value = null
+      confirmArmed.value = false
+      return
+    }
+    const detail = err?.data?.detail
+    const msg = err?.data?.message
+      ?? (typeof detail === 'string' ? detail : null)
+      ?? err?.message
+      ?? t('finanzas.arqueo.registerError')
+    submitError.value = String(msg).includes('superpone')
       ? 'Ya existe un arqueo para este período.'
-      : msg
+      : String(msg)
     confirmArmed.value = false
   } finally {
     isSubmitting.value = false

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -1071,7 +1071,7 @@ const {
   goToBillingFromQuotaLimitModal,
   handleCreateClick,
 } = useOperationalQuotaGate('cash_closes_per_period')
-const { handleQuotaError } = useQuotaExceeded()
+const { handleQuotaError, getQuotaMessage } = useQuotaExceeded()
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 const { currentTenant } = useTenantReactive()

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -1682,7 +1682,9 @@ const submitCierre = async () => {
     cache.invalidateQueries({ key: ['cierre', 'list'] })
     clearStorage()
   } catch (err: any) {
-    if (handleQuotaError(err, { resource: 'cash_closes_per_period' })) {
+    if (handleQuotaError(err, { resource: 'cash_closes_per_period', showInline: false })) {
+      quotaLimitModalMessage.value = getQuotaMessage(err, 'cash_closes_per_period')
+      quotaLimitModalOpen.value = true
       submitError.value = null
       confirmArmed.value = false
       return

--- a/pages/finanzas/arqueo/z.vue
+++ b/pages/finanzas/arqueo/z.vue
@@ -1039,6 +1039,16 @@
     </template>
 
   </div>
+
+  <UiConfirmActionModal
+    v-model="quotaLimitModalOpen"
+    :title="t('billing.upgrade.quotaBlocked')"
+    :message="quotaLimitModalMessage"
+    :confirm-label="t('nav.miPlan')"
+    :cancel-label="t('billing.close')"
+    @confirm="goToBillingFromQuotaLimitModal"
+    @cancel="closeQuotaLimitModal"
+  />
 </template>
 
 <script setup lang="ts">
@@ -1047,10 +1057,21 @@ import { useQueryCache } from '@pinia/colada'
 import { enUS, es as dateFnsEs } from 'date-fns/locale'
 import { formatDistanceStrict } from 'date-fns'
 import { buildCierreWindowBody, buildCierreWindowParams, isShiftOpen } from '~/composables/useCierreShiftWindow'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
+import { useQuotaExceeded } from '~/composables/useQuotaExceeded'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 const { t, locale } = useI18n({ useScope: 'global' })
 useHead({ title: () => t('finanzas.head.z') })
+
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+} = useOperationalQuotaGate('cash_closes_per_period')
+const { handleQuotaError } = useQuotaExceeded()
 
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 const { currentTenant } = useTenantReactive()
@@ -1633,7 +1654,7 @@ const handleConfirmButton = async () => {
     armTimeout = setTimeout(() => { confirmArmed.value = true }, 500)
     return
   }
-  await submitCierre()
+  void handleCreateClick(() => { void submitCierre() })
 }
 
 // ── Submit ────────────────────────────────────────────────────────────────
@@ -1661,10 +1682,19 @@ const submitCierre = async () => {
     cache.invalidateQueries({ key: ['cierre', 'list'] })
     clearStorage()
   } catch (err: any) {
-    const msg = err?.data?.message ?? err?.data?.detail ?? err?.message ?? t('finanzas.arqueo.registerError')
-    submitError.value = msg.includes('superpone')
+    if (handleQuotaError(err, { resource: 'cash_closes_per_period' })) {
+      submitError.value = null
+      confirmArmed.value = false
+      return
+    }
+    const detail = err?.data?.detail
+    const msg = err?.data?.message
+      ?? (typeof detail === 'string' ? detail : null)
+      ?? err?.message
+      ?? t('finanzas.arqueo.registerError')
+    submitError.value = String(msg).includes('superpone')
       ? 'Ya existe un arqueo para este período.'
-      : msg
+      : String(msg)
     confirmArmed.value = false
   } finally {
     isSubmitting.value = false


### PR DESCRIPTION
## Summary
- Extend `useBilling` with all Finanzas operational quota keys for reuse by later batches.
- Gate Arqueo hub / apertura / Z / nuevo with `active_open_cash_shifts` and `cash_closes_per_period` (Mi Plan modal at cap).
- Handle `429 quota_exceeded` on open-shift and close submit; X / list / detail stay ungated.

## Test plan
- [x] `bun test composables/useBillingOperationalQuota.test.ts`
- [ ] Manual: at cap, hub Abrir turno / template Z open Mi Plan; under cap flows unchanged

## Validation evidence
```text
bun test composables/useBillingOperationalQuota.test.ts
11 pass
0 fail
```

Closes #1836
Epic: #1834

Made with [Cursor](https://cursor.com)