### PR TITLE
feat(crm): Pedidos # links to Ventas order detail

### DIFF
--- a/pages/crm/clientes/[id].vue
+++ b/pages/crm/clientes/[id].vue
@@ -790,7 +790,15 @@ onUnmounted(() => {
           <div class="bg-white border border-border rounded-lg p-4">
             <div class="flex justify-between items-start mb-2">
               <div>
-                <p class="font-medium text-text-primary"># {{ item.order_number }}</p>
+                <NuxtLink
+                  v-if="item.order_id"
+                  :to="`/ventas/${item.order_id}`"
+                  class="font-medium text-primary hover:underline"
+                  :aria-label="`#${item.order_number}`"
+                >
+                  # {{ item.order_number }}
+                </NuxtLink>
+                <p v-else class="font-medium text-text-primary"># {{ item.order_number }}</p>
                 <p class="text-sm text-text-secondary">{{ formatDate(item.date) }}</p>
               </div>
               <span :class="['text-xs px-2 py-1 rounded-full font-medium', statusColors[item.status] || 'bg-gray-100 text-gray-800']">
@@ -805,8 +813,16 @@ onUnmounted(() => {
         </template>
 
         <!-- Desktop Cells -->
-        <template #cell-order_number="{ value }">
-          <span class="text-sm font-medium text-text-primary">#{{ value }}</span>
+        <template #cell-order_number="{ value, row }">
+          <NuxtLink
+            v-if="row.order_id"
+            :to="`/ventas/${row.order_id}`"
+            class="text-sm font-medium text-primary hover:underline"
+            :aria-label="`#${value}`"
+          >
+            #{{ value }}
+          </NuxtLink>
+          <span v-else class="text-sm font-medium text-text-primary">#{{ value }}</span>
         </template>
 
         <template #cell-date="{ value }">


### PR DESCRIPTION
## Summary
- Pedidos history `#order_number` (mobile + desktop) links to `/ventas/{order_id}`
- Uses row `order_id` UUID; label stays human order number with aria-label
- Matches bitacora cross-module pattern (always link; ventas middleware gates)

Depends on #1931 / #1934 (CRM path). Stacked on `wr-1931-crm-module-move`.

Closes #1933

## Test plan
- [ ] CRM customer with orders — click `#` on desktop → `/ventas/{uuid}`
- [ ] Same on mobile card
- [ ] User without Ventas module hits normal module gate

## Validation evidence
```
# Plan validation: manual only (no automated tests for this UI link)

git diff --stat
 pages/crm/clientes/[id].vue | 22 ++++++++++++++++++++--
 1 file changed, 20 insertions(+), 2 deletions(-)

# Payload field confirmed in prior delta: orders items use order_id (UUID)
# Pattern mirrored: pages/operaciones/bitacora.vue NuxtLink /ventas/${order_id}
```

Made with [Cursor](https://cursor.com)