### PR TITLE
fix(operaciones): Mi Plan quota modal on Mesas/Comandas/QR (#1904)

### DIFF
--- a/components/mesas/MesaPanel.vue
+++ b/components/mesas/MesaPanel.vue
@@ -146,9 +146,17 @@
             :qr-quota-blocked="qrQuotaBlocked"
             :qr-quota-message="qrQuotaMessage"
             @updated="(data) => emit('qr-updated', data)"
+            @quota-blocked="emit('qr-quota-blocked')"
           />
 
-          <p v-if="createBlocked" class="text-sm text-state-warning-text bg-state-warning-bg border border-state-warning-border rounded-lg px-3 py-2">
+          <p
+            v-if="createBlocked"
+            class="text-sm text-state-warning-text bg-state-warning-bg border border-state-warning-border rounded-lg px-3 py-2 cursor-pointer"
+            role="button"
+            tabindex="0"
+            @click="emit('quota-blocked')"
+            @keydown.enter.prevent="emit('quota-blocked')"
+          >
             {{ createQuotaNotice }}
           </p>
 
@@ -169,7 +177,7 @@
           </button>
           <button
             type="button"
-            :disabled="saving || createBlocked"
+            :disabled="saving"
             :title="createBlocked ? createQuotaNotice : undefined"
             class="flex-1 h-11 rounded-lg bg-action-primary-bg text-sm font-semibold text-action-primary-text transition-all hover:bg-action-primary-hover-bg focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed active:scale-[0.98] shadow-sm shadow-action-primary-bg/30"
             @click="submit"
@@ -211,6 +219,8 @@ interface Emits {
   (e: 'update:modelValue', v: boolean): void
   (e: 'saved', table: any): void
   (e: 'qr-updated', table: Record<string, unknown>): void
+  (e: 'quota-blocked'): void
+  (e: 'qr-quota-blocked'): void
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -293,9 +303,7 @@ function validate() {
 
 async function submit() {
   if (createBlocked.value) {
-    errors.value = {
-      general: createQuotaNotice.value,
-    }
+    emit('quota-blocked')
     return
   }
 
@@ -341,7 +349,17 @@ async function submit() {
     close()
   } catch (err: any) {
     const detail = err?.data?.detail ?? err?.message ?? 'Error al guardar'
-    errors.value.general = detail
+    const isQuota = err?.status === 429 ||
+      err?.statusCode === 429 ||
+      err?.data?.code === 'quota_exceeded' ||
+      err?.data?.error === 'quota_exceeded' ||
+      detail?.code === 'quota_exceeded' ||
+      detail?.error === 'quota_exceeded'
+    if (isQuota) {
+      emit('quota-blocked')
+      return
+    }
+    errors.value.general = typeof detail === 'string' ? detail : 'Error al guardar'
   } finally {
     saving.value = false
   }

--- a/components/mesas/TableQrControls.vue
+++ b/components/mesas/TableQrControls.vue
@@ -22,6 +22,7 @@ const props = withDefaults(defineProps<{
 
 const emit = defineEmits<{
   updated: [table: Record<string, unknown>]
+  'quota-blocked': []
 }>()
 
 const toast = useToast()
@@ -57,7 +58,13 @@ const qrErrorMessage = (err: any, fallback: string) => {
 }
 
 const showQuotaBlocked = () => {
-  toast.warning(quotaMessage.value, { title: 'Cupo de QR agotado' })
+  emit('quota-blocked')
+}
+
+const onActivationToggleClick = (e: Event) => {
+  if (!isActivationBlocked.value) return
+  e.preventDefault()
+  showQuotaBlocked()
 }
 
 const toggleQr = async () => {
@@ -81,6 +88,10 @@ const toggleQr = async () => {
       { title: newEnabled ? 'Activado' : 'Desactivado' },
     )
   } catch (err: any) {
+    if (isQuotaExceededError(err)) {
+      showQuotaBlocked()
+      return
+    }
     toast.error(qrErrorMessage(err, 'Error al cambiar el QR'), { title: 'Error' })
   } finally {
     isToggling.value = false
@@ -125,15 +136,15 @@ const regenerateToken = async () => {
       </div>
       <label
         class="relative inline-flex items-center cursor-pointer flex-shrink-0"
-        :class="(isToggling || isActivationBlocked) ? 'opacity-50' : ''"
+        :class="isToggling ? 'opacity-50' : ''"
         :title="isActivationBlocked ? quotaMessage : undefined"
-        @click="isActivationBlocked && showQuotaBlocked()"
+        @click="onActivationToggleClick"
       >
         <input
           type="checkbox"
           class="sr-only peer"
           :checked="!!table.qr_enabled"
-          :disabled="isToggling || isActivationBlocked"
+          :disabled="isToggling"
           @change="toggleQr"
         >
         <div
@@ -144,7 +155,11 @@ const regenerateToken = async () => {
 
     <p
       v-if="isActivationBlocked"
-      class="text-xs text-state-warning-text bg-state-warning-bg border border-state-warning-border rounded-lg px-3 py-2"
+      class="text-xs text-state-warning-text bg-state-warning-bg border border-state-warning-border rounded-lg px-3 py-2 cursor-pointer"
+      role="button"
+      tabindex="0"
+      @click="showQuotaBlocked"
+      @keydown.enter.prevent="showQuotaBlocked"
     >
       {{ quotaMessage }}
     </p>
@@ -217,15 +232,15 @@ const regenerateToken = async () => {
   <div v-else class="flex flex-wrap items-center gap-1.5">
     <label
       class="relative inline-flex items-center cursor-pointer flex-shrink-0"
-      :class="(isToggling || isActivationBlocked) ? 'opacity-50' : ''"
+      :class="isToggling ? 'opacity-50' : ''"
       :title="isActivationBlocked ? quotaMessage : (table.qr_enabled ? 'Desactivar QR' : 'Activar QR')"
-      @click="isActivationBlocked && showQuotaBlocked()"
+      @click="onActivationToggleClick"
     >
       <input
         type="checkbox"
         class="sr-only peer"
         :checked="!!table.qr_enabled"
-        :disabled="isToggling || isActivationBlocked"
+        :disabled="isToggling"
         @change="toggleQr"
       >
       <div

--- a/composables/useOperationalQuotaGate.ts
+++ b/composables/useOperationalQuotaGate.ts
@@ -84,6 +84,7 @@ export function useOperationalQuotaGate(resource: OperationalQuotaKey) {
   return {
     quotaLimitModalOpen,
     quotaLimitModalMessage,
+    openQuotaLimitModalWithMessage,
     closeQuotaLimitModal,
     goToBillingFromQuotaLimitModal,
     handleCreateClick,

--- a/pages/operaciones/comandas.vue
+++ b/pages/operaciones/comandas.vue
@@ -639,7 +639,6 @@ const { data: stationsData, asyncStatus: stationsAsyncStatus, refetch: refetchSt
 })
 const stations = computed(() => stationsData.value?.data ?? [])
 const activeKitchenQuota = computed(() => operationalQuotas.value.active_kitchens)
-const isActiveKitchenQuotaBlocked = computed(() => activeKitchenQuota.value.blocked)
 const activeKitchenQuotaMessage = computed(() => {
   const quota = activeKitchenQuota.value
   const metric = quota.metric
@@ -931,10 +930,6 @@ const isLoadingDeactivateInfo = ref(false)
 const isConfirmingDeactivate = ref(false)
 
 const openEditStation = (st: any) => { editingStation.value = st; stationModalOpen.value = true }
-
-const showActiveKitchenQuotaBlocked = () => {
-  openQuotaLimitModalWithMessage(activeKitchenQuotaMessage.value)
-}
 
 const openCreateStation = () => {
   void handleCreateClick(() => {

--- a/pages/operaciones/comandas.vue
+++ b/pages/operaciones/comandas.vue
@@ -147,21 +147,13 @@
         <button
           type="button"
           @click="openCreateStation"
-          :disabled="isActiveKitchenQuotaBlocked"
-          :title="isActiveKitchenQuotaBlocked ? activeKitchenQuotaMessage : t('operaciones.comandas.createStation')"
+          :title="t('operaciones.comandas.createStation')"
           class="flex items-center gap-1.5 px-3 py-2 text-xs font-medium bg-action-primary-bg text-action-primary-text rounded-lg hover:bg-action-primary-hover-bg transition-colors min-h-[36px]"
-          :class="isActiveKitchenQuotaBlocked ? 'opacity-50 cursor-not-allowed hover:bg-action-primary-bg' : ''"
         >
           <PlusIcon class="w-3.5 h-3.5" />
           {{ t('operaciones.comandas.newStation') }}
         </button>
       </div>
-      <p
-        v-if="isActiveKitchenQuotaBlocked"
-        class="mb-4 rounded-lg border border-state-warning-border bg-state-warning-bg px-3 py-2 text-xs text-state-warning-text"
-      >
-        {{ activeKitchenQuotaMessage }}
-      </p>
 
       <UiResponsiveDataView
         :data="stations"
@@ -518,6 +510,16 @@
       @submit="handleSaveStation"
     />
   </div>
+
+  <UiConfirmActionModal
+    v-model="quotaLimitModalOpen"
+    :title="t('billing.upgrade.quotaBlocked')"
+    :message="quotaLimitModalMessage"
+    :confirm-label="t('nav.miPlan')"
+    :cancel-label="t('billing.close')"
+    @confirm="goToBillingFromQuotaLimitModal"
+    @cancel="closeQuotaLimitModal"
+  />
 </template>
 
 <script setup lang="ts">
@@ -535,6 +537,7 @@ import {
   PencilSquareIcon,
 } from '@heroicons/vue/24/outline'
 import QRCode from 'qrcode'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
 
 definePageMeta({ layout: 'dashboard', module: 'operaciones' })
 useHead({ title: () => t('operaciones.head.comandas') })
@@ -542,6 +545,14 @@ useHead({ title: () => t('operaciones.head.comandas') })
 const { currentTenant } = useTenantReactive()
 const toast = useToast()
 const { operationalQuotas, fetchBillingOverview } = useBilling()
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  openQuotaLimitModalWithMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+} = useOperationalQuotaGate('active_kitchens')
 
 // ─── Business profile (operaciones audience aggregator — gated under OPERACIONES) ───
 const cache = useQueryCache()
@@ -922,17 +933,14 @@ const isConfirmingDeactivate = ref(false)
 const openEditStation = (st: any) => { editingStation.value = st; stationModalOpen.value = true }
 
 const showActiveKitchenQuotaBlocked = () => {
-  toast.warning(activeKitchenQuotaMessage.value, { title: t('operaciones.comandas.quotaTitle') })
+  openQuotaLimitModalWithMessage(activeKitchenQuotaMessage.value)
 }
 
 const openCreateStation = () => {
-  if (isActiveKitchenQuotaBlocked.value) {
-    showActiveKitchenQuotaBlocked()
-    return
-  }
-
-  editingStation.value = null
-  stationModalOpen.value = true
+  void handleCreateClick(() => {
+    editingStation.value = null
+    stationModalOpen.value = true
+  })
 }
 
 const isQuotaExceededError = (err: any) => {
@@ -967,9 +975,9 @@ const stationErrorMessage = (err: any, fallback: string) => {
 }
 
 const handleSaveStation = async (formData: any) => {
-  if (!editingStation.value && isActiveKitchenQuotaBlocked.value) {
-    showActiveKitchenQuotaBlocked()
-    return
+  if (!editingStation.value) {
+    const allowed = await handleCreateClick(() => {})
+    if (!allowed) return
   }
 
   isSavingStation.value = true
@@ -988,6 +996,10 @@ const handleSaveStation = async (formData: any) => {
       await refreshStationsAndBilling()
     }
   } catch (e: any) {
+    if (isQuotaExceededError(e)) {
+      openQuotaLimitModalWithMessage(quotaExceededMessageFromError(e))
+      return
+    }
     toast.error(stationErrorMessage(e, t('operaciones.comandas.stationSaveError')), { title: t('operaciones.comandas.error') })
   } finally {
     isSavingStation.value = false
@@ -997,10 +1009,8 @@ const handleSaveStation = async (formData: any) => {
 const handleToggleStation = async (station: any) => {
   if (togglingStationId.value === station.id) return
   if (!station.is_active) {
-    if (isActiveKitchenQuotaBlocked.value) {
-      showActiveKitchenQuotaBlocked()
-      return
-    }
+    const allowed = await handleCreateClick(() => {})
+    if (!allowed) return
 
     togglingStationId.value = station.id
     try {
@@ -1008,6 +1018,10 @@ const handleToggleStation = async (station: any) => {
       toast.success(t('operaciones.comandas.active'))
       await refreshStationsAndBilling()
     } catch (e: any) {
+      if (isQuotaExceededError(e)) {
+        openQuotaLimitModalWithMessage(quotaExceededMessageFromError(e))
+        return
+      }
       toast.error(stationErrorMessage(e, t('operaciones.comandas.stationActivateError')), { title: t('operaciones.comandas.error') })
     } finally {
       togglingStationId.value = null

--- a/pages/operaciones/mesas.vue
+++ b/pages/operaciones/mesas.vue
@@ -33,9 +33,9 @@ const {
 const {
   quotaLimitModalOpen: qrQuotaModalOpen,
   quotaLimitModalMessage: qrQuotaModalMessage,
+  openQuotaLimitModalWithMessage: openQrQuotaModal,
   closeQuotaLimitModal: closeQrQuotaModal,
   goToBillingFromQuotaLimitModal: goToBillingFromQrQuota,
-  handleCreateClick: handleQrCreateClick,
 } = useOperationalQuotaGate('active_qr_tables')
 
 // ── Data ───────────────────────────────────────────────────────────────────
@@ -373,8 +373,8 @@ const activeQrQuotaMessage = computed(() => {
   })
 })
 
-const onQrQuotaBlocked = () => {
-  void handleQrCreateClick(() => {})
+const onQrQuotaBlocked = (message?: string) => {
+  openQrQuotaModal(message || activeQrQuotaMessage.value)
 }
 
 const onCreateQuotaBlocked = (message?: string) => {

--- a/pages/operaciones/mesas.vue
+++ b/pages/operaciones/mesas.vue
@@ -7,6 +7,7 @@ import {
   areTableOrdersEqual,
   getTableOrderIds,
 } from '~/composables/useTableOrderDraft'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
 
 definePageMeta({ layout: 'dashboard', module: 'operaciones' })
 
@@ -21,6 +22,21 @@ const {
   getOperationalQuota,
   fetchBillingOverview,
 } = useBilling()
+const {
+  quotaLimitModalOpen: tableQuotaModalOpen,
+  quotaLimitModalMessage: tableQuotaModalMessage,
+  openQuotaLimitModalWithMessage: openTableQuotaModal,
+  closeQuotaLimitModal: closeTableQuotaModal,
+  goToBillingFromQuotaLimitModal: goToBillingFromTableQuota,
+  handleCreateClick: handleTableCreateClick,
+} = useOperationalQuotaGate('active_tables_including_bar')
+const {
+  quotaLimitModalOpen: qrQuotaModalOpen,
+  quotaLimitModalMessage: qrQuotaModalMessage,
+  closeQuotaLimitModal: closeQrQuotaModal,
+  goToBillingFromQuotaLimitModal: goToBillingFromQrQuota,
+  handleCreateClick: handleQrCreateClick,
+} = useOperationalQuotaGate('active_qr_tables')
 
 // ── Data ───────────────────────────────────────────────────────────────────
 const { data: tablesData, status: tablesStatus, asyncStatus: tablesAsyncStatus, error: tablesError, refetch } = useQuery({
@@ -128,8 +144,11 @@ const showPanel = ref(false)
 const panelTable = ref<any>(null)
 
 const openPanel = (table: any = null) => {
-  if (!table && isActiveTableQuotaBlocked.value) {
-    showActiveTableQuotaBlocked()
+  if (!table) {
+    void handleTableCreateClick(() => {
+      panelTable.value = null
+      showPanel.value = true
+    })
     return
   }
 
@@ -256,10 +275,9 @@ const activatingId = ref<string | null>(null)
 
 const activateTable = async (id: string) => {
   if (activatingId.value) return
-  if (isActiveTableQuotaBlocked.value) {
-    showActiveTableQuotaBlocked()
-    return
-  }
+
+  const allowed = await handleTableCreateClick(() => {})
+  if (!allowed) return
 
   activatingId.value = id
   try {
@@ -267,6 +285,10 @@ const activateTable = async (id: string) => {
     await refreshTablesAndBilling()
     toast.success(`${singular.value} activada`, { title: 'Activado' })
   } catch (err: any) {
+    if (isQuotaExceededError(err)) {
+      openTableQuotaModal(quotaExceededMessageFromError(err))
+      return
+    }
     toast.error(tableErrorMessage(err, `Error al activar la ${singularLower.value}`), { title: 'Error' })
   } finally {
     activatingId.value = null
@@ -335,10 +357,6 @@ const activeTableQuotaMessage = computed(() => {
   })
 })
 
-const showActiveTableQuotaBlocked = () => {
-  toast.warning(activeTableQuotaMessage.value, { title: t('operaciones.mesas.quotaFull') })
-}
-
 const activeQrQuota = computed(() => getOperationalQuota('active_qr_tables'))
 const isActiveQrQuotaBlocked = computed(() => activeQrQuota.value.blocked)
 const activeQrQuotaMessage = computed(() => {
@@ -354,6 +372,14 @@ const activeQrQuotaMessage = computed(() => {
     limit: metric.limit.toLocaleString(numberLocale),
   })
 })
+
+const onQrQuotaBlocked = () => {
+  void handleQrCreateClick(() => {})
+}
+
+const onCreateQuotaBlocked = (message?: string) => {
+  openTableQuotaModal(message || activeTableQuotaMessage.value)
+}
 
 const isQuotaExceededError = (err: any) => {
   const detail = err?.data?.detail
@@ -607,10 +633,8 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
         <template #trailing>
           <button
             type="button"
-            :disabled="isActiveTableQuotaBlocked"
-            :title="isActiveTableQuotaBlocked ? activeTableQuotaMessage : t('operaciones.mesas.newTable', { table: singularLower })"
+            :title="t('operaciones.mesas.newTable', { table: singularLower })"
             class="h-9 px-4 rounded-lg bg-primary text-sm font-semibold text-primary-foreground hover:bg-action-primary-hover-bg focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 active:scale-[0.98] transition-all shadow-sm shadow-primary/30 whitespace-nowrap"
-            :class="isActiveTableQuotaBlocked ? 'opacity-50 cursor-not-allowed hover:bg-primary' : ''"
             @click="openPanel(null)"
           >
             <span class="hidden sm:inline">{{ t('operaciones.mesas.newTable', { table: singularLower }) }}</span>
@@ -618,16 +642,6 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
           </button>
         </template>
       </UiAdvancedFiltersBar>
-
-      <div
-        v-if="isActiveTableQuotaBlocked"
-        class="flex min-w-0 items-center gap-3 rounded-lg border border-state-warning-border bg-state-warning-bg px-3 py-2 text-xs text-state-warning-text"
-      >
-        <p class="min-w-0 flex-1 truncate" :title="activeTableQuotaMessage">{{ activeTableQuotaMessage }}</p>
-        <NuxtLink to="/gestion/billing/uso" class="inline-flex flex-shrink-0 font-semibold underline underline-offset-2">
-          {{ t('operaciones.mesas.viewPlan') }}
-        </NuxtLink>
-      </div>
 
       <section
         class="rounded-xl border border-data-table-border bg-data-table-container-bg shadow-sm overflow-hidden"
@@ -733,6 +747,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
                     :qr-quota-blocked="isActiveQrQuotaBlocked"
                     :qr-quota-message="activeQrQuotaMessage"
                     @updated="onTableQrUpdated"
+                    @quota-blocked="onQrQuotaBlocked"
                   />
                 </div>
               </div>
@@ -767,6 +782,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
                   :qr-quota-blocked="isActiveQrQuotaBlocked"
                   :qr-quota-message="activeQrQuotaMessage"
                   @updated="onTableQrUpdated"
+                  @quota-blocked="onQrQuotaBlocked"
                 />
               </div>
 
@@ -841,6 +857,7 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
                 :qr-quota-blocked="isActiveQrQuotaBlocked"
                 :qr-quota-message="activeQrQuotaMessage"
                 @updated="onTableQrUpdated"
+                @quota-blocked="onQrQuotaBlocked"
               />
             </div>
             <div class="flex items-center justify-end gap-1">
@@ -881,8 +898,8 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
                 <span class="text-[10px] font-bold uppercase tracking-tight px-2 py-0.5 rounded-full bg-status-chip-bg text-status-chip-text border border-status-chip-border">Inactiva</span>
                 <button
                   :aria-label="`Activar ${item.name}`"
-                  :disabled="activatingId === item.id || isActiveTableQuotaBlocked"
-                  :title="isActiveTableQuotaBlocked ? activeTableQuotaMessage : `Activar ${item.name}`"
+                  :disabled="activatingId === item.id"
+                  :title="`Activar ${item.name}`"
                   class="flex items-center gap-1.5 min-h-[36px] px-3 rounded-lg text-xs font-semibold text-state-success-text border border-state-success-border hover:bg-state-success-bg transition-colors disabled:opacity-50"
                   @click="activateTable(item.id)"
                 >
@@ -919,8 +936,8 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
             <div class="flex items-center justify-end gap-2">
               <button
                 :aria-label="`Activar ${row.name}`"
-                :disabled="activatingId === row.id || isActiveTableQuotaBlocked"
-                :title="isActiveTableQuotaBlocked ? activeTableQuotaMessage : `Activar ${row.name}`"
+                :disabled="activatingId === row.id"
+                :title="`Activar ${row.name}`"
                 class="flex items-center gap-1.5 h-8 px-3 rounded-lg text-xs font-semibold text-state-success-text border border-state-success-border hover:bg-state-success-bg transition-colors focus:outline-none focus:ring-2 focus:ring-state-success-border disabled:opacity-50"
                 @click="activateTable(row.id)"
               >
@@ -950,6 +967,8 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
       :qr-quota-message="activeQrQuotaMessage"
       @saved="onSaved"
       @qr-updated="onTableQrUpdated"
+      @quota-blocked="onCreateQuotaBlocked"
+      @qr-quota-blocked="onQrQuotaBlocked"
     />
 
     <!-- ══════ DEACTIVATE MODAL ══════ -->
@@ -1143,5 +1162,24 @@ const tenantMembers = computed<Array<{ id: string; name: string; role: string }>
         </div>
       </Transition>
     </Teleport>
+
+    <UiConfirmActionModal
+      v-model="tableQuotaModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="tableQuotaModalMessage"
+      :confirm-label="t('nav.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromTableQuota"
+      @cancel="closeTableQuotaModal"
+    />
+    <UiConfirmActionModal
+      v-model="qrQuotaModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="qrQuotaModalMessage"
+      :confirm-label="t('nav.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQrQuota"
+      @cancel="closeQrQuotaModal"
+    />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Mesas create/reactivate and QR activation open the Mi Plan upgrade modal at quota cap
- Comandas kitchen create/activate uses the same pattern via `useOperationalQuotaGate`
- Keep CTAs clickable; API 429 still opens the modal

Closes #1904

## Test plan
- [ ] Starter at mesa cap: Nueva mesa → modal → Mi Plan
- [ ] Reactivate mesa at cap → modal
- [ ] Activate QR at QR cap → modal
- [ ] Nueva estación cocina at kitchen cap → modal
- [ ] Below cap: flows still create/activate normally

## Validation evidence
```
$ node --experimental-strip-types --test composables/useBillingOperationalQuota.test.ts
# tests 13
# pass 13
# fail 0
```

## wr-context
See `.wr/1904.yaml` on this branch (LLM contract; gitignored locally).

Made with [Cursor](https://cursor.com)