### PR TITLE
fix(pos): hide checkout summary tax row when tax is zero

### DIFF
--- a/.wr/1891.yaml
+++ b/.wr/1891.yaml
@@ -1,0 +1,52 @@
+# Compact plan — uno0uno/warocol.com#1891 (epic #1890 batch 1). Keep <=80 lines.
+issue: 1891
+title: "Load menu tax maps in POS/orders tax config + hide $0 tax on tickets"
+repo: both
+repo_remote: uno0uno/api-warolabs # + front PR uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+stack: both
+branch: wr-1891-pos-tax-menu-config
+front_branch: wr-1891-hide-zero-tax-summary
+front_cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+closes: "Closes uno0uno/warocol.com#1891"
+
+paths:
+  - app/services/cierre_service.py # WIP: SELECT + decode menu maps
+  - tests/test_menu_category_tax_resolve.py # WIP: loader test
+  - ../front_nuxt/pages/pos/checkout.vue # hide summary tax rows at $0 (~4006, ~4509)
+
+ac:
+  - "_get_tenant_tax_config returns menu_category_line_map + exempt_menu_category_ids (decoded)"
+  - "Exempt menu category (inherit): POS tax-preview + completed order tax amount = 0"
+  - "Checkout Resumen de la Orden: no tax row when (standard_tax+liquor_tax)==0"
+  - "Print tickets/ventas already v-if>0 — no change unless a $0 line remains"
+  - "pytest tests/test_menu_category_tax_resolve.py passes; listed in PR"
+
+out_of_scope:
+  - DIAN/jurisdiction labels (#1892)
+  - FE auto-email (#1893)
+  - Cash keypad (#1894)
+  - Re-plumbing category_id (#1889 merged)
+  - Facturación settings UI
+
+hints:
+  entry: "cierre_service._get_tenant_tax_config → pos_cart/orders/tables tax paths"
+  pattern: "checkout.vue ~4866 / ReceiptPrintTicket.vue ~337 v-if tax > 0"
+  wip: "API diff already on main working tree — branch + commit; do not rewrite"
+  front: "v-if on summary tax divs only; keep label localization unchanged"
+  tests: "cd api_warocol.com && ./venv/bin/pytest tests/test_menu_category_tax_resolve.py -q"
+
+risk:
+  sensitive: false
+  areas: [tax-config-read]
+
+skip:
+  audits: [ux, color, typography, security-full]
+
+steps:
+  - "API: pull main, branch wr-1891-pos-tax-menu-config, commit WIP, push, PR → api-warolabs"
+  - "Front: pull main, branch wr-1891-hide-zero-tax-summary, gate checkout summary tax rows, PR → warocol.com"
+  - "Both PR bodies: Closes uno0uno/warocol.com#1891 (or Closes #1891 on warocol.com PR)"
+
+next:
+  after_pr: "/wr-next uno0uno/warocol.com#1890"

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -4003,10 +4003,13 @@ onUnmounted(() => {
 	                <span>{{ waroRewardLabel ? `WaRo: ${waroRewardLabel}` : t('pos.checkout.summary.waroRedeem') }}</span>
                 <span class="font-medium">- {{ formatCurrency(waroDiscountCop) }}</span>
               </div>
-              <div class="flex justify-between text-sm text-text-secondary">
-	                <span>{{ taxPreview ? localizedInternalTaxLabel(taxPreview.standard_tax_label) : t('pos.checkout.summary.taxesZero') }}</span>
+              <div
+                v-if="taxPreview && (taxPreview.standard_tax + taxPreview.liquor_tax) > 0"
+                class="flex justify-between text-sm text-text-secondary"
+              >
+	                <span>{{ localizedInternalTaxLabel(taxPreview.standard_tax_label) }}</span>
                 <span class="font-medium text-text-primary">
-                  {{ formatCurrency(taxPreview ? (taxPreview.standard_tax + taxPreview.liquor_tax) : 0) }}
+                  {{ formatCurrency(taxPreview.standard_tax + taxPreview.liquor_tax) }}
                 </span>
               </div>
               <div
@@ -4505,10 +4508,13 @@ onUnmounted(() => {
 	              <span>{{ waroRewardLabel ? `WaRo: ${waroRewardLabel}` : t('pos.checkout.summary.waroRedeem') }}</span>
               <span class="font-medium">- {{ formatCurrency(waroDiscountCop) }}</span>
             </div>
-            <div class="flex justify-between text-sm text-text-secondary">
-	              <span>{{ taxPreview ? localizedInternalTaxLabel(taxPreview.standard_tax_label) : t('pos.checkout.summary.taxesZero') }}</span>
+            <div
+              v-if="taxPreview && (taxPreview.standard_tax + taxPreview.liquor_tax) > 0"
+              class="flex justify-between text-sm text-text-secondary"
+            >
+	              <span>{{ localizedInternalTaxLabel(taxPreview.standard_tax_label) }}</span>
               <span class="font-medium text-text-primary">
-                {{ formatCurrency(taxPreview ? (taxPreview.standard_tax + taxPreview.liquor_tax) : 0) }}
+                {{ formatCurrency(taxPreview.standard_tax + taxPreview.liquor_tax) }}
               </span>
             </div>
             <div


### PR DESCRIPTION
## Summary
- Resumen de la Orden no longer shows an IVA/tax line when `standard_tax + liquor_tax` is 0 (desktop + mobile summary).
- Pairs with api-warolabs PR that loads menu exempt maps into POS tax config.

Closes #1891

## Test plan
- [ ] Exempt category cart: summary has no tax row; total = subtotal
- [ ] Taxable cart: tax row still visible with correct amount
- [ ] Prefactura/receipt print already hid $0 lines — unchanged

## Validation evidence

```text
Front-only template gate (v-if). API validation on companion PR:
./venv/bin/pytest tests/test_menu_category_tax_resolve.py -q → 15 passed
```


Made with [Cursor](https://cursor.com)