### PR TITLE
feat(operaciones): gate Promociones create on plan quota

### DIFF
--- a/.wr/1921.yaml
+++ b/.wr/1921.yaml
@@ -1,0 +1,35 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1921
+title: "Starter: growth quota for Operaciones Promociones (tenant_promotions)"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1921-promotions-quota
+
+paths:
+  - composables/useBilling.ts
+  - pages/operaciones/promociones/index.vue
+  - components/promociones/PromocionPanel.vue
+  - pages/gestion/billing/uso.vue
+
+ac:
+  - "Create CTA gated via useOperationalQuotaGate(tenant_promotions)"
+  - "Panel POST 429 → quota-blocked → Mi Plan modal"
+  - "Mi Plan uso shows tenant_promotions"
+
+out_of_scope:
+  - API companion PR
+
+hints:
+  entry: "openCreate / PromocionPanel onSubmit"
+  pattern: "pages/integraciones.vue api_tokens gate"
+  tests: "API pytest companion"
+
+risk: low
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "depends on API PR"

--- a/components/promociones/PromocionPanel.vue
+++ b/components/promociones/PromocionPanel.vue
@@ -410,6 +410,7 @@ interface Emits {
   (e: 'update:modelValue', v: boolean): void
   (e: 'saved'): void
   (e: 'deleted'): void
+  (e: 'quota-blocked', message: string): void
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -794,12 +795,43 @@ async function onSubmit() {
     close()
     emit('saved')
   } catch (e: any) {
+    if (!isEdit.value && isQuotaExceededError(e)) {
+      emit('quota-blocked', quotaExceededMessageFromError(e))
+      close()
+      return
+    }
     const detail = extractFetchDetail(e)
     validationErrors.value = [detail]
     toast.error(detail, { title: t('operaciones.promociones.saveFailedTitle') })
   } finally {
     isSaving.value = false
   }
+}
+
+function isQuotaExceededError(err: any) {
+  const detail = err?.data?.detail
+  const details = err?.data?.details
+  return err?.status === 429 ||
+    err?.statusCode === 429 ||
+    err?.data?.code === 'quota_exceeded' ||
+    err?.data?.error === 'quota_exceeded' ||
+    detail?.code === 'quota_exceeded' ||
+    detail?.error === 'quota_exceeded' ||
+    details?.code === 'quota_exceeded'
+}
+
+function quotaExceededMessageFromError(err: any) {
+  const detail = err?.data?.detail ?? err?.data?.details ?? err?.data ?? {}
+  const used = typeof detail.used === 'number' ? detail.used : null
+  const limit = typeof detail.limit === 'number' ? detail.limit : null
+
+  if (used !== null && limit !== null) {
+    return `Alcanzaste el límite de promociones de tu plan. Uso actual: ${used.toLocaleString('es-CO')} de ${limit.toLocaleString('es-CO')} promociones. Revisa Mi Plan para ampliar tu cupo.`
+  }
+
+  return typeof detail === 'string'
+    ? detail
+    : (detail?.message || t('billing.upgrade.quotaBlocked'))
 }
 
 function openDeleteConfirm() {

--- a/composables/useBilling.ts
+++ b/composables/useBilling.ts
@@ -32,6 +32,7 @@ export type BillingQuotaKey =
   | 'supplier_payments_per_period'
   | 'payment_methods'
   | 'api_tokens'
+  | 'tenant_promotions'
   | 'accounting_period_closes_per_period'
   | 'manual_journal_entries_per_period'
   | 'modifier_groups'
@@ -162,6 +163,7 @@ export type OperationalQuotaKey =
   | 'supplier_payments_per_period'
   | 'payment_methods'
   | 'api_tokens'
+  | 'tenant_promotions'
   | 'accounting_period_closes_per_period'
   | 'manual_journal_entries_per_period'
   | 'modifier_groups'
@@ -348,6 +350,14 @@ export const BILLING_QUOTA_RESOURCE_CONFIG: Record<BillingQuotaKey, BillingQuota
     blockedMessage: 'Alcanzaste el límite de API keys de tu plan.',
     unlimitedMessage: 'Puedes crear API keys sin límite por override.',
   },
+  tenant_promotions: {
+    key: 'tenant_promotions',
+    label: 'Promociones',
+    description: 'Promociones configuradas en Operaciones',
+    unit: 'promociones',
+    blockedMessage: 'Alcanzaste el límite de promociones de tu plan.',
+    unlimitedMessage: 'Puedes crear promociones sin límite por override.',
+  },
   accounting_period_closes_per_period: {
     key: 'accounting_period_closes_per_period',
     label: 'Cierres contables mensuales por periodo',
@@ -407,6 +417,7 @@ export const STARTER_DISPLAY_QUOTA_KEYS: BillingQuotaKey[] = [
   'completed_online_orders_per_month',
   'admin_users',
   'api_tokens',
+  'tenant_promotions',
 ]
 
 export const OPERATIONAL_QUOTA_KEYS: OperationalQuotaKey[] = [
@@ -427,6 +438,7 @@ export const OPERATIONAL_QUOTA_KEYS: OperationalQuotaKey[] = [
   'supplier_payments_per_period',
   'payment_methods',
   'api_tokens',
+  'tenant_promotions',
   'accounting_period_closes_per_period',
   'manual_journal_entries_per_period',
   'modifier_groups',

--- a/pages/gestion/billing/uso.vue
+++ b/pages/gestion/billing/uso.vue
@@ -125,6 +125,7 @@ const quotaDisplayConfig = [
   BILLING_QUOTA_RESOURCE_CONFIG.completed_online_orders_per_month,
   BILLING_QUOTA_RESOURCE_CONFIG.electronic_invoices_per_period,
   BILLING_QUOTA_RESOURCE_CONFIG.api_tokens,
+  BILLING_QUOTA_RESOURCE_CONFIG.tenant_promotions,
 ]
 
 const usageLabels = computed<Record<string, { resource: string; description: string; unit: string; notIncluded?: string }>>(() => ({
@@ -136,6 +137,7 @@ const usageLabels = computed<Record<string, { resource: string; description: str
   completed_online_orders_per_month: { resource: t('billing.quotaOnlineOrders'), description: t('billing.quotaOnlineOrdersDescription'), unit: t('billing.unitOnlineOrders') },
   electronic_invoices_per_period: { resource: t('billing.quotaInvoices'), description: t('billing.quotaInvoicesDescription'), unit: t('billing.unitInvoices'), notIncluded: t('billing.notIncluded') },
   api_tokens: { resource: t('billing.quotaApiTokens', 'API keys'), description: t('billing.quotaApiTokensDescription', 'Claves de API activas para integraciones'), unit: t('billing.unitApiTokens', 'API keys') },
+  tenant_promotions: { resource: t('billing.quotaPromotions', 'Promociones'), description: t('billing.quotaPromotionsDescription', 'Promociones configuradas en Operaciones'), unit: t('billing.unitPromotions', 'promociones') },
   menu_products: { resource: t('billing.quota.menu_products'), description: t('billing.starterUsageValidatedOnSave'), unit: t('billing.unitProducts') },
   menu_categories: { resource: t('billing.quota.menu_categories'), description: t('billing.starterUsageValidatedOnSave'), unit: t('billing.unitCategories') },
   tenant_ingredients: { resource: t('billing.quota.tenant_ingredients'), description: t('billing.starterUsageValidatedOnSave'), unit: t('billing.unitIngredients') },

--- a/pages/operaciones/promociones/index.vue
+++ b/pages/operaciones/promociones/index.vue
@@ -75,7 +75,7 @@
           <button
             type="button"
             class="btn-primary px-4 py-2 rounded-lg text-sm font-medium whitespace-nowrap min-h-[44px]"
-            @click="openPanel(null)"
+            @click="openCreate"
           >
             {{ t('operaciones.promociones.newPromotion') }}
           </button>
@@ -278,6 +278,7 @@
       :promotion-id="panelPromotionId"
       @saved="onPanelSaved"
       @deleted="onPanelSaved"
+      @quota-blocked="onCreateQuotaBlocked"
     />
 
     <PromocionesPromotionScopePopover
@@ -298,6 +299,16 @@
       @confirm="confirmDeletePromotion"
       @cancel="cancelDeletePromotion"
     />
+
+    <UiConfirmActionModal
+      v-model="quotaLimitModalOpen"
+      :title="t('billing.upgrade.quotaBlocked')"
+      :message="quotaLimitModalMessage"
+      :confirm-label="t('nav.miPlan')"
+      :cancel-label="t('billing.close')"
+      @confirm="goToBillingFromQuotaLimitModal"
+      @cancel="closeQuotaLimitModal"
+    />
   </div>
 </template>
 
@@ -307,6 +318,7 @@ import type { Column } from '~/components/ui/ResponsiveDataView.vue'
 import { useQuery, useQueryCache } from '@pinia/colada'
 import { PencilIcon as PencilOutlineIcon, TrashIcon as TrashOutlineIcon } from '@heroicons/vue/24/outline'
 import { PencilIcon as PencilSolidIcon, TrashIcon as TrashSolidIcon } from '@heroicons/vue/24/solid'
+import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
 import {
   formatPromoTypeLabel,
   formatPromoValue,
@@ -341,6 +353,14 @@ const router = useRouter()
 const { currentTenant } = useTenantReactive()
 const cache = useQueryCache()
 const toast = useToast()
+const {
+  quotaLimitModalOpen,
+  quotaLimitModalMessage,
+  openQuotaLimitModalWithMessage,
+  closeQuotaLimitModal,
+  goToBillingFromQuotaLimitModal,
+  handleCreateClick,
+} = useOperationalQuotaGate('tenant_promotions')
 
 const {
   data: opsContextData,
@@ -578,6 +598,16 @@ function openPanel(item: PromotionRow | null) {
   showPanel.value = true
 }
 
+function openCreate() {
+  void handleCreateClick(() => openPanel(null))
+}
+
+function onCreateQuotaBlocked(message: string) {
+  showPanel.value = false
+  panelPromotionId.value = null
+  openQuotaLimitModalWithMessage(message)
+}
+
 function openEdit(item: PromotionRow) {
   openPanel(item)
 }
@@ -632,7 +662,7 @@ async function onPanelSaved() {
 function openFromQuery() {
   if (skipOpenFromQuery.value) return
   if (route.query.nuevo === '1') {
-    openPanel(null)
+    openCreate()
     return
   }
   const id = route.query.id


### PR DESCRIPTION
## Summary
- Wire `tenant_promotions` into billing remaining-usage / Mi Plan Uso.
- “Nueva promoción” uses `useOperationalQuotaGate`; panel POST `quota_exceeded` opens Mi Plan modal.
- Companion API: https://github.com/uno0uno/api-warolabs/pull/742

Closes #1921

## Test plan
- [ ] Starter at 1 promo: Nueva promoción → Mi Plan modal
- [ ] Starter at 0: create works
- [ ] Edit/delete still work at cap
- [ ] Mi Plan → Uso shows Promociones

## Validation evidence
```text
API companion: ./venv/bin/pytest tests/test_quota_enforcement.py -k tenant_promotions -q
→ 3 passed, 60 deselected
Front: mirrors integraciones api_tokens gate (page handlers + panel emit).
```

## wr-context
See `.wr/1921.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)