### PR TITLE
feat(analitica): category filter on Ventas and Rentabilidad

### DIFF
--- a/.wr/1926.yaml
+++ b/.wr/1926.yaml
@@ -1,0 +1,53 @@
+# Machine contract — wr-plan #1926 (batch Extends #1928). Keep ≤80 lines.
+issue: 1926
+title: "Batch 1: Analítica filters — category on Ventas and Rentabilidad"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+issue_ref: uno0uno/warocol.com#1926
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-1926-analitica-category-filters
+companion_repo: api_warocol.com
+companion_remote: uno0uno/api-warolabs
+companion_cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/api_warocol.com
+companion_branch: wr-1926-analitica-category-filters
+risk: low
+
+paths:
+  - pages/analitica/ventas.vue
+  - pages/analitica/rentabilidad.vue
+  - i18n/locales/*/analitica.json
+  - .wr/1926.yaml
+
+api_paths:
+  - app/routers/orders.py
+  - app/services/orders_service.py
+  - app/routers/analytics.py
+  - app/services/analytics_service.py
+  - tests/test_analytics_dual_cost.py
+  - tests/test_analytics_ingredients.py
+
+ac:
+  - Ventas: category_id scopes dashboard/metrics/sales-flow to item-attributed revenue
+  - Rentabilidad: category_id scopes food-cost KPI + menu-analysis rows
+  - Empty category_id = all; no crash if tenant has zero categories
+  - clearFilters clears category with date/payment/status
+  - API tests for category_id filter (omit vs set)
+  - Tips endpoint left unfiltered this batch
+
+out_of_scope:
+  - Food-cost / combo math (#1927)
+  - /orders/tips category filter
+  - Ingredientes string category changes
+  - Despacho, Clientes, Puntos
+
+hints:
+  entry: "delta #1926 — category_id UUID; item-attributed"
+  pattern: "orders_service products-sold category_id ~4128; ingredientes filter chrome"
+  categories_ui: "$fetch('/api/menu/categories') — same as MenuCatalogFiltersBar"
+  contract: "payment/status order-level AND category item-level"
+  ship: "API PR first (or pair); front Closes #1926; API Closes/Refs #1926"
+  tests: "pytest tests/test_analytics_dual_cost.py -v; add focused category_id cases"
+
+skip:
+  audits: [ux, color, typography]

--- a/i18n/locales/ar/analitica.json
+++ b/i18n/locales/ar/analitica.json
@@ -24,7 +24,8 @@
       "status": "الحالة",
       "all": "الكل",
       "loading": "جارٍ التحميل...",
-      "actions": "الإجراءات"
+      "actions": "الإجراءات",
+      "category": "الفئة"
     },
     "ventas": {
       "grossSales": "إجمالي المبيعات",
@@ -55,7 +56,8 @@
       "taxGeneric": "الضريبة",
       "marginCta": "قد يكون طبقك الأكثر مبيعًا هو الأقل ربحية",
       "viewMargin": "عرض الربحية ←",
-      "taxFallback": "INC 8%"
+      "taxFallback": "INC 8%",
+      "filterCategory": "تصفية حسب الفئة"
     },
     "rentabilidad": {
       "foodCostReal": "التكلفة الفعلية للطعام",
@@ -94,7 +96,8 @@
       "emptyProducts": "لا توجد منتجات للتحليل",
       "emptyProductsSub": "ستظهر المنتجات هنا بمجرد وجود مبيعات في الفترة المحددة",
       "unitsShort": "{count} وحدة",
-      "revenueTooltip": "تعكس الإيرادات السعر الصافي بعد الخصومات المطبقة"
+      "revenueTooltip": "تعكس الإيرادات السعر الصافي بعد الخصومات المطبقة",
+      "filterCategory": "تصفية حسب الفئة"
     },
     "puntos": {
       "toggleHint": "تفعيل أو تعطيل نظام نقاط Waros",

--- a/i18n/locales/de/analitica.json
+++ b/i18n/locales/de/analitica.json
@@ -24,7 +24,8 @@
       "status": "Status",
       "all": "Alle",
       "loading": "Wird geladen...",
-      "actions": "Aktionen"
+      "actions": "Aktionen",
+      "category": "Kategorie"
     },
     "ventas": {
       "grossSales": "Bruttoverkäufe",
@@ -55,7 +56,8 @@
       "taxGeneric": "Steuer",
       "marginCta": "Ihr Bestseller könnte Ihr schlechtestes Geschäft sein",
       "viewMargin": "Rentabilität anzeigen →",
-      "taxFallback": "INC 8%"
+      "taxFallback": "INC 8%",
+      "filterCategory": "Nach Kategorie filtern"
     },
     "rentabilidad": {
       "foodCostReal": "Tatsächliche Food Cost",
@@ -94,7 +96,8 @@
       "emptyProducts": "Keine Produkte zur Analyse vorhanden",
       "emptyProductsSub": "Produkte werden hier angezeigt, sobald im ausgewählten Zeitraum Verkäufe getätigt wurden",
       "unitsShort": "{count} Stk.",
-      "revenueTooltip": "Der Umsatz spiegelt den Nettopreis nach Abzug von Rabatten wider"
+      "revenueTooltip": "Der Umsatz spiegelt den Nettopreis nach Abzug von Rabatten wider",
+      "filterCategory": "Nach Kategorie filtern"
     },
     "puntos": {
       "toggleHint": "WARO-Punktesystem aktivieren oder deaktivieren",

--- a/i18n/locales/en/analitica.json
+++ b/i18n/locales/en/analitica.json
@@ -24,7 +24,8 @@
       "status": "Status",
       "all": "All",
       "loading": "Loading...",
-      "actions": "Actions"
+      "actions": "Actions",
+      "category": "Category"
     },
     "ventas": {
       "grossSales": "Gross sales",
@@ -55,7 +56,8 @@
       "taxGeneric": "Tax",
       "marginCta": "Your best seller may be your worst margin",
       "viewMargin": "View profitability →",
-      "taxFallback": "INC 8%"
+      "taxFallback": "INC 8%",
+      "filterCategory": "Filter by category"
     },
     "rentabilidad": {
       "foodCostReal": "Actual food cost",
@@ -94,7 +96,8 @@
       "emptyProducts": "No products to analyze",
       "emptyProductsSub": "Products will appear here once there are sales in the selected period",
       "unitsShort": "{count} units",
-      "revenueTooltip": "Revenue reflects the net price after applied discounts"
+      "revenueTooltip": "Revenue reflects the net price after applied discounts",
+      "filterCategory": "Filter by category"
     },
     "puntos": {
       "toggleHint": "Enable or disable the Waros points system",

--- a/i18n/locales/es/analitica.json
+++ b/i18n/locales/es/analitica.json
@@ -24,7 +24,8 @@
       "status": "Estado",
       "all": "Todos",
       "loading": "Cargando...",
-      "actions": "Acciones"
+      "actions": "Acciones",
+      "category": "Categoría"
     },
     "ventas": {
       "grossSales": "Ventas Brutas",
@@ -55,7 +56,8 @@
       "taxGeneric": "Impuesto",
       "marginCta": "Tu plato más vendido puede ser tu peor negocio",
       "viewMargin": "Ver Rentabilidad →",
-      "taxFallback": "INC 8%"
+      "taxFallback": "INC 8%",
+      "filterCategory": "Filtrar por categoría"
     },
     "rentabilidad": {
       "foodCostReal": "Food Cost Real",
@@ -94,7 +96,8 @@
       "emptyProducts": "No hay productos para analizar",
       "emptyProductsSub": "Los productos aparecerán aquí cuando haya ventas en el período seleccionado",
       "unitsShort": "{count} uds",
-      "revenueTooltip": "Los ingresos reflejan el precio neto después de descuentos aplicados"
+      "revenueTooltip": "Los ingresos reflejan el precio neto después de descuentos aplicados",
+      "filterCategory": "Filtrar por categoría"
     },
     "puntos": {
       "toggleHint": "Activar o desactivar el sistema de puntos Waros",

--- a/i18n/locales/fr/analitica.json
+++ b/i18n/locales/fr/analitica.json
@@ -24,7 +24,8 @@
       "status": "Statut",
       "all": "Tous",
       "loading": "Chargement...",
-      "actions": "Actions"
+      "actions": "Actions",
+      "category": "Catégorie"
     },
     "ventas": {
       "grossSales": "Ventes brutes",
@@ -55,7 +56,8 @@
       "taxGeneric": "Taxe",
       "marginCta": "Votre plat le plus vendu peut être le moins rentable",
       "viewMargin": "Voir la rentabilité →",
-      "taxFallback": "INC 8%"
+      "taxFallback": "INC 8%",
+      "filterCategory": "Filtrer par catégorie"
     },
     "rentabilidad": {
       "foodCostReal": "Coût alimentaire réel",
@@ -94,7 +96,8 @@
       "emptyProducts": "Aucun produit à analyser",
       "emptyProductsSub": "Les produits apparaîtront ici une fois qu'il y aura des ventes durant la période sélectionnée",
       "unitsShort": "{count} unités",
-      "revenueTooltip": "Les revenus reflètent le prix net après application des remises"
+      "revenueTooltip": "Les revenus reflètent le prix net après application des remises",
+      "filterCategory": "Filtrer par catégorie"
     },
     "puntos": {
       "toggleHint": "Activer ou désactiver le système de points WARO",

--- a/i18n/locales/hi/analitica.json
+++ b/i18n/locales/hi/analitica.json
@@ -24,7 +24,8 @@
       "status": "स्थिति",
       "all": "सभी",
       "loading": "लोड हो रहा है...",
-      "actions": "कार्यवाहियाँ"
+      "actions": "कार्यवाहियाँ",
+      "category": "श्रेणी"
     },
     "ventas": {
       "grossSales": "सकल बिक्री",
@@ -55,7 +56,8 @@
       "taxGeneric": "कर",
       "marginCta": "आपका सबसे ज़्यादा बिकने वाला व्यंजन आपका सबसे खराब मार्जिन वाला हो सकता है",
       "viewMargin": "लाभप्रदता देखें →",
-      "taxFallback": "INC 8%"
+      "taxFallback": "INC 8%",
+      "filterCategory": "श्रेणी से फ़िल्टर करें"
     },
     "rentabilidad": {
       "foodCostReal": "वास्तविक फूड कॉस्ट",
@@ -94,7 +96,8 @@
       "emptyProducts": "विश्लेषण करने के लिए कोई उत्पाद नहीं हैं",
       "emptyProductsSub": "चयनित अवधि में बिक्री होने पर उत्पाद यहां दिखाई देंगे",
       "unitsShort": "{count} इकाइयाँ",
-      "revenueTooltip": "राजस्व लागू छूट के बाद शुद्ध मूल्य को दर्शाता है"
+      "revenueTooltip": "राजस्व लागू छूट के बाद शुद्ध मूल्य को दर्शाता है",
+      "filterCategory": "श्रेणी से फ़िल्टर करें"
     },
     "puntos": {
       "toggleHint": "WARO पॉइंट सिस्टम को सक्रिय या निष्क्रिय करें",

--- a/i18n/locales/pt/analitica.json
+++ b/i18n/locales/pt/analitica.json
@@ -24,7 +24,8 @@
       "status": "Status",
       "all": "Todos",
       "loading": "Carregando...",
-      "actions": "Ações"
+      "actions": "Ações",
+      "category": "Categoria"
     },
     "ventas": {
       "grossSales": "Vendas Brutas",
@@ -55,7 +56,8 @@
       "taxGeneric": "Imposto",
       "marginCta": "Seu prato mais vendido pode ser o seu pior negócio",
       "viewMargin": "Ver Rentabilidade →",
-      "taxFallback": "INC 8%"
+      "taxFallback": "INC 8%",
+      "filterCategory": "Filtrar por categoria"
     },
     "rentabilidad": {
       "foodCostReal": "Food Cost Real",
@@ -94,7 +96,8 @@
       "emptyProducts": "Não há produtos para analisar",
       "emptyProductsSub": "Os produtos aparecerão aqui quando houver vendas no período selecionado",
       "unitsShort": "{count} unid.",
-      "revenueTooltip": "A receita reflete o preço líquido após os descontos aplicados"
+      "revenueTooltip": "A receita reflete o preço líquido após os descontos aplicados",
+      "filterCategory": "Filtrar por categoria"
     },
     "puntos": {
       "toggleHint": "Ativar ou desativar o sistema de pontos Waros",

--- a/i18n/locales/zh/analitica.json
+++ b/i18n/locales/zh/analitica.json
@@ -24,7 +24,8 @@
       "status": "状态",
       "all": "全部",
       "loading": "加载中...",
-      "actions": "操作"
+      "actions": "操作",
+      "category": "类别"
     },
     "ventas": {
       "grossSales": "销售总额",
@@ -55,7 +56,8 @@
       "taxGeneric": "税费",
       "marginCta": "你最畅销的菜品可能是利润最低的",
       "viewMargin": "查看盈利能力 →",
-      "taxFallback": "INC 8%"
+      "taxFallback": "INC 8%",
+      "filterCategory": "按类别筛选"
     },
     "rentabilidad": {
       "foodCostReal": "实际食材成本",
@@ -94,7 +96,8 @@
       "emptyProducts": "无产品可分析",
       "emptyProductsSub": "选定期间有销售后，产品将显示在此处",
       "unitsShort": "{count} 件",
-      "revenueTooltip": "收入反映了应用折扣后的净价"
+      "revenueTooltip": "收入反映了应用折扣后的净价",
+      "filterCategory": "按类别筛选"
     },
     "puntos": {
       "toggleHint": "启用或禁用 Waros 积分系统",

--- a/pages/analitica/rentabilidad.vue
+++ b/pages/analitica/rentabilidad.vue
@@ -17,13 +17,34 @@ const lastUpdateText = computed(() => formatDistanceToNow(lastUpdate.value, { ad
 
 const { dateRangeDates, presetDates, maxDate, formatDateRange, dateRange } = useDateRangePresets()
 const { timezone } = useTenantTimezone()
+const categoryFilter = ref<string | null>(null)
+
+const { data: categoriesData } = useQuery({
+  key: () => ['menu', 'categories', currentTenant.value?.id],
+  query: () => $fetch('/api/menu/categories'),
+  enabled: () => !!currentTenant.value,
+  staleTime: 300_000,
+})
+const menuCategories = computed(() =>
+  (categoriesData.value as { data?: { id: string; name: string }[] })?.data ?? []
+)
+
+const clearRentabilidadFilters = () => {
+  dateRangeDates.value = null
+  categoryFilter.value = null
+}
 
 const { data: foodCostData, status: foodCostStatus, asyncStatus: foodCostAsyncStatus, error: foodCostError, refetch: refetchFoodCost } = useQuery({
-  key: () => ['analytics', 'food-cost', currentTenant.value?.id, { from: dateRange.value.from, to: dateRange.value.to }],
+  key: () => ['analytics', 'food-cost', currentTenant.value?.id, {
+    from: dateRange.value.from,
+    to: dateRange.value.to,
+    category_id: categoryFilter.value || null,
+  }],
   query: () => $fetch('/api/analytics/food-cost', {
     params: {
       date_from: dateRange.value.from || undefined,
-      date_to: dateRange.value.to || undefined
+      date_to: dateRange.value.to || undefined,
+      category_id: categoryFilter.value || undefined,
     }
   }),
   enabled: () => !!currentTenant.value,
@@ -31,11 +52,16 @@ const { data: foodCostData, status: foodCostStatus, asyncStatus: foodCostAsyncSt
 })
 
 const { data: menuAnalysisData, status: menuStatus, asyncStatus: menuAsyncStatus, refetch: refetchMenuAnalysis } = useQuery({
-  key: () => ['analytics', 'menu-analysis', currentTenant.value?.id, { from: dateRange.value.from, to: dateRange.value.to }],
+  key: () => ['analytics', 'menu-analysis', currentTenant.value?.id, {
+    from: dateRange.value.from,
+    to: dateRange.value.to,
+    category_id: categoryFilter.value || null,
+  }],
   query: () => $fetch('/api/analytics/menu-analysis', {
     params: {
       date_from: dateRange.value.from || undefined,
       date_to: dateRange.value.to || undefined,
+      category_id: categoryFilter.value || undefined,
       limit: 200
     }
   }),
@@ -216,12 +242,20 @@ onUnmounted(() => {
               menu-class-name="dp-custom-menu"
               calendar-cell-class-name="dp-custom-cell"
             />
+            <select
+              v-model="categoryFilter"
+              :aria-label="t('analitica.rentabilidad.filterCategory')"
+              class="h-10 ps-3 pe-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer min-w-[130px] flex-shrink-0"
+            >
+              <option :value="null">{{ t('analitica.common.category') }}</option>
+              <option v-for="cat in menuCategories" :key="cat.id" :value="cat.id">{{ cat.name }}</option>
+            </select>
             <button
-              v-if="dateRangeDates"
-              @click="dateRangeDates = null"
+              v-if="dateRangeDates || categoryFilter"
+              @click="clearRentabilidadFilters"
               class="h-10 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-secondary hover:text-text-primary hover:border-primary transition-colors flex-shrink-0"
-              :title="t('analitica.rentabilidad.clearFilter')"
-              :aria-label="t('analitica.rentabilidad.clearFilter')"
+              :title="t('analitica.common.clearFilters')"
+              :aria-label="t('analitica.common.clearFilters')"
             >
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />

--- a/pages/analitica/ventas.vue
+++ b/pages/analitica/ventas.vue
@@ -17,6 +17,7 @@ const currentTime = ref<Date>(new Date());
 
 const paymentMethodFilter = ref<string | null>(null);
 const statusFilter = ref<string | null>(null);
+const categoryFilter = ref<string | null>(null);
 const { dateRangeDates, presetDates, maxDate, formatDateRange, dateRange } = useDateRangePresets()
 const { timezone, todayISO, addDaysISO, monthBounds } = useTenantTimezone()
 
@@ -36,16 +37,28 @@ const paymentGroups = computed(() =>
   (paymentGroupsData.value?.data ?? []).filter(g => g.isActive).sort((a, b) => a.sortOrder - b.sortOrder)
 )
 
+const { data: categoriesData } = useQuery({
+  key: () => ['menu', 'categories', currentTenant.value?.id],
+  query: () => $fetch('/api/menu/categories'),
+  enabled: () => !!currentTenant.value,
+  staleTime: 300_000,
+})
+const menuCategories = computed(() =>
+  (categoriesData.value as { data?: { id: string; name: string }[] })?.data ?? []
+)
+
 // Single dashboard call — no date filter needed.
 const { data: dashboardData, status: dashboardStatus, asyncStatus: dashboardAsyncStatus, error: metricsError, refetch: refetchDashboard } = useQuery({
   key: () => ['analytics', 'ventas-dashboard', currentTenant.value?.id, {
     payment_method: paymentMethodFilter.value || null,
     status: statusFilter.value || null,
+    category_id: categoryFilter.value || null,
   }],
   query: () => $fetch('/api/orders/dashboard', {
     params: {
       payment_method: paymentMethodFilter.value || undefined,
-      status: statusFilter.value || undefined
+      status: statusFilter.value || undefined,
+      category_id: categoryFilter.value || undefined,
     }
   }),
   enabled: () => !!currentTenant.value,
@@ -59,13 +72,15 @@ const { data: filteredMetricsData, status: filteredMetricsStatus, asyncStatus: f
     to: dateRange.value.to,
     payment_method: paymentMethodFilter.value || null,
     status: statusFilter.value || null,
+    category_id: categoryFilter.value || null,
   }],
   query: () => $fetch('/api/orders/metrics', {
     params: {
       date_from: dateRange.value.from || undefined,
       date_to: dateRange.value.to || undefined,
       payment_method: paymentMethodFilter.value || undefined,
-      status: statusFilter.value || undefined
+      status: statusFilter.value || undefined,
+      category_id: categoryFilter.value || undefined,
     }
   }),
   enabled: () => !!currentTenant.value && !!hasDateFilter.value,
@@ -104,13 +119,15 @@ const { data: salesFlowData, status: salesFlowStatus, asyncStatus: salesFlowAsyn
     to: dateRange.value.to,
     payment_method: paymentMethodFilter.value || null,
     status: statusFilter.value || null,
+    category_id: categoryFilter.value || null,
   }],
   query: () => $fetch('/api/orders/sales-flow', {
     params: {
       date_from: dateRange.value.from || undefined,
       date_to: dateRange.value.to || undefined,
       payment_method: paymentMethodFilter.value || undefined,
-      status: statusFilter.value || undefined
+      status: statusFilter.value || undefined,
+      category_id: categoryFilter.value || undefined,
     }
   }),
   enabled: () => !!currentTenant.value,
@@ -248,6 +265,7 @@ onUnmounted(() => {
 const clearFilters = () => {
   paymentMethodFilter.value = null
   statusFilter.value = null
+  categoryFilter.value = null
   dateRangeDates.value = null
   lastUpdate.value = new Date()
 }
@@ -342,13 +360,17 @@ const metrics = computed(() => {
             <option :value="null">{{ t('analitica.ventas.paymentMethod') }}</option>
             <option v-for="group in paymentGroups" :key="group.slug" :value="group.slug">{{ group.name }}</option>
           </select>
+          <select v-model="categoryFilter" :aria-label="t('analitica.ventas.filterCategory')" class="h-10 ps-3 pe-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer min-w-[130px] flex-shrink-0">
+            <option :value="null">{{ t('analitica.common.category') }}</option>
+            <option v-for="cat in menuCategories" :key="cat.id" :value="cat.id">{{ cat.name }}</option>
+          </select>
           <select v-model="statusFilter" :aria-label="t('analitica.ventas.filterStatus')" class="h-10 ps-3 pe-3 rounded-lg border-2 border-border bg-background text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-primary cursor-pointer min-w-[120px] flex-shrink-0">
             <option :value="null">{{ t('analitica.common.status') }}</option>
             <option value="completed">{{ t('analitica.ventas.completed') }}</option>
             <option value="cancelled">{{ t('analitica.ventas.canceled') }}</option>
             <option value="pending">{{ t('analitica.ventas.pending') }}</option>
           </select>
-          <button v-if="dateRangeDates || paymentMethodFilter || statusFilter" @click="clearFilters" class="h-10 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-secondary hover:text-text-primary hover:border-primary transition-colors flex-shrink-0" :title="t('analitica.common.clearFilters')" :aria-label="t('analitica.common.clearFilters')">
+          <button v-if="dateRangeDates || paymentMethodFilter || statusFilter || categoryFilter" @click="clearFilters" class="h-10 px-3 rounded-lg border-2 border-border bg-background text-sm text-text-secondary hover:text-text-primary hover:border-primary transition-colors flex-shrink-0" :title="t('analitica.common.clearFilters')" :aria-label="t('analitica.common.clearFilters')">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
           </button>
         </div>


### PR DESCRIPTION
## Summary
- Category select on `/analitica/ventas` and `/analitica/rentabilidad`
- Passes `category_id` to dashboard/metrics/sales-flow and food-cost/menu-analysis
- i18n keys for category filter (8 locales)
- clearFilters clears category with other filters

Closes #1926

Companion API: https://github.com/uno0uno/api-warolabs/pull/744

## Validation evidence
```
API companion pytest (same batch):
pytest tests/test_analytics_category_filter.py tests/test_analytics_dual_cost.py -v
8 passed in 0.13s
```
Front: no unit suite for these pages; manual QA on filters.

## Test plan
- [ ] Ventas: pick category → KPIs/chart update; clear restores all
- [ ] Rentabilidad: pick category → Food Cost + matrix update
- [ ] No categories tenant: dropdown only “Categoría” / all
- [ ] Deploy with api-warolabs#744

## wr-context
See `.wr/1926.yaml` on this branch.