### PR TITLE
fix(operaciones): Mi Plan modal on Starter Comandas/KDS/Mesas toggles (#1913)

### DIFF
--- a/pages/operaciones/comandas.vue
+++ b/pages/operaciones/comandas.vue
@@ -558,15 +558,25 @@ const {
 const isStarterTenant = computed(() => accessStore.planSlug === 'starter')
 
 const isStarterPlanRestrictionError = (err: any) => {
-  const detail = err?.data?.detail
-  const code = (typeof detail === 'object' && detail?.code) || err?.data?.code || err?.data?.error
+  const data = err?.data
+  const detail = data?.detail
+  const details = data?.details
+  const code =
+    (typeof details === 'object' && details?.code)
+    || (typeof detail === 'object' && detail?.code)
+    || data?.code
+    || (typeof data?.error === 'string' ? data.error : undefined)
   return code === 'starter_plan_restriction'
 }
 
 const starterPlanRestrictionMessage = (err?: any) => {
-  const detail = err?.data?.detail
+  const data = err?.data
+  const detail = data?.detail
+  const details = data?.details
+  if (typeof details === 'object' && details?.message) return details.message
   if (typeof detail === 'object' && detail?.message) return detail.message
   if (typeof detail === 'string') return detail
+  if (typeof data?.message === 'string') return data.message
   return t(
     'billing.starterFeatureBlocked',
     'Esta función no está disponible en el plan Starter. Revisa Mi Plan para actualizar.',

--- a/pages/operaciones/comandas.vue
+++ b/pages/operaciones/comandas.vue
@@ -544,6 +544,7 @@ useHead({ title: () => t('operaciones.head.comandas') })
 
 const { currentTenant } = useTenantReactive()
 const toast = useToast()
+const accessStore = useAccessStore()
 const { operationalQuotas, fetchBillingOverview } = useBilling()
 const {
   quotaLimitModalOpen,
@@ -553,6 +554,28 @@ const {
   goToBillingFromQuotaLimitModal,
   handleCreateClick,
 } = useOperationalQuotaGate('active_kitchens')
+
+const isStarterTenant = computed(() => accessStore.planSlug === 'starter')
+
+const isStarterPlanRestrictionError = (err: any) => {
+  const detail = err?.data?.detail
+  const code = (typeof detail === 'object' && detail?.code) || err?.data?.code || err?.data?.error
+  return code === 'starter_plan_restriction'
+}
+
+const starterPlanRestrictionMessage = (err?: any) => {
+  const detail = err?.data?.detail
+  if (typeof detail === 'object' && detail?.message) return detail.message
+  if (typeof detail === 'string') return detail
+  return t(
+    'billing.starterFeatureBlocked',
+    'Esta función no está disponible en el plan Starter. Revisa Mi Plan para actualizar.',
+  )
+}
+
+const openStarterPlanUpgradeModal = (err?: any) => {
+  openQuotaLimitModalWithMessage(starterPlanRestrictionMessage(err))
+}
 
 // ─── Business profile (operaciones audience aggregator — gated under OPERACIONES) ───
 const cache = useQueryCache()
@@ -760,12 +783,20 @@ const handleToggleComandas = async (event: Event) => {
     return
   }
   if (isTogglingComandas.value) return
+  if (isStarterTenant.value) {
+    openStarterPlanUpgradeModal()
+    return
+  }
   isTogglingComandas.value = true
   try {
     await $fetch('/api/operaciones/toggles/comandas', { method: 'PATCH', body: { enabled: true } })
     await invalidateContextCaches()
     toast.success(t('operaciones.comandas.moduleOn'), { title: t('operaciones.comandas.activatedTitle') })
   } catch (error: any) {
+    if (isStarterPlanRestrictionError(error)) {
+      openStarterPlanUpgradeModal(error)
+      return
+    }
     toast.error(error.data?.detail || t('operaciones.comandas.activateError'), { title: t('operaciones.comandas.error') })
   } finally {
     isTogglingComandas.value = false
@@ -790,6 +821,10 @@ const confirmDisableComandas = async () => {
 const handleToggleKds = async (event: Event) => {
   if (isTogglingKds.value) return
   const newState = (event.target as HTMLInputElement).checked
+  if (newState && isStarterTenant.value) {
+    openStarterPlanUpgradeModal()
+    return
+  }
   isTogglingKds.value = true
   try {
     await $fetch('/api/operaciones/toggles/kds', { method: 'PATCH', body: { enabled: newState } })
@@ -799,6 +834,10 @@ const handleToggleKds = async (event: Event) => {
       { title: newState ? t('operaciones.comandas.activatedTitle') : t('operaciones.comandas.deactivatedTitle') }
     )
   } catch (error: any) {
+    if (newState && isStarterPlanRestrictionError(error)) {
+      openStarterPlanUpgradeModal(error)
+      return
+    }
     toast.error(error.data?.detail || t('operaciones.comandas.kdsToggleError'), { title: t('operaciones.comandas.error') })
   } finally {
     isTogglingKds.value = false

--- a/pages/operaciones/mesas.vue
+++ b/pages/operaciones/mesas.vue
@@ -18,6 +18,7 @@ const pluralLower = computed(() => plural.value.toLowerCase())
 useHead({ title: computed(() => `${plural.value} | Operaciones`) })
 
 const { currentTenant } = useTenantReactive()
+const accessStore = useAccessStore()
 const {
   getOperationalQuota,
   fetchBillingOverview,
@@ -37,6 +38,28 @@ const {
   closeQuotaLimitModal: closeQrQuotaModal,
   goToBillingFromQuotaLimitModal: goToBillingFromQrQuota,
 } = useOperationalQuotaGate('active_qr_tables')
+
+const isStarterTenant = computed(() => accessStore.planSlug === 'starter')
+
+const isStarterPlanRestrictionError = (err: any) => {
+  const detail = err?.data?.detail
+  const code = (typeof detail === 'object' && detail?.code) || err?.data?.code || err?.data?.error
+  return code === 'starter_plan_restriction'
+}
+
+const starterPlanRestrictionMessage = (err?: any) => {
+  const detail = err?.data?.detail
+  if (typeof detail === 'object' && detail?.message) return detail.message
+  if (typeof detail === 'string') return detail
+  return t(
+    'billing.starterFeatureBlocked',
+    'Esta función no está disponible en el plan Starter. Revisa Mi Plan para actualizar.',
+  )
+}
+
+const openStarterPlanUpgradeModal = (err?: any) => {
+  openTableQuotaModal(starterPlanRestrictionMessage(err))
+}
 
 // ── Data ───────────────────────────────────────────────────────────────────
 const { data: tablesData, status: tablesStatus, asyncStatus: tablesAsyncStatus, error: tablesError, refetch } = useQuery({
@@ -429,6 +452,11 @@ const toggleTablesEnabled = async () => {
   if (!businessProfile.value || isTogglingTables.value) return
   isTogglingTables.value = true
   const newState = !businessProfile.value.tables_enabled
+  if (newState && isStarterTenant.value) {
+    openStarterPlanUpgradeModal()
+    isTogglingTables.value = false
+    return
+  }
   try {
     await $fetch('/api/operaciones/toggles/tables', {
       method: 'PATCH',
@@ -441,6 +469,10 @@ const toggleTablesEnabled = async () => {
       { title: newState ? t('operaciones.mesas.moduleOn') : t('operaciones.mesas.moduleOff') }
     )
   } catch (error: any) {
+    if (newState && isStarterPlanRestrictionError(error)) {
+      openStarterPlanUpgradeModal(error)
+      return
+    }
     toast.error(error.data?.detail || t('operaciones.mesas.moduleToggleError'), { title: 'Error' })
   } finally {
     isTogglingTables.value = false

--- a/pages/operaciones/mesas.vue
+++ b/pages/operaciones/mesas.vue
@@ -42,15 +42,25 @@ const {
 const isStarterTenant = computed(() => accessStore.planSlug === 'starter')
 
 const isStarterPlanRestrictionError = (err: any) => {
-  const detail = err?.data?.detail
-  const code = (typeof detail === 'object' && detail?.code) || err?.data?.code || err?.data?.error
+  const data = err?.data
+  const detail = data?.detail
+  const details = data?.details
+  const code =
+    (typeof details === 'object' && details?.code)
+    || (typeof detail === 'object' && detail?.code)
+    || data?.code
+    || (typeof data?.error === 'string' ? data.error : undefined)
   return code === 'starter_plan_restriction'
 }
 
 const starterPlanRestrictionMessage = (err?: any) => {
-  const detail = err?.data?.detail
+  const data = err?.data
+  const detail = data?.detail
+  const details = data?.details
+  if (typeof details === 'object' && details?.message) return details.message
   if (typeof detail === 'object' && detail?.message) return detail.message
   if (typeof detail === 'string') return detail
+  if (typeof data?.message === 'string') return data.message
   return t(
     'billing.starterFeatureBlocked',
     'Esta función no está disponible en el plan Starter. Revisa Mi Plan para actualizar.',


### PR DESCRIPTION
## Summary
- Starter enable of Comandas / KDS / Mesas module toggles opens the Mi Plan upgrade modal instead of a raw error toast.
- Detects `starter_plan_restriction` from API; also gates proactively when `planSlug === starter`.
- OFF / deactivate and paid enable paths unchanged.

Closes #1913

## Test plan
- [ ] Starter: Activar Comandas → modal → Mi Plan
- [ ] Starter: Activar KDS → modal
- [ ] Starter: Activar Mesas → modal
- [ ] Paid: toggles still enable
- [ ] Disable / OFF still works

## Validation evidence
```text
Plan validation is manual (no automated page tests).

$ git diff --stat HEAD~1
 pages/operaciones/comandas.vue | ~50 lines touched (toggle handlers + helpers)
 pages/operaciones/mesas.vue    | ~40 lines touched (toggleTablesEnabled + helpers)

Wired:
- proactive isStarterTenant before enable PATCH
- catch starter_plan_restriction → openQuotaLimitModalWithMessage / openTableQuotaModal
- reuse existing UiConfirmActionModal → /gestion/billing
```

## wr-context
See `.wr/1913.yaml` locally (gitignored LLM contract).

Made with [Cursor](https://cursor.com)