### PR TITLE
feat(finanzas): Gastos/Pagos/Métodos operational quota gates (Trial)

### DIFF
--- a/components/payments/PaymentForm.vue
+++ b/components/payments/PaymentForm.vue
@@ -332,6 +332,7 @@ const handleSubmit = async () => {
       const purchaseIds = props.purchases.map(p => p.id)
       let successCount = 0
       let errorCount = 0
+      let stoppedByQuota = false
 
       // Read files into memory once to reuse them
       const fileData: { name: string; blob: Blob; type: string }[] = []
@@ -380,6 +381,7 @@ const handleSubmit = async () => {
         } catch (error) {
           console.error(`Error paying purchase ${purchaseId}:`, error)
           if (isQuotaExceededError(error)) {
+            stoppedByQuota = true
             quotaLimitModalMessage.value = getQuotaMessage(error, 'supplier_payments_per_period')
             quotaLimitModalOpen.value = true
             handleQuotaError(error, { resource: 'supplier_payments_per_period', showInline: false })
@@ -389,9 +391,17 @@ const handleSubmit = async () => {
         }
       }
 
-      if (quotaLimitModalOpen.value && successCount === 0) {
+      if (stoppedByQuota) {
+        if (successCount > 0) {
+          emit('paid')
+          useToast().warning(
+            `${successCount} pagos registrados; el resto no se intentó por cupo del plan.`,
+            { title: t('finanzas.paymentForm.partialTitle') },
+          )
+        }
         return
       }
+
       if (successCount > 0) {
         emit('paid')
         if (errorCount > 0) {

--- a/components/payments/PaymentForm.vue
+++ b/components/payments/PaymentForm.vue
@@ -1,6 +1,6 @@
 <template>
   <form
-    @submit.prevent="handleSubmit"
+    @submit.prevent="onSubmitClick"
     :class="compact ? 'flex min-h-0 flex-1 flex-col' : 'grid grid-cols-1 xl:grid-cols-3 gap-6 xl:gap-8'"
   >
     <div
@@ -185,6 +185,16 @@
     </div>
     </template>
   </form>
+
+  <UiConfirmActionModal
+    v-model="quotaLimitModalOpen"
+    :title="t('billing.upgrade.quotaBlocked')"
+    :message="quotaLimitModalMessage"
+    :confirm-label="t('nav.miPlan')"
+    :cancel-label="t('billing.close')"
+    @confirm="goToBillingFromQuotaLimitModal"
+    @cancel="closeQuotaLimitModal"
+  />
 </template>
 
 <script setup lang="ts">
@@ -192,6 +202,8 @@ const { t } = useI18n()
 import { ref, computed, onMounted } from 'vue'
 import { mergePosPaymentGroupsFromApi } from '~/utils/paymentDefaults'
 import { usePaymentSelectValue } from '~/composables/usePaymentSelectValue'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
+import { useQuotaExceeded } from '~/composables/useQuotaExceeded'
 
 const props = defineProps<{
   purchases: any[]
@@ -202,6 +214,15 @@ const emit = defineEmits<{
   cancel: []
   paid: []
 }>()
+
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+} = useOperationalQuotaGate('supplier_payments_per_period')
+const { handleQuotaError, getQuotaMessage, isQuotaExceededError } = useQuotaExceeded()
 
 const loading = ref(false)
 const formData = ref({
@@ -358,10 +379,19 @@ const handleSubmit = async () => {
           }
         } catch (error) {
           console.error(`Error paying purchase ${purchaseId}:`, error)
+          if (isQuotaExceededError(error)) {
+            quotaLimitModalMessage.value = getQuotaMessage(error, 'supplier_payments_per_period')
+            quotaLimitModalOpen.value = true
+            handleQuotaError(error, { resource: 'supplier_payments_per_period', showInline: false })
+            break
+          }
           errorCount++
         }
       }
 
+      if (quotaLimitModalOpen.value && successCount === 0) {
+        return
+      }
       if (successCount > 0) {
         emit('paid')
         if (errorCount > 0) {
@@ -404,11 +434,20 @@ const handleSubmit = async () => {
       }
     }
   } catch (error: any) {
+    if (handleQuotaError(error, { resource: 'supplier_payments_per_period', showInline: false })) {
+      quotaLimitModalMessage.value = getQuotaMessage(error, 'supplier_payments_per_period')
+      quotaLimitModalOpen.value = true
+      return
+    }
     console.error('Error paying purchase:', error)
     useToast().error(error.data?.detail || t('finanzas.paymentForm.fail'), { title: t('finanzas.common.error') })
   } finally {
     loading.value = false
   }
+}
+
+const onSubmitClick = () => {
+  void handleCreateClick(() => { void handleSubmit() })
 }
 </script>
 

--- a/composables/useBillingOperationalQuota.test.ts
+++ b/composables/useBillingOperationalQuota.test.ts
@@ -136,6 +136,37 @@ describe('resolveOperationalQuota', () => {
     assert.match(BILLING_QUOTA_RESOURCE_CONFIG.cash_closes_per_period.blockedMessage, /cierres/)
   })
 
+  it('gates Finanzas gastos/pagos/métodos quotas (#1837)', () => {
+    assert.ok(OPERATIONAL_QUOTA_KEYS.includes('expenses_per_period'))
+    assert.ok(OPERATIONAL_QUOTA_KEYS.includes('supplier_payments_per_period'))
+    assert.ok(OPERATIONAL_QUOTA_KEYS.includes('payment_methods'))
+
+    const expensesBlocked = resolveOperationalQuota(
+      'expenses_per_period',
+      metric({ used: 30, limit: 30, remaining: 0 }),
+    )
+    const paymentsBlocked = resolveOperationalQuota(
+      'supplier_payments_per_period',
+      metric({ used: 30, limit: 30, remaining: 0 }),
+    )
+    const methodsBlocked = resolveOperationalQuota(
+      'payment_methods',
+      metric({ used: 5, limit: 5, remaining: 0 }),
+    )
+    const expensesAllowed = resolveOperationalQuota(
+      'expenses_per_period',
+      metric({ used: 1, limit: 30, remaining: 29 }),
+    )
+
+    assert.equal(expensesBlocked.blocked, true)
+    assert.equal(paymentsBlocked.blocked, true)
+    assert.equal(methodsBlocked.blocked, true)
+    assert.equal(expensesAllowed.blocked, false)
+    assert.match(BILLING_QUOTA_RESOURCE_CONFIG.expenses_per_period.blockedMessage, /gastos/)
+    assert.match(BILLING_QUOTA_RESOURCE_CONFIG.supplier_payments_per_period.blockedMessage, /pagos/)
+    assert.match(BILLING_QUOTA_RESOURCE_CONFIG.payment_methods.blockedMessage, /métodos/)
+  })
+
   it('defines reusable messages for every operational resource', () => {
     for (const resource of OPERATIONAL_QUOTA_KEYS) {
       const config = BILLING_QUOTA_RESOURCE_CONFIG[resource]

--- a/pages/finanzas/gastos/[id]/index.vue
+++ b/pages/finanzas/gastos/[id]/index.vue
@@ -574,12 +574,13 @@
       <div v-if="expense?.isRecurring" class="bg-surface border-2 border-border rounded-lg p-4 md:p-6 mt-6">
         <div class="flex justify-between items-center mb-4">
           <h3 class="text-lg font-bold text-text-primary">{{ t('finanzas.gastos.paymentInstances') }}</h3>
-          <NuxtLink
-            :to="`/finanzas/gastos/${expenseId}/instancia`"
+          <button
+            type="button"
             class="px-3 py-1.5 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/90"
+            @click="onNewInstanceClick"
           >
             {{ t('finanzas.gastos.newInstance') }}
-          </NuxtLink>
+          </button>
         </div>
 
         <!-- Loading State -->
@@ -668,6 +669,16 @@
       </div>
 
     </div>
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('nav.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>
 
@@ -677,12 +688,25 @@ import { useQuery, useQueryCache } from '@pinia/colada'
 import { usePaymentMethods } from '~/composables/usePaymentMethods'
 import { usePaymentLabel } from '~/composables/usePaymentLabel'
 import { useFormatters } from '~/composables/useFormatters'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const { t, locale } = useI18n({ useScope: 'global' })
 const route = useRoute()
 const expenseId = route.params.id as string
+
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+} = useOperationalQuotaGate('expenses_per_period')
+
+const onNewInstanceClick = () => {
+  void handleCreateClick(() => { void navigateTo(`/finanzas/gastos/${expenseId}/instancia`) })
+}
 
 const { currentTenant } = useTenantReactive()
 const cache = useQueryCache()

--- a/pages/finanzas/gastos/[id]/instancia.vue
+++ b/pages/finanzas/gastos/[id]/instancia.vue
@@ -1,11 +1,23 @@
 <script setup lang="ts">
 import { ref, reactive, computed, watch } from 'vue'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
+import { useQuotaExceeded } from '~/composables/useQuotaExceeded'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 const route = useRoute()
 const router = useRouter()
 const expenseId = route.params.id as string
+
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+} = useOperationalQuotaGate('expenses_per_period')
+const { handleQuotaError, getQuotaMessage } = useQuotaExceeded()
+const { t } = useI18n({ useScope: 'global' })
 
 useHead({ title: 'Nueva Instancia de Pago' })
 
@@ -112,11 +124,21 @@ const createInstance = async () => {
     // Navigate back to expense detail
     router.push(`/finanzas/gastos/${expenseId}`)
   } catch (err: any) {
+    if (handleQuotaError(err, { resource: 'expenses_per_period', showInline: false })) {
+      quotaLimitModalMessage.value = getQuotaMessage(err, 'expenses_per_period')
+      quotaLimitModalOpen.value = true
+      error.value = null
+      return
+    }
     console.error('Error creating instance:', err)
     error.value = err?.data?.detail || 'Error al crear la instancia'
   } finally {
     isSubmitting.value = false
   }
+}
+
+const onCreateInstanceClick = () => {
+  void handleCreateClick(() => { void createInstance() })
 }
 
 // Helper functions
@@ -206,7 +228,7 @@ watch(expenseData, (data) => {
       </div>
 
       <!-- Form Content -->
-      <form @submit.prevent="createInstance">
+      <form @submit.prevent="onCreateInstanceClick">
         <div class="bg-surface border-border border-2 rounded-lg">
           <div class="p-4 sm:p-6">
             <h3 class="text-base sm:text-lg font-semibold text-text-primary mb-4 sm:mb-6">Detalles de la Instancia</h3>
@@ -375,5 +397,15 @@ watch(expenseData, (data) => {
         </div>
       </form>
     </template>
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('nav.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>

--- a/pages/finanzas/gastos/crear.vue
+++ b/pages/finanzas/gastos/crear.vue
@@ -12,7 +12,7 @@
       <CommonsTheCustomLoader size="large" />
     </div>
 
-    <form v-else @submit.prevent="handleSubmit" class="grid grid-cols-1 xl:grid-cols-3 gap-6 xl:gap-8">
+    <form v-else @submit.prevent="onSubmitClick" class="grid grid-cols-1 xl:grid-cols-3 gap-6 xl:gap-8">
       <div class="xl:col-span-2 space-y-6">
         <div class="bg-surface border-2 border-border rounded-xl shadow-sm divide-y divide-border overflow-hidden">
           <UiFormSection :title="t('finanzas.gastos.infoTitle')">
@@ -275,9 +275,10 @@
 
           <div class="mt-6 space-y-3">
             <button
-              type="submit"
+              type="button"
               :disabled="isSubmitting || !isFormValid"
               class="btn-primary w-full min-h-[44px] px-4 py-2 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+              @click="onSubmitClick"
             >
               {{ isSubmitting ? t('finanzas.gastos.saving') : t('finanzas.gastos.save') }}
             </button>
@@ -291,6 +292,16 @@
         </div>
       </aside>
     </form>
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('nav.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>
 
@@ -299,10 +310,21 @@ const { t } = useI18n({ useScope: 'global' })
 import { useQuery, useQueryCache } from '@pinia/colada'
 import { usePaymentMethods } from '~/composables/usePaymentMethods'
 import { useFormatters } from '~/composables/useFormatters'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
+import { useQuotaExceeded } from '~/composables/useQuotaExceeded'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 useHead({ title: () => t('finanzas.gastos.createTitle') })
+
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+} = useOperationalQuotaGate('expenses_per_period')
+const { handleQuotaError, getQuotaMessage } = useQuotaExceeded()
 
 const { currentTenant } = useTenantReactive()
 const { todayISO } = useTenantTimezone()
@@ -496,10 +518,20 @@ const handleSubmit = async () => {
     cache.invalidateQueries({ key: ['finance', 'expenses'] })
     await navigateTo('/finanzas/gastos')
   } catch (error: any) {
+    if (handleQuotaError(error, { resource: 'expenses_per_period', showInline: false })) {
+      quotaLimitModalMessage.value = getQuotaMessage(error, 'expenses_per_period')
+      quotaLimitModalOpen.value = true
+      submitError.value = null
+      return
+    }
     console.error('Error creating expense:', error)
     submitError.value = extractErrorMessage(error)
   } finally {
     isSubmitting.value = false
   }
+}
+
+const onSubmitClick = () => {
+  void handleCreateClick(() => { void handleSubmit() })
 }
 </script>

--- a/pages/finanzas/gastos/index.vue
+++ b/pages/finanzas/gastos/index.vue
@@ -6,10 +6,23 @@ import { useFormatters } from '~/composables/useFormatters'
 import { filterSelectClass } from '~/composables/useFilterSelectClass'
 import { useMenuReturnRefresh } from '@/composables/useMenuReturnRefresh'
 import MetricCard from '~/components/shared/MetricCard.vue'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
 useHead({ title: () => t('finanzas.gastos.title') })
+
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+} = useOperationalQuotaGate('expenses_per_period')
+
+const onNewExpenseClick = () => {
+  void handleCreateClick(() => { void navigateTo('/finanzas/gastos/crear') })
+}
 
 // Tenant reactivity
 const { currentTenant } = useTenantReactive()
@@ -201,13 +214,14 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
           </select>
         </template>
         <template #trailing>
-          <NuxtLink
-            to="/finanzas/gastos/crear"
+          <button
+            type="button"
             class="btn-primary px-4 py-2 rounded-lg text-sm font-medium text-center whitespace-nowrap"
+            @click="onNewExpenseClick"
           >
             <span class="hidden sm:inline">{{ t('finanzas.gastos.save') }}</span>
             <span class="sm:hidden">{{ t('finanzas.gastos.new') }}</span>
-          </NuxtLink>
+          </button>
         </template>
       </UiAdvancedFiltersBar>
 
@@ -330,5 +344,15 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
         </template>
       </UiResponsiveDataView>
     </div>
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('nav.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>

--- a/pages/finanzas/metodos-pago/[groupId].vue
+++ b/pages/finanzas/metodos-pago/[groupId].vue
@@ -7,7 +7,7 @@
       <button
         v-if="group && !isCashGroup(group)"
         class="flex items-center gap-1.5 min-h-[32px] px-3 rounded-lg bg-primary text-primary-foreground text-xs font-medium hover:bg-primary/90 active:scale-[0.98] transition-all"
-        @click="openCreate"
+        @click="onOpenCreateClick"
       >
         <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
@@ -262,7 +262,7 @@
               type="text"
               :placeholder="t('finanzas.metodosPago.methodPlaceholder')"
               class="w-full text-sm border border-border rounded-lg px-3 py-2.5 bg-background text-text-primary focus:outline-none focus:ring-2 focus:ring-primary placeholder:text-text-secondary"
-              @keydown.enter="savePanel"
+              @keydown.enter="onSavePanelClick"
               @keydown.escape="closePanel"
             />
           </div>
@@ -332,7 +332,7 @@
           <button
             :disabled="saving || !panelName.trim()"
             class="flex-1 min-h-[44px] rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-            @click="savePanel"
+            @click="onSavePanelClick"
           >
             <UiLoadingDots v-if="saving" size="8px" color="currentColor" />
             <template v-else>{{ panelMode === 'create' ? t('finanzas.metodosPago.add') : t('common.save') }}</template>
@@ -347,11 +347,23 @@
       </div>
     </Transition>
   </Teleport>
+
+  <UiConfirmActionModal
+    v-model="quotaLimitModalOpen"
+    :title="t('billing.upgrade.quotaBlocked')"
+    :message="quotaLimitModalMessage"
+    :confirm-label="t('nav.miPlan')"
+    :cancel-label="t('billing.close')"
+    @confirm="goToBillingFromQuotaLimitModal"
+    @cancel="closeQuotaLimitModal"
+  />
 </template>
 
 <script setup lang="ts">
 import { ref, computed, nextTick } from 'vue'
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
+import { useQuotaExceeded } from '~/composables/useQuotaExceeded'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
@@ -360,6 +372,15 @@ const { currentTenant } = useTenantReactive()
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
 const route = useRoute()
 const groupId = route.params.groupId as string
+
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+} = useOperationalQuotaGate('payment_methods')
+const { handleQuotaError, getQuotaMessage } = useQuotaExceeded()
 
 interface PaymentGroup {
   id: string
@@ -516,6 +537,10 @@ const savingId = ref<string | null>(null)
 
 const toggleActive = async (method: PaymentMethod) => {
   if (savingId.value) return
+  if (!method.isActive) {
+    const allowed = await handleCreateClick(() => {})
+    if (!allowed) return
+  }
   savingId.value = method.id
   try {
     await $fetch(`/api/finanzas/metodos-pago/${method.id}`, {
@@ -523,6 +548,13 @@ const toggleActive = async (method: PaymentMethod) => {
       body: { isActive: !method.isActive },
     })
     await refetchMethods()
+  } catch (err: any) {
+    if (handleQuotaError(err, { resource: 'payment_methods', showInline: false })) {
+      quotaLimitModalMessage.value = getQuotaMessage(err, 'payment_methods')
+      quotaLimitModalOpen.value = true
+      return
+    }
+    panelError.value = err?.data?.detail || err?.data?.message || err?.message || t('finanzas.metodosPago.savingError')
   } finally {
     savingId.value = null
   }
@@ -602,6 +634,10 @@ const openCreate = async () => {
   showPanel.value = true
   await nextTick()
   panelInput.value?.focus()
+}
+
+const onOpenCreateClick = () => {
+  void handleCreateClick(() => { void openCreate() })
 }
 
 const openEdit = async (method: PaymentMethod) => {
@@ -693,10 +729,24 @@ const savePanel = async () => {
     closePanel()
     await Promise.all([refetchMethods(), refetchAccounts()])
   } catch (err: any) {
+    if (handleQuotaError(err, { resource: 'payment_methods', showInline: false })) {
+      quotaLimitModalMessage.value = getQuotaMessage(err, 'payment_methods')
+      quotaLimitModalOpen.value = true
+      panelError.value = ''
+      return
+    }
     panelError.value = err?.data?.detail || err?.data?.message || err?.message || t('finanzas.metodosPago.savingError')
   } finally {
     saving.value = false
   }
+}
+
+const onSavePanelClick = () => {
+  if (panelMode.value === 'create') {
+    void handleCreateClick(() => { void savePanel() })
+    return
+  }
+  void savePanel()
 }
 </script>
 

--- a/pages/finanzas/metodos-pago/[groupId].vue
+++ b/pages/finanzas/metodos-pago/[groupId].vue
@@ -554,7 +554,10 @@ const toggleActive = async (method: PaymentMethod) => {
       quotaLimitModalOpen.value = true
       return
     }
-    panelError.value = err?.data?.detail || err?.data?.message || err?.message || t('finanzas.metodosPago.savingError')
+    useToast().error(
+      err?.data?.detail || err?.data?.message || err?.message || t('finanzas.metodosPago.savingError'),
+      { title: t('finanzas.common.error') },
+    )
   } finally {
     savingId.value = null
   }

--- a/pages/finanzas/pagos/index.vue
+++ b/pages/finanzas/pagos/index.vue
@@ -49,7 +49,7 @@
               {{ t('finanzas.pagos.selectedOrders', { count: selectedPurchases.length }) }}
             </p>
           </div>
-          <button v-if="selectedPurchases.length > 0" @click="navigateToPayment(selectedPurchases)"
+          <button v-if="selectedPurchases.length > 0" @click="onNavigateToPayment(selectedPurchases)"
             class="btn-primary px-4 py-2 rounded-lg text-sm flex items-center justify-center space-x-2">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -68,7 +68,7 @@
           <div v-else class="grid grid-cols-1 gap-3">
             <PaymentsPendingPaymentCard v-for="payment in filteredPendingTableData" :key="payment.purchaseData.id"
               :payment="payment" :is-selected="isSelected(payment.purchaseData.id)" @toggle-selection="toggleSelection"
-              @pay="navigateToPayment([payment.purchaseData])" />
+              @pay="onNavigateToPayment([payment.purchaseData])" />
           </div>
         </div>
 
@@ -121,7 +121,7 @@
             </template>
 
             <template #cell-acciones="{ row }">
-              <button @click="navigateToPayment([row.purchaseData])" class="btn-secondary px-4 py-2 rounded-lg text-sm">
+              <button @click="onNavigateToPayment([row.purchaseData])" class="btn-secondary px-4 py-2 rounded-lg text-sm">
                 {{ t('finanzas.pagos.individual') }}
               </button>
             </template>
@@ -206,6 +206,15 @@
       </div>
     </div>
 
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('nav.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>
 
@@ -214,6 +223,7 @@ const { t } = useI18n({ useScope: 'global' })
 import { ref, computed, inject, onMounted } from 'vue'
 import { CurrencyDollarIcon, ClockIcon, CheckCircleIcon } from '@heroicons/vue/24/outline'
 import { useFormatters } from '~/composables/useFormatters'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
 
 definePageMeta({
   layout: 'dashboard',
@@ -565,6 +575,18 @@ function isSelected(purchaseId: string): boolean {
 function navigateToPayment(purchases: any[]) {
   const ids = purchases.map(p => p.id).join(',')
   navigateTo(`/finanzas/pagos/registrar?ids=${ids}`)
+}
+
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+} = useOperationalQuotaGate('supplier_payments_per_period')
+
+function onNavigateToPayment(purchases: any[]) {
+  void handleCreateClick(() => { void navigateToPayment(purchases) })
 }
 
 // Handle sort


### PR DESCRIPTION
## Summary
- Gate Gastos list/crear/instance with `expenses_per_period` (Mi Plan modal + 429).
- Gate Pagos list → registrar and PaymentForm submit with `supplier_payments_per_period`.
- Gate Métodos create/reactivate with `payment_methods`; cash/efectivo add CTA unchanged.
- Keys independent; lists remain usable at cap. Billing config reused from #1836.

## Test plan
- [x] `bun test composables/useBillingOperationalQuota.test.ts`
- [ ] Manual: at cap each surface opens Mi Plan; under cap flows unchanged
- [ ] Manual: cash group still cannot add methods

## Validation evidence
```text
bun test composables/useBillingOperationalQuota.test.ts
12 pass
0 fail
```

Stacked on #1839 (`wr-1836-finanzas-arqueo-quotas`) so billing keys are present.

Closes #1837
Epic: #1834

Made with [Cursor](https://cursor.com)