### PR TITLE
fix(finanzas): i18n system chart account names on Cuentas (#1901)

### DIFF
--- a/i18n/locales/ar/finanzas.json
+++ b/i18n/locales/ar/finanzas.json
@@ -755,6 +755,20 @@
         "income": "الإيرادات",
         "expenses": "المصروفات",
         "costs": "التكاليف"
+      },
+      "systemAccounts": {
+        "cash": "نقد",
+        "bank": "بنك",
+        "accountsReceivable": "ذمم مدينة",
+        "inventory": "مخزون",
+        "accountsPayable": "ذمم دائنة",
+        "taxPayable": "الضرائب المستحقة",
+        "customerAdvances": "سلف العملاء",
+        "salesRevenue": "إيرادات المبيعات",
+        "otherIncome": "إيرادات أخرى",
+        "payrollExpense": "مصروف الرواتب",
+        "bankFeesExpense": "رسوم بنكية",
+        "costOfGoodsSold": "تكلفة البضاعة المباعة"
       }
     },
     "conciliacion": {

--- a/i18n/locales/de/finanzas.json
+++ b/i18n/locales/de/finanzas.json
@@ -755,6 +755,20 @@
         "income": "Einnahmen",
         "expenses": "Ausgaben",
         "costs": "Kosten"
+      },
+      "systemAccounts": {
+        "cash": "Kasse",
+        "bank": "Bank",
+        "accountsReceivable": "Forderungen",
+        "inventory": "Vorräte",
+        "accountsPayable": "Verbindlichkeiten",
+        "taxPayable": "Steuerverbindlichkeiten",
+        "customerAdvances": "Kundenanzahlungen",
+        "salesRevenue": "Umsatzerlöse",
+        "otherIncome": "Sonstige Erträge",
+        "payrollExpense": "Personalaufwand",
+        "bankFeesExpense": "Bankgebühren",
+        "costOfGoodsSold": "Wareneinsatz"
       }
     },
     "conciliacion": {

--- a/i18n/locales/en/finanzas.json
+++ b/i18n/locales/en/finanzas.json
@@ -734,6 +734,20 @@
         "income": "Income",
         "expenses": "Expenses",
         "costs": "Costs"
+      },
+      "systemAccounts": {
+        "cash": "Cash",
+        "bank": "Bank",
+        "accountsReceivable": "Accounts receivable",
+        "inventory": "Inventory",
+        "accountsPayable": "Accounts payable",
+        "taxPayable": "Tax payable",
+        "customerAdvances": "Customer advances",
+        "salesRevenue": "Sales revenue",
+        "otherIncome": "Other income",
+        "payrollExpense": "Payroll expense",
+        "bankFeesExpense": "Bank fees expense",
+        "costOfGoodsSold": "Cost of goods sold"
       }
     },
     "conciliacion": {

--- a/i18n/locales/es/finanzas.json
+++ b/i18n/locales/es/finanzas.json
@@ -734,6 +734,20 @@
         "income": "Ingresos",
         "expenses": "Gastos",
         "costs": "Costos"
+      },
+      "systemAccounts": {
+        "cash": "Efectivo",
+        "bank": "Banco",
+        "accountsReceivable": "Cuentas por cobrar",
+        "inventory": "Inventario",
+        "accountsPayable": "Cuentas por pagar",
+        "taxPayable": "Impuestos por pagar",
+        "customerAdvances": "Anticipos de clientes",
+        "salesRevenue": "Ingresos por ventas",
+        "otherIncome": "Otros ingresos",
+        "payrollExpense": "Gasto de nómina",
+        "bankFeesExpense": "Comisiones bancarias",
+        "costOfGoodsSold": "Costo de ventas"
       }
     },
     "conciliacion": {

--- a/i18n/locales/fr/finanzas.json
+++ b/i18n/locales/fr/finanzas.json
@@ -755,6 +755,20 @@
         "income": "Produits",
         "expenses": "Charges",
         "costs": "Coûts"
+      },
+      "systemAccounts": {
+        "cash": "Caisse",
+        "bank": "Banque",
+        "accountsReceivable": "Comptes clients",
+        "inventory": "Stocks",
+        "accountsPayable": "Comptes fournisseurs",
+        "taxPayable": "Taxes à payer",
+        "customerAdvances": "Avances clients",
+        "salesRevenue": "Produits des ventes",
+        "otherIncome": "Autres produits",
+        "payrollExpense": "Charges de personnel",
+        "bankFeesExpense": "Frais bancaires",
+        "costOfGoodsSold": "Coût des marchandises vendues"
       }
     },
     "conciliacion": {

--- a/i18n/locales/hi/finanzas.json
+++ b/i18n/locales/hi/finanzas.json
@@ -755,6 +755,20 @@
         "income": "आय",
         "expenses": "व्यय",
         "costs": "लागत"
+      },
+      "systemAccounts": {
+        "cash": "नकद",
+        "bank": "बैंक",
+        "accountsReceivable": "प्राप्य खाते",
+        "inventory": "इन्वेंटरी",
+        "accountsPayable": "देय खाते",
+        "taxPayable": "देय कर",
+        "customerAdvances": "ग्राहक अग्रिम",
+        "salesRevenue": "बिक्री राजस्व",
+        "otherIncome": "अन्य आय",
+        "payrollExpense": "पेरोल व्यय",
+        "bankFeesExpense": "बैंक शुल्क",
+        "costOfGoodsSold": "बेची गई वस्तु की लागत"
       }
     },
     "conciliacion": {

--- a/i18n/locales/pt/finanzas.json
+++ b/i18n/locales/pt/finanzas.json
@@ -755,6 +755,20 @@
         "income": "Receitas",
         "expenses": "Despesas",
         "costs": "Custos"
+      },
+      "systemAccounts": {
+        "cash": "Caixa",
+        "bank": "Banco",
+        "accountsReceivable": "Contas a receber",
+        "inventory": "Estoque",
+        "accountsPayable": "Contas a pagar",
+        "taxPayable": "Impostos a pagar",
+        "customerAdvances": "Adiantamentos de clientes",
+        "salesRevenue": "Receita de vendas",
+        "otherIncome": "Outras receitas",
+        "payrollExpense": "Despesa com folha",
+        "bankFeesExpense": "Tarifas bancárias",
+        "costOfGoodsSold": "Custo das mercadorias vendidas"
       }
     },
     "conciliacion": {

--- a/i18n/locales/zh/finanzas.json
+++ b/i18n/locales/zh/finanzas.json
@@ -755,6 +755,20 @@
         "income": "收入",
         "expenses": "费用",
         "costs": "成本"
+      },
+      "systemAccounts": {
+        "cash": "现金",
+        "bank": "银行",
+        "accountsReceivable": "应收账款",
+        "inventory": "存货",
+        "accountsPayable": "应付账款",
+        "taxPayable": "应交税费",
+        "customerAdvances": "客户预收款",
+        "salesRevenue": "销售收入",
+        "otherIncome": "其他收入",
+        "payrollExpense": "工资费用",
+        "bankFeesExpense": "银行手续费",
+        "costOfGoodsSold": "销货成本"
       }
     },
     "conciliacion": {

--- a/pages/finanzas/contabilidad/cuentas/[id].vue
+++ b/pages/finanzas/contabilidad/cuentas/[id].vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, nextTick, onMounted, onUnmounted } from 'vue'
 import MetricCard from '~/components/shared/MetricCard.vue'
-import { getAccountLevel, getAccountLevelKey, getAccountLevelVariant } from '~/utils/accountingDisplay'
+import { getAccountLevel, getAccountLevelKey, getAccountLevelVariant, localizeSystemAccountName } from '~/utils/accountingDisplay'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
@@ -93,6 +93,11 @@ const { data: accountsData, refetch: refetchAccounts } = useQuery({
 const account = computed<TenantAccount | null>(() =>
   accountsData.value?.data?.find(a => a.id === accountId.value) ?? null
 )
+const displayAccountName = (acct: { code: string; name: string }) =>
+  localizeSystemAccountName(acct, key => t(key))
+const accountDisplayName = computed(() =>
+  account.value ? displayAccountName(account.value) : '',
+)
 const accountClassLabel = computed(() =>
   account.value ? (CLASS_SHORT[account.value.accountClass] || account.value.accountClass) : ''
 )
@@ -111,7 +116,7 @@ const subAccounts = computed<TenantAccount[]>(() =>
 )
 
 useHead(() => ({
-  title: account.value ? `${account.value.code} · ${account.value.name}` : t('finanzas.contabilidad.accountTitle'),
+  title: account.value ? `${account.value.code} · ${accountDisplayName.value}` : t('finanzas.contabilidad.accountTitle'),
 }))
 
 // ── Toggle active ──────────────────────────────────────────────────────────
@@ -438,7 +443,7 @@ const openEntryDetail = (entry: { id: string }) => {
               <div class="flex items-start gap-2 min-w-0">
                 <h2
                   class="text-[22px] sm:text-[24px] leading-[29px] sm:leading-[32px] font-extrabold text-[#211d35] break-words">
-                  {{ account.name }}
+                  {{ accountDisplayName }}
                 </h2>
                 <svg v-if="account.isSystem" class="mt-1.5 h-4 w-4 flex-shrink-0 text-[#3e4451]/70" fill="none"
                   stroke="currentColor" viewBox="0 0 24 24" :aria-label="t('finanzas.contabilidad.systemAccount')">
@@ -483,7 +488,7 @@ const openEntryDetail = (entry: { id: string }) => {
             <button type="button"
               v-if="account.isDetail && account.accountClass === '1' && account.normalBalance === 'debit' && account.isActive"
               class="inline-flex min-h-[38px] items-center gap-2 rounded-lg border border-[#7c3bed] px-3.5 text-sm font-semibold leading-5 text-[#7c3bed] transition-colors hover:bg-[rgba(124,59,237,0.08)] focus:outline-none focus:ring-2 focus:ring-[#7c3bed]/25 active:scale-[0.98]"
-              :aria-label="t('finanzas.contabilidad.updateRealBalanceOf', { name: account.name })" @click="showAdjustPanel = true">
+              :aria-label="t('finanzas.contabilidad.updateRealBalanceOf', { name: accountDisplayName })" @click="showAdjustPanel = true">
               <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                   d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -734,7 +739,7 @@ const openEntryDetail = (entry: { id: string }) => {
               <div class="min-w-0">
                 <h2 class="text-base font-bold text-text-primary leading-tight">{{ t('finanzas.contabilidad.createSubaccount') }}</h2>
                 <p class="text-xs text-text-secondary leading-snug mt-0.5 font-mono">
-                  {{ account?.code }} · {{ account?.name }}
+                  {{ account?.code }} · {{ accountDisplayName }}
                 </p>
               </div>
             </div>

--- a/pages/finanzas/contabilidad/cuentas/index.vue
+++ b/pages/finanzas/contabilidad/cuentas/index.vue
@@ -2,7 +2,10 @@
 const { t, locale } = useI18n({ useScope: 'global' })
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import MetricCard from '~/components/shared/MetricCard.vue'
-import { getAccountLevel, getAccountLevelKey, getAccountLevelVariant } from '~/utils/accountingDisplay'
+import { getAccountLevel, getAccountLevelKey, getAccountLevelVariant, localizeSystemAccountName } from '~/utils/accountingDisplay'
+
+const displayAccountName = (account: { code: string; name: string }) =>
+  localizeSystemAccountName(account, key => t(key))
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: () => t('finanzas.contabilidad.accountsTitle') })
@@ -368,7 +371,7 @@ onUnmounted(() => { clearRefreshHandler(refetchAll) })
                     <div class="flex-1 min-w-0">
                       <div class="flex items-center gap-1.5">
                         <span class="text-xs font-mono text-text-secondary flex-shrink-0">{{ item.code }}</span>
-                        <span class="text-sm font-medium text-text-primary truncate">{{ item.name }}</span>
+                        <span class="text-sm font-medium text-text-primary truncate">{{ displayAccountName(item) }}</span>
                       </div>
                       <div class="flex items-center gap-1.5 mt-0.5">
                         <UiStatusBadge v-if="showAll" :value="accountLevelDisplay(item).label" format="text" :variant="accountLevelDisplay(item).variant" size="sm" />
@@ -423,7 +426,7 @@ onUnmounted(() => { clearRefreshHandler(refetchAll) })
                     class="text-sm text-text-primary"
                     :class="row.isDetail ? 'font-medium' : 'font-normal text-text-secondary italic'"
                   >
-                    {{ row.name }}
+                    {{ displayAccountName(row) }}
                   </span>
                 </template>
 

--- a/utils/accountingDisplay.test.ts
+++ b/utils/accountingDisplay.test.ts
@@ -4,6 +4,7 @@ import {
   getAccountIndentClass,
   getAccountLevel,
   getAccountLevelKey,
+  localizeSystemAccountName,
 } from './accountingDisplay.ts'
 
 describe('accounting display metadata', () => {
@@ -17,5 +18,29 @@ describe('accounting display metadata', () => {
   it('falls back to detail metadata without inspecting a code', () => {
     assert.equal(getAccountLevel({ isDetail: true }), 4)
     assert.equal(getAccountLevelKey({ isDetail: true }), 'subaccount')
+  })
+})
+
+describe('localizeSystemAccountName', () => {
+  const t = (key: string) => {
+    if (key === 'finanzas.contabilidad.systemAccounts.cash') return 'Efectivo'
+    if (key === 'finanzas.contabilidad.systemAccounts.taxPayable') return 'Impuestos por pagar'
+    return key
+  }
+
+  it('maps known global managerial codes via i18n', () => {
+    assert.equal(localizeSystemAccountName({ code: '1000', name: 'Cash' }, t), 'Efectivo')
+    assert.equal(localizeSystemAccountName({ code: '2100', name: 'Tax payable' }, t), 'Impuestos por pagar')
+  })
+
+  it('keeps CO PUC / custom stored names when code is not in the global map', () => {
+    assert.equal(
+      localizeSystemAccountName({ code: '1105', name: 'Caja general' }, t),
+      'Caja general',
+    )
+    assert.equal(
+      localizeSystemAccountName({ code: '100005', name: 'Caja secundaria' }, t),
+      'Caja secundaria',
+    )
   })
 })

--- a/utils/accountingDisplay.ts
+++ b/utils/accountingDisplay.ts
@@ -1,3 +1,35 @@
+/** Global managerial chart codes (non-CO). CO PUC uses different codes — left as stored. */
+export const GLOBAL_SYSTEM_ACCOUNT_I18N_KEYS: Record<string, string> = {
+  '1000': 'cash',
+  '1010': 'bank',
+  '1100': 'accountsReceivable',
+  '1200': 'inventory',
+  '2000': 'accountsPayable',
+  '2100': 'taxPayable',
+  '2200': 'customerAdvances',
+  '4000': 'salesRevenue',
+  '4010': 'otherIncome',
+  '5000': 'payrollExpense',
+  '5100': 'bankFeesExpense',
+  '6000': 'costOfGoodsSold',
+}
+
+export type AccountNameSource = {
+  code?: string | null
+  name?: string | null
+}
+
+export const localizeSystemAccountName = (
+  account: AccountNameSource,
+  translate: (key: string) => string,
+): string => {
+  const stored = String(account.name ?? '').trim()
+  const code = String(account.code ?? '').trim()
+  const slug = GLOBAL_SYSTEM_ACCOUNT_I18N_KEYS[code]
+  if (!slug) return stored
+  return translate(`finanzas.contabilidad.systemAccounts.${slug}`)
+}
+
 export type AccountLevelMetadata = {
   level?: number | null
   isDetail?: boolean


### PR DESCRIPTION
## Summary
- Localize the 12 global managerial system account names via `finanzas.contabilidad.systemAccounts`
- Apply on Cuentas list and detail (title, header, aria)
- CO PUC / custom codes keep the stored API name

Closes #1901

## Test plan
- [ ] MX tenant, UI es: list shows Efectivo, Banco, Impuestos por pagar (not Cash / Tax payable)
- [ ] Open account detail — same localized name
- [ ] Switch locale en — English labels
- [ ] CO PUC tenant — Spanish PUC names unchanged

## Validation evidence
```
$ node --experimental-strip-types --test utils/accountingDisplay.test.ts
# tests 4
# suites 2
# pass 4
# fail 0
```

## wr-context
See `.wr/1901.yaml` on this branch (LLM contract; gitignored locally).

Made with [Cursor](https://cursor.com)