### PR TITLE
fix(pos): full-viewport customer identification search

### DIFF
--- a/components/pos/CustomerIdentificationModal.vue
+++ b/components/pos/CustomerIdentificationModal.vue
@@ -2,12 +2,17 @@
   <Transition name="sheet">
     <div
       v-if="modelValue"
-      class="fixed inset-0 z-[60] flex items-end md:items-center justify-center md:p-4 bg-overlay-backdrop/50"
+      class="fixed inset-0 z-[60] flex bg-overlay-backdrop/50"
       @click.self="handleClose"
     >
-      <div class="bottom-sheet-panel bg-surface w-full md:max-w-md border border-border flex flex-col rounded-t-2xl md:rounded-2xl shadow-2xl max-h-[85vh] md:max-h-[90vh]" @click.stop>
+      <div
+        class="bottom-sheet-panel bg-surface w-full h-full max-h-[100dvh] flex flex-col"
+        role="dialog"
+        aria-modal="true"
+        @click.stop
+      >
 
-        <!-- Mobile drag handle -->
+        <!-- Mobile drag handle (kept for familiarity; panel is full-viewport) -->
         <div class="flex justify-center pt-3 pb-1 md:hidden flex-shrink-0" aria-hidden="true">
           <div class="w-10 h-1 rounded-full bg-border"></div>
         </div>


### PR DESCRIPTION
## Summary
- `PosCustomerIdentificationModal` uses a full-viewport panel (no `md:max-w-md` mid-page card)
- Shared by Ventas detail, POS, crear, and órdenes

Closes #1937

## Test plan
- [ ] `/ventas/{id}` → Cambiar cliente — searcher fills the screen
- [ ] Search + select still assigns the customer
- [ ] POS open customer ID looks the same

## Validation evidence
```
bunx vitest run components/pos/CustomerIdentificationModal.test.ts
✓ 3 tests passed
```

## wr-context
See local `.wr/1937.yaml` (gitignored).

Made with [Cursor](https://cursor.com)