### PR TITLE
feat(finanzas): Asientos + Cierre contable operational quota gates (Trial)

### DIFF
--- a/composables/useBillingOperationalQuota.test.ts
+++ b/composables/useBillingOperationalQuota.test.ts
@@ -167,6 +167,32 @@ describe('resolveOperationalQuota', () => {
     assert.match(BILLING_QUOTA_RESOURCE_CONFIG.payment_methods.blockedMessage, /métodos/)
   })
 
+  it('gates Finanzas asientos/cierre quotas (#1838)', () => {
+    assert.ok(OPERATIONAL_QUOTA_KEYS.includes('manual_journal_entries_per_period'))
+    assert.ok(OPERATIONAL_QUOTA_KEYS.includes('accounting_period_closes_per_period'))
+
+    const jeBlocked = resolveOperationalQuota(
+      'manual_journal_entries_per_period',
+      metric({ used: 30, limit: 30, remaining: 0 }),
+    )
+    const closeBlocked = resolveOperationalQuota(
+      'accounting_period_closes_per_period',
+      metric({ used: 3, limit: 3, remaining: 0 }),
+    )
+    const jeAllowed = resolveOperationalQuota(
+      'manual_journal_entries_per_period',
+      metric({ used: 1, limit: 30, remaining: 29 }),
+    )
+    const jeMissing = resolveOperationalQuota('manual_journal_entries_per_period')
+
+    assert.equal(jeBlocked.blocked, true)
+    assert.equal(closeBlocked.blocked, true)
+    assert.equal(jeAllowed.blocked, false)
+    assert.equal(jeMissing.blocked, false)
+    assert.match(BILLING_QUOTA_RESOURCE_CONFIG.manual_journal_entries_per_period.blockedMessage, /asientos/)
+    assert.match(BILLING_QUOTA_RESOURCE_CONFIG.accounting_period_closes_per_period.blockedMessage, /cierres/)
+  })
+
   it('defines reusable messages for every operational resource', () => {
     for (const resource of OPERATIONAL_QUOTA_KEYS) {
       const config = BILLING_QUOTA_RESOURCE_CONFIG[resource]

--- a/pages/finanzas/cierre-contable/index.vue
+++ b/pages/finanzas/cierre-contable/index.vue
@@ -280,6 +280,8 @@ const handleClose = async () => {
     selectedMonth.value = null
   } catch (err: any) {
     if (handleQuotaError(err, { resource: 'accounting_period_closes_per_period', showInline: false })) {
+      showModal.value = false
+      selectedMonth.value = null
       quotaLimitModalMessage.value = getQuotaMessage(err, 'accounting_period_closes_per_period')
       quotaLimitModalOpen.value = true
       return

--- a/pages/finanzas/cierre-contable/index.vue
+++ b/pages/finanzas/cierre-contable/index.vue
@@ -56,7 +56,7 @@
               />
               <button
                 v-if="!item.isFuture && item.status === 'open'"
-                @click="openModal(item)"
+                @click="onOpenCloseClick(item)"
                 class="flex items-center justify-center w-8 h-8 rounded-lg text-text-secondary hover:bg-destructive/10 hover:text-destructive transition-colors"
                 :title="t('finanzas.cierreContable.closePeriod')"
                 :aria-label="t('finanzas.cierreContable.closePeriod')"
@@ -93,7 +93,7 @@
           <div class="flex justify-center">
             <button
               v-if="!row.isFuture && row.status === 'open'"
-              @click="openModal(row)"
+              @click="onOpenCloseClick(row)"
               class="flex items-center justify-center w-8 h-8 rounded-lg text-text-secondary hover:bg-destructive/10 hover:text-destructive transition-colors"
               :title="t('finanzas.cierreContable.closePeriod')"
               :aria-label="t('finanzas.cierreContable.closePeriod')"
@@ -137,7 +137,7 @@
                 {{ t('finanzas.common.cancel') }}
               </button>
               <button
-                @click="handleClose"
+                @click="onConfirmCloseClick"
                 :disabled="closing"
                 class="flex-1 min-h-[44px] px-4 py-2 bg-destructive text-white rounded-lg text-sm font-semibold hover:bg-destructive/90 transition-colors disabled:opacity-50"
               >
@@ -149,6 +149,15 @@
       </div>
     </Teleport>
 
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('nav.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>
 
@@ -156,9 +165,20 @@
 const { t } = useI18n({ useScope: 'global' })
 import { ref, computed, watch } from 'vue'
 import { useFormatters } from '~/composables/useFormatters'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
+import { useQuotaExceeded } from '~/composables/useQuotaExceeded'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: () => t('finanzas.head.cierre') })
+
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+} = useOperationalQuotaGate('accounting_period_closes_per_period')
+const { handleQuotaError, getQuotaMessage } = useQuotaExceeded()
 
 const { formatDateTime } = useFormatters()
 const { todayISO } = useTenantTimezone()
@@ -239,6 +259,10 @@ const openModal = (m: { number: number; name: string }) => {
   showModal.value = true
 }
 
+const onOpenCloseClick = (m: { number: number; name: string }) => {
+  void handleCreateClick(() => { openModal(m) })
+}
+
 const closeModal = () => {
   if (closing.value) return
   showModal.value = false
@@ -255,9 +279,18 @@ const handleClose = async () => {
     showModal.value = false
     selectedMonth.value = null
   } catch (err: any) {
+    if (handleQuotaError(err, { resource: 'accounting_period_closes_per_period', showInline: false })) {
+      quotaLimitModalMessage.value = getQuotaMessage(err, 'accounting_period_closes_per_period')
+      quotaLimitModalOpen.value = true
+      return
+    }
     alert(err?.data?.detail ?? err?.data?.message ?? t('finanzas.cierreContable.closeError'))
   } finally {
     closing.value = false
   }
+}
+
+const onConfirmCloseClick = () => {
+  void handleCreateClick(() => { void handleClose() })
 }
 </script>

--- a/pages/finanzas/contabilidad/asientos/crear.vue
+++ b/pages/finanzas/contabilidad/asientos/crear.vue
@@ -1,10 +1,21 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import MetricCard from '~/components/shared/MetricCard.vue'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
+import { useQuotaExceeded } from '~/composables/useQuotaExceeded'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 const { t } = useI18n({ useScope: 'global' })
 useHead({ title: () => t('finanzas.contabilidad.createEntryHead') })
+
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+} = useOperationalQuotaGate('manual_journal_entries_per_period')
+const { handleQuotaError, getQuotaMessage } = useQuotaExceeded()
 
 const { currentTenant } = useTenantReactive()
 const { todayISO } = useTenantTimezone()
@@ -121,6 +132,12 @@ const handleSaveDraft = async () => {
     await $fetch('/api/accounting/journal-entries', { method: 'POST', body: buildPayload() })
     router.push('/finanzas/contabilidad/asientos')
   } catch (err: any) {
+    if (handleQuotaError(err, { resource: 'manual_journal_entries_per_period', showInline: false })) {
+      quotaLimitModalMessage.value = getQuotaMessage(err, 'manual_journal_entries_per_period')
+      quotaLimitModalOpen.value = true
+      submitError.value = null
+      return
+    }
     submitError.value = err?.data?.detail || err?.data?.message || t('finanzas.contabilidad.saveEntryError')
   } finally {
     saving.value = false
@@ -138,10 +155,24 @@ const handlePost = async () => {
     await $fetch(`/api/accounting/journal-entries/${res.data.id}/post`, { method: 'POST' })
     router.push('/finanzas/contabilidad/asientos')
   } catch (err: any) {
+    if (handleQuotaError(err, { resource: 'manual_journal_entries_per_period', showInline: false })) {
+      quotaLimitModalMessage.value = getQuotaMessage(err, 'manual_journal_entries_per_period')
+      quotaLimitModalOpen.value = true
+      submitError.value = null
+      return
+    }
     submitError.value = err?.data?.detail || err?.data?.message || t('finanzas.contabilidad.postEntryError')
   } finally {
     posting.value = false
   }
+}
+
+const onSaveDraftClick = () => {
+  void handleCreateClick(() => { void handleSaveDraft() })
+}
+
+const onPostClick = () => {
+  void handleCreateClick(() => { void handlePost() })
 }
 
 // ── Mutual exclusion: debit clears credit and vice versa ──────────────────────
@@ -388,7 +419,7 @@ const onCreditInput = (line: EntryLine) => {
           :disabled="saving || posting"
           class="min-h-[44px] px-5 rounded-lg border-2 border-border text-sm font-medium text-text-primary hover:bg-surface-secondary transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
           :aria-label="saving ? t('finanzas.contabilidad.savingDraft') : t('finanzas.contabilidad.saveDraft')"
-          @click="handleSaveDraft"
+          @click="onSaveDraftClick"
         >
           <svg v-if="saving" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
@@ -401,7 +432,7 @@ const onCreditInput = (line: EntryLine) => {
           :disabled="saving || posting"
           class="min-h-[44px] px-5 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
           :aria-label="posting ? t('finanzas.contabilidad.posting') : t('finanzas.contabilidad.createAndPost')"
-          @click="handlePost"
+          @click="onPostClick"
         >
           <svg v-if="posting" class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
@@ -412,5 +443,15 @@ const onCreditInput = (line: EntryLine) => {
       </div>
 
     </div>
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('nav.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>

--- a/pages/finanzas/contabilidad/asientos/index.vue
+++ b/pages/finanzas/contabilidad/asientos/index.vue
@@ -3,9 +3,22 @@ const { t } = useI18n({ useScope: 'global' })
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { filterSelectClass } from '~/composables/useFilterSelectClass'
 import MetricCard from '~/components/shared/MetricCard.vue'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: () => t('finanzas.head.asientos') })
+
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+} = useOperationalQuotaGate('manual_journal_entries_per_period')
+
+const onNewEntryClick = () => {
+  void handleCreateClick(() => { void navigateTo('/finanzas/contabilidad/asientos/crear') })
+}
 
 const { currentTenant } = useTenantReactive()
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
@@ -294,16 +307,17 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
           </select>
         </template>
         <template #trailing>
-          <NuxtLink
-            to="/finanzas/contabilidad/asientos/crear"
+          <button
+            type="button"
             class="h-10 px-3 flex items-center gap-1.5 rounded-lg border border-primary text-primary text-sm font-medium hover:bg-primary/10 transition-colors whitespace-nowrap shrink-0"
             :aria-label="t('finanzas.contabilidad.createEntry')"
+            @click="onNewEntryClick"
           >
             <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
             </svg>
             <span class="hidden sm:inline">{{ t('finanzas.contabilidad.newEntry') }}</span>
-          </NuxtLink>
+          </button>
         </template>
       </UiAdvancedFiltersBar>
 
@@ -528,6 +542,16 @@ onUnmounted(() => { clearRefreshHandler(refetch) })
         </div>
       </div>
     </Teleport>
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('nav.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- Gate Asientos list→crear and draft/post submit with `manual_journal_entries_per_period`.
- Gate Cierre contable close action with `accounting_period_closes_per_period`.
- Void, list filters, year nav, and Cuentas/Balance/P&L/Cartera/Conciliación stay ungated.
- Billing keys reused from #1836/#1839 (already on main).

## Test plan
- [x] `bun test composables/useBillingOperationalQuota.test.ts`
- [ ] Manual: at cap, Crear asiento / Cerrar mes open Mi Plan; under cap flows unchanged
- [ ] Manual: auto JE rows still listed; void still works

## Validation evidence
```text
bun test composables/useBillingOperationalQuota.test.ts
13 pass
0 fail
```

Closes #1838
Epic: #1834

Made with [Cursor](https://cursor.com)