### PR TITLE
fix(shell): neutral WARO brand in dashboard header

### DIFF
--- a/components/dashboard/DashboardShellHeader.vue
+++ b/components/dashboard/DashboardShellHeader.vue
@@ -11,7 +11,7 @@
           <img
             :key="route.fullPath"
             :src="logoAnimationSrc"
-            alt="WARO Colombia"
+            alt="WARO"
             class="h-10 w-full object-contain"
           />
         </NuxtLink>
@@ -119,7 +119,7 @@ const dashboardHome = computed(() =>
 )
 
 const logoAnimationSrc = computed(() =>
-  `/brand/waro-colombia-animated.svg?route=${encodeURIComponent(route.fullPath)}`,
+  `/brand/waro-animated.svg?route=${encodeURIComponent(route.fullPath)}`,
 )
 
 defineProps<{


### PR DESCRIPTION
## Summary
- `DashboardShellHeader` uses `waro-animated.svg` + alt **WARO** (same as sidebar from #1938)

Refs #1936

## Test plan
- [ ] xl desktop collapsed shell: header logo has no Colombia wordmark

## Validation evidence
```
rg -n 'waro-animated|alt=\"WARO\"' components/dashboard/DashboardShellHeader.vue
```

Made with [Cursor](https://cursor.com)