### PR TITLE
feat(integraciones): Mi Plan modal on api_tokens quota (#1908)

### DIFF
--- a/composables/useBilling.ts
+++ b/composables/useBilling.ts
@@ -31,6 +31,7 @@ export type BillingQuotaKey =
   | 'expenses_per_period'
   | 'supplier_payments_per_period'
   | 'payment_methods'
+  | 'api_tokens'
   | 'accounting_period_closes_per_period'
   | 'manual_journal_entries_per_period'
   | 'modifier_groups'
@@ -160,6 +161,7 @@ export type OperationalQuotaKey =
   | 'expenses_per_period'
   | 'supplier_payments_per_period'
   | 'payment_methods'
+  | 'api_tokens'
   | 'accounting_period_closes_per_period'
   | 'manual_journal_entries_per_period'
   | 'modifier_groups'
@@ -338,6 +340,14 @@ export const BILLING_QUOTA_RESOURCE_CONFIG: Record<BillingQuotaKey, BillingQuota
     blockedMessage: 'Alcanzaste el límite de métodos de pago de tu plan.',
     unlimitedMessage: 'Puedes crear métodos de pago sin límite por override.',
   },
+  api_tokens: {
+    key: 'api_tokens',
+    label: 'API keys',
+    description: 'Claves de API activas para integraciones',
+    unit: 'API keys',
+    blockedMessage: 'Alcanzaste el límite de API keys de tu plan.',
+    unlimitedMessage: 'Puedes crear API keys sin límite por override.',
+  },
   accounting_period_closes_per_period: {
     key: 'accounting_period_closes_per_period',
     label: 'Cierres contables mensuales por periodo',
@@ -396,6 +406,7 @@ export const STARTER_DISPLAY_QUOTA_KEYS: BillingQuotaKey[] = [
   'recipe_bases',
   'completed_online_orders_per_month',
   'admin_users',
+  'api_tokens',
 ]
 
 export const OPERATIONAL_QUOTA_KEYS: OperationalQuotaKey[] = [
@@ -415,6 +426,7 @@ export const OPERATIONAL_QUOTA_KEYS: OperationalQuotaKey[] = [
   'expenses_per_period',
   'supplier_payments_per_period',
   'payment_methods',
+  'api_tokens',
   'accounting_period_closes_per_period',
   'manual_journal_entries_per_period',
   'modifier_groups',

--- a/pages/integraciones.vue
+++ b/pages/integraciones.vue
@@ -282,11 +282,22 @@
         </div>
       </div>
     </Teleport>
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('nav.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import { useFormatters } from '~/composables/useFormatters'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
 
 definePageMeta({ layout: 'dashboard', module: 'integraciones' })
 const { t } = useI18n({ useScope: 'global' })
@@ -294,6 +305,14 @@ useHead({ title: () => t('integraciones.pageTitle') })
 
 const toast = useToast()
 const { currentTenant } = useTenantReactive()
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  openQuotaLimitModalWithMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+} = useOperationalQuotaGate('api_tokens')
 
 // Table columns configuration
 const tableColumns = computed(() => [
@@ -351,14 +370,42 @@ const deleting = ref(false)
 const { formatDate: _fmtDate } = useFormatters()
 const formatDate = (dateString) => _fmtDate(dateString)
 
-const openCreateModal = () => {
+const openCreatePanel = () => {
   createForm.name = ''
   createForm.expiresInDays = null
   createError.value = ''
   showCreateModal.value = true
 }
 
+const openCreateModal = () => {
+  void handleCreateClick(() => openCreatePanel())
+}
+
 const closeCreateModal = () => { showCreateModal.value = false }
+
+const isQuotaExceededError = (err: any) => {
+  const detail = err?.data?.detail
+  return err?.status === 429 ||
+    err?.statusCode === 429 ||
+    err?.data?.code === 'quota_exceeded' ||
+    err?.data?.error === 'quota_exceeded' ||
+    detail?.code === 'quota_exceeded' ||
+    detail?.error === 'quota_exceeded'
+}
+
+const quotaExceededMessageFromError = (err: any) => {
+  const detail = err?.data?.detail ?? err?.data ?? {}
+  const used = typeof detail.used === 'number' ? detail.used : null
+  const limit = typeof detail.limit === 'number' ? detail.limit : null
+
+  if (used !== null && limit !== null) {
+    return `Alcanzaste el límite de API keys de tu plan. Uso actual: ${used.toLocaleString('es-CO')} de ${limit.toLocaleString('es-CO')} API keys. Revisa Mi Plan para ampliar tu cupo.`
+  }
+
+  return typeof detail === 'string'
+    ? detail
+    : (detail?.message || t('billing.upgrade.quotaBlocked'))
+}
 
 const createToken = async () => {
   creating.value = true
@@ -380,7 +427,12 @@ const createToken = async () => {
     } else {
       createError.value = response.message || t('integraciones.createError')
     }
-  } catch (err) {
+  } catch (err: any) {
+    if (isQuotaExceededError(err)) {
+      closeCreateModal()
+      openQuotaLimitModalWithMessage(quotaExceededMessageFromError(err))
+      return
+    }
     createError.value = err.data?.message || t('integraciones.createTokenError')
   } finally {
     creating.value = false


### PR DESCRIPTION
## Summary
- Wire `useOperationalQuotaGate('api_tokens')` + `UiConfirmActionModal` on Integraciones Crear API key.
- 429 `quota_exceeded` opens the same Mi Plan modal.
- Expose `api_tokens` in billing quota config / Starter usage display.

Closes #1908

Companion API: https://github.com/uno0uno/api-warolabs/pull/740

## Test plan
- [ ] Starter: Crear API key → upgrade modal → Mi Plan
- [ ] Below/entitled cap: create flow unchanged
- [ ] Forced 429 on create → modal

## Validation evidence
```text
Plan validation is API pytest + manual UI (no front unit test for this page).
Front diff: composables/useBilling.ts + pages/integraciones.vue

API companion evidence:
$ pytest tests/test_billing_plan_quotas.py tests/test_billing_remaining_usage.py \
    tests/test_quota_enforcement.py::test_api_tokens_growth_quota_* -q
16 passed in 0.09s
```