### PR TITLE
fix(operaciones): reset Starter toggles after Mi Plan modal

### DIFF
--- a/.wr/1915.yaml
+++ b/.wr/1915.yaml
@@ -1,0 +1,40 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1915
+title: "Fix: Starter Operaciones toggles show ON after Mi Plan modal (Comandas/Mesas)"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1915-starter-toggle-checked-reset
+
+paths:
+  - pages/operaciones/comandas.vue
+  - pages/operaciones/mesas.vue
+
+ac:
+  - "Starter Comandas ON → Mi Plan modal + switch visually OFF"
+  - "Starter KDS ON → same"
+  - "Starter Mesas ON → same"
+  - "Refresh keeps modules disabled if they were off"
+  - "Non-Starter paths unchanged"
+  - "starter_plan_restriction catch also resets checkbox"
+
+out_of_scope:
+  - Promociones / Turnos / Personalizar / Propinas locks
+  - Country-aware banner
+  - Turnos create quota
+
+hints:
+  entry: "handleToggleComandas / handleToggleKds / toggleTablesEnabled"
+  pattern: "Force input.checked=false on starter early-return + catch (Vue controlled checkbox)"
+  tests: "none — page handlers; verify with rg on reset sites"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "manual Starter smoke on Operaciones Comandas/Mesas"

--- a/pages/operaciones/comandas.vue
+++ b/pages/operaciones/comandas.vue
@@ -794,6 +794,7 @@ const handleToggleComandas = async (event: Event) => {
   }
   if (isTogglingComandas.value) return
   if (isStarterTenant.value) {
+    ;(event.target as HTMLInputElement).checked = false
     openStarterPlanUpgradeModal()
     return
   }
@@ -803,6 +804,7 @@ const handleToggleComandas = async (event: Event) => {
     await invalidateContextCaches()
     toast.success(t('operaciones.comandas.moduleOn'), { title: t('operaciones.comandas.activatedTitle') })
   } catch (error: any) {
+    ;(event.target as HTMLInputElement).checked = false
     if (isStarterPlanRestrictionError(error)) {
       openStarterPlanUpgradeModal(error)
       return
@@ -830,8 +832,10 @@ const confirmDisableComandas = async () => {
 
 const handleToggleKds = async (event: Event) => {
   if (isTogglingKds.value) return
-  const newState = (event.target as HTMLInputElement).checked
+  const input = event.target as HTMLInputElement
+  const newState = input.checked
   if (newState && isStarterTenant.value) {
+    input.checked = false
     openStarterPlanUpgradeModal()
     return
   }
@@ -844,6 +848,7 @@ const handleToggleKds = async (event: Event) => {
       { title: newState ? t('operaciones.comandas.activatedTitle') : t('operaciones.comandas.deactivatedTitle') }
     )
   } catch (error: any) {
+    if (newState) input.checked = false
     if (newState && isStarterPlanRestrictionError(error)) {
       openStarterPlanUpgradeModal(error)
       return

--- a/pages/operaciones/mesas.vue
+++ b/pages/operaciones/mesas.vue
@@ -458,11 +458,13 @@ onUnmounted(() => clearRefreshHandler(refreshAll))
 const posStore = usePOSStore()
 const toast = useToast()
 const isTogglingTables = ref(false)
-const toggleTablesEnabled = async () => {
+const toggleTablesEnabled = async (event?: Event) => {
   if (!businessProfile.value || isTogglingTables.value) return
+  const input = event?.target as HTMLInputElement | undefined
   isTogglingTables.value = true
   const newState = !businessProfile.value.tables_enabled
   if (newState && isStarterTenant.value) {
+    if (input) input.checked = false
     openStarterPlanUpgradeModal()
     isTogglingTables.value = false
     return
@@ -479,6 +481,8 @@ const toggleTablesEnabled = async () => {
       { title: newState ? t('operaciones.mesas.moduleOn') : t('operaciones.mesas.moduleOff') }
     )
   } catch (error: any) {
+    // Controlled checkbox: Vue won't revert :checked if the prop stays false.
+    if (input && newState) input.checked = false
     if (newState && isStarterPlanRestrictionError(error)) {
       openStarterPlanUpgradeModal(error)
       return


### PR DESCRIPTION
## Summary
- Force `input.checked = false` when Starter blocks enabling Comandas, KDS, or Mesas so the controlled toggle does not stay visually ON after the Mi Plan modal.
- Same reset on `starter_plan_restriction` catch paths when the proactive plan gate is skipped.

Closes #1915

## Test plan
- [ ] Starter: enable Comandas → modal + switch OFF
- [ ] Starter: enable KDS → modal + switch OFF
- [ ] Starter: enable Mesas → modal + switch OFF
- [ ] Refresh: modules still off if they were off
- [ ] Pro: enable/disable still works

## Validation evidence
```text
$ rg -n "checked = false" pages/operaciones/comandas.vue pages/operaciones/mesas.vue
pages/operaciones/comandas.vue:797:    ;(event.target as HTMLInputElement).checked = false
pages/operaciones/comandas.vue:807:    ;(event.target as HTMLInputElement).checked = false
pages/operaciones/comandas.vue:838:    input.checked = false
pages/operaciones/comandas.vue:851:    if (newState) input.checked = false
pages/operaciones/mesas.vue:467:    if (input) input.checked = false
pages/operaciones/mesas.vue:485:    if (input && newState) input.checked = false
```
No page-handler unit tests in scope (handlers only).

## wr-context
See `.wr/1915.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)