### PR TITLE
chore(billing): policy lock Mi Negocio/Despacho; api_tokens on uso (#1909)

### DIFF
--- a/pages/gestion/billing/uso.vue
+++ b/pages/gestion/billing/uso.vue
@@ -124,6 +124,7 @@ const quotaDisplayConfig = [
   BILLING_QUOTA_RESOURCE_CONFIG.active_qr_tables,
   BILLING_QUOTA_RESOURCE_CONFIG.completed_online_orders_per_month,
   BILLING_QUOTA_RESOURCE_CONFIG.electronic_invoices_per_period,
+  BILLING_QUOTA_RESOURCE_CONFIG.api_tokens,
 ]
 
 const usageLabels = computed<Record<string, { resource: string; description: string; unit: string; notIncluded?: string }>>(() => ({
@@ -134,6 +135,7 @@ const usageLabels = computed<Record<string, { resource: string; description: str
   active_qr_tables: { resource: t('billing.quotaQrTables'), description: t('billing.quotaQrTablesDescription'), unit: t('billing.unitQrTables') },
   completed_online_orders_per_month: { resource: t('billing.quotaOnlineOrders'), description: t('billing.quotaOnlineOrdersDescription'), unit: t('billing.unitOnlineOrders') },
   electronic_invoices_per_period: { resource: t('billing.quotaInvoices'), description: t('billing.quotaInvoicesDescription'), unit: t('billing.unitInvoices'), notIncluded: t('billing.notIncluded') },
+  api_tokens: { resource: t('billing.quotaApiTokens', 'API keys'), description: t('billing.quotaApiTokensDescription', 'Claves de API activas para integraciones'), unit: t('billing.unitApiTokens', 'API keys') },
   menu_products: { resource: t('billing.quota.menu_products'), description: t('billing.starterUsageValidatedOnSave'), unit: t('billing.unitProducts') },
   menu_categories: { resource: t('billing.quota.menu_categories'), description: t('billing.starterUsageValidatedOnSave'), unit: t('billing.unitCategories') },
   tenant_ingredients: { resource: t('billing.quota.tenant_ingredients'), description: t('billing.starterUsageValidatedOnSave'), unit: t('billing.unitIngredients') },
@@ -180,7 +182,8 @@ const starterFallbackRows = computed(() => {
       const rawLimit = starterPlan.value?.quotas?.[key]
       if (rawLimit === null || rawLimit === undefined) return null
       const limit = Number(rawLimit)
-      if (!Number.isFinite(limit) || limit <= 0) return null
+      // Include limit === 0 (e.g. api_tokens on Starter) as display-only policy lock (#1909).
+      if (!Number.isFinite(limit) || limit < 0) return null
       const config = BILLING_QUOTA_RESOURCE_CONFIG[key]
       return {
         resourceKey: key,
@@ -191,7 +194,7 @@ const starterFallbackRows = computed(() => {
         remaining: null,
         percentage: null,
         unit: usageLabels.value[key]?.unit ?? config.unit,
-        emptyMessage: null,
+        emptyMessage: limit === 0 ? t('billing.zeroAvailable') : null,
         limitsOnly: true,
       }
     })

--- a/pages/negocio.vue
+++ b/pages/negocio.vue
@@ -303,6 +303,10 @@
         </div>
       </div>
 
+      <!--
+        Policy (#1909 / epic #1906): Starter online-orders banner is informational only.
+        Do not gate Mi Negocio save/edit on plan quotas — Despacho and Mi Negocio stay ungated.
+      -->
       <div
         v-if="isStarterPlan && businessProfile?.accepts_online_orders && !isEditMode"
         class="rounded-xl border border-amber-300/80 bg-amber-50 px-4 py-3 dark:border-amber-800/40 dark:bg-amber-950/20"


### PR DESCRIPTION
## Summary
- Codify policy: Mi Negocio Starter online hint stays **informational** (no save-quota gate); Despacho remains ungated.
- Mi Plan `uso`: show `api_tokens` usage row (incl. Starter limit 0) as display-only.

Closes #1909

## Test plan
- [ ] Starter Mi Negocio: save profile without upgrade modal
- [ ] Despacho pages load without quota CTAs
- [ ] Mi Plan → Uso shows API keys row when remaining-usage / starter quotas available

## Validation evidence
```text
$ rg -n "useOperationalQuotaGate|quota_exceeded|UiConfirmActionModal" \
    pages/negocio.vue pages/despacho pages/gestion/billing/uso.vue
(no matches — ungated OK)

$ ls pages/despacho
comandas.vue  domicilios/  en-mesa/

Policy note added above Starter online hint in pages/negocio.vue.
api_tokens added to quotaDisplayConfig + starter fallback allows limit === 0.
```

Made with [Cursor](https://cursor.com)