### PR TITLE
feat(tax): US/CA jurisdiction picker in Facturación (Refs #1848)

### DIFF
--- a/composables/useTenantTaxProfile.test.ts
+++ b/composables/useTenantTaxProfile.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  countryNeedsJurisdiction,
   primaryTaxLine,
   taxCategoryOptions,
   taxConfigHasTaxes,
@@ -47,5 +48,11 @@ describe('useTenantTaxProfile', () => {
       category_map: { standard: 'iva', exempt: null },
     })
     expect(line?.key).toBe('iva')
+  })
+
+  it('detects US/CA jurisdiction countries', () => {
+    expect(countryNeedsJurisdiction('US')).toBe(true)
+    expect(countryNeedsJurisdiction('ca')).toBe(true)
+    expect(countryNeedsJurisdiction('PA')).toBe(false)
   })
 })

--- a/composables/useTenantTaxProfile.ts
+++ b/composables/useTenantTaxProfile.ts
@@ -1,7 +1,8 @@
 /**
- * Tenant tax profile helpers — warocol.com#1846.
+ * Tenant tax profile helpers — warocol.com#1846 / #1847 / #1848.
  * Consumes GET /tenant/tax-config tax_lines + category_map (#1845).
- * Wave-1 presets are transitional until #1847 server packs.
+ * Server wave-1 packs (#1847) and US/CA jurisdictions (#1848) are SoT;
+ * WAVE1_TAX_PRESETS remain a client fallback for wave-1 countries.
  */
 
 export type TaxLineDraft = {
@@ -18,6 +19,18 @@ export type Wave1TaxPreset = {
   lines: TaxLineDraft[]
   category_map: Record<string, string | null>
 }
+
+export type TaxJurisdictionOption = {
+  code: string
+  label: string
+  regime: string
+  rate: number
+  lines: TaxLineDraft[]
+  components?: TaxLineDraft[]
+}
+
+/** Countries that require state/province jurisdiction for tax rates. */
+export const JURISDICTION_COUNTRY_CODES = ['US', 'CA'] as const
 
 /** Epic #1843 wave-1 shortlist — one primary rate + exempt. */
 export const WAVE1_TAX_PRESETS: Record<string, Wave1TaxPreset> = {
@@ -56,6 +69,11 @@ export const WAVE1_TAX_PRESETS: Record<string, Wave1TaxPreset> = {
 }
 
 export const WAVE1_COUNTRY_CODES = Object.keys(WAVE1_TAX_PRESETS)
+
+export function countryNeedsJurisdiction(countryCode: string | null | undefined): boolean {
+  const code = String(countryCode || '').toUpperCase()
+  return (JURISDICTION_COUNTRY_CODES as readonly string[]).includes(code)
+}
 
 export function normalizeTaxLines(raw: unknown): TaxLineDraft[] {
   if (!Array.isArray(raw)) return []
@@ -112,10 +130,8 @@ export function taxCategoryOptions(cfg: Record<string, unknown> | null | undefin
     if ('standard' in map) opts.push('standard')
     if ('liquor' in map && map.liquor) opts.push('liquor')
     if ('exempt' in map || opts.length) opts.push('exempt')
-    // de-dupe while preserving order
     return [...new Set(opts)]
   }
-  // CO column path: always offer the three legacy categories
   return ['standard', 'liquor', 'exempt']
 }
 
@@ -124,12 +140,35 @@ export function wave1PresetForCountry(countryCode: string): Wave1TaxPreset | nul
   return WAVE1_TAX_PRESETS[code] ?? null
 }
 
+export function normalizeJurisdictionOptions(raw: unknown): TaxJurisdictionOption[] {
+  if (!Array.isArray(raw)) return []
+  const out: TaxJurisdictionOption[] = []
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue
+    const row = item as Record<string, unknown>
+    const code = String(row.code || '').trim().toUpperCase()
+    if (!code) continue
+    out.push({
+      code,
+      label: String(row.label || code),
+      regime: String(row.regime || ''),
+      rate: Number(row.rate) || 0,
+      lines: normalizeTaxLines(row.lines),
+      components: normalizeTaxLines(row.components),
+    })
+  }
+  return out
+}
+
 export function useTenantTaxProfile() {
   return {
     WAVE1_COUNTRY_CODES,
     WAVE1_TAX_PRESETS,
+    JURISDICTION_COUNTRY_CODES,
+    countryNeedsJurisdiction,
     normalizeTaxLines,
     normalizeCategoryMap,
+    normalizeJurisdictionOptions,
     taxConfigHasTaxes,
     primaryTaxLine,
     taxCategoryOptions,

--- a/docs/usuarios/facturacion.md
+++ b/docs/usuarios/facturacion.md
@@ -78,6 +78,14 @@ En ese caso WARO no agrega impuesto estándar al POS ni fuerza IVA 19% para habi
 
 Si el negocio es responsable de IVA o sus ventas deben liquidar Impoconsumo, no uses el modo sin impuesto: activa el impuesto correspondiente antes de vender y valida el modo **Incluido** o **Sumado** con tu contador.
 
+### Negocios fuera de Colombia (modo comercial)
+
+Si tu negocio opera en otro país del catálogo WARO, WARO aplica un **impuesto estándar de referencia** según el país (o, en EE. UU./Canadá, según el estado o provincia que elijas). En **Facturación → Impuestos aplicados a ventas** puedes **ajustar el porcentaje** cuando tu contador lo indique; el preset es solo el punto de partida.
+
+Para **EE. UU. y Canadá**, v1 usa tasas de referencia a **nivel estado/provincia**. Los impuestos locales de ciudad o condado (meal tax, etc.) **no** están en esta versión: documenta el ajuste manual con tu contador si aplica.
+
+Esto no reemplaza la facturación electrónica local (DIAN, CFDI, etc.) cuando aplique en tu jurisdicción.
+
 ---
 
 ## Proveedor de facturación electrónica

--- a/i18n/locales/en/facturacion.json
+++ b/i18n/locales/en/facturacion.json
@@ -176,13 +176,18 @@
       "commercialBody": "Configure sales tax for your country (WARO commercial mode). Load a wave-1 country preset and optionally override the rate.",
       "wave1Preset": "Country preset (wave 1)",
       "wave1PresetPlaceholder": "Choose a country…",
-      "wave1PresetHint": "Selecting a country loads rate and label. Save to apply to POS and menu. Server packs arrive in a later delivery.",
+      "wave1PresetHint": "Selecting a country loads rate and label. Save to apply to POS and menu.",
+      "stateLabel": "US state",
+      "provinceLabel": "Canadian province / territory",
+      "jurisdictionPlaceholder": "Choose a jurisdiction…",
+      "jurisdictionHint": "WARO uses a state/province reference rate. City/local meal taxes are out of v1; confirm the percentage with your accountant.",
+      "jurisdictionRequired": "Choose a state or province before saving.",
       "lineLabel": "Tax name",
       "ratePercent": "Rate (%)",
       "howCommercial": "How to apply the tax",
       "commercialIncludedHint": "The rate is already included in the sale price.",
       "commercialAddedHint": "The rate is added on top of the base price.",
-      "commercialSaveInvalid": "Choose a preset or enter a name and a rate greater than 0 before saving."
+      "commercialSaveInvalid": "Choose a preset/jurisdiction or enter a name and a valid rate before saving."
     },
     "provider": {
       "title": "Electronic invoicing provider",

--- a/i18n/locales/es/facturacion.json
+++ b/i18n/locales/es/facturacion.json
@@ -176,13 +176,18 @@
       "commercialBody": "Configura el impuesto de ventas del país (modo comercial WARO). Puedes cargar un preset de la ola 1 y ajustar el porcentaje.",
       "wave1Preset": "Preset por país (ola 1)",
       "wave1PresetPlaceholder": "Elegir país…",
-      "wave1PresetHint": "Al elegir un país se cargan tasa y etiqueta. Guarda para aplicarlas a POS y menú. Los packs de servidor llegan en una entrega posterior.",
+      "wave1PresetHint": "Al elegir un país se cargan tasa y etiqueta. Guarda para aplicarlas a POS y menú.",
+      "stateLabel": "Estado (EE. UU.)",
+      "provinceLabel": "Provincia / territorio (Canadá)",
+      "jurisdictionPlaceholder": "Elegir jurisdicción…",
+      "jurisdictionHint": "WARO usa una tasa de referencia a nivel estado/provincia. Impuestos locales de ciudad no están en v1; confirma el porcentaje con tu contador.",
+      "jurisdictionRequired": "Elige un estado o provincia antes de guardar.",
       "lineLabel": "Nombre del impuesto",
       "ratePercent": "Tasa (%)",
       "howCommercial": "Cómo aplicar el impuesto",
       "commercialIncludedHint": "La tasa ya está dentro del precio de venta.",
       "commercialAddedHint": "La tasa se suma al precio base.",
-      "commercialSaveInvalid": "Elige un preset o ingresa un nombre y una tasa mayor que 0 antes de guardar."
+      "commercialSaveInvalid": "Elige un preset/jurisdicción o ingresa un nombre y una tasa válida antes de guardar."
     },
     "provider": {
       "title": "Proveedor de facturación electrónica",

--- a/pages/facturacion/index.vue
+++ b/pages/facturacion/index.vue
@@ -233,11 +233,24 @@ const {
   WAVE1_COUNTRY_CODES,
   primaryTaxLine,
   wave1PresetForCountry,
+  countryNeedsJurisdiction,
+  normalizeJurisdictionOptions,
 } = useTenantTaxProfile()
 
 const showCommercialTaxUi = computed(() => isWaroCommercial.value)
+const profileCountryCode = computed(
+  () => financialProfile.value?.country_code?.toUpperCase() || '',
+)
+const showJurisdictionPicker = computed(() =>
+  showCommercialTaxUi.value && countryNeedsJurisdiction(profileCountryCode.value),
+)
+const showWave1Preset = computed(() =>
+  showCommercialTaxUi.value && !showJurisdictionPicker.value,
+)
 
 const commercialPresetCountry = ref('')
+const commercialJurisdictionCode = ref('')
+const jurisdictionOptions = ref<ReturnType<typeof normalizeJurisdictionOptions>>([])
 const commercialLine = reactive({
   key: 'standard',
   label: '',
@@ -254,25 +267,30 @@ const syncCommercialFromConfig = (cfg: Record<string, any> | null) => {
     commercialLine.ratePct = 0
     commercialLine.included_in_price = false
     commercialLine.gl_role = 'iva'
-    return
+  } else {
+    commercialLine.key = line.key
+    commercialLine.label = line.label
+    commercialLine.ratePct = Math.round(line.rate * 10000) / 100
+    commercialLine.included_in_price = line.included_in_price
+    commercialLine.gl_role = line.gl_role || 'iva'
   }
-  commercialLine.key = line.key
-  commercialLine.label = line.label
-  commercialLine.ratePct = Math.round(line.rate * 10000) / 100
-  commercialLine.included_in_price = line.included_in_price
-  commercialLine.gl_role = line.gl_role || 'iva'
-  const profileCountry = financialProfile.value?.country_code?.toUpperCase() || ''
+
+  if (cfg?.tax_jurisdiction_code) {
+    commercialJurisdictionCode.value = String(cfg.tax_jurisdiction_code).toUpperCase()
+  }
+
+  const profileCountry = profileCountryCode.value
   if (profileCountry && WAVE1_COUNTRY_CODES.includes(profileCountry)) {
     const preset = wave1PresetForCountry(profileCountry)
-    if (preset?.lines[0]?.key === line.key) {
+    if (preset?.lines[0]?.key === line?.key) {
       commercialPresetCountry.value = profileCountry
       return
     }
   }
   const matched = WAVE1_COUNTRY_CODES.find((code) => {
     const preset = wave1PresetForCountry(code)
-    return preset?.lines[0]?.key === line.key
-      && Math.abs((preset?.lines[0]?.rate || 0) - line.rate) < 1e-9
+    return preset?.lines[0]?.key === line?.key
+      && Math.abs((preset?.lines[0]?.rate || 0) - (line?.rate || 0)) < 1e-9
   })
   if (matched) commercialPresetCountry.value = matched
 }
@@ -293,6 +311,41 @@ const onCommercialPresetChange = () => {
   if (commercialPresetCountry.value) applyWave1Preset(commercialPresetCountry.value)
 }
 
+const applyJurisdictionOption = (code: string) => {
+  const option = jurisdictionOptions.value.find(item => item.code === code)
+  if (!option) return
+  commercialJurisdictionCode.value = code
+  const line = option.lines[0]
+  if (!line) return
+  commercialLine.key = line.key
+  commercialLine.label = line.label
+  commercialLine.ratePct = Math.round(line.rate * 10000) / 100
+  commercialLine.included_in_price = line.included_in_price
+  commercialLine.gl_role = line.gl_role || 'iva'
+}
+
+const onJurisdictionChange = () => {
+  if (commercialJurisdictionCode.value) {
+    applyJurisdictionOption(commercialJurisdictionCode.value)
+  }
+}
+
+const loadJurisdictionOptions = async (country: string) => {
+  if (!countryNeedsJurisdiction(country)) {
+    jurisdictionOptions.value = []
+    return
+  }
+  try {
+    const res = await $fetch<{ success: boolean; data: unknown }>(
+      '/api/api/tenant/tax-jurisdictions',
+      { query: { country } },
+    )
+    jurisdictionOptions.value = normalizeJurisdictionOptions(res?.data)
+  } catch {
+    jurisdictionOptions.value = []
+  }
+}
+
 watch(taxConfig, (cfg) => {
   if (!cfg) return
   taxForm.inc_applicable = cfg.inc_applicable
@@ -304,11 +357,18 @@ watch(taxConfig, (cfg) => {
 }, { immediate: true })
 
 watch(
-  () => financialProfile.value?.country_code,
-  (code) => {
+  () => profileCountryCode.value,
+  async (code) => {
     if (!showCommercialTaxUi.value || !code) return
+    await loadJurisdictionOptions(code)
+    if (showJurisdictionPicker.value) {
+      if (commercialJurisdictionCode.value) {
+        applyJurisdictionOption(commercialJurisdictionCode.value)
+      }
+      return
+    }
     if (commercialLine.label) return
-    if (WAVE1_COUNTRY_CODES.includes(code.toUpperCase())) {
+    if (WAVE1_COUNTRY_CODES.includes(code)) {
       applyWave1Preset(code)
     }
   },
@@ -322,9 +382,18 @@ const saveTaxConfig = async () => {
   isSavingTax.value = true
   try {
     if (showCommercialTaxUi.value) {
-      const ratePct = Number(commercialLine.ratePct) || 0
-      if (ratePct <= 0 || !commercialLine.label.trim()) {
+      const ratePct = Number(commercialLine.ratePct)
+      if (
+        !commercialLine.label.trim()
+        || Number.isNaN(ratePct)
+        || ratePct < 0
+        || (ratePct === 0 && !showJurisdictionPicker.value)
+      ) {
         toast.error(t('facturacion.tax.commercialSaveInvalid'), { title: t('facturacion.common.error') })
+        return
+      }
+      if (showJurisdictionPicker.value && !commercialJurisdictionCode.value) {
+        toast.error(t('facturacion.tax.jurisdictionRequired'), { title: t('facturacion.common.error') })
         return
       }
       const rate = Math.max(0, ratePct) / 100
@@ -351,6 +420,9 @@ const saveTaxConfig = async () => {
           liquor_tax_applicable: false,
           tax_lines,
           category_map,
+          ...(showJurisdictionPicker.value
+            ? { tax_jurisdiction_code: commercialJurisdictionCode.value }
+            : {}),
         },
       })
     } else {
@@ -1184,7 +1256,31 @@ const taxLevels = [
 
       <!-- Commercial / non-DIAN: tax_lines preset + rate override -->
       <div v-if="showCommercialTaxUi" class="space-y-5">
-        <div class="space-y-2">
+        <div v-if="showJurisdictionPicker" class="space-y-2">
+          <label for="tax-jurisdiction" class="text-sm font-medium text-text-primary">
+            {{ profileCountryCode === 'CA'
+              ? t('facturacion.tax.provinceLabel')
+              : t('facturacion.tax.stateLabel') }}
+          </label>
+          <select
+            id="tax-jurisdiction"
+            v-model="commercialJurisdictionCode"
+            class="w-full min-h-[44px] rounded-lg border-2 border-border bg-background px-3 text-sm text-text-primary"
+            @change="onJurisdictionChange"
+          >
+            <option value="">{{ t('facturacion.tax.jurisdictionPlaceholder') }}</option>
+            <option
+              v-for="option in jurisdictionOptions"
+              :key="option.code"
+              :value="option.code"
+            >
+              {{ option.code }} — {{ option.label }} ({{ Math.round(option.rate * 10000) / 100 }}%)
+            </option>
+          </select>
+          <p class="text-xs text-text-secondary">{{ t('facturacion.tax.jurisdictionHint') }}</p>
+        </div>
+
+        <div v-else-if="showWave1Preset" class="space-y-2">
           <label for="wave1-tax-preset" class="text-sm font-medium text-text-primary">
             {{ t('facturacion.tax.wave1Preset') }}
           </label>


### PR DESCRIPTION
## Summary
- Facturación shows state/province picker when tenant country is US/CA (hides wave-1 preset).
- Loads catalog from GET `/tenant/tax-jurisdictions`; saves via PUT `tax_jurisdiction_code` + tax_lines.
- Docs note: city/local meal taxes out of v1; commercial % override still allowed.

## Validation evidence
```
$ npx vitest run composables/useTenantTaxProfile.test.ts
 ✓ composables/useTenantTaxProfile.test.ts (7 tests) 2ms
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

## Test plan
- [ ] US tenant: state picker appears; TX save applies 8.25%
- [ ] CA tenant: province picker; ON vs BC different labels/rates
- [ ] Wave-1 country (PA): wave-1 preset still shown
- [ ] Depends on api-warolabs#729 + #1846 commercial UX

Refs uno0uno/warocol.com#1848
API: https://github.com/uno0uno/api-warolabs/pull/729