### PR TITLE
fix(tax): parse jsonb string tax_lines from API

### DIFF
--- a/composables/useTenantTaxProfile.test.ts
+++ b/composables/useTenantTaxProfile.test.ts
@@ -29,6 +29,17 @@ describe('useTenantTaxProfile', () => {
     })).toBe(true)
   })
 
+  it('parses jsonb string tax_lines from API (asyncpg)', () => {
+    const cfg = {
+      commercial_tax_applicable: true,
+      tax_lines: '[{"key":"iva","rate":0.16,"label":"IVA 16%","gl_role":"iva","included_in_price":false}]',
+      category_map: '{"exempt":null,"liquor":"iva","standard":"iva"}',
+    }
+    expect(taxConfigHasTaxes(cfg)).toBe(true)
+    expect(taxCategoryOptions(cfg)).toEqual(['standard', 'liquor', 'exempt'])
+    expect(primaryTaxLine(cfg)?.label).toBe('IVA 16%')
+  })
+
   it('respects commercial_tax_applicable flag for tax_lines path', () => {
     const lines = [{ key: 'iva', label: 'IVA 16%', rate: 0.16, included_in_price: false, gl_role: 'iva' }]
     expect(taxConfigHasTaxes({ tax_lines: lines })).toBe(true)

--- a/composables/useTenantTaxProfile.ts
+++ b/composables/useTenantTaxProfile.ts
@@ -138,10 +138,23 @@ export function countryNeedsJurisdiction(countryCode: string | null | undefined)
   return (JURISDICTION_COUNTRY_CODES as readonly string[]).includes(code)
 }
 
+/** asyncpg often returns jsonb as a JSON string — accept both shapes. */
+function parseJsonField(raw: unknown): unknown {
+  if (typeof raw !== 'string') return raw
+  const trimmed = raw.trim()
+  if (!trimmed) return raw
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return raw
+  }
+}
+
 export function normalizeTaxLines(raw: unknown): TaxLineDraft[] {
-  if (!Array.isArray(raw)) return []
+  const parsed = parseJsonField(raw)
+  if (!Array.isArray(parsed)) return []
   const lines: TaxLineDraft[] = []
-  for (const item of raw) {
+  for (const item of parsed) {
     if (!item || typeof item !== 'object') continue
     const row = item as Record<string, unknown>
     const key = String(row.key || '').trim()
@@ -158,9 +171,10 @@ export function normalizeTaxLines(raw: unknown): TaxLineDraft[] {
 }
 
 export function normalizeCategoryMap(raw: unknown): Record<string, string | null> | null {
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
+  const parsed = parseJsonField(raw)
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
   const out: Record<string, string | null> = {}
-  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
     out[key] = value == null || value === '' ? null : String(value)
   }
   return out

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -947,7 +947,7 @@ const { data: taxConfigData } = useQuery({
   staleTime: 30_000,
 })
 const taxConfig = computed(() => taxConfigData.value?.data ?? null)
-const { taxConfigHasTaxes, taxCategoryOptions, primaryTaxLine } = useTenantTaxProfile()
+const { taxConfigHasTaxes, taxCategoryOptions, primaryTaxLine, normalizeTaxLines, normalizeCategoryMap } = useTenantTaxProfile()
 const hasTaxes = computed(() => taxConfigHasTaxes(taxConfig.value))
 const taxCategories = computed(() => taxCategoryOptions(taxConfig.value))
 const standardTaxHint = computed(() => {
@@ -956,10 +956,10 @@ const standardTaxHint = computed(() => {
   return t('menu.productos.incVatRates')
 })
 const liquorTaxHint = computed(() => {
-  const map = taxConfig.value?.category_map
+  const map = normalizeCategoryMap(taxConfig.value?.category_map)
   const liquorKey = map?.liquor
-  const lines = Array.isArray(taxConfig.value?.tax_lines) ? taxConfig.value.tax_lines : []
-  const line = liquorKey ? lines.find((l: any) => l.key === liquorKey) : null
+  const lines = normalizeTaxLines(taxConfig.value?.tax_lines)
+  const line = liquorKey ? lines.find(l => l.key === liquorKey) : null
   if (line?.label) return line.label
   return t('menu.productos.liquorVat')
 })

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -786,7 +786,7 @@ const { data: taxConfigData } = useQuery({
   staleTime: 30_000,
 })
 const taxConfig = computed(() => taxConfigData.value?.data ?? null)
-const { taxConfigHasTaxes, taxCategoryOptions, primaryTaxLine } = useTenantTaxProfile()
+const { taxConfigHasTaxes, taxCategoryOptions, primaryTaxLine, normalizeTaxLines, normalizeCategoryMap } = useTenantTaxProfile()
 const hasTaxes = computed(() => taxConfigHasTaxes(taxConfig.value))
 const taxCategories = computed(() => taxCategoryOptions(taxConfig.value))
 const standardTaxHint = computed(() => {
@@ -795,10 +795,10 @@ const standardTaxHint = computed(() => {
   return t('menu.productos.incVatRates')
 })
 const liquorTaxHint = computed(() => {
-  const map = taxConfig.value?.category_map
+  const map = normalizeCategoryMap(taxConfig.value?.category_map)
   const liquorKey = map?.liquor
-  const lines = Array.isArray(taxConfig.value?.tax_lines) ? taxConfig.value.tax_lines : []
-  const line = liquorKey ? lines.find((l: any) => l.key === liquorKey) : null
+  const lines = normalizeTaxLines(taxConfig.value?.tax_lines)
+  const line = liquorKey ? lines.find(l => l.key === liquorKey) : null
   if (line?.label) return line.label
   return t('menu.productos.liquorVat')
 })


### PR DESCRIPTION
## Summary
- Parse `tax_lines` / `category_map` when the API returns jsonb as JSON strings (asyncpg quirk)
- Menú product create/edit liquor hints use the same normalizers so labels resolve correctly

Unblocks Facturación/Menú matrix work under epic #1871 (pairs with api-warolabs#734 decode).

Refs uno0uno/warocol.com#1871

## Validation evidence
```text
$ bun test composables/useTenantTaxProfile.test.ts
 18 pass
 0 fail
 43 expect() calls
Ran 18 tests across 1 file. [194.00ms]
```

## Test plan
- [ ] Commercial tenant with string jsonb tax_lines: Menú shows tax categories and liquor line label
- [ ] CO tenant unchanged
- [ ] Unit test for asyncpg string parse passes