### PR TITLE
feat(registro): capture US/CA geo defaults once (#1854)

### DIFF
--- a/components/Auth/RegistrationForm.vue
+++ b/components/Auth/RegistrationForm.vue
@@ -166,6 +166,36 @@
             </div>
           </div>
 
+          <div v-if="needsJurisdiction">
+            <label for="registration-tax-jurisdiction" class="mb-1.5 block text-sm font-semibold text-text-primary">
+              {{ businessCountryCode === 'CA' ? t('facturacion.tax.provinceLabel') : t('facturacion.tax.stateLabel') }}
+            </label>
+            <select
+              id="registration-tax-jurisdiction"
+              v-model="taxJurisdictionCode"
+              required
+              :disabled="sending || optionsLoading"
+              :aria-invalid="Boolean(fieldErrors.taxJurisdictionCode)"
+              :aria-describedby="fieldErrors.taxJurisdictionCode ? 'registration-jurisdiction-error' : 'registration-jurisdiction-hint'"
+              class="form-input"
+            >
+              <option value="" disabled>{{ t('facturacion.tax.jurisdictionPlaceholder') }}</option>
+              <option
+                v-for="option in jurisdictionOptions"
+                :key="option.code"
+                :value="option.code"
+              >
+                {{ option.label }} ({{ option.code }})
+              </option>
+            </select>
+            <p id="registration-jurisdiction-hint" class="mt-1 text-xs text-form-control-help">
+              {{ t('facturacion.tax.jurisdictionHint') }}
+            </p>
+            <p v-if="fieldErrors.taxJurisdictionCode" id="registration-jurisdiction-error" class="field-error" role="alert">
+              {{ fieldErrors.taxJurisdictionCode }}
+            </p>
+          </div>
+
           <div>
             <label class="flex cursor-pointer items-start gap-3 text-sm text-text-secondary">
               <input
@@ -293,6 +323,11 @@ import {
   writeVerifiedPublicCtaAttribution,
 } from '~/utils/publicCta'
 import { trackOnboardingEvent } from '~/utils/onboardingAnalytics'
+import {
+  countryNeedsJurisdiction,
+  normalizeJurisdictionOptions,
+  type TaxJurisdictionOption,
+} from '~/composables/useTenantTaxProfile'
 
 interface RegistrationCatalogOption {
   country_code: string
@@ -323,8 +358,10 @@ const phoneNumber = ref('')
 const businessName = ref('')
 const businessCountryCode = ref('')
 const baseCurrencyCode = ref('')
+const taxJurisdictionCode = ref('')
 const consent = ref(false)
 const registrationCatalog = ref<RegistrationCatalogOption[]>([])
+const taxJurisdictionsByCountry = ref<Record<string, TaxJurisdictionOption[]>>({})
 const phoneCountries = ref<PhoneCountryOption[]>([])
 const optionsLoading = ref(true)
 const attribution = ref<RegistrationAttribution>({})
@@ -342,6 +379,7 @@ const fieldErrors = reactive({
   businessName: '',
   businessCountryCode: '',
   baseCurrencyCode: '',
+  taxJurisdictionCode: '',
   consent: '',
 })
 
@@ -360,6 +398,12 @@ const updateVerificationCode = (event: Event) => { verificationCode.value = norm
 
 const compatibleCurrencies = computed(() =>
   registrationCatalog.value.find(option => option.country_code === businessCountryCode.value)?.currency_codes ?? [],
+)
+
+const needsJurisdiction = computed(() => countryNeedsJurisdiction(businessCountryCode.value))
+
+const jurisdictionOptions = computed(() =>
+  taxJurisdictionsByCountry.value[businessCountryCode.value.toUpperCase()] ?? [],
 )
 
 const countryLabel = (code: string) => {
@@ -394,6 +438,11 @@ const handleBusinessCountryChange = () => {
   if (!compatibleCurrencies.value.includes(baseCurrencyCode.value)) {
     baseCurrencyCode.value = compatibleCurrencies.value[0] || ''
   }
+  if (!needsJurisdiction.value) {
+    taxJurisdictionCode.value = ''
+  } else if (!jurisdictionOptions.value.some(option => option.code === taxJurisdictionCode.value)) {
+    taxJurisdictionCode.value = ''
+  }
 }
 
 const currentDraft = () => createRegistrationDraft({
@@ -404,6 +453,7 @@ const currentDraft = () => createRegistrationDraft({
   businessName: businessName.value,
   businessCountryCode: businessCountryCode.value,
   baseCurrencyCode: baseCurrencyCode.value,
+  taxJurisdictionCode: taxJurisdictionCode.value,
   consent: consent.value,
   attribution: attribution.value,
   phase: phase.value,
@@ -441,6 +491,9 @@ const validateForm = () => {
   fieldErrors.baseCurrencyCode = compatibleCurrencies.value.includes(baseCurrencyCode.value)
     ? ''
     : t('onboarding.selectCurrency')
+  fieldErrors.taxJurisdictionCode = !needsJurisdiction.value || jurisdictionOptions.value.some(option => option.code === taxJurisdictionCode.value)
+    ? ''
+    : t('facturacion.tax.jurisdictionRequired')
   fieldErrors.consent = consent.value ? '' : t('auth.consentRequired')
 
   const firstInvalid = fieldErrors.email ? 'registration-email'
@@ -449,8 +502,9 @@ const validateForm = () => {
         : fieldErrors.businessName ? 'registration-business-name'
           : fieldErrors.businessCountryCode ? 'registration-business-country'
             : fieldErrors.baseCurrencyCode ? 'registration-base-currency'
-              : fieldErrors.consent ? 'registration-consent'
-                : null
+              : fieldErrors.taxJurisdictionCode ? 'registration-tax-jurisdiction'
+                : fieldErrors.consent ? 'registration-consent'
+                  : null
   if (firstInvalid) nextTick(() => focusInput(firstInvalid))
   return !firstInvalid
 }
@@ -575,6 +629,7 @@ watch(phoneNumber, (value) => {
 watch(businessName, () => { fieldErrors.businessName = ''; if (phase.value === 'form') persistDraft() })
 watch(businessCountryCode, () => { fieldErrors.businessCountryCode = ''; if (phase.value === 'form') persistDraft() })
 watch(baseCurrencyCode, () => { fieldErrors.baseCurrencyCode = ''; if (phase.value === 'form') persistDraft() })
+watch(taxJurisdictionCode, () => { fieldErrors.taxJurisdictionCode = ''; if (phase.value === 'form') persistDraft() })
 watch(consent, () => { fieldErrors.consent = ''; if (phase.value === 'form') persistDraft() })
 watch(verificationCode, (value) => { verificationCode.value = normalizeRegistrationPhone(value).slice(0, 6); error.value = '' })
 
@@ -589,6 +644,7 @@ onMounted(async () => {
     businessName.value = stored.businessName
     businessCountryCode.value = stored.businessCountryCode
     baseCurrencyCode.value = stored.baseCurrencyCode
+    taxJurisdictionCode.value = stored.taxJurisdictionCode || ''
     consent.value = stored.consent
     phase.value = stored.phase
     sentAt.value = stored.sentAt
@@ -601,11 +657,17 @@ onMounted(async () => {
     const response = await $fetch<{
       catalog: RegistrationCatalogOption[]
       phone_countries: PhoneCountryOption[]
+      tax_jurisdictions?: Record<string, unknown>
     }>('/api/auth/registration/options', {
       credentials: 'include',
     })
     registrationCatalog.value = response.catalog
     phoneCountries.value = response.phone_countries
+    const mapped: Record<string, TaxJurisdictionOption[]> = {}
+    for (const [country, rows] of Object.entries(response.tax_jurisdictions || {})) {
+      mapped[country.toUpperCase()] = normalizeJurisdictionOptions(rows)
+    }
+    taxJurisdictionsByCountry.value = mapped
     const storedPhoneCountry = phoneCountries.value.find(option =>
       option.country_code === phoneCountryIso.value
       && String(option.calling_code) === phoneCountryCode.value,
@@ -619,8 +681,13 @@ onMounted(async () => {
     if (!registrationCatalog.value.some(option => option.country_code === businessCountryCode.value)) {
       businessCountryCode.value = ''
       baseCurrencyCode.value = ''
+      taxJurisdictionCode.value = ''
     } else if (!compatibleCurrencies.value.includes(baseCurrencyCode.value)) {
       baseCurrencyCode.value = compatibleCurrencies.value[0] || ''
+    }
+    if (!needsJurisdiction.value
+      || !jurisdictionOptions.value.some(option => option.code === taxJurisdictionCode.value)) {
+      if (!needsJurisdiction.value) taxJurisdictionCode.value = ''
     }
   } catch {
     error.value = t('auth.registrationSendError')

--- a/components/Auth/RegistrationForm.vue
+++ b/components/Auth/RegistrationForm.vue
@@ -687,7 +687,7 @@ onMounted(async () => {
     }
     if (!needsJurisdiction.value
       || !jurisdictionOptions.value.some(option => option.code === taxJurisdictionCode.value)) {
-      if (!needsJurisdiction.value) taxJurisdictionCode.value = ''
+      taxJurisdictionCode.value = ''
     }
   } catch {
     error.value = t('auth.registrationSendError')

--- a/components/operaciones/FinancialProfileSettings.vue
+++ b/components/operaciones/FinancialProfileSettings.vue
@@ -6,6 +6,11 @@ import {
   getCompatibleCurrencyCodes,
   type FinancialProfileDraft,
 } from '~/composables/useTenantFinancialProfile'
+import {
+  countryNeedsJurisdiction,
+  normalizeJurisdictionOptions,
+  type TaxJurisdictionOption,
+} from '~/composables/useTenantTaxProfile'
 
 const { t, locale } = useI18n({ useScope: 'global' })
 const toast = useToast()
@@ -22,9 +27,11 @@ const {
 
 const draft = ref<FinancialProfileDraft>(createFinancialProfileDraft())
 const showConfirmation = ref(false)
+const jurisdictionOptions = ref<TaxJurisdictionOption[]>([])
+const jurisdictionsLoading = ref(false)
 
 watch(profile, (nextProfile) => {
-  if (nextProfile) draft.value = createFinancialProfileDraft(nextProfile)
+  if (nextProfile) draft.value = createFinancialProfileDraft(nextProfile, draft.value.tax_jurisdiction_code)
 }, { immediate: true })
 
 const compatibleCurrencyCodes = computed(() => getCompatibleCurrencyCodes(
@@ -36,11 +43,40 @@ watch(() => draft.value.country_code, () => {
   if (!compatibleCurrencyCodes.value.includes(draft.value.base_currency_code)) {
     draft.value.base_currency_code = compatibleCurrencyCodes.value[0] ?? ''
   }
+  if (!countryNeedsJurisdiction(draft.value.country_code)) {
+    draft.value.tax_jurisdiction_code = ''
+  }
 })
 
+const needsJurisdiction = computed(() => countryNeedsJurisdiction(draft.value.country_code))
 const canSubmit = computed(() => canSubmitFinancialProfile(response.value, draft.value))
 // Hard lock: country/currency read-only after first configure (profile exists).
 const isLocked = computed(() => !!response.value?.profile)
+
+const loadJurisdictionOptions = async (country: string) => {
+  if (!countryNeedsJurisdiction(country)) {
+    jurisdictionOptions.value = []
+    return
+  }
+  jurisdictionsLoading.value = true
+  try {
+    const res = await $fetch<{ success: boolean; data: unknown }>(
+      '/api/api/tenant/tax-jurisdictions',
+      { query: { country } },
+    )
+    jurisdictionOptions.value = normalizeJurisdictionOptions(res?.data)
+  } catch {
+    jurisdictionOptions.value = []
+  } finally {
+    jurisdictionsLoading.value = false
+  }
+}
+
+watch(
+  () => draft.value.country_code,
+  (code) => { void loadJurisdictionOptions(code) },
+  { immediate: true },
+)
 
 const makeDisplayNames = (type: 'region' | 'currency') => {
   try {
@@ -66,6 +102,9 @@ const queryErrorMessage = computed(() => {
 
 const confirmationMessage = computed(() => {
   if (!profile.value) return ''
+  if (needsJurisdiction.value && draft.value.tax_jurisdiction_code) {
+    return `${countryLabel(draft.value.country_code)} · ${draft.value.tax_jurisdiction_code}`
+  }
   return t('operaciones.personalizar.financial.confirmMessage', {
     currentCountry: countryLabel(profile.value.country_code),
     currentCurrency: currencyLabel(profile.value.base_currency_code),
@@ -213,9 +252,41 @@ const confirmSave = async () => {
         </div>
       </fieldset>
 
-      <div v-if="!isLocked" class="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+      <div
+        v-if="needsJurisdiction"
+        class="mt-4 flex flex-col gap-1"
+      >
+        <label for="financial-tax-jurisdiction" class="text-sm font-medium text-text-primary">
+          {{ draft.country_code === 'CA'
+            ? t('facturacion.tax.provinceLabel')
+            : t('facturacion.tax.stateLabel') }}
+        </label>
+        <select
+          id="financial-tax-jurisdiction"
+          v-model="draft.tax_jurisdiction_code"
+          :disabled="isSaving || jurisdictionsLoading"
+          class="min-h-11 rounded-lg border-2 border-form-control-border bg-form-control-bg px-3 py-2 text-sm text-form-control-text focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <option value="">{{ t('facturacion.tax.jurisdictionPlaceholder') }}</option>
+          <option
+            v-for="option in jurisdictionOptions"
+            :key="option.code"
+            :value="option.code"
+          >
+            {{ option.label }} ({{ option.code }})
+          </option>
+        </select>
+        <p class="text-xs leading-snug text-form-control-help">
+          {{ t('facturacion.tax.jurisdictionHint') }}
+        </p>
+      </div>
+
+      <div
+        v-if="needsJurisdiction"
+        class="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between"
+      >
         <p class="max-w-2xl text-xs leading-snug text-text-secondary">
-          {{ t('operaciones.personalizar.financial.irreversibleHelp') }}
+          {{ t('facturacion.tax.jurisdictionRequired') }}
         </p>
         <button
           type="button"

--- a/composables/useTenantFinancialProfile.test.ts
+++ b/composables/useTenantFinancialProfile.test.ts
@@ -53,6 +53,7 @@ describe('tenant financial-profile helpers', () => {
     assert.deepEqual(createFinancialProfileDraft(response.profile), {
       country_code: 'CO',
       base_currency_code: 'COP',
+      tax_jurisdiction_code: '',
     })
     assert.deepEqual(getCompatibleCurrencyCodes(response.catalog, 'PA'), ['USD', 'PAB'])
     assert.deepEqual(getCompatibleCurrencyCodes(response.catalog, 'XX'), [])
@@ -71,6 +72,35 @@ describe('tenant financial-profile helpers', () => {
       ...response,
       eligibility: { eligible: false, lock_type: 'permanent', reason_codes: ['permanent_orders'] },
     }, panama), false)
+  })
+
+  it('allows US/CA jurisdiction completion without changing country', () => {
+    const usResponse = {
+      ...response,
+      profile: {
+        ...response.profile,
+        country_code: 'US',
+        base_currency_code: 'USD',
+        accounting_localization: 'WARO_HOSPITALITY_GLOBAL_V1',
+        document_mode: 'waro_commercial',
+        fiscal_provider: null,
+      },
+      capabilities: {
+        ...response.capabilities,
+        colombia_puc: false,
+        matias_dian: false,
+      },
+    }
+    assert.equal(canSubmitFinancialProfile(usResponse, {
+      country_code: 'US',
+      base_currency_code: 'USD',
+      tax_jurisdiction_code: 'TX',
+    }), true)
+    assert.equal(canSubmitFinancialProfile(usResponse, {
+      country_code: 'US',
+      base_currency_code: 'USD',
+      tax_jurisdiction_code: '',
+    }), false)
   })
 
   it('uses server minor units with a safe fallback', () => {

--- a/composables/useTenantFinancialProfile.ts
+++ b/composables/useTenantFinancialProfile.ts
@@ -47,6 +47,7 @@ export interface TenantFinancialProfileResponse {
 export interface FinancialProfileDraft {
   country_code: string
   base_currency_code: string
+  tax_jurisdiction_code?: string
 }
 
 export const financialProfileQueryKey = (tenantId?: string | null) =>
@@ -75,9 +76,13 @@ export const isColombiaPucProfile = (
 
 export const createFinancialProfileDraft = (
   profile?: TenantFinancialProfile | null,
+  jurisdictionCode?: string | null,
 ): FinancialProfileDraft => ({
   country_code: profile?.country_code ?? '',
   base_currency_code: profile?.base_currency_code ?? '',
+  tax_jurisdiction_code: jurisdictionCode
+    ? String(jurisdictionCode).trim().toUpperCase()
+    : '',
 })
 
 export const getCompatibleCurrencyCodes = (
@@ -104,11 +109,19 @@ export const hasFinancialProfileChanges = (
 
 export const canSubmitFinancialProfile = (
   response: TenantFinancialProfileResponse | null,
-  _draft: FinancialProfileDraft,
+  draft: FinancialProfileDraft,
 ): boolean => {
-  // Country/currency are immutable once a profile exists (hard lock).
-  void _draft
-  return false
+  if (!response?.profile) return false
+  // Country/currency stay immutable; allow US/CA jurisdiction completion only.
+  if (
+    response.profile.country_code !== draft.country_code
+    || response.profile.base_currency_code !== draft.base_currency_code
+  ) {
+    return false
+  }
+  const country = draft.country_code?.toUpperCase()
+  if (country !== 'US' && country !== 'CA') return false
+  return Boolean(draft.tax_jurisdiction_code?.trim())
 }
 
 export const useTenantFinancialProfile = () => {
@@ -168,6 +181,9 @@ export const useTenantFinancialProfile = () => {
         body: {
           country_code: draft.country_code,
           base_currency_code: draft.base_currency_code,
+          ...(draft.tax_jurisdiction_code
+            ? { tax_jurisdiction_code: draft.tax_jurisdiction_code }
+            : {}),
         },
       })
     },

--- a/utils/registrationFlow.test.ts
+++ b/utils/registrationFlow.test.ts
@@ -45,8 +45,8 @@ test('round-trips a normalized draft and removes it after its TTL', () => {
     phoneCountryCode: '+57',
     phoneNumber: '300 123 4567',
     businessName: '  Panaderia   Central  ',
-    businessCountryCode: 'co',
-    baseCurrencyCode: 'cop',
+    businessCountryCode: 'CO',
+    baseCurrencyCode: 'COP',
     consent: true,
     attribution: { source: 'home', variant: 'a' },
     phase: 'code',
@@ -62,6 +62,7 @@ test('round-trips a normalized draft and removes it after its TTL', () => {
     businessName: 'Panaderia Central',
     businessCountryCode: 'CO',
     baseCurrencyCode: 'COP',
+    taxJurisdictionCode: '',
     consent: true,
     attribution: { source: 'home', variant: 'a' },
     phase: 'code',
@@ -113,4 +114,29 @@ test('builds the exact API payload and computes resend cooldown', () => {
   })
   assert.equal(getRegistrationCooldownSeconds(10_000, 10_001), 30)
   assert.equal(getRegistrationCooldownSeconds(10_000, 40_000), 0)
+})
+
+test('includes tax_jurisdiction_code for US drafts', () => {
+  const draft = createRegistrationDraft({
+    email: 'owner@example.com',
+    phoneCountryCode: '1',
+    phoneNumber: '4155551234',
+    businessName: 'Cafe Mission',
+    businessCountryCode: 'US',
+    baseCurrencyCode: 'USD',
+    taxJurisdictionCode: 'ca',
+    consent: true,
+  }, 10_000)
+
+  assert.equal(draft.taxJurisdictionCode, 'CA')
+  assert.deepEqual(buildRegistrationPayload(draft), {
+    email: 'owner@example.com',
+    phone_country_code: 1,
+    phone_number: '4155551234',
+    business_name: 'Cafe Mission',
+    country_code: 'US',
+    base_currency_code: 'USD',
+    tax_jurisdiction_code: 'CA',
+    consent: true,
+  })
 })

--- a/utils/registrationFlow.ts
+++ b/utils/registrationFlow.ts
@@ -18,6 +18,7 @@ export interface RegistrationDraft {
   businessName: string
   businessCountryCode: string
   baseCurrencyCode: string
+  taxJurisdictionCode: string
   consent: boolean
   attribution: RegistrationAttribution
   phase: RegistrationPhase
@@ -73,6 +74,7 @@ export const createRegistrationDraft = (
   businessName: normalizeRegistrationBusinessName(values.businessName),
   businessCountryCode: normalizeCatalogCode(values.businessCountryCode, 2),
   baseCurrencyCode: normalizeCatalogCode(values.baseCurrencyCode, 3),
+  taxJurisdictionCode: normalizeCatalogCode(values.taxJurisdictionCode, 10),
   consent: values.consent === true,
   attribution: sanitizeRegistrationAttribution(values.attribution ?? {}),
   phase: values.phase === 'code' ? 'code' : 'form',
@@ -134,13 +136,19 @@ export const getRegistrationCooldownSeconds = (sentAt: number | null, now = Date
   return Math.max(0, Math.ceil((sentAt + REGISTRATION_RESEND_COOLDOWN_MS - now) / 1000))
 }
 
-export const buildRegistrationPayload = (draft: RegistrationDraft) => ({
-  email: normalizeRegistrationEmail(draft.email),
-  phone_country_code: Number(normalizeRegistrationPhone(draft.phoneCountryCode)),
-  phone_number: normalizeRegistrationPhone(draft.phoneNumber),
-  business_name: normalizeRegistrationBusinessName(draft.businessName),
-  country_code: normalizeCatalogCode(draft.businessCountryCode, 2),
-  base_currency_code: normalizeCatalogCode(draft.baseCurrencyCode, 3),
-  consent: draft.consent as true,
-  ...sanitizeRegistrationAttribution(draft.attribution),
-})
+export const buildRegistrationPayload = (draft: RegistrationDraft) => {
+  const country_code = normalizeCatalogCode(draft.businessCountryCode, 2)
+  const payload: Record<string, unknown> = {
+    email: normalizeRegistrationEmail(draft.email),
+    phone_country_code: Number(normalizeRegistrationPhone(draft.phoneCountryCode)),
+    phone_number: normalizeRegistrationPhone(draft.phoneNumber),
+    business_name: normalizeRegistrationBusinessName(draft.businessName),
+    country_code,
+    base_currency_code: normalizeCatalogCode(draft.baseCurrencyCode, 3),
+    consent: draft.consent as true,
+    ...sanitizeRegistrationAttribution(draft.attribution),
+  }
+  const jurisdiction = normalizeCatalogCode(draft.taxJurisdictionCode, 10)
+  if (jurisdiction) payload.tax_jurisdiction_code = jurisdiction
+  return payload
+}


### PR DESCRIPTION
## Summary
- Registration form requires US state / CA province when country needs jurisdiction; payload includes `tax_jurisdiction_code`.
- Loads jurisdiction options from public `/registration/options`.
- Financial profile settings can complete US/CA jurisdiction without unlocking country/currency.

Closes #1854.

Companion API: pair with api-warolabs PR on branch `wr-1854-geo-capture-onboarding`.

## Validation evidence
```text
bun test utils/registrationFlow.test.ts composables/useTenantFinancialProfile.test.ts
11 pass
0 fail
```

API (companion):
```text
./venv/bin/pytest tests/test_hospitality_tax_jurisdictions.py tests/test_onboarding_geo_defaults.py tests/test_magic_link_registration_contract.py -q
26 passed
```

## Test plan
- [ ] Registro US/CA blocks submit without state/province
- [ ] After verify, tax lines exist for chosen state; TZ seeded
- [ ] Wave-1 PA still works without jurisdiction field
- [ ] CO registration unchanged


Made with [Cursor](https://cursor.com)