### PR TITLE
fix(operaciones): gate Starter Turnos create with Mi Plan modal

### DIFF
--- a/.wr/1916.yaml
+++ b/.wr/1916.yaml
@@ -1,0 +1,34 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1916
+title: "Starter: block creating Operaciones Turnos (shift templates) with Mi Plan modal"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1916-starter-shift-templates
+
+paths:
+  - pages/operaciones/turnos.vue
+
+ac:
+  - "Starter Nuevo turno → Mi Plan modal, no panel"
+  - "Starter reactivate → Mi Plan modal"
+  - "Catch starter_plan_restriction → same modal"
+  - "Edit/deactivate unchanged"
+
+out_of_scope:
+  - API (companion PR on api-warolabs)
+  - Country banner (#1917)
+
+hints:
+  entry: "openCreate / reactivate"
+  pattern: "pages/operaciones/mesas.vue starter modal helpers"
+  tests: "none — page handlers"
+
+risk: low
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "depends on API PR merge for SoT"

--- a/pages/operaciones/turnos.vue
+++ b/pages/operaciones/turnos.vue
@@ -150,6 +150,16 @@
       :loading="isDeactivating"
       @confirm="performDeactivate"
     />
+
+    <UiConfirmActionModal
+      v-model="starterPlanModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="starterPlanModalMessage"
+      :confirm-label="t('nav.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromStarterModal"
+      @cancel="closeStarterPlanModal"
+    />
   </div>
 </template>
 
@@ -158,6 +168,7 @@ const { t } = useI18n({ useScope: 'global' })
 import { ArrowPathIcon, NoSymbolIcon, PencilSquareIcon } from '@heroicons/vue/24/outline'
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
 import type { ShiftTemplate } from '~/components/operaciones/ShiftTemplatePanel.vue'
+import { useAccessStore } from '~/stores/access'
 
 definePageMeta({ layout: 'dashboard', module: 'operaciones' })
 useHead({ title: () => t('operaciones.head.turnos') })
@@ -165,7 +176,53 @@ useHead({ title: () => t('operaciones.head.turnos') })
 const { currentTenant } = useTenantReactive()
 const cache = useQueryCache()
 const toast = useToast()
+const accessStore = useAccessStore()
 const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
+
+const isStarterTenant = computed(() => accessStore.planSlug === 'starter')
+
+const isStarterPlanRestrictionError = (err: any) => {
+  const data = err?.data
+  const detail = data?.detail
+  const details = data?.details
+  const code =
+    (typeof details === 'object' && details?.code)
+    || (typeof detail === 'object' && detail?.code)
+    || data?.code
+    || (typeof data?.error === 'string' ? data.error : undefined)
+  return code === 'starter_plan_restriction'
+}
+
+const starterPlanRestrictionMessage = (err?: any) => {
+  const data = err?.data
+  const detail = data?.detail
+  const details = data?.details
+  if (typeof details === 'object' && details?.message) return details.message
+  if (typeof detail === 'object' && detail?.message) return detail.message
+  if (typeof detail === 'string') return detail
+  if (typeof data?.message === 'string') return data.message
+  return t(
+    'billing.starterFeatureBlocked',
+    'Esta función no está disponible en el plan Starter. Revisa Mi Plan para actualizar.',
+  )
+}
+
+const starterPlanModalOpen = ref(false)
+const starterPlanModalMessage = ref('')
+
+const openStarterPlanUpgradeModal = (err?: any) => {
+  starterPlanModalMessage.value = starterPlanRestrictionMessage(err)
+  starterPlanModalOpen.value = true
+}
+
+const closeStarterPlanModal = () => {
+  starterPlanModalOpen.value = false
+}
+
+const goToBillingFromStarterModal = async () => {
+  starterPlanModalOpen.value = false
+  await navigateTo('/gestion/billing')
+}
 
 const columns: Column[] = [
   { key: 'name', title: t('operaciones.turnos.name'), sortable: false },
@@ -211,6 +268,10 @@ const panelOpen = ref(false)
 const panelTemplate = ref<ShiftTemplate | null>(null)
 
 const openCreate = () => {
+  if (isStarterTenant.value) {
+    openStarterPlanUpgradeModal()
+    return
+  }
   panelTemplate.value = null
   panelOpen.value = true
 }
@@ -256,6 +317,10 @@ const performDeactivate = async () => {
 }
 
 const reactivate = async (row: ShiftTemplate) => {
+  if (isStarterTenant.value) {
+    openStarterPlanUpgradeModal()
+    return
+  }
   try {
     await $fetch(`/api/operaciones/shifts/${row.id}`, {
       method: 'PATCH',
@@ -264,6 +329,10 @@ const reactivate = async (row: ShiftTemplate) => {
     await cache.invalidateQueries({ key: ['operaciones', 'shifts'] })
     toast.success(t('operaciones.turnos.reactivatedToast', { name: row.name }))
   } catch (err: any) {
+    if (isStarterPlanRestrictionError(err)) {
+      openStarterPlanUpgradeModal(err)
+      return
+    }
     toast.error(err?.data?.detail || t('operaciones.turnos.reactivateError'), { title: 'Error' })
   }
 }


### PR DESCRIPTION
## Summary
- Starter: **Nuevo turno** and **reactivar** open Mi Plan modal instead of creating/reactivating.
- Catch `starter_plan_restriction` from API on reactivate and show the same modal.
- Companion API SoT: https://github.com/uno0uno/api-warolabs/pull/741

Closes #1916

## Test plan
- [ ] Starter: Nuevo turno → modal, panel does not open
- [ ] Starter: reactivar → modal
- [ ] Starter: editar / desactivar still works
- [ ] Pro: create/reactivate unchanged

## Validation evidence
```text
API companion: ./venv/bin/pytest tests/test_quota_enforcement.py -k shift_template_growth -q
→ 2 passed, 58 deselected
Front: page-handler gate only (no unit test target); mirrors mesas/comandas starter modal pattern.
```

## wr-context
See `.wr/1916.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)