### PR TITLE
fix(pos): dynamic liquor tax labels on checkout and receipts (#1899)

### DIFF
--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -84,6 +84,7 @@ const props = defineProps<{
   waroDiscountAmount?: number
   standardTaxLabel?: string | null
   standardTax?: number
+  liquorTaxLabel?: string | null
   liquorTax?: number
   orderTotal: number
   tipLabel?: string
@@ -166,6 +167,12 @@ const displayStandardTaxLabel = computed(() =>
   localizedInternalTaxLabel(props.standardTaxLabel),
 )
 
+const displayLiquorTaxLabel = computed(() => {
+  const raw = String(props.liquorTaxLabel ?? '').trim()
+  if (!raw) return t('pos.receipt.liquorVat')
+  return localizedInternalTaxLabel(raw)
+})
+
 const invoiceNumberLabel = computed(() => {
   const invoice = props.invoice
   if (!invoice) return null
@@ -215,7 +222,7 @@ const invoiceTaxLines = computed(() => {
     lines.push({ label: displayStandardTaxLabel.value, amount: props.standardTax })
   }
   if (Number(props.liquorTax) > 0) {
-    lines.push({ label: t('pos.checkout.liquorVat'), rate: 5, amount: props.liquorTax })
+    lines.push({ label: displayLiquorTaxLabel.value, amount: props.liquorTax })
   }
   return lines
 })
@@ -341,7 +348,7 @@ const printableItems = computed(() =>
         <span>{{ money(standardTax) }}</span>
       </div>
       <div v-if="Number(liquorTax) > 0" class="receipt-item receipt-small">
-        <span>{{ t('pos.receipt.liquorVat') }}</span>
+        <span>{{ displayLiquorTaxLabel }}</span>
         <span>{{ money(liquorTax) }}</span>
       </div>
     </template>

--- a/composables/useTenantTaxProfile.test.ts
+++ b/composables/useTenantTaxProfile.test.ts
@@ -21,6 +21,7 @@ import {
   taxLineForCategory,
   validateCommercialMatrix,
   wave1PresetForCountry,
+  additiveOrderTaxTotal,
 } from './useTenantTaxProfile'
 
 describe('useTenantTaxProfile', () => {
@@ -375,5 +376,33 @@ describe('useTenantTaxProfile', () => {
     expect(legacyTaxCategoryFromResolution(cfg, {
       tax_resolution: 'exempt',
     })).toBe('exempt')
+  })
+
+  it('additiveOrderTaxTotal includes exclusive MX IVA and skips included CO INC', () => {
+    const mx = {
+      tax_lines: [{ key: 'iva', label: 'IVA 16%', rate: 0.16, included_in_price: false, gl_role: 'iva' }],
+      category_map: { standard: 'iva', liquor: 'iva', exempt: null },
+    }
+    expect(additiveOrderTaxTotal(0, 371, mx)).toBe(371)
+    expect(additiveOrderTaxTotal(371, 0, mx)).toBe(371)
+
+    expect(additiveOrderTaxTotal(800, 0, {
+      inc_applicable: true,
+      inc_included_in_price: true,
+    })).toBe(0)
+    expect(additiveOrderTaxTotal(800, 1000, {
+      inc_applicable: true,
+      inc_included_in_price: true,
+      liquor_tax_applicable: true,
+    })).toBe(1000)
+  })
+
+  it('additiveOrderTaxTotal falls back to preview sum when tax_lines missing from context', () => {
+    // POS restaurant-context used to omit commercial tax_lines (MX trial).
+    expect(additiveOrderTaxTotal(0, 186, {
+      inc_applicable: false,
+      iva_applicable: false,
+      liquor_tax_applicable: false,
+    })).toBe(186)
   })
 })

--- a/composables/useTenantTaxProfile.ts
+++ b/composables/useTenantTaxProfile.ts
@@ -381,6 +381,45 @@ export function primaryTaxLine(cfg: Record<string, unknown> | null | undefined):
   return taxLineForCategory(cfg, 'standard')
 }
 
+/**
+ * Tax dollars charged on top of product prices (mirrors API additive_order_tax_total).
+ * Included-in-price standard tax is extractive — omitted from amount due.
+ */
+export function additiveOrderTaxTotal(
+  standardTax: number,
+  liquorTax: number,
+  cfg: Record<string, unknown> | null | undefined,
+): number {
+  const std = Number(standardTax) || 0
+  const liq = Number(liquorTax) || 0
+  const stdLine = taxLineForCategory(cfg, 'standard')
+  const liqLine = taxLineForCategory(cfg, 'liquor')
+
+  let stdAdditive = false
+  if (stdLine) {
+    stdAdditive = !stdLine.included_in_price
+  } else if (cfg?.inc_applicable) {
+    stdAdditive = !Boolean(cfg.inc_included_in_price ?? true)
+  } else if (cfg?.iva_applicable) {
+    stdAdditive = !Boolean(cfg.iva_included_in_price ?? false)
+  }
+
+  let liqAdditive = false
+  if (liqLine) {
+    liqAdditive = !liqLine.included_in_price
+  } else if (cfg?.liquor_tax_applicable) {
+    liqAdditive = true
+  }
+
+  // restaurant-context historically omitted tax_lines; if we cannot classify but
+  // the preview already computed taxes, treat them as additive (MX / commercial).
+  if (!stdLine && !liqLine && !cfg?.inc_applicable && !cfg?.iva_applicable && !cfg?.liquor_tax_applicable) {
+    return std + liq
+  }
+
+  return (stdAdditive ? std : 0) + (liqAdditive ? liq : 0)
+}
+
 /** Product tax_category keys to show in Menú (shared POS + venta directa). */
 export function taxCategoryOptions(cfg: Record<string, unknown> | null | undefined): TaxCategoryKey[] {
   if (!taxConfigHasTaxes(cfg)) return []

--- a/i18n/locales/ar/pos.json
+++ b/i18n/locales/ar/pos.json
@@ -43,6 +43,8 @@
       "delivered": "تم التسليم",
       "firedAt": "بدء التحضير:",
       "perUnit": "لكل وحدة",
+      "taxLine": "{label} · {amount}",
+      "taxIncluded": "يشمل {label} · {amount}",
       "note": "ملاحظة:",
       "decreaseQtyAria": "تقليل الكمية",
       "increaseQtyAria": "زيادة الكمية",

--- a/i18n/locales/de/pos.json
+++ b/i18n/locales/de/pos.json
@@ -43,6 +43,8 @@
       "delivered": "Geliefert",
       "firedAt": "Bestellt:",
       "perUnit": "Stk.",
+      "taxLine": "{label} · {amount}",
+      "taxIncluded": "Inkl. {label} · {amount}",
       "note": "Hinweis:",
       "decreaseQtyAria": "Menge reduzieren",
       "increaseQtyAria": "Menge erhöhen",

--- a/i18n/locales/en/pos.json
+++ b/i18n/locales/en/pos.json
@@ -43,6 +43,8 @@
       "delivered": "Delivered",
       "firedAt": "Fired:",
       "perUnit": "ea",
+      "taxLine": "{label} · {amount}",
+      "taxIncluded": "Includes {label} · {amount}",
       "note": "Note:",
       "decreaseQtyAria": "Decrease quantity",
       "increaseQtyAria": "Increase quantity",

--- a/i18n/locales/es/pos.json
+++ b/i18n/locales/es/pos.json
@@ -43,6 +43,8 @@
       "delivered": "Entregado",
       "firedAt": "Fuego:",
       "perUnit": "c/u",
+      "taxLine": "{label} · {amount}",
+      "taxIncluded": "Incluye {label} · {amount}",
       "note": "Nota:",
       "decreaseQtyAria": "Reducir cantidad",
       "increaseQtyAria": "Aumentar cantidad",

--- a/i18n/locales/fr/pos.json
+++ b/i18n/locales/fr/pos.json
@@ -43,6 +43,8 @@
       "delivered": "Livré",
       "firedAt": "Envoyé à :",
       "perUnit": "l'unité",
+      "taxLine": "{label} · {amount}",
+      "taxIncluded": "Inclut {label} · {amount}",
       "note": "Note :",
       "decreaseQtyAria": "Diminuer la quantité",
       "increaseQtyAria": "Augmenter la quantité",

--- a/i18n/locales/hi/pos.json
+++ b/i18n/locales/hi/pos.json
@@ -43,6 +43,8 @@
       "delivered": "डिलीवर किया गया",
       "firedAt": "भेजा गया:",
       "perUnit": "प्रत्येक",
+      "taxLine": "{label} · {amount}",
+      "taxIncluded": "शामिल {label} · {amount}",
       "note": "नोट:",
       "decreaseQtyAria": "मात्रा घटाएँ",
       "increaseQtyAria": "मात्रा बढ़ाएँ",

--- a/i18n/locales/pt/pos.json
+++ b/i18n/locales/pt/pos.json
@@ -43,6 +43,8 @@
       "delivered": "Entregue",
       "firedAt": "Disparado:",
       "perUnit": "cada",
+      "taxLine": "{label} · {amount}",
+      "taxIncluded": "Inclui {label} · {amount}",
       "note": "Nota:",
       "decreaseQtyAria": "Diminuir quantidade",
       "increaseQtyAria": "Aumentar quantidade",

--- a/i18n/locales/zh/pos.json
+++ b/i18n/locales/zh/pos.json
@@ -43,6 +43,8 @@
       "delivered": "已送达",
       "firedAt": "下单时间:",
       "perUnit": "每件",
+      "taxLine": "{label} · {amount}",
+      "taxIncluded": "含 {label} · {amount}",
       "note": "备注:",
       "decreaseQtyAria": "减少数量",
       "increaseQtyAria": "增加数量",

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -163,6 +163,7 @@ const orderResult = ref<{
   standard_tax?: number
   liquor_tax?: number
   standard_tax_label?: string
+  liquor_tax_label?: string
   order_id?: string
   order_ids?: string[]
   order_numbers?: number[]
@@ -302,6 +303,7 @@ type TaxPreview = {
   standard_tax: number
   liquor_tax: number
   standard_tax_label: string
+  liquor_tax_label?: string
 }
 
 type PromoPreviewLine = {
@@ -316,6 +318,10 @@ type PromoPreviewLine = {
   promoType?: string | null
   locked_promo_type?: string | null
   subtotal_after_promo?: number
+  tax_amount?: number
+  tax_label?: string | null
+  tax_rate?: number | null
+  included_in_price?: boolean | null
 }
 
 type CheckoutPromoPreview = {
@@ -763,9 +769,11 @@ const discountedTotal = computed(() =>
 )
 // warocol.com#639 — final amount charged to the customer when tipping is enabled.
 // total_amount on orders never includes tip (tax-base invariant from migration 079);
-// charged_amount = total_amount + tip_amount lives at the payment layer only.
+// charged_amount = total_amount + additive tax + tip (see additiveTaxTotal after taxPreview).
 const finalChargedAmount = computed(() =>
-  discountedTotal.value + tipSettlementTotal(tipAmount.value, tipTaxAmount.value),
+  discountedTotal.value
+  + additiveTaxTotal.value
+  + tipSettlementTotal(tipAmount.value, tipTaxAmount.value),
 )
 
 // ── Parallel-loading queries (replaces manual refreshTaxPreview + #656 rehydration $fetch).
@@ -799,6 +807,7 @@ const { data: posTaxPreviewData } = useQuery({
       standard_tax: number
       liquor_tax: number
       standard_tax_label: string
+      liquor_tax_label?: string
       subtotal?: number
       promo_savings?: number
       subtotal_after_promos?: number
@@ -822,6 +831,7 @@ const taxPreview = computed<TaxPreview | null>(() => {
       standard_tax: Number(session.standard_tax) || 0,
       liquor_tax: Number(session.liquor_tax) || 0,
       standard_tax_label: localizedInternalTaxLabel(session.standard_tax_label),
+      liquor_tax_label: localizedInternalTaxLabel(session.liquor_tax_label),
     }
   }
   const data = posTaxPreviewData.value
@@ -830,8 +840,18 @@ const taxPreview = computed<TaxPreview | null>(() => {
     standard_tax: Number(data.standard_tax) || 0,
     liquor_tax: Number(data.liquor_tax) || 0,
     standard_tax_label: localizedInternalTaxLabel(data.standard_tax_label),
+    liquor_tax_label: localizedInternalTaxLabel(data.liquor_tax_label),
   }
 })
+
+/** Exclusive tax added on top of product prices (MX IVA); omitted when included_in_price (CO INC). */
+const additiveTaxTotal = computed(() =>
+  additiveOrderTaxTotal(
+    taxPreview.value?.standard_tax ?? 0,
+    taxPreview.value?.liquor_tax ?? 0,
+    tenantTaxConfig.value as Record<string, unknown> | null,
+  ),
+)
 
 // Tax preview is auto-recomputed via useQuery (mesaCurrentData / posTaxPreviewData)
 // — discount/cart changes invalidate the query keys, no manual debounce needed.
@@ -935,7 +955,9 @@ const voidPaymentTarget = ref<{ id: string; amount: number; payment_method: stri
 const voidPaymentReason = ref('')
 const voidPaymentError = ref('')
 const splitAmountDue = computed(() =>
-  discountedTotal.value + tipSettlementTotal(tipAmount.value, tipTaxAmount.value),
+  discountedTotal.value
+  + additiveTaxTotal.value
+  + tipSettlementTotal(tipAmount.value, tipTaxAmount.value),
 )
 const splitRemaining = computed(() => Math.max(0, splitAmountDue.value - splitPaidTotal.value))
 const splitIsComplete = computed(() => splitRemaining.value <= 0.01)
@@ -1021,6 +1043,7 @@ function openSplitSuccessModal(completeData: Record<string, any>) {
     standard_tax: Number(completeData.standard_tax ?? taxPreview.value?.standard_tax ?? 0),
     liquor_tax: Number(completeData.liquor_tax ?? taxPreview.value?.liquor_tax ?? 0),
     standard_tax_label: localizedInternalTaxLabel(completeData.standard_tax_label ?? taxPreview.value?.standard_tax_label),
+    liquor_tax_label: localizedInternalTaxLabel(completeData.liquor_tax_label ?? taxPreview.value?.liquor_tax_label),
     ...(tipAmount.value > 0
       ? {
           tip_amount: Number(completeData.tip_amount ?? tipAmount.value),
@@ -1669,6 +1692,25 @@ const getLinePromoPreview = (item: any): PromoPreviewLine | undefined => {
   return key ? promoLineById.value.get(key) : undefined
 }
 
+const getLineTaxInfo = (item: any): { amount: number; label: string; includedInPrice: boolean } | null => {
+  const preview = getLinePromoPreview(item)
+  const amount = Number(preview?.tax_amount) || 0
+  if (amount <= 0) return null
+  return {
+    amount,
+    label: localizedInternalTaxLabel(preview?.tax_label),
+    includedInPrice: preview?.included_in_price === true,
+  }
+}
+
+const formatLineTaxDisplay = (info: { amount: number; label: string; includedInPrice: boolean }): string => {
+  const amount = formatCurrency(info.amount)
+  if (info.includedInPrice) {
+    return t('pos.cartItem.taxIncluded', { label: info.label, amount })
+  }
+  return t('pos.cartItem.taxLine', { label: info.label, amount })
+}
+
 const getLinePromoSavings = (item: any): number => {
   if (isLinePromoOptedOut(item)) return 0
   const preview = getLinePromoPreview(item)
@@ -1879,6 +1921,7 @@ const processOrder = async () => {
           standard_tax: taxPreview.value?.standard_tax ?? 0,
           liquor_tax: taxPreview.value?.liquor_tax ?? 0,
           standard_tax_label: localizedInternalTaxLabel(taxPreview.value?.standard_tax_label),
+          liquor_tax_label: localizedInternalTaxLabel(taxPreview.value?.liquor_tax_label),
         }
         wasMesaMode.value = false
         cartItemsSnapshot.value = [...cartItems.value]
@@ -1968,6 +2011,7 @@ const processOrder = async () => {
         standard_tax: Number(closeData.standard_tax) || 0,
         liquor_tax: Number(closeData.liquor_tax) || 0,
         standard_tax_label: localizedInternalTaxLabel(closeData.standard_tax_label),
+        liquor_tax_label: localizedInternalTaxLabel(closeData.liquor_tax_label),
         ...promoFieldsFromCloseResponse(closeData, _subtotal),
         ...(discountEnabled.value && _discountAmt > 0
           ? { discount_amount: _discountAmt, subtotal: _subtotal }
@@ -2082,6 +2126,7 @@ const processOrder = async () => {
         standard_tax?: number
         liquor_tax?: number
         standard_tax_label?: string
+        liquor_tax_label?: string
         next_table_session_id?: string | null
         subtotal?: number
         promo_savings?: number
@@ -2106,6 +2151,7 @@ const processOrder = async () => {
         standard_tax: response.data.standard_tax ?? 0,
         liquor_tax: response.data.liquor_tax ?? 0,
         standard_tax_label: localizedInternalTaxLabel(response.data.standard_tax_label),
+        liquor_tax_label: localizedInternalTaxLabel(response.data.liquor_tax_label),
         ...promoFieldsFromCloseResponse(response.data, _subtotalPos),
         ...(discountEnabled.value && _discountAmtPos > 0
           ? { discount_amount: _discountAmtPos, subtotal: _subtotalPos }
@@ -2540,12 +2586,10 @@ const receiptDocumentLabel = computed(() => {
   return label
 })
 
-const prefacturaTaxTotal = computed(() => {
-  if (!taxPreview.value) return 0
-  return (taxPreview.value.standard_tax || 0) + (taxPreview.value.liquor_tax || 0)
-})
+const prefacturaTaxTotal = computed(() => additiveTaxTotal.value)
 
 // Mesa runningTotal already includes session taxes; counter cartTotal is pre-tax.
+// Counter amount due adds only additive (exclusive) tax — included-in-price tax stays in prices.
 const prefacturaOrderTotal = computed(() => {
   if (isKitchenServiceMode.value) return discountedTotal.value
   return discountedTotal.value + prefacturaTaxTotal.value
@@ -2684,8 +2728,7 @@ const receiptInvoiceTaxLines = computed(() => {
       amount: Number(result.standard_tax) || 0,
     },
     {
-      label: t('pos.checkout.liquorVat'),
-      rate: 5,
+      label: localizedInternalTaxLabel(result.liquor_tax_label) || t('pos.receipt.liquorVat'),
       amount: Number(result.liquor_tax) || 0,
     },
   ].filter(line => Number(line.amount) > 0)
@@ -2948,6 +2991,7 @@ const sendReceiptEmail = async () => {
         standard_tax: orderResult.value.standard_tax ?? 0,
         liquor_tax: orderResult.value.liquor_tax ?? 0,
         standard_tax_label: localizedInternalTaxLabel(orderResult.value.standard_tax_label),
+        liquor_tax_label: localizedInternalTaxLabel(orderResult.value.liquor_tax_label),
         promo_savings: orderResult.value.promo_savings ?? 0,
         promo_breakdown: orderResult.value.promo_breakdown ?? [],
         waro_redemption_summary: orderResult.value.waro_redemption_summary ?? null,
@@ -3321,6 +3365,13 @@ onUnmounted(() => {
                     + {{ mod.name }}<template v-if="(mod.quantity ?? 1) > 1"> ×{{ mod.quantity ?? 1 }}</template> · {{ formatCurrency(modifierLineTotal(mod)) }}
                   </p>
                 </div>
+
+                <p
+                  v-if="getLineTaxInfo(item)"
+                  class="text-xs text-text-tertiary mt-0.5"
+                >
+                  {{ formatLineTaxDisplay(getLineTaxInfo(item)!) }}
+                </p>
 
                 <!-- Notes -->
                 <p v-if="item.notes" class="text-xs text-text-tertiary italic mt-0.5">{{ item.notes }}</p>
@@ -4903,7 +4954,7 @@ onUnmounted(() => {
               <span class="text-sm font-medium text-text-primary">{{ formatCurrency(orderResult.standard_tax) }}</span>
             </div>
             <div v-if="orderResult.liquor_tax && orderResult.liquor_tax > 0" class="flex items-center justify-between gap-3">
-              <span class="text-sm text-text-secondary">{{ t('pos.receipt.liquorVat') }}</span>
+              <span class="text-sm text-text-secondary">{{ localizedInternalTaxLabel(orderResult.liquor_tax_label) || t('pos.receipt.liquorVat') }}</span>
               <span class="text-sm font-medium text-text-primary">{{ formatCurrency(orderResult.liquor_tax) }}</span>
             </div>
             <div class="flex items-center justify-between gap-3" :class="(orderResult.discount_amount || orderResult.waro_discount_cop || orderResult.standard_tax || orderResult.liquor_tax) ? 'border-t border-border pt-2.5' : ''">
@@ -5213,6 +5264,7 @@ onUnmounted(() => {
       :waro-discount-amount="orderResultWaroDiscountCop"
       :standard-tax-label="orderResult.standard_tax_label"
       :standard-tax="Number(orderResult.standard_tax) || 0"
+      :liquor-tax-label="orderResult.liquor_tax_label"
       :liquor-tax="Number(orderResult.liquor_tax) || 0"
       :order-total="Number(orderResult.total_amount) || 0"
       :tip-label="receiptTipLabel"
@@ -5331,7 +5383,7 @@ onUnmounted(() => {
       <span>{{ formatCurrency(taxPreview.standard_tax) }}</span>
     </div>
     <div v-if="taxPreview && taxPreview.liquor_tax > 0" class="receipt-item">
-      <span>{{ t('pos.receipt.liquorVat') }}</span>
+      <span>{{ taxPreview.liquor_tax_label || t('pos.receipt.liquorVat') }}</span>
       <span>{{ formatCurrency(taxPreview.liquor_tax) }}</span>
     </div>
     <!-- warocol.com#739 + #939 — pre-bill totals include tip, advance, and split settlement when applicable -->
@@ -5493,7 +5545,7 @@ onUnmounted(() => {
         <span>{{ formatCurrency(orderResult.standard_tax) }}</span>
       </div>
       <div v-if="orderResult?.liquor_tax && orderResult.liquor_tax > 0" class="receipt-item receipt-small">
-	        <span>{{ t('pos.receipt.liquorVat') }}</span>
+	        <span>{{ localizedInternalTaxLabel(orderResult.liquor_tax_label) || t('pos.receipt.liquorVat') }}</span>
         <span>{{ formatCurrency(orderResult.liquor_tax) }}</span>
       </div>
     </template>

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -720,8 +720,7 @@ const saleReceiptInvoiceTaxLines = computed(() => {
       amount: Number(o.standard_tax) || 0,
     },
     {
-      label: t('ventas.detail.liquorVat'),
-      rate: 5,
+      label: o.liquor_tax_label || t('ventas.detail.liquorVat'),
       amount: Number(o.liquor_tax) || 0,
     },
   ].filter(line => Number(line.amount) > 0)
@@ -1974,7 +1973,7 @@ onUnmounted(() => {
                 <span class="text-sm tabular-nums text-text-secondary">{{ formatCurrency(order.standard_tax) }}</span>
               </div>
               <div v-if="order.liquor_tax > 0" class="flex items-center justify-between gap-10">
-                <span class="text-sm text-text-secondary">{{ t('ventas.detail.liquorVat') }}</span>
+                <span class="text-sm text-text-secondary">{{ order.liquor_tax_label || t('ventas.detail.liquorVat') }}</span>
                 <span class="text-sm tabular-nums text-text-secondary">{{ formatCurrency(order.liquor_tax) }}</span>
               </div>
               <div
@@ -2224,6 +2223,7 @@ onUnmounted(() => {
       :waro-discount-amount="effectiveWaroDiscountCop"
       :standard-tax-label="order.standard_tax_label"
       :standard-tax="Number(order.standard_tax) || 0"
+      :liquor-tax-label="order.liquor_tax_label"
       :liquor-tax="Number(order.liquor_tax) || 0"
       :order-total="Number(order.total_amount) || 0"
       :tip-label="receiptTipLabel"


### PR DESCRIPTION
## Summary
- Use `liquor_tax_label` from the API on checkout modal, prefactura, print ticket, and ventas detail
- Fallback to i18n `liquorVat` only when the API label is missing
- Include additive order tax in cash / Total a Pagar settlement UI

Closes #1899

Companion: api-warolabs PR (same branch `wr-1899-tax-labels`)

## Test plan
- [ ] MX tenant: ticket shows tenant IVA label (e.g. IVA 16%), not hardcoded IVA licores 5%
- [ ] Prefactura + printed receipt + ventas detail agree on tax label
- [ ] CO liquor distinct line still shows liquor label when amount > 0
- [ ] Cash settlement includes additive IVA when applicable


Made with [Cursor](https://cursor.com)