### PR TITLE
feat(pos): replace cash presets with numeric keypad

### DIFF
--- a/.wr/1894.yaml
+++ b/.wr/1894.yaml
@@ -1,0 +1,51 @@
+# Compact plan — uno0uno/warocol.com#1894 (epic #1890 batch 4). Keep <=80 lines.
+issue: 1894
+title: "POS Efectivo recibido numeric keypad (1–9 + 0)"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1894-cash-numeric-keypad
+closes: "Closes #1894"
+
+paths:
+  - components/checkout/CashTenderPanel.vue # replace COP presets with digit keypad
+  - i18n/locales/es/pos.json # optional backspace/clear aria labels under pos.cash
+  - i18n/locales/en/pos.json # mirror
+
+ac:
+  - "Cashier can enter arbitrary amount with digits 1–9 and 0 (e.g. 145) without denomination presets"
+  - "Sin vuelto still sets cashReceived = amountToCharge; Vuelto/shortfall still correct"
+  - "Display still uses integer-money locale formatting (MXN/COP etc.)"
+  - "Touch-friendly keys (min-h ~56px+); backspace and/or clear present"
+  - "Manual POS cash payment check noted in PR"
+
+out_of_scope:
+  - Tax / DIAN labels / FE email (#1891–#1893)
+  - checkout.vue payment method selection
+  - cash_received API / backend validation
+  - finanzas/arqueo denomination UI
+
+hints:
+  entry: "CashTenderPanel.vue — remove cashPresetsExtra (~25–30, ~87–97)"
+  keep: "Sin vuelto button; vuelto/shortfall; text input optional for hardware kb"
+  model: "append digit to integer string of cashReceived; formatIntegerMoney/parseIntegerMoney"
+  layout: "grid-cols-3: 1-9, then row with ⌫ / 0 / C (or similar)"
+  callers: "checkout.vue CheckoutCashTenderPanel mounts — no API change"
+  tests: "manual POS cash tender; no unit harness required unless extract digit helper"
+
+risk:
+  sensitive: false
+  areas: [pos-cash-ui]
+
+skip:
+  audits: [ux-full, color, typography, security-full]
+
+steps:
+  - "pull main; branch wr-1894-cash-numeric-keypad"
+  - "Replace presets with keypad; keep Sin vuelto + vuelto"
+  - "Add es/en aria for backspace/clear if needed"
+  - "PR closes #1894; note MXN 145 manual check"
+
+next:
+  after_pr: "/wr-next uno0uno/warocol.com#1890"

--- a/components/checkout/CashTenderPanel.vue
+++ b/components/checkout/CashTenderPanel.vue
@@ -22,12 +22,7 @@ const uiLocale = computed<UiLocale>(() =>
   normalizeUiLocale(locale.value),
 )
 
-const cashPresetsExtra = [
-  { label: '+ $1.000', offset: 1000 },
-  { label: '+ $5.000', offset: 5000 },
-  { label: '+ $10.000', offset: 10000 },
-  { label: '+ $20.000', offset: 20000 },
-] as const
+const keypadDigits = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const
 
 const { formatCurrency } = useFormatters()
 
@@ -48,6 +43,24 @@ const onCashReceivedInput = (e: Event) => {
   input.value = formatIntegerMoney(raw, uiLocale.value)
 }
 
+const appendDigit = (digit: string) => {
+  const current = Math.max(0, Math.floor(Number(cashReceived.value) || 0))
+  const next = `${current === 0 ? '' : String(current)}${digit}`
+  // Cap length to avoid absurd POS amounts from repeated taps
+  if (next.length > 12) return
+  cashReceived.value = Number(next)
+}
+
+const backspaceDigit = () => {
+  const current = Math.max(0, Math.floor(Number(cashReceived.value) || 0))
+  const next = String(current).slice(0, -1)
+  cashReceived.value = next ? Number(next) : 0
+}
+
+const clearAmount = () => {
+  cashReceived.value = 0
+}
+
 const showVuelto = computed(() => {
   if (props.requireInputForFeedback && cashReceived.value <= 0) return false
   return cashShortfall.value <= 0.01
@@ -56,6 +69,9 @@ const showShortfall = computed(() => {
   if (props.requireInputForFeedback && cashReceived.value <= 0) return false
   return cashShortfall.value > 0.01
 })
+
+const keyBtnClass =
+  'min-h-[56px] px-4 py-3 rounded-lg bg-surface-secondary dark:bg-surface text-text-primary text-xl font-semibold hover:bg-border/50 transition-colors focus:outline-none focus:ring-2 focus:ring-primary active:scale-95'
 </script>
 
 <template>
@@ -84,15 +100,44 @@ const showShortfall = computed(() => {
     >
       {{ t('pos.cash.exact') }}
     </button>
-    <div class="grid grid-cols-2 gap-3">
+    <div
+      class="grid grid-cols-3 gap-3"
+      role="group"
+      :aria-label="t('pos.cash.keypadAria')"
+    >
       <button
-        v-for="preset in cashPresetsExtra"
-        :key="preset.label"
+        v-for="digit in keypadDigits"
+        :key="digit"
         type="button"
-        class="min-h-[56px] px-4 py-3 rounded-lg bg-surface-secondary dark:bg-surface text-text-primary text-base font-semibold hover:bg-border/50 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
-        @click="cashReceived = (cashReceived || 0) + preset.offset"
+        :class="keyBtnClass"
+        :aria-label="t('pos.cash.digitAria', { digit })"
+        @click="appendDigit(digit)"
       >
-        {{ preset.label }}
+        {{ digit }}
+      </button>
+      <button
+        type="button"
+        :class="keyBtnClass"
+        :aria-label="t('pos.cash.backspaceAria')"
+        @click="backspaceDigit"
+      >
+        ⌫
+      </button>
+      <button
+        type="button"
+        :class="keyBtnClass"
+        :aria-label="t('pos.cash.digitAria', { digit: '0' })"
+        @click="appendDigit('0')"
+      >
+        0
+      </button>
+      <button
+        type="button"
+        :class="keyBtnClass"
+        :aria-label="t('pos.cash.clearAria')"
+        @click="clearAmount"
+      >
+        {{ t('pos.cash.clear') }}
       </button>
     </div>
     <div

--- a/i18n/locales/en/pos.json
+++ b/i18n/locales/en/pos.json
@@ -426,7 +426,12 @@
       "exact": "No change",
       "exactAria": "Pay exact amount, no change",
       "change": "Change",
-      "shortfall": "{amount} still due"
+      "shortfall": "{amount} still due",
+      "keypadAria": "Cash amount numeric keypad",
+      "digitAria": "Digit {digit}",
+      "backspaceAria": "Delete last digit",
+      "clear": "C",
+      "clearAria": "Clear amount"
     },
     "payment": {
       "tableAdvance": "Table advance",

--- a/i18n/locales/es/pos.json
+++ b/i18n/locales/es/pos.json
@@ -426,7 +426,12 @@
       "exact": "Sin vuelto",
       "exactAria": "Pagar exacto, sin vuelto",
       "change": "Vuelto",
-      "shortfall": "Falta cobrar {amount}"
+      "shortfall": "Falta cobrar {amount}",
+      "keypadAria": "Teclado numérico de efectivo",
+      "digitAria": "Dígito {digit}",
+      "backspaceAria": "Borrar último dígito",
+      "clear": "C",
+      "clearAria": "Borrar monto"
     },
     "payment": {
       "tableAdvance": "Anticipo mesa",


### PR DESCRIPTION
## Summary
- Replace COP \`+ \$1.000\` presets in Efectivo recibido with a touch numeric keypad (1–9, 0, ⌫, C).
- Keep Sin vuelto + Vuelto/shortfall and integer-money locale formatting.

Closes #1894

## Test plan
- [ ] POS cash: enter 145 via keypad; vuelto correct vs amount due
- [ ] Sin vuelto still sets exact amount
- [ ] ⌫ and C work; MXN/COP display formatting unchanged
- [ ] Split cash tender still works if used

## Validation evidence

```text
JSON i18n parse: ok
Digit append logic smoke:
  0→1→4→5 = 145
  backspace = 14
  append 0 on empty = 0
Manual POS cash tender required on device/browser.
```


Made with [Cursor](https://cursor.com)