### PR TITLE
fix(shell): country-aware Starter trial price anchor

### DIFF
--- a/.wr/1917.yaml
+++ b/.wr/1917.yaml
@@ -1,0 +1,38 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1917
+title: "Trial banner: country-aware price anchor (MX vs CO COP)"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1917-trial-banner-country-anchor
+
+paths:
+  - utils/publicCta.ts
+  - utils/publicCta.test.ts
+  - layouts/dashboard.vue
+
+ac:
+  - "MX/MXN tenant trial banner does not show COP"
+  - "CO/COP tenants keep existing COP monthlyEquivalent"
+  - "EN locale coherent for both"
+  - "Logo WARO Colombia deferred (chrome unchanged)"
+  - "No billing checkout currency change"
+
+out_of_scope:
+  - Full multi-country pricing catalog
+  - Public marketing CTAs (stay COP)
+  - Shell logo rename
+
+hints:
+  entry: "resolveTrialPriceAnchor + dashboard subscriptionBannerMessage"
+  pattern: "useTenantFinancialProfile country_code / base_currency_code"
+  tests: "node --experimental-strip-types --test utils/publicCta.test.ts"
+
+risk: low
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "manual smoke Starter MX tenant banner"

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -87,7 +87,7 @@ import { useNotifications } from '~/composables/useNotifications'
 import { useBilling } from '~/composables/useBilling'
 import { usePosMobileCart } from '~/composables/usePosMobileCart'
 import { getDashboardHome } from '~/utils/internalAccess'
-import { PUBLIC_OFFER, resolveTrialPriceAnchor } from '~/utils/publicCta'
+import { resolveTrialPriceAnchor } from '~/utils/publicCta'
 import { useTenantFinancialProfile } from '~/composables/useTenantFinancialProfile'
 
 const { t, locale } = useI18n()

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -87,7 +87,8 @@ import { useNotifications } from '~/composables/useNotifications'
 import { useBilling } from '~/composables/useBilling'
 import { usePosMobileCart } from '~/composables/usePosMobileCart'
 import { getDashboardHome } from '~/utils/internalAccess'
-import { PUBLIC_OFFER } from '~/utils/publicCta'
+import { PUBLIC_OFFER, resolveTrialPriceAnchor } from '~/utils/publicCta'
+import { useTenantFinancialProfile } from '~/composables/useTenantFinancialProfile'
 
 const { t, locale } = useI18n()
 
@@ -100,6 +101,7 @@ const dashboardHome = computed(() =>
   getDashboardHome(accessStore.modules, { isLoaded: accessStore.isLoaded }),
 )
 const { accessStatus, fetchAccessStatus } = useBilling({ overview: false })
+const { profile: financialProfile } = useTenantFinancialProfile()
 const isBillingBlocked = computed(() =>
   accessStore.can('mi_plan') && accessStatus.value?.level === 'blocked',
 )
@@ -122,9 +124,11 @@ const subscriptionBannerMessage = computed(() => {
   if (!status || !level) return ''
   // Prefer localized conversion copy for Starter; API starter message is operational, not CTA.
   if (level === 'starter') {
-    const priceAnchor = String(locale.value || '').startsWith('en')
-      ? 'under COP 8,000/month'
-      : PUBLIC_OFFER.monthlyEquivalent
+    const priceAnchor = resolveTrialPriceAnchor({
+      locale: locale.value,
+      countryCode: financialProfile.value?.country_code,
+      currencyCode: financialProfile.value?.base_currency_code,
+    })
     return t('shell.subscriptionTrial', { priceAnchor })
   }
   if (status.message) return status.message

--- a/utils/publicCta.test.ts
+++ b/utils/publicCta.test.ts
@@ -4,11 +4,13 @@ import test from 'node:test'
 import {
   PUBLIC_CTA_ATTRIBUTION_KEY,
   PUBLIC_CTA_COMPARISON,
+  PUBLIC_OFFER,
   activatePublicCta,
   buildPublicCtaRegistrationRoute,
   getPublicCta,
   readPublicCtaAttribution,
   resolveBlogCtaIntent,
+  resolveTrialPriceAnchor,
   writeVerifiedPublicCtaAttribution,
 } from './publicCta.ts'
 
@@ -84,4 +86,34 @@ test('restores server-bound attribution in a fresh magic-link tab', () => {
 
   assert.deepEqual(readPublicCtaAttribution(storage), restored)
   assert.equal(values.get(PUBLIC_CTA_ATTRIBUTION_KEY)?.includes('email'), false)
+})
+
+test('trial banner price anchor stays COP for Colombia tenants', () => {
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'es', countryCode: 'CO', currencyCode: 'COP' }),
+    PUBLIC_OFFER.monthlyEquivalent,
+  )
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'en', countryCode: 'CO', currencyCode: 'COP' }),
+    'under COP 8,000/month',
+  )
+})
+
+test('trial banner price anchor avoids COP for Mexico tenants', () => {
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'es', countryCode: 'MX', currencyCode: 'MXN' }),
+    'el Plan Pro',
+  )
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'en', countryCode: 'MX', currencyCode: 'MXN' }),
+    'Plan Pro',
+  )
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'es', countryCode: null, currencyCode: 'MXN' }),
+    'el Plan Pro',
+  )
+  assert.doesNotMatch(
+    resolveTrialPriceAnchor({ locale: 'es', countryCode: 'MX', currencyCode: 'MXN' }),
+    /COP/i,
+  )
 })

--- a/utils/publicCta.ts
+++ b/utils/publicCta.ts
@@ -43,6 +43,25 @@ export const PUBLIC_OFFER = Object.freeze({
   activation: 'El acceso a los módulos se activa después del pago.',
 })
 
+/** In-app Starter trial banner price slot (warocol.com#1917). Public marketing CTAs stay COP. */
+export function resolveTrialPriceAnchor(options: {
+  locale?: string | null
+  countryCode?: string | null
+  currencyCode?: string | null
+} = {}): string {
+  const isEn = String(options.locale || '').toLowerCase().startsWith('en')
+  const country = String(options.countryCode || '').toUpperCase()
+  const currency = String(options.currencyCode || '').toUpperCase()
+  const isMexico = country === 'MX' || currency === 'MXN'
+
+  if (isMexico) {
+    // No approved MXN list price yet — avoid showing COP to MX tenants.
+    return isEn ? 'Plan Pro' : 'el Plan Pro'
+  }
+
+  return isEn ? 'under COP 8,000/month' : PUBLIC_OFFER.monthlyEquivalent
+}
+
 // Activate only after recording a verifiable source, date, scope and disclosure here.
 export const PUBLIC_CTA_COMPARISON: PublicCtaComparison | null = null
 


### PR DESCRIPTION
## Summary
- Add `resolveTrialPriceAnchor` so MX/MXN tenants do not see COP in the dashboard Starter trial banner.
- Colombia/COP keeps the existing “menos de COP 8.000/mes” (and EN COP variant).
- Chrome logo “WARO Colombia” unchanged (deferred). Public marketing CTAs still COP.

Closes #1917

## Test plan
- [ ] Starter MX tenant: banner has no COP
- [ ] Starter CO tenant: banner still shows COP monthly equivalent
- [ ] Switch UI locale EN on MX: coherent “from Plan Pro”

## Validation evidence
```text
$ node --experimental-strip-types --test utils/publicCta.test.ts
# tests 7
# pass 7
# fail 0
```

## wr-context
See `.wr/1917.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)