### PR TITLE
feat(tax): Facturación tax_lines + Menú categories (Closes #1846)

### DIFF
--- a/composables/useTenantFinancialProfile.ts
+++ b/composables/useTenantFinancialProfile.ts
@@ -176,6 +176,7 @@ export const useTenantFinancialProfile = () => {
         cache.invalidateQueries({ key: ['tenant', 'financial-profile'] }),
         cache.invalidateQueries({ key: ['tenant', 'business-profile'] }),
         cache.invalidateQueries({ key: ['operaciones', 'restaurant-context'] }),
+        cache.invalidateQueries({ key: ['tenant', 'tax-config'] }),
       ])
     },
   })

--- a/composables/useTenantTaxProfile.test.ts
+++ b/composables/useTenantTaxProfile.test.ts
@@ -12,6 +12,12 @@ describe('useTenantTaxProfile', () => {
     expect(taxConfigHasTaxes({ iva_applicable: false, liquor_tax_applicable: false })).toBe(false)
   })
 
+  it('ignores zero-rate tax_lines for hasTaxes', () => {
+    expect(taxConfigHasTaxes({
+      tax_lines: [{ key: 'standard', label: '', rate: 0, included_in_price: false, gl_role: 'iva' }],
+    })).toBe(false)
+  })
+
   it('detects commercial tax_lines', () => {
     expect(taxConfigHasTaxes({
       tax_lines: [{ key: 'gst', label: 'GST 10%', rate: 0.1, included_in_price: true, gl_role: 'iva' }],

--- a/composables/useTenantTaxProfile.test.ts
+++ b/composables/useTenantTaxProfile.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  primaryTaxLine,
+  taxCategoryOptions,
+  taxConfigHasTaxes,
+  wave1PresetForCountry,
+} from './useTenantTaxProfile'
+
+describe('useTenantTaxProfile', () => {
+  it('detects CO column taxes', () => {
+    expect(taxConfigHasTaxes({ inc_applicable: true })).toBe(true)
+    expect(taxConfigHasTaxes({ iva_applicable: false, liquor_tax_applicable: false })).toBe(false)
+  })
+
+  it('detects commercial tax_lines', () => {
+    expect(taxConfigHasTaxes({
+      tax_lines: [{ key: 'gst', label: 'GST 10%', rate: 0.1, included_in_price: true, gl_role: 'iva' }],
+    })).toBe(true)
+  })
+
+  it('returns wave-1 PA preset', () => {
+    const preset = wave1PresetForCountry('pa')
+    expect(preset?.lines[0]?.rate).toBe(0.07)
+    expect(preset?.category_map.exempt).toBeNull()
+  })
+
+  it('category options from category_map', () => {
+    const opts = taxCategoryOptions({
+      tax_lines: [{ key: 'iva', label: 'IVA 19%', rate: 0.19, included_in_price: false, gl_role: 'iva' }],
+      category_map: { standard: 'iva', liquor: 'iva', exempt: null },
+    })
+    expect(opts).toEqual(['standard', 'liquor', 'exempt'])
+  })
+
+  it('primary line follows category_map.standard', () => {
+    const line = primaryTaxLine({
+      tax_lines: [
+        { key: 'other', label: 'Other', rate: 0.05, included_in_price: false, gl_role: 'iva' },
+        { key: 'iva', label: 'IVA 19%', rate: 0.19, included_in_price: false, gl_role: 'iva' },
+      ],
+      category_map: { standard: 'iva', exempt: null },
+    })
+    expect(line?.key).toBe('iva')
+  })
+})

--- a/composables/useTenantTaxProfile.ts
+++ b/composables/useTenantTaxProfile.ts
@@ -1,0 +1,138 @@
+/**
+ * Tenant tax profile helpers — warocol.com#1846.
+ * Consumes GET /tenant/tax-config tax_lines + category_map (#1845).
+ * Wave-1 presets are transitional until #1847 server packs.
+ */
+
+export type TaxLineDraft = {
+  key: string
+  label: string
+  rate: number
+  included_in_price: boolean
+  gl_role: string
+}
+
+export type TaxCategoryKey = 'standard' | 'liquor' | 'exempt'
+
+export type Wave1TaxPreset = {
+  lines: TaxLineDraft[]
+  category_map: Record<string, string | null>
+}
+
+/** Epic #1843 wave-1 shortlist — one primary rate + exempt. */
+export const WAVE1_TAX_PRESETS: Record<string, Wave1TaxPreset> = {
+  PA: {
+    lines: [{ key: 'itbms', label: 'ITBMS 7%', rate: 0.07, included_in_price: false, gl_role: 'iva' }],
+    category_map: { standard: 'itbms', liquor: 'itbms', exempt: null },
+  },
+  CL: {
+    lines: [{ key: 'iva', label: 'IVA 19%', rate: 0.19, included_in_price: false, gl_role: 'iva' }],
+    category_map: { standard: 'iva', liquor: 'iva', exempt: null },
+  },
+  DO: {
+    lines: [{ key: 'itbis', label: 'ITBIS 18%', rate: 0.18, included_in_price: false, gl_role: 'iva' }],
+    category_map: { standard: 'itbis', liquor: 'itbis', exempt: null },
+  },
+  UY: {
+    lines: [{ key: 'iva', label: 'IVA 22%', rate: 0.22, included_in_price: false, gl_role: 'iva' }],
+    category_map: { standard: 'iva', liquor: 'iva', exempt: null },
+  },
+  AU: {
+    lines: [{ key: 'gst', label: 'GST 10%', rate: 0.10, included_in_price: true, gl_role: 'iva' }],
+    category_map: { standard: 'gst', liquor: 'gst', exempt: null },
+  },
+  NZ: {
+    lines: [{ key: 'gst', label: 'GST 15%', rate: 0.15, included_in_price: true, gl_role: 'iva' }],
+    category_map: { standard: 'gst', liquor: 'gst', exempt: null },
+  },
+  SG: {
+    lines: [{ key: 'gst', label: 'GST 9%', rate: 0.09, included_in_price: true, gl_role: 'iva' }],
+    category_map: { standard: 'gst', liquor: 'gst', exempt: null },
+  },
+  AE: {
+    lines: [{ key: 'vat', label: 'VAT 5%', rate: 0.05, included_in_price: false, gl_role: 'iva' }],
+    category_map: { standard: 'vat', liquor: 'vat', exempt: null },
+  },
+}
+
+export const WAVE1_COUNTRY_CODES = Object.keys(WAVE1_TAX_PRESETS)
+
+export function normalizeTaxLines(raw: unknown): TaxLineDraft[] {
+  if (!Array.isArray(raw)) return []
+  const lines: TaxLineDraft[] = []
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue
+    const row = item as Record<string, unknown>
+    const key = String(row.key || '').trim()
+    if (!key) continue
+    lines.push({
+      key,
+      label: String(row.label || key),
+      rate: Number(row.rate) || 0,
+      included_in_price: Boolean(row.included_in_price),
+      gl_role: String(row.gl_role || 'iva'),
+    })
+  }
+  return lines
+}
+
+export function normalizeCategoryMap(raw: unknown): Record<string, string | null> | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
+  const out: Record<string, string | null> = {}
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    out[key] = value == null || value === '' ? null : String(value)
+  }
+  return out
+}
+
+export function taxConfigHasTaxes(cfg: Record<string, unknown> | null | undefined): boolean {
+  if (!cfg) return false
+  if (cfg.inc_applicable || cfg.iva_applicable || cfg.liquor_tax_applicable) return true
+  return normalizeTaxLines(cfg.tax_lines).length > 0
+}
+
+export function primaryTaxLine(cfg: Record<string, unknown> | null | undefined): TaxLineDraft | null {
+  const lines = normalizeTaxLines(cfg?.tax_lines)
+  if (!lines.length) return null
+  const map = normalizeCategoryMap(cfg?.category_map)
+  const standardKey = map?.standard
+  if (standardKey) {
+    const match = lines.find(line => line.key === standardKey)
+    if (match) return match
+  }
+  return lines[0] ?? null
+}
+
+/** Product tax_category keys to show in Menú (shared POS + venta directa). */
+export function taxCategoryOptions(cfg: Record<string, unknown> | null | undefined): TaxCategoryKey[] {
+  if (!taxConfigHasTaxes(cfg)) return []
+  const map = normalizeCategoryMap(cfg?.category_map)
+  if (map) {
+    const opts: TaxCategoryKey[] = []
+    if ('standard' in map) opts.push('standard')
+    if ('liquor' in map && map.liquor) opts.push('liquor')
+    if ('exempt' in map || opts.length) opts.push('exempt')
+    // de-dupe while preserving order
+    return [...new Set(opts)]
+  }
+  // CO column path: always offer the three legacy categories
+  return ['standard', 'liquor', 'exempt']
+}
+
+export function wave1PresetForCountry(countryCode: string): Wave1TaxPreset | null {
+  const code = String(countryCode || '').toUpperCase()
+  return WAVE1_TAX_PRESETS[code] ?? null
+}
+
+export function useTenantTaxProfile() {
+  return {
+    WAVE1_COUNTRY_CODES,
+    WAVE1_TAX_PRESETS,
+    normalizeTaxLines,
+    normalizeCategoryMap,
+    taxConfigHasTaxes,
+    primaryTaxLine,
+    taxCategoryOptions,
+    wave1PresetForCountry,
+  }
+}

--- a/composables/useTenantTaxProfile.ts
+++ b/composables/useTenantTaxProfile.ts
@@ -88,7 +88,7 @@ export function normalizeCategoryMap(raw: unknown): Record<string, string | null
 export function taxConfigHasTaxes(cfg: Record<string, unknown> | null | undefined): boolean {
   if (!cfg) return false
   if (cfg.inc_applicable || cfg.iva_applicable || cfg.liquor_tax_applicable) return true
-  return normalizeTaxLines(cfg.tax_lines).length > 0
+  return normalizeTaxLines(cfg.tax_lines).some(line => line.rate > 0)
 }
 
 export function primaryTaxLine(cfg: Record<string, unknown> | null | undefined): TaxLineDraft | null {

--- a/i18n/locales/en/facturacion.json
+++ b/i18n/locales/en/facturacion.json
@@ -172,7 +172,16 @@
       "incAddedHint": "The 8% is added on top. Example: $10,000 base → $10,800 charged",
       "ivaIncludedHint": "The 19% is already included in the price. Example: $11,900 → $10,000 base + $1,900 VAT",
       "ivaAddedHint": "The 19% is added on top. Example: $10,000 base → $11,900 charged",
-      "save": "Save configuration"
+      "save": "Save configuration",
+      "commercialBody": "Configure sales tax for your country (WARO commercial mode). Load a wave-1 country preset and optionally override the rate.",
+      "wave1Preset": "Country preset (wave 1)",
+      "wave1PresetPlaceholder": "Choose a country…",
+      "wave1PresetHint": "Selecting a country loads rate and label. Save to apply to POS and menu. Server packs arrive in a later delivery.",
+      "lineLabel": "Tax name",
+      "ratePercent": "Rate (%)",
+      "howCommercial": "How to apply the tax",
+      "commercialIncludedHint": "The rate is already included in the sale price.",
+      "commercialAddedHint": "The rate is added on top of the base price."
     },
     "provider": {
       "title": "Electronic invoicing provider",

--- a/i18n/locales/en/facturacion.json
+++ b/i18n/locales/en/facturacion.json
@@ -181,7 +181,8 @@
       "ratePercent": "Rate (%)",
       "howCommercial": "How to apply the tax",
       "commercialIncludedHint": "The rate is already included in the sale price.",
-      "commercialAddedHint": "The rate is added on top of the base price."
+      "commercialAddedHint": "The rate is added on top of the base price.",
+      "commercialSaveInvalid": "Choose a preset or enter a name and a rate greater than 0 before saving."
     },
     "provider": {
       "title": "Electronic invoicing provider",

--- a/i18n/locales/es/facturacion.json
+++ b/i18n/locales/es/facturacion.json
@@ -181,7 +181,8 @@
       "ratePercent": "Tasa (%)",
       "howCommercial": "Cómo aplicar el impuesto",
       "commercialIncludedHint": "La tasa ya está dentro del precio de venta.",
-      "commercialAddedHint": "La tasa se suma al precio base."
+      "commercialAddedHint": "La tasa se suma al precio base.",
+      "commercialSaveInvalid": "Elige un preset o ingresa un nombre y una tasa mayor que 0 antes de guardar."
     },
     "provider": {
       "title": "Proveedor de facturación electrónica",

--- a/i18n/locales/es/facturacion.json
+++ b/i18n/locales/es/facturacion.json
@@ -172,7 +172,16 @@
       "incAddedHint": "El 8% se agrega encima. Ej: $10.000 base → cobro $10.800",
       "ivaIncludedHint": "El 19% ya está dentro del precio. Ej: $11.900 → base $10.000 + IVA $1.900",
       "ivaAddedHint": "El 19% se agrega encima. Ej: $10.000 base → cobro $11.900",
-      "save": "Guardar configuración"
+      "save": "Guardar configuración",
+      "commercialBody": "Configura el impuesto de ventas del país (modo comercial WARO). Puedes cargar un preset de la ola 1 y ajustar el porcentaje.",
+      "wave1Preset": "Preset por país (ola 1)",
+      "wave1PresetPlaceholder": "Elegir país…",
+      "wave1PresetHint": "Al elegir un país se cargan tasa y etiqueta. Guarda para aplicarlas a POS y menú. Los packs de servidor llegan en una entrega posterior.",
+      "lineLabel": "Nombre del impuesto",
+      "ratePercent": "Tasa (%)",
+      "howCommercial": "Cómo aplicar el impuesto",
+      "commercialIncludedHint": "La tasa ya está dentro del precio de venta.",
+      "commercialAddedHint": "La tasa se suma al precio base."
     },
     "provider": {
       "title": "Proveedor de facturación electrónica",

--- a/pages/facturacion/index.vue
+++ b/pages/facturacion/index.vue
@@ -261,6 +261,20 @@ const syncCommercialFromConfig = (cfg: Record<string, any> | null) => {
   commercialLine.ratePct = Math.round(line.rate * 10000) / 100
   commercialLine.included_in_price = line.included_in_price
   commercialLine.gl_role = line.gl_role || 'iva'
+  const profileCountry = financialProfile.value?.country_code?.toUpperCase() || ''
+  if (profileCountry && WAVE1_COUNTRY_CODES.includes(profileCountry)) {
+    const preset = wave1PresetForCountry(profileCountry)
+    if (preset?.lines[0]?.key === line.key) {
+      commercialPresetCountry.value = profileCountry
+      return
+    }
+  }
+  const matched = WAVE1_COUNTRY_CODES.find((code) => {
+    const preset = wave1PresetForCountry(code)
+    return preset?.lines[0]?.key === line.key
+      && Math.abs((preset?.lines[0]?.rate || 0) - line.rate) < 1e-9
+  })
+  if (matched) commercialPresetCountry.value = matched
 }
 
 const applyWave1Preset = (countryCode: string) => {
@@ -308,9 +322,13 @@ const saveTaxConfig = async () => {
   isSavingTax.value = true
   try {
     if (showCommercialTaxUi.value) {
-      const rate = Math.max(0, Number(commercialLine.ratePct) || 0) / 100
+      const ratePct = Number(commercialLine.ratePct) || 0
+      if (ratePct <= 0 || !commercialLine.label.trim()) {
+        toast.error(t('facturacion.tax.commercialSaveInvalid'), { title: t('facturacion.common.error') })
+        return
+      }
+      const rate = Math.max(0, ratePct) / 100
       const label = commercialLine.label.trim()
-        || `${commercialLine.key.toUpperCase()} ${commercialLine.ratePct}%`
       const tax_lines = [{
         key: commercialLine.key || 'standard',
         label,

--- a/pages/facturacion/index.vue
+++ b/pages/facturacion/index.vue
@@ -25,6 +25,7 @@ const {
   isFiscalIntegrated,
   isMatiasDian,
   isWaroCommercial,
+  profile: financialProfile,
   isLoading: isFinancialProfileLoading,
 } = useTenantFinancialProfile()
 
@@ -228,6 +229,56 @@ const taxForm = reactive({
 })
 const isSavingTax = ref(false)
 
+const {
+  WAVE1_COUNTRY_CODES,
+  primaryTaxLine,
+  wave1PresetForCountry,
+} = useTenantTaxProfile()
+
+const showCommercialTaxUi = computed(() => isWaroCommercial.value)
+
+const commercialPresetCountry = ref('')
+const commercialLine = reactive({
+  key: 'standard',
+  label: '',
+  ratePct: 0,
+  included_in_price: false,
+  gl_role: 'iva',
+})
+
+const syncCommercialFromConfig = (cfg: Record<string, any> | null) => {
+  const line = primaryTaxLine(cfg)
+  if (!line) {
+    commercialLine.key = 'standard'
+    commercialLine.label = ''
+    commercialLine.ratePct = 0
+    commercialLine.included_in_price = false
+    commercialLine.gl_role = 'iva'
+    return
+  }
+  commercialLine.key = line.key
+  commercialLine.label = line.label
+  commercialLine.ratePct = Math.round(line.rate * 10000) / 100
+  commercialLine.included_in_price = line.included_in_price
+  commercialLine.gl_role = line.gl_role || 'iva'
+}
+
+const applyWave1Preset = (countryCode: string) => {
+  const preset = wave1PresetForCountry(countryCode)
+  if (!preset) return
+  commercialPresetCountry.value = countryCode.toUpperCase()
+  const line = preset.lines[0]
+  commercialLine.key = line.key
+  commercialLine.label = line.label
+  commercialLine.ratePct = Math.round(line.rate * 10000) / 100
+  commercialLine.included_in_price = line.included_in_price
+  commercialLine.gl_role = line.gl_role
+}
+
+const onCommercialPresetChange = () => {
+  if (commercialPresetCountry.value) applyWave1Preset(commercialPresetCountry.value)
+}
+
 watch(taxConfig, (cfg) => {
   if (!cfg) return
   taxForm.inc_applicable = cfg.inc_applicable
@@ -235,7 +286,20 @@ watch(taxConfig, (cfg) => {
   taxForm.iva_applicable = cfg.iva_applicable
   taxForm.iva_included_in_price = cfg.iva_included_in_price
   taxForm.liquor_tax_applicable = cfg.liquor_tax_applicable
+  syncCommercialFromConfig(cfg)
 }, { immediate: true })
+
+watch(
+  () => financialProfile.value?.country_code,
+  (code) => {
+    if (!showCommercialTaxUi.value || !code) return
+    if (commercialLine.label) return
+    if (WAVE1_COUNTRY_CODES.includes(code.toUpperCase())) {
+      applyWave1Preset(code)
+    }
+  },
+  { immediate: true },
+)
 
 watch(() => taxForm.inc_applicable, (val) => { if (val) taxForm.iva_applicable = false })
 watch(() => taxForm.iva_applicable, (val) => { if (val) taxForm.inc_applicable = false })
@@ -243,8 +307,38 @@ watch(() => taxForm.iva_applicable, (val) => { if (val) taxForm.inc_applicable =
 const saveTaxConfig = async () => {
   isSavingTax.value = true
   try {
-    applySalesTaxProfile()
-    await $fetch('/api/api/tenant/tax-config', { method: 'PUT', body: { ...taxForm } })
+    if (showCommercialTaxUi.value) {
+      const rate = Math.max(0, Number(commercialLine.ratePct) || 0) / 100
+      const label = commercialLine.label.trim()
+        || `${commercialLine.key.toUpperCase()} ${commercialLine.ratePct}%`
+      const tax_lines = [{
+        key: commercialLine.key || 'standard',
+        label,
+        rate,
+        included_in_price: commercialLine.included_in_price,
+        gl_role: commercialLine.gl_role || 'iva',
+      }]
+      const category_map = {
+        standard: tax_lines[0].key,
+        liquor: tax_lines[0].key,
+        exempt: null,
+      }
+      await $fetch('/api/api/tenant/tax-config', {
+        method: 'PUT',
+        body: {
+          inc_applicable: false,
+          inc_included_in_price: true,
+          iva_applicable: false,
+          iva_included_in_price: false,
+          liquor_tax_applicable: false,
+          tax_lines,
+          category_map,
+        },
+      })
+    } else {
+      applySalesTaxProfile()
+      await $fetch('/api/api/tenant/tax-config', { method: 'PUT', body: { ...taxForm } })
+    }
     await refreshTaxConfig()
     invalidateReadiness()
     toast.success(t('facturacion.toasts.taxSaved'), { title: t('facturacion.common.saved') })
@@ -1067,10 +1161,88 @@ const taxLevels = [
         {{ t('facturacion.tax.title') }}
       </h3>
       <p class="text-xs text-text-secondary mb-4">
-        {{ t('facturacion.tax.body') }}
+        {{ showCommercialTaxUi ? t('facturacion.tax.commercialBody') : t('facturacion.tax.body') }}
       </p>
 
-      <div class="space-y-5">
+      <!-- Commercial / non-DIAN: tax_lines preset + rate override -->
+      <div v-if="showCommercialTaxUi" class="space-y-5">
+        <div class="space-y-2">
+          <label for="wave1-tax-preset" class="text-sm font-medium text-text-primary">
+            {{ t('facturacion.tax.wave1Preset') }}
+          </label>
+          <select
+            id="wave1-tax-preset"
+            v-model="commercialPresetCountry"
+            class="w-full min-h-[44px] rounded-lg border-2 border-border bg-background px-3 text-sm text-text-primary"
+            @change="onCommercialPresetChange"
+          >
+            <option value="">{{ t('facturacion.tax.wave1PresetPlaceholder') }}</option>
+            <option v-for="code in WAVE1_COUNTRY_CODES" :key="code" :value="code">
+              {{ code }} — {{ wave1PresetForCountry(code)?.lines[0]?.label }}
+            </option>
+          </select>
+          <p class="text-xs text-text-secondary">{{ t('facturacion.tax.wave1PresetHint') }}</p>
+        </div>
+
+        <div class="space-y-2">
+          <label for="commercial-tax-label" class="text-sm font-medium text-text-primary">
+            {{ t('facturacion.tax.lineLabel') }}
+          </label>
+          <input
+            id="commercial-tax-label"
+            v-model="commercialLine.label"
+            type="text"
+            class="w-full min-h-[44px] rounded-lg border-2 border-border bg-background px-3 text-sm text-text-primary"
+          >
+        </div>
+
+        <div class="space-y-2">
+          <label for="commercial-tax-rate" class="text-sm font-medium text-text-primary">
+            {{ t('facturacion.tax.ratePercent') }}
+          </label>
+          <input
+            id="commercial-tax-rate"
+            v-model.number="commercialLine.ratePct"
+            type="number"
+            min="0"
+            max="100"
+            step="0.01"
+            class="w-full min-h-[44px] rounded-lg border-2 border-border bg-background px-3 text-sm text-text-primary tabular-nums"
+          >
+        </div>
+
+        <div class="grid grid-cols-2 gap-2" role="group" :aria-label="t('facturacion.tax.howCommercial')">
+          <button
+            type="button"
+            @click="commercialLine.included_in_price = true"
+            :class="[
+              'flex flex-col items-start gap-1.5 py-3 px-3 rounded-xl border-2 transition-all focus:outline-none text-start',
+              commercialLine.included_in_price
+                ? 'border-primary bg-primary/8 text-primary shadow-md shadow-primary/10'
+                : 'border-border bg-background text-text-tertiary hover:border-primary/30 hover:text-text-secondary hover:bg-surface-secondary/60'
+            ]"
+          >
+            <span class="text-xs font-bold leading-tight">{{ t('facturacion.tax.included') }}</span>
+            <span class="text-[10px] leading-snug">{{ t('facturacion.tax.commercialIncludedHint') }}</span>
+          </button>
+          <button
+            type="button"
+            @click="commercialLine.included_in_price = false"
+            :class="[
+              'flex flex-col items-start gap-1.5 py-3 px-3 rounded-xl border-2 transition-all focus:outline-none text-start',
+              !commercialLine.included_in_price
+                ? 'border-primary bg-primary/8 text-primary shadow-md shadow-primary/10'
+                : 'border-border bg-background text-text-tertiary hover:border-primary/30 hover:text-text-secondary hover:bg-surface-secondary/60'
+            ]"
+          >
+            <span class="text-xs font-bold leading-tight">{{ t('facturacion.tax.added') }}</span>
+            <span class="text-[10px] leading-snug">{{ t('facturacion.tax.commercialAddedHint') }}</span>
+          </button>
+        </div>
+      </div>
+
+      <!-- CO fiscal-integrated: INC / IVA / liquor -->
+      <div v-else class="space-y-5">
 
         <!-- INC -->
         <!-- tax toggles (i18n chrome) -->

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -284,6 +284,7 @@
           <UiFormSection v-if="hasTaxes" :title="t('menu.productos.taxCategory')">
             <div class="grid grid-cols-1 sm:grid-cols-3 gap-3" role="group" :aria-label="t('menu.productos.taxCategory')">
               <button
+                v-if="taxCategories.includes('standard')"
                 type="button"
                 @click="form.tax_category = 'standard'"
                 :class="[
@@ -294,9 +295,10 @@
                 ]"
               >
                 <span class="text-sm font-semibold">{{ t('menu.productos.foodBeverage') }}</span>
-                <span class="text-xs leading-snug">{{ t('menu.productos.incVatRates') }}</span>
+                <span class="text-xs leading-snug">{{ standardTaxHint }}</span>
               </button>
               <button
+                v-if="taxCategories.includes('liquor')"
                 type="button"
                 @click="form.tax_category = 'liquor'"
                 :class="[
@@ -307,9 +309,10 @@
                 ]"
               >
                 <span class="text-sm font-semibold">{{ t('menu.productos.takeawayLiquor') }}</span>
-                <span class="text-xs leading-snug">{{ t('menu.productos.liquorVat') }}</span>
+                <span class="text-xs leading-snug">{{ liquorTaxHint }}</span>
               </button>
               <button
+                v-if="taxCategories.includes('exempt')"
                 type="button"
                 @click="form.tax_category = 'exempt'"
                 :class="[
@@ -944,9 +947,22 @@ const { data: taxConfigData } = useQuery({
   staleTime: 30_000,
 })
 const taxConfig = computed(() => taxConfigData.value?.data ?? null)
-const hasTaxes = computed(() =>
-  !!(taxConfig.value?.inc_applicable || taxConfig.value?.iva_applicable || taxConfig.value?.liquor_tax_applicable)
-)
+const { taxConfigHasTaxes, taxCategoryOptions, primaryTaxLine } = useTenantTaxProfile()
+const hasTaxes = computed(() => taxConfigHasTaxes(taxConfig.value))
+const taxCategories = computed(() => taxCategoryOptions(taxConfig.value))
+const standardTaxHint = computed(() => {
+  const line = primaryTaxLine(taxConfig.value)
+  if (line?.label) return line.label
+  return t('menu.productos.incVatRates')
+})
+const liquorTaxHint = computed(() => {
+  const map = taxConfig.value?.category_map
+  const liquorKey = map?.liquor
+  const lines = Array.isArray(taxConfig.value?.tax_lines) ? taxConfig.value.tax_lines : []
+  const line = liquorKey ? lines.find((l: any) => l.key === liquorKey) : null
+  if (line?.label) return line.label
+  return t('menu.productos.liquorVat')
+})
 
 // Get product ID from route
 const productId = route.params.id as string

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -299,6 +299,7 @@
             >
               <div class="grid grid-cols-1 sm:grid-cols-3 gap-3" role="group" :aria-label="t('menu.productos.taxCategory')">
                 <button
+                  v-if="taxCategories.includes('standard')"
                   type="button"
                   @click="form.tax_category = 'standard'"
                   :class="[
@@ -309,9 +310,10 @@
                   ]"
                 >
                   <span class="text-sm font-semibold">{{ t('menu.productos.foodBeverage') }}</span>
-                  <span class="text-xs leading-snug">{{ t('menu.productos.incVatRates') }}</span>
+                  <span class="text-xs leading-snug">{{ standardTaxHint }}</span>
                 </button>
                 <button
+                  v-if="taxCategories.includes('liquor')"
                   type="button"
                   @click="form.tax_category = 'liquor'"
                   :class="[
@@ -322,9 +324,10 @@
                   ]"
                 >
                   <span class="text-sm font-semibold">{{ t('menu.productos.takeawayLiquor') }}</span>
-                  <span class="text-xs leading-snug">{{ t('menu.productos.liquorVat') }}</span>
+                  <span class="text-xs leading-snug">{{ liquorTaxHint }}</span>
                 </button>
                 <button
+                  v-if="taxCategories.includes('exempt')"
                   type="button"
                   @click="form.tax_category = 'exempt'"
                   :class="[
@@ -783,9 +786,22 @@ const { data: taxConfigData } = useQuery({
   staleTime: 30_000,
 })
 const taxConfig = computed(() => taxConfigData.value?.data ?? null)
-const hasTaxes = computed(() =>
-  !!(taxConfig.value?.inc_applicable || taxConfig.value?.iva_applicable || taxConfig.value?.liquor_tax_applicable)
-)
+const { taxConfigHasTaxes, taxCategoryOptions, primaryTaxLine } = useTenantTaxProfile()
+const hasTaxes = computed(() => taxConfigHasTaxes(taxConfig.value))
+const taxCategories = computed(() => taxCategoryOptions(taxConfig.value))
+const standardTaxHint = computed(() => {
+  const line = primaryTaxLine(taxConfig.value)
+  if (line?.label) return line.label
+  return t('menu.productos.incVatRates')
+})
+const liquorTaxHint = computed(() => {
+  const map = taxConfig.value?.category_map
+  const liquorKey = map?.liquor
+  const lines = Array.isArray(taxConfig.value?.tax_lines) ? taxConfig.value.tax_lines : []
+  const line = liquorKey ? lines.find((l: any) => l.key === liquorKey) : null
+  if (line?.label) return line.label
+  return t('menu.productos.liquorVat')
+})
 
 const isSubmitting = ref(false)
 const submitError = ref<string | null>(null)


### PR DESCRIPTION
## Summary
- Commercial Facturación: wave-1 country preset + label/rate/included override → PUT `tax_lines` + `category_map`.
- CO fiscal path keeps INC/IVA/liquor toggles; DIAN chrome stays behind `isFiscalIntegrated`.
- Menú crear/editar (+ resale): `hasTaxes` includes `tax_lines`; category options from `category_map` (same `tax_category` field).

Closes #1846

## Validation evidence
```text
$ npx vitest run composables/useTenantTaxProfile.test.ts
 ✓ composables/useTenantTaxProfile.test.ts (5 tests) 3ms
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Manual: CO toggles unchanged when fiscal-integrated; commercial preset PA→ITBMS 7% save; Menú/resale shows categories when taxes active.

## Test plan
- [ ] CO tenant: INC/IVA/liquor UI unchanged; DIAN sections visible
- [ ] Commercial tenant: select wave-1 country, override %, save; Menú shows categories
- [ ] Depends on api-warolabs#727 + migration 118 for `tax_lines` persist


Made with [Cursor](https://cursor.com)