### PR TITLE
fix(tax): persist unassigned category chips after save

### DIFF
--- a/composables/useTenantTaxProfile.test.ts
+++ b/composables/useTenantTaxProfile.test.ts
@@ -246,6 +246,18 @@ describe('useTenantTaxProfile', () => {
     })).toBeNull()
   })
 
+  it('matrix save preserves explicit null category map (no primary fallback)', () => {
+    const payload = buildCommercialMatrixSavePayload({
+      lines: [{ key: 'iva', label: 'IVA 16%', rate: 0.16, included_in_price: false, gl_role: 'iva' }],
+      category_map: { standard: null, liquor: null, exempt: null },
+    })
+    expect(payload.category_map).toEqual({
+      standard: null,
+      liquor: null,
+      exempt: null,
+    })
+  })
+
   it('blocks removing a line still referenced by category_map', () => {
     expect(canRemoveTaxLine('iva', { standard: 'iva', liquor: 'iva', exempt: null })).toBe(false)
     expect(canRemoveTaxLine('mwst_standard', {

--- a/composables/useTenantTaxProfile.ts
+++ b/composables/useTenantTaxProfile.ts
@@ -248,7 +248,17 @@ export function validateCommercialMatrix(options: {
 /**
  * Full-matrix commercial PUT body (#1874).
  * Prefer this over primary-only buildCommercialTaxSavePayload.
+ * Explicit null/empty category mappings must persist (do not ?? to primary).
  */
+export function resolveCategoryMapValue(
+  value: string | null | undefined,
+  fallback: string | null,
+): string | null {
+  if (value === undefined) return fallback
+  if (value == null || value === '') return null
+  return String(value)
+}
+
 export function buildCommercialMatrixSavePayload(options: {
   lines: TaxLineDraft[]
   category_map: Record<string, string | null>
@@ -260,10 +270,12 @@ export function buildCommercialMatrixSavePayload(options: {
     included_in_price: Boolean(line.included_in_price),
     gl_role: String(line.gl_role || 'iva'),
   }))
+  const primaryKey = tax_lines[0]?.key || null
+  const standard = resolveCategoryMapValue(options.category_map?.standard, primaryKey)
   const category_map: Record<string, string | null> = {
-    standard: options.category_map?.standard ?? (tax_lines[0]?.key || null),
-    liquor: options.category_map?.liquor ?? options.category_map?.standard ?? (tax_lines[0]?.key || null),
-    exempt: options.category_map?.exempt ?? null,
+    standard,
+    liquor: resolveCategoryMapValue(options.category_map?.liquor, standard),
+    exempt: resolveCategoryMapValue(options.category_map?.exempt, null),
   }
   return { tax_lines, category_map }
 }
@@ -476,5 +488,6 @@ export function useTenantTaxProfile() {
     validateCommercialMatrix,
     canRemoveTaxLine,
     suggestTaxLineKey,
+    resolveCategoryMapValue,
   }
 }

--- a/pages/facturacion/index.vue
+++ b/pages/facturacion/index.vue
@@ -253,6 +253,7 @@ const {
   suggestTaxLineKey,
   normalizeTaxLines,
   normalizeCategoryMap,
+  resolveCategoryMapValue,
   countryNeedsJurisdiction,
   shouldShowWave1CountryPicker,
   shouldShowJurisdictionPicker,
@@ -396,8 +397,9 @@ const uiLinesToDraft = () => commercialLines.value.map(line => ({
 
 const setCategoryMapFrom = (map: Record<string, string | null> | null | undefined, fallbackKey?: string | null) => {
   const primary = fallbackKey || map?.standard || commercialLines.value[0]?.key || null
-  commercialCategoryMap.standard = map?.standard ?? primary
-  commercialCategoryMap.liquor = map?.liquor ?? primary
+  // Explicit null must stick after unassign; only undefined falls back to primary.
+  commercialCategoryMap.standard = resolveCategoryMapValue(map?.standard, primary)
+  commercialCategoryMap.liquor = resolveCategoryMapValue(map?.liquor, primary)
   // Exempt products never map to a tax line.
   commercialCategoryMap.exempt = null
 }


### PR DESCRIPTION
## Summary
- Preserve explicit `null` in `category_map` when building the commercial matrix save payload
- Same on Facturación reload (`setCategoryMapFrom`) so chips stay off after Guardar
- Unit test covers null map (no primary-key fallback)

Closes #1879

## Test plan
- [ ] MX tenant: remove Estándar + Licores chips → Guardar → reload → chips stay off
- [ ] Re-add Estándar via searcher → save → chip returns
- [ ] Exento remains unmapped (no chip / no line)

## Validation evidence
```text
$ bun test composables/useTenantTaxProfile.test.ts
bun test v1.2.21 (7c45ed97)

  26 pass
  0 fail
  63 expect() calls
Ran 26 tests across 1 file. [1454.00ms]
```

## wr-context
See `.wr/1879.yaml` on this branch (LLM contract; gitignored locally if present).

Made with [Cursor](https://cursor.com)