### PR TITLE
Batch 4: Comandas by station + ventas reprint routing

### DIFF
--- a/composables/useCajaTicketPrint.test.ts
+++ b/composables/useCajaTicketPrint.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, mock } from 'bun:test'
+import { printTicketViaCajaOrBrowser } from './useCajaTicketPrint'
+import type { LocalPrintBridge } from './useLocalPrintBridge'
+
+function fakeBridge(overrides: Partial<LocalPrintBridge> = {}): LocalPrintBridge {
+  return {
+    isAvailable: () => true,
+    connect: mock(() => Promise.resolve()),
+    listPrinters: mock(() => Promise.resolve(['STAR_TP586'])),
+    printRawEscPos: mock(() => Promise.resolve()),
+    printEscPosTestTicket: mock(() => Promise.resolve()),
+    printHtml: mock(() => Promise.resolve()),
+    ...overrides,
+  }
+}
+
+describe('printTicketViaCajaOrBrowser', () => {
+  it('prints HTML via bridge when caja is assigned', async () => {
+    const printHtml = mock(() => Promise.resolve())
+    const browserPrint = mock(() => {})
+    const bridge = fakeBridge({ printHtml })
+
+    const result = await printTicketViaCajaOrBrowser('pos-receipt', {
+      getCajaPrinterName: async () => 'STAR_TP586',
+      bridge,
+      getElementHtml: () => '<div id="pos-receipt">OK</div>',
+      browserPrint,
+    })
+
+    expect(result).toBe('bridge')
+    expect(printHtml).toHaveBeenCalledTimes(1)
+    expect(printHtml).toHaveBeenCalledWith('STAR_TP586', '<div id="pos-receipt">OK</div>')
+    expect(browserPrint).toHaveBeenCalledTimes(0)
+  })
+
+  it('falls back to browser when caja assignment is missing', async () => {
+    const printHtml = mock(() => Promise.resolve())
+    const browserPrint = mock(() => {})
+    const bridge = fakeBridge({ printHtml })
+
+    const result = await printTicketViaCajaOrBrowser('pos-prefactura', {
+      getCajaPrinterName: async () => null,
+      bridge,
+      getElementHtml: () => '<div id="pos-prefactura">Pref</div>',
+      browserPrint,
+    })
+
+    expect(result).toBe('browser')
+    expect(printHtml).toHaveBeenCalledTimes(0)
+    expect(browserPrint).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to browser when bridge printHtml fails', async () => {
+    const browserPrint = mock(() => {})
+    const bridge = fakeBridge({
+      connect: mock(() => Promise.resolve()),
+      printHtml: mock(() => Promise.reject(new Error('QZ down'))),
+    })
+
+    const result = await printTicketViaCajaOrBrowser('pos-receipt', {
+      getCajaPrinterName: async () => 'STAR_TP586',
+      bridge,
+      getElementHtml: () => '<div id="pos-receipt">OK</div>',
+      browserPrint,
+    })
+
+    expect(result).toBe('browser')
+    expect(browserPrint).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to browser when element HTML is missing', async () => {
+    const printHtml = mock(() => Promise.resolve())
+    const browserPrint = mock(() => {})
+
+    const result = await printTicketViaCajaOrBrowser('missing', {
+      getCajaPrinterName: async () => 'STAR_TP586',
+      bridge: fakeBridge({ printHtml }),
+      getElementHtml: () => null,
+      browserPrint,
+    })
+
+    expect(result).toBe('browser')
+    expect(printHtml).toHaveBeenCalledTimes(0)
+    expect(browserPrint).toHaveBeenCalledTimes(1)
+  })
+})

--- a/composables/useCajaTicketPrint.test.ts
+++ b/composables/useCajaTicketPrint.test.ts
@@ -83,4 +83,17 @@ describe('printTicketViaCajaOrBrowser', () => {
     expect(printHtml).toHaveBeenCalledTimes(0)
     expect(browserPrint).toHaveBeenCalledTimes(1)
   })
+
+  it('supports deferred browserPrint so callers can arm afterprint first', async () => {
+    const deferred = mock(() => {})
+    const result = await printTicketViaCajaOrBrowser('pos-receipt', {
+      getCajaPrinterName: async () => null,
+      bridge: fakeBridge(),
+      getElementHtml: () => '<div/>',
+      browserPrint: () => {},
+    })
+    expect(result).toBe('browser')
+    deferred()
+    expect(deferred).toHaveBeenCalledTimes(1)
+  })
 })

--- a/composables/useCajaTicketPrint.ts
+++ b/composables/useCajaTicketPrint.ts
@@ -1,0 +1,95 @@
+/**
+ * Prefactura/factura → configured caja printer via QZ HTML (warocol.com#1950).
+ * Falls back to window.print when bridge or caja assignment is missing.
+ */
+import {
+  useLocalPrintBridge,
+  type LocalPrintBridge,
+} from '~/composables/useLocalPrintBridge'
+
+export type CajaTicketPrintResult = 'bridge' | 'browser'
+
+export type CajaTicketPrintDeps = {
+  getCajaPrinterName: () => Promise<string | null | undefined>
+  bridge?: LocalPrintBridge
+  getElementHtml?: (elementId: string) => string | null
+  browserPrint?: () => void
+}
+
+function defaultGetElementHtml(elementId: string): string | null {
+  if (typeof document === 'undefined') return null
+  const el = document.getElementById(elementId)
+  if (!el) return null
+  const html = el.outerHTML?.trim()
+  return html || null
+}
+
+/**
+ * Try QZ HTML print to the tenant caja printer; otherwise call browserPrint().
+ * Never throws — browser fallback absorbs bridge errors.
+ */
+export async function printTicketViaCajaOrBrowser(
+  elementId: string,
+  deps: CajaTicketPrintDeps,
+): Promise<CajaTicketPrintResult> {
+  const browserPrint = deps.browserPrint ?? (() => {
+    if (typeof window !== 'undefined') window.print()
+  })
+  const getHtml = deps.getElementHtml ?? defaultGetElementHtml
+
+  let caja: string | null | undefined
+  try {
+    caja = await deps.getCajaPrinterName()
+  } catch {
+    browserPrint()
+    return 'browser'
+  }
+
+  const printerName = (caja || '').trim()
+  if (!printerName) {
+    browserPrint()
+    return 'browser'
+  }
+
+  const html = getHtml(elementId)
+  if (!html) {
+    browserPrint()
+    return 'browser'
+  }
+
+  const bridge = deps.bridge ?? useLocalPrintBridge()
+  try {
+    await bridge.connect()
+    await bridge.printHtml(printerName, html)
+    return 'bridge'
+  } catch {
+    browserPrint()
+    return 'browser'
+  }
+}
+
+export function useCajaTicketPrint() {
+  const { assignments, refetch } = usePrinterAssignments()
+  const bridge = useLocalPrintBridge()
+
+  async function getCajaPrinterName(): Promise<string | null> {
+    if (!assignments.value) {
+      try {
+        await refetch()
+      } catch {
+        /* fall through */
+      }
+    }
+    const name = assignments.value?.caja_printer_name || assignments.value?.resolved_caja
+    return name?.trim() || null
+  }
+
+  async function printElement(elementId: string): Promise<CajaTicketPrintResult> {
+    return printTicketViaCajaOrBrowser(elementId, {
+      getCajaPrinterName,
+      bridge,
+    })
+  }
+
+  return { printElement, getCajaPrinterName }
+}

--- a/composables/useCajaTicketPrint.ts
+++ b/composables/useCajaTicketPrint.ts
@@ -84,10 +84,14 @@ export function useCajaTicketPrint() {
     return name?.trim() || null
   }
 
-  async function printElement(elementId: string): Promise<CajaTicketPrintResult> {
+  async function printElement(
+    elementId: string,
+    options?: { browserPrint?: () => void },
+  ): Promise<CajaTicketPrintResult> {
     return printTicketViaCajaOrBrowser(elementId, {
       getCajaPrinterName,
       bridge,
+      browserPrint: options?.browserPrint,
     })
   }
 

--- a/composables/useCajaTicketPrint.ts
+++ b/composables/useCajaTicketPrint.ts
@@ -86,12 +86,16 @@ export function useCajaTicketPrint() {
 
   async function printElement(
     elementId: string,
-    options?: { browserPrint?: () => void },
+    options?: {
+      browserPrint?: () => void
+      getElementHtml?: (elementId: string) => string | null
+    },
   ): Promise<CajaTicketPrintResult> {
     return printTicketViaCajaOrBrowser(elementId, {
       getCajaPrinterName,
       bridge,
       browserPrint: options?.browserPrint,
+      getElementHtml: options?.getElementHtml,
     })
   }
 

--- a/composables/useComandaPrint.test.ts
+++ b/composables/useComandaPrint.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'bun:test'
+import { mapComandasForPrint } from './useComandaPrint'
+
+describe('mapComandasForPrint', () => {
+  it('preserves station_id alongside station_name', () => {
+    const mapped = mapComandasForPrint([
+      {
+        id: 'c1',
+        comanda_number: 12,
+        station_id: '11111111-1111-1111-1111-111111111111',
+        station_name: 'Barra',
+        items: [{ kitchen_name: 'Café', quantity: 1 }],
+      },
+    ])
+    expect(mapped).toHaveLength(1)
+    expect(mapped[0]!.station_id).toBe('11111111-1111-1111-1111-111111111111')
+    expect(mapped[0]!.station_name).toBe('Barra')
+  })
+
+  it('sets station_id null when missing', () => {
+    const mapped = mapComandasForPrint([
+      {
+        comanda_number: 1,
+        station_name: 'Sin id',
+        items: [{ kitchen_name: 'X', quantity: 2 }],
+      },
+    ])
+    expect(mapped[0]!.station_id).toBeNull()
+  })
+})

--- a/composables/useComandaPrint.ts
+++ b/composables/useComandaPrint.ts
@@ -1,5 +1,6 @@
 /**
  * Kitchen comanda ticket printing (#753) — browser print via hidden DOM + body class.
+ * Prefer printComandasViaBridgeOrBrowser (warocol.com#1951) for station routing.
  */
 
 import { DEFAULT_TENANT_TIMEZONE, normalizeTimezone } from '~/utils/bogotaDate'
@@ -36,6 +37,7 @@ export function formatComandaModifierLabel(
 export type ComandaPrintPayload = {
   id?: string
   comanda_number: number | string
+  station_id?: string | null
   station_name?: string | null
   table_display_name?: string | null
   fired_at?: string | null
@@ -91,6 +93,7 @@ export function mapComandasForPrint(rawComandas: unknown[]): ComandaPrintPayload
     .map((c) => ({
     id: c.id != null ? String(c.id) : undefined,
     comanda_number: (c.comanda_number as number | string) ?? '—',
+    station_id: c.station_id != null ? String(c.station_id) : null,
     station_name: (c.station_name as string) ?? null,
     table_display_name: (c.table_display_name as string) ?? null,
     fired_at: c.fired_at != null ? String(c.fired_at) : null,

--- a/composables/useLocalPrintBridge.test.ts
+++ b/composables/useLocalPrintBridge.test.ts
@@ -128,13 +128,53 @@ describe('createLocalPrintBridge', () => {
     expect(windowPrint).toHaveBeenCalledTimes(0)
   })
 
-  it('useLocalPrintBridge returns singleton', () => {
+  it('prints HTML as pixel/html with ~58mm page width', async () => {
+    const printSpy = mock(() => Promise.resolve(undefined))
+    const create = mock((name: string, options?: Record<string, unknown>) => ({ name, options }))
+
     __setLocalPrintBridgeClientForTests({
-      websocket: { connect: mock(() => Promise.resolve(undefined)), isActive: () => false },
+      websocket: {
+        connect: mock(() => Promise.resolve(undefined)),
+        isActive: () => true,
+      },
+      printers: { find: mock(() => Promise.resolve(['STAR_TP586'])) },
+      configs: { create },
+      print: printSpy,
+    })
+
+    const bridge = createLocalPrintBridge()
+    await bridge.printHtml('STAR_TP586', '<div id="pos-receipt">Ticket</div>')
+
+    expect(create).toHaveBeenCalledTimes(1)
+    const createArgs = create.mock.calls[0] as unknown as [string, Record<string, unknown>]
+    expect(createArgs[0]).toBe('STAR_TP586')
+    expect(createArgs[1]).toMatchObject({
+      size: { width: 2.25 },
+      units: 'in',
+      scaleContent: true,
+      rasterize: true,
+    })
+
+    expect(printSpy).toHaveBeenCalledTimes(1)
+    const call = printSpy.mock.calls[0] as unknown as [unknown, Array<Record<string, unknown>>]
+    expect(call[1]![0]).toMatchObject({
+      type: 'pixel',
+      format: 'html',
+      flavor: 'plain',
+      data: '<div id="pos-receipt">Ticket</div>',
+      options: { pageWidth: 2.25 },
+    })
+  })
+
+  it('printHtml rejects empty printer or html', async () => {
+    __setLocalPrintBridgeClientForTests({
+      websocket: { connect: mock(() => Promise.resolve(undefined)), isActive: () => true },
       printers: { find: mock(() => Promise.resolve([])) },
       configs: { create: mock(() => ({})) },
       print: mock(() => Promise.resolve(undefined)),
     })
-    expect(useLocalPrintBridge()).toBe(useLocalPrintBridge())
+    const bridge = createLocalPrintBridge()
+    await expect(bridge.printHtml('', '<div/>')).rejects.toMatchObject({ code: 'INVALID' })
+    await expect(bridge.printHtml('STAR', '  ')).rejects.toMatchObject({ code: 'INVALID' })
   })
 })

--- a/composables/useLocalPrintBridge.ts
+++ b/composables/useLocalPrintBridge.ts
@@ -91,6 +91,7 @@ export type LocalPrintBridge = {
   listPrinters: () => Promise<string[]>
   printRawEscPos: (printerName: string, data: Uint8Array | string) => Promise<void>
   printEscPosTestTicket: (printerName: string, message?: string) => Promise<void>
+  printHtml: (printerName: string, html: string, options?: { pageWidthIn?: number }) => Promise<void>
 }
 
 export function createLocalPrintBridge(): LocalPrintBridge {
@@ -174,6 +175,45 @@ export function createLocalPrintBridge(): LocalPrintBridge {
 
     async printEscPosTestTicket(printerName: string, message?: string) {
       await this.printRawEscPos(printerName, buildEscPosTestTicketBytes(message))
+    },
+
+    async printHtml(printerName: string, html: string, options?: { pageWidthIn?: number }) {
+      const name = printerName?.trim()
+      if (!name) {
+        throw new LocalPrintBridgeError('INVALID', 'Printer name is required')
+      }
+      if (!html?.trim()) {
+        throw new LocalPrintBridgeError('INVALID', 'HTML content is required')
+      }
+      const qz = await ensureQz()
+      if (qz.websocket.isActive?.()) {
+        connected = true
+      } else if (!connected) {
+        await this.connect()
+      }
+      const pageWidthIn = options?.pageWidthIn ?? 2.25 // ~58mm thermal
+      const config = qz.configs.create(name, {
+        size: { width: pageWidthIn },
+        units: 'in',
+        scaleContent: true,
+        rasterize: true,
+      })
+      const printData = [
+        {
+          type: 'pixel',
+          format: 'html',
+          flavor: 'plain',
+          data: html,
+          options: { pageWidth: pageWidthIn },
+        },
+      ]
+      try {
+        await qz.print(config, printData)
+      } catch (err) {
+        if (err instanceof LocalPrintBridgeError) throw err
+        const detail = err instanceof Error ? err.message : String(err)
+        throw new LocalPrintBridgeError('PRINT_FAILED', `HTML print failed: ${detail}`)
+      }
     },
   }
 }

--- a/composables/useStationTicketPrint.test.ts
+++ b/composables/useStationTicketPrint.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, mock } from 'bun:test'
+import {
+  groupComandasByPrinter,
+  printComandasViaBridgeOrBrowser,
+  resolveComandaPrinterName,
+} from './useStationTicketPrint'
+import type { ComandaPrintPayload } from './useComandaPrint'
+import type { LocalPrintBridge } from './useLocalPrintBridge'
+
+const STATION_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+const STATION_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+
+function comanda(
+  stationId: string | null,
+  number: number,
+): ComandaPrintPayload {
+  return {
+    comanda_number: number,
+    station_id: stationId,
+    station_name: stationId ? `S-${number}` : null,
+    items: [{ kitchen_name: 'Item', quantity: 1 }],
+  }
+}
+
+function fakeBridge(overrides: Partial<LocalPrintBridge> = {}): LocalPrintBridge {
+  return {
+    isAvailable: () => true,
+    connect: mock(() => Promise.resolve()),
+    listPrinters: mock(() => Promise.resolve([])),
+    printRawEscPos: mock(() => Promise.resolve()),
+    printEscPosTestTicket: mock(() => Promise.resolve()),
+    printHtml: mock(() => Promise.resolve()),
+    ...overrides,
+  }
+}
+
+describe('resolveComandaPrinterName', () => {
+  it('uses station mapping when present', () => {
+    expect(
+      resolveComandaPrinterName(STATION_A, {
+        resolved: { [STATION_A]: 'BAR' },
+        resolved_caja: 'CAJA',
+      }),
+    ).toBe('BAR')
+  })
+
+  it('falls back to caja when station unmapped', () => {
+    expect(
+      resolveComandaPrinterName(STATION_A, {
+        resolved: { [STATION_A]: null },
+        resolved_caja: 'CAJA',
+      }),
+    ).toBe('CAJA')
+  })
+})
+
+describe('groupComandasByPrinter', () => {
+  it('groups by resolved printer and merges shared printers', () => {
+    const groups = groupComandasByPrinter(
+      [comanda(STATION_A, 1), comanda(STATION_B, 2), comanda(STATION_A, 3)],
+      {
+        resolved: { [STATION_A]: 'BAR', [STATION_B]: 'BAR' },
+        resolved_caja: 'CAJA',
+      },
+    )
+    expect(groups).toHaveLength(1)
+    expect(groups[0]!.printerName).toBe('BAR')
+    expect(groups[0]!.comandas.map((c) => c.comanda_number)).toEqual([1, 2, 3])
+  })
+
+  it('sends unmapped stations to caja', () => {
+    const groups = groupComandasByPrinter(
+      [comanda(STATION_A, 1), comanda(STATION_B, 2)],
+      {
+        resolved: { [STATION_A]: 'COCINA', [STATION_B]: null },
+        resolved_caja: 'CAJA',
+      },
+    )
+    expect(groups).toHaveLength(2)
+    const cocina = groups.find((g) => g.printerName === 'COCINA')
+    const caja = groups.find((g) => g.printerName === 'CAJA')
+    expect(cocina?.comandas).toHaveLength(1)
+    expect(caja?.comandas).toHaveLength(1)
+  })
+})
+
+describe('printComandasViaBridgeOrBrowser', () => {
+  it('prints one HTML job per printer via bridge', async () => {
+    const printHtml = mock(() => Promise.resolve())
+    const setQueue = mock((_c: ComandaPrintPayload[]) => {})
+    const browserPrint = mock(() => {})
+
+    const result = await printComandasViaBridgeOrBrowser(
+      [comanda(STATION_A, 1), comanda(STATION_B, 2)],
+      {
+        setQueue,
+        getResolveMap: async () => ({
+          resolved: { [STATION_A]: 'BAR', [STATION_B]: 'COCINA' },
+          resolved_caja: 'CAJA',
+        }),
+        bridge: fakeBridge({ printHtml }),
+        getElementHtml: () => '<div id="pos-comanda-print">ok</div>',
+        browserPrint,
+        waitForDom: async () => {},
+      },
+    )
+
+    expect(result).toBe('bridge')
+    expect(printHtml).toHaveBeenCalledTimes(2)
+    expect(browserPrint).toHaveBeenCalledTimes(0)
+    expect(setQueue.mock.calls.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('falls back to browser when no printers resolved', async () => {
+    const printHtml = mock(() => Promise.resolve())
+    const browserPrint = mock(() => {})
+    const setQueue = mock((_c: ComandaPrintPayload[]) => {})
+
+    const result = await printComandasViaBridgeOrBrowser([comanda(null, 1)], {
+      setQueue,
+      getResolveMap: async () => ({ resolved: {}, resolved_caja: null }),
+      bridge: fakeBridge({ printHtml }),
+      getElementHtml: () => '<div/>',
+      browserPrint,
+      waitForDom: async () => {},
+    })
+
+    expect(result).toBe('browser')
+    expect(printHtml).toHaveBeenCalledTimes(0)
+    expect(browserPrint).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to browser when bridge fails', async () => {
+    const browserPrint = mock(() => {})
+    const result = await printComandasViaBridgeOrBrowser([comanda(STATION_A, 1)], {
+      setQueue: mock(() => {}),
+      getResolveMap: async () => ({
+        resolved: { [STATION_A]: 'BAR' },
+        resolved_caja: 'CAJA',
+      }),
+      bridge: fakeBridge({
+        connect: mock(() => Promise.reject(new Error('down'))),
+      }),
+      getElementHtml: () => '<div/>',
+      browserPrint,
+      waitForDom: async () => {},
+    })
+    expect(result).toBe('browser')
+    expect(browserPrint).toHaveBeenCalledTimes(1)
+  })
+})

--- a/composables/useStationTicketPrint.test.ts
+++ b/composables/useStationTicketPrint.test.ts
@@ -148,4 +148,31 @@ describe('printComandasViaBridgeOrBrowser', () => {
     expect(result).toBe('browser')
     expect(browserPrint).toHaveBeenCalledTimes(1)
   })
+
+  it('leaves queue as leftovers only when some groups lack a printer', async () => {
+    const printHtml = mock(() => Promise.resolve())
+    const queued: ComandaPrintPayload[][] = []
+    const setQueue = mock((c: ComandaPrintPayload[]) => { queued.push(c) })
+    const browserPrint = mock(() => {})
+
+    const result = await printComandasViaBridgeOrBrowser(
+      [comanda(STATION_A, 1), comanda(null, 2)],
+      {
+        setQueue,
+        getResolveMap: async () => ({
+          resolved: { [STATION_A]: 'BAR' },
+          resolved_caja: null,
+        }),
+        bridge: fakeBridge({ printHtml }),
+        getElementHtml: () => '<div id="pos-comanda-print">ok</div>',
+        browserPrint,
+        waitForDom: async () => {},
+      },
+    )
+
+    expect(result).toBe('browser')
+    expect(printHtml).toHaveBeenCalledTimes(1)
+    const lastQueue = queued[queued.length - 1]!
+    expect(lastQueue.map((c) => c.comanda_number)).toEqual([2])
+  })
 })

--- a/composables/useStationTicketPrint.ts
+++ b/composables/useStationTicketPrint.ts
@@ -1,0 +1,187 @@
+/**
+ * Station-routed comanda printing via QZ HTML (warocol.com#1951).
+ * Groups by resolved station printer (else caja); falls back to window.print.
+ */
+import {
+  useLocalPrintBridge,
+  type LocalPrintBridge,
+} from '~/composables/useLocalPrintBridge'
+import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
+import { nextTick } from 'vue'
+
+export type StationTicketPrintResult = 'bridge' | 'browser'
+
+export type PrinterResolveMap = {
+  resolved: Record<string, string | null>
+  resolved_caja: string | null
+}
+
+export type ComandaPrinterGroup = {
+  printerName: string | null
+  comandas: ComandaPrintPayload[]
+}
+
+export function resolveComandaPrinterName(
+  stationId: string | null | undefined,
+  map: PrinterResolveMap,
+): string | null {
+  const sid = (stationId || '').trim()
+  if (sid) {
+    const mapped = map.resolved[sid]
+    if (mapped != null && String(mapped).trim()) return String(mapped).trim()
+  }
+  const caja = map.resolved_caja || null
+  return caja?.trim() || null
+}
+
+/** Group comandas by resolved printer name (shared printers → one job). */
+export function groupComandasByPrinter(
+  comandas: ComandaPrintPayload[],
+  map: PrinterResolveMap,
+): ComandaPrinterGroup[] {
+  const order: string[] = []
+  const byKey = new Map<string, ComandaPrintPayload[]>()
+  for (const comanda of comandas) {
+    const printerName = resolveComandaPrinterName(comanda.station_id, map)
+    const key = printerName ?? ''
+    if (!byKey.has(key)) {
+      byKey.set(key, [])
+      order.push(key)
+    }
+    byKey.get(key)!.push(comanda)
+  }
+  return order.map((key) => ({
+    printerName: key || null,
+    comandas: byKey.get(key)!,
+  }))
+}
+
+function defaultGetElementHtml(elementId: string): string | null {
+  if (typeof document === 'undefined') return null
+  const el = document.getElementById(elementId)
+  if (!el) return null
+  const html = el.outerHTML?.trim()
+  return html || null
+}
+
+export type PrintComandasViaBridgeDeps = {
+  setQueue: (comandas: ComandaPrintPayload[]) => void
+  getResolveMap: () => Promise<PrinterResolveMap | null>
+  bridge?: LocalPrintBridge
+  elementId?: string
+  getElementHtml?: (elementId: string) => string | null
+  browserPrint?: () => void
+  waitForDom?: () => Promise<void>
+}
+
+/**
+ * Print comandas grouped by station→printer (else caja).
+ * Never throws — browser fallback on missing assignment / bridge errors.
+ */
+export async function printComandasViaBridgeOrBrowser(
+  comandas: ComandaPrintPayload[],
+  deps: PrintComandasViaBridgeDeps,
+): Promise<StationTicketPrintResult> {
+  const browserPrint = deps.browserPrint ?? (() => {
+    if (typeof window !== 'undefined') window.print()
+  })
+  const elementId = deps.elementId ?? 'pos-comanda-print'
+  const getHtml = deps.getElementHtml ?? defaultGetElementHtml
+  const waitForDom = deps.waitForDom ?? (() => nextTick())
+
+  if (!comandas.length) {
+    return 'browser'
+  }
+
+  let map: PrinterResolveMap | null
+  try {
+    map = await deps.getResolveMap()
+  } catch {
+    deps.setQueue(comandas)
+    await waitForDom()
+    browserPrint()
+    return 'browser'
+  }
+
+  if (!map) {
+    deps.setQueue(comandas)
+    await waitForDom()
+    browserPrint()
+    return 'browser'
+  }
+
+  const groups = groupComandasByPrinter(comandas, map)
+  const withPrinter = groups.filter((g) => g.printerName)
+  if (!withPrinter.length) {
+    deps.setQueue(comandas)
+    await waitForDom()
+    browserPrint()
+    return 'browser'
+  }
+
+  const bridge = deps.bridge ?? useLocalPrintBridge()
+  try {
+    await bridge.connect()
+    for (const group of withPrinter) {
+      deps.setQueue(group.comandas)
+      await waitForDom()
+      const html = getHtml(elementId)
+      if (!html) throw new Error('Missing comanda print DOM')
+      await bridge.printHtml(group.printerName!, html)
+    }
+    // Unmapped leftovers (no caja) — rare; browser once for those.
+    const without = groups.filter((g) => !g.printerName).flatMap((g) => g.comandas)
+    if (without.length) {
+      deps.setQueue(without)
+      await waitForDom()
+      browserPrint()
+      deps.setQueue(comandas)
+      return 'browser'
+    }
+    deps.setQueue(comandas)
+    return 'bridge'
+  } catch {
+    deps.setQueue(comandas)
+    await waitForDom()
+    browserPrint()
+    return 'browser'
+  }
+}
+
+export function useStationTicketPrint() {
+  const { assignments, refetch } = usePrinterAssignments()
+  const bridge = useLocalPrintBridge()
+
+  async function getResolveMap(): Promise<PrinterResolveMap | null> {
+    if (!assignments.value) {
+      try {
+        await refetch()
+      } catch {
+        /* fall through */
+      }
+    }
+    const data = assignments.value
+    if (!data) return null
+    return {
+      resolved: data.resolved ?? {},
+      resolved_caja: data.resolved_caja ?? data.caja_printer_name ?? null,
+    }
+  }
+
+  async function printComandas(
+    comandas: ComandaPrintPayload[],
+    options: {
+      setQueue: (comandas: ComandaPrintPayload[]) => void
+      browserPrint?: () => void
+    },
+  ): Promise<StationTicketPrintResult> {
+    return printComandasViaBridgeOrBrowser(comandas, {
+      setQueue: options.setQueue,
+      getResolveMap,
+      bridge,
+      browserPrint: options.browserPrint,
+    })
+  }
+
+  return { printComandas, getResolveMap }
+}

--- a/composables/useStationTicketPrint.ts
+++ b/composables/useStationTicketPrint.ts
@@ -129,13 +129,13 @@ export async function printComandasViaBridgeOrBrowser(
       if (!html) throw new Error('Missing comanda print DOM')
       await bridge.printHtml(group.printerName!, html)
     }
-    // Unmapped leftovers (no caja) — rare; browser once for those.
+    // Unmapped leftovers (no caja) — leave queue as leftovers so deferred
+    // callers' window.print only reprints those, not bridge-printed groups.
     const without = groups.filter((g) => !g.printerName).flatMap((g) => g.comandas)
     if (without.length) {
       deps.setQueue(without)
       await waitForDom()
       browserPrint()
-      deps.setQueue(comandas)
       return 'browser'
     }
     deps.setQueue(comandas)

--- a/pages/despacho/domicilios/[id].vue
+++ b/pages/despacho/domicilios/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { inject, watch, nextTick, onMounted, onUnmounted } from 'vue'
+import { inject, watch, onMounted, onUnmounted } from 'vue'
 import { Printer } from 'lucide-vue-next'
 import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
 import { useStationTicketPrint } from '~/composables/useStationTicketPrint'

--- a/pages/despacho/domicilios/[id].vue
+++ b/pages/despacho/domicilios/[id].vue
@@ -2,7 +2,7 @@
 import { inject, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import { Printer } from 'lucide-vue-next'
 import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
-import { printComandaTickets } from '~/composables/useComandaPrint'
+import { useStationTicketPrint } from '~/composables/useStationTicketPrint'
 
 definePageMeta({ layout: 'dashboard', module: 'despacho' })
 const { t } = useI18n({ useScope: 'global' })
@@ -186,10 +186,33 @@ const canPrintComanda = computed(() =>
   !!order.value && comandaPrintPayload.value.some(comanda => comanda.items.length > 0),
 )
 
+const comandaPrintQueueOverride = ref<ComandaPrintPayload[] | null>(null)
+const comandaTicketsForPrint = computed(
+  () => comandaPrintQueueOverride.value ?? comandaPrintPayload.value,
+)
+const { printComandas: printComandasRouted } = useStationTicketPrint()
+
 async function printOrderComanda() {
   if (!canPrintComanda.value) return
-  await nextTick()
-  printComandaTickets()
+  const queue = comandaPrintPayload.value
+  document.body.classList.add('printing-comanda')
+  void document.body.offsetHeight
+  const cleanup = () => {
+    document.body.classList.remove('printing-comanda')
+    window.removeEventListener('afterprint', cleanup)
+    comandaPrintQueueOverride.value = null
+  }
+  const mode = await printComandasRouted(queue, {
+    setQueue: (c) => { comandaPrintQueueOverride.value = c },
+    browserPrint: () => {},
+  })
+  if (mode === 'bridge') {
+    cleanup()
+    return
+  }
+  window.addEventListener('afterprint', cleanup, { once: true })
+  setTimeout(cleanup, 4000)
+  window.print()
 }
 
 // Dashboard layout inject — dynamic back button
@@ -646,7 +669,7 @@ onUnmounted(() => {
     </Teleport>
 
     <PosComandaPrintTickets
-      :comandas="comandaPrintPayload"
+      :comandas="comandaTicketsForPrint"
       :business-name="businessName"
     />
   </div>

--- a/pages/despacho/en-mesa/[id].vue
+++ b/pages/despacho/en-mesa/[id].vue
@@ -2,7 +2,7 @@
 import { inject, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import { Printer } from 'lucide-vue-next'
 import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
-import { printComandaTickets } from '~/composables/useComandaPrint'
+import { useStationTicketPrint } from '~/composables/useStationTicketPrint'
 import { formatTableQrPayment } from '~/composables/formatTableQrPayment'
 import { notifyTableSessionUpdated, storeTableQrPaymentIntent } from '~/composables/useTableSessionSync'
 import { useNotifications } from '~/composables/useNotifications'
@@ -250,10 +250,33 @@ const canPrintComanda = computed(() =>
   !!request.value && comandaPrintPayload.value.some(comanda => comanda.items.length > 0),
 )
 
+const comandaPrintQueueOverride = ref<ComandaPrintPayload[] | null>(null)
+const comandaTicketsForPrint = computed(
+  () => comandaPrintQueueOverride.value ?? comandaPrintPayload.value,
+)
+const { printComandas: printComandasRouted } = useStationTicketPrint()
+
 async function printQrComanda() {
   if (!canPrintComanda.value) return
-  await nextTick()
-  printComandaTickets()
+  const queue = comandaPrintPayload.value
+  document.body.classList.add('printing-comanda')
+  void document.body.offsetHeight
+  const cleanup = () => {
+    document.body.classList.remove('printing-comanda')
+    window.removeEventListener('afterprint', cleanup)
+    comandaPrintQueueOverride.value = null
+  }
+  const mode = await printComandasRouted(queue, {
+    setQueue: (c) => { comandaPrintQueueOverride.value = c },
+    browserPrint: () => {},
+  })
+  if (mode === 'bridge') {
+    cleanup()
+    return
+  }
+  window.addEventListener('afterprint', cleanup, { once: true })
+  setTimeout(cleanup, 4000)
+  window.print()
 }
 </script>
 
@@ -428,7 +451,7 @@ async function printQrComanda() {
     </div>
 
     <PosComandaPrintTickets
-      :comandas="comandaPrintPayload"
+      :comandas="comandaTicketsForPrint"
       :business-name="businessName"
     />
   </div>

--- a/pages/despacho/en-mesa/[id].vue
+++ b/pages/despacho/en-mesa/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { inject, watch, nextTick, onMounted, onUnmounted } from 'vue'
+import { inject, watch, onMounted, onUnmounted } from 'vue'
 import { Printer } from 'lucide-vue-next'
 import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
 import { useStationTicketPrint } from '~/composables/useStationTicketPrint'

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -2543,10 +2543,15 @@ const printReceipt = async () => {
     document.body.classList.remove('printing-receipt-ticket')
     window.removeEventListener('afterprint', cleanup)
   }
-  // Register before printElement — browser fallback calls window.print inside helper.
+  // Defer window.print until after await so body print classes stay until fallback.
+  const mode = await printTicketElement('pos-receipt', { browserPrint: () => {} })
+  if (mode === 'bridge') {
+    cleanup()
+    return
+  }
   window.addEventListener('afterprint', cleanup)
   setTimeout(cleanup, 1500)
-  await printTicketElement('pos-receipt')
+  window.print()
 }
 
 // Issue #535 — tenant fiscal data for the prefactura header.
@@ -2874,13 +2879,18 @@ const printPrefactura = async () => {
     document.body.classList.remove('printing-prefactura')
     window.removeEventListener('afterprint', cleanup)
   }
-  // Register before printElement — browser fallback calls window.print inside helper.
+
+  await nextTick()
+  // Defer window.print until after await so body print classes stay until fallback.
+  const mode = await printTicketElement('pos-prefactura', { browserPrint: () => {} })
+  if (mode === 'bridge') {
+    cleanup()
+    return
+  }
   window.addEventListener('afterprint', cleanup)
   // Defensive fallback for browsers where afterprint may not fire on cancel.
   setTimeout(cleanup, 2000)
-
-  await nextTick()
-  await printTicketElement('pos-prefactura')
+  window.print()
 }
 
 // Re-emit after a recoverable failure (e.g. Matias 401) — skips fiscal wizard.

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -19,6 +19,7 @@ import { computePromoEligibleSubtotal, linePromoSavingsForProduct } from '~/util
 import { normalizeFiscalDocumentId } from '~/utils/fiscalDocument'
 import { posDebugLog, posDebugSerializeError } from '~/utils/posDebugLog'
 import { buildReceiptTicketItems, consolidateReceiptPrintLines } from '~/utils/receiptPrintLines'
+import { useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
 import { modifierLineTotal } from '~/utils/saleModifierOption'
 import {
   buildCustomerIdentityPresentation,
@@ -51,6 +52,7 @@ const posStore = usePOSStore()
 const cache = useQueryCache()
 const toast = useToast()
 const { currentTenant, businessProfile } = useTenantReactive()
+const { printElement: printTicketElement } = useCajaTicketPrint()
 
 /** POS-scoped tenant display/settings — available to cashier via restaurant-context. */
 const posCheckoutContext = computed(() => settingsData.value?.data ?? null)
@@ -2541,9 +2543,10 @@ const printReceipt = async () => {
     document.body.classList.remove('printing-receipt-ticket')
     window.removeEventListener('afterprint', cleanup)
   }
+  // Register before printElement — browser fallback calls window.print inside helper.
   window.addEventListener('afterprint', cleanup)
-  window.print()
   setTimeout(cleanup, 1500)
+  await printTicketElement('pos-receipt')
 }
 
 // Issue #535 — tenant fiscal data for the prefactura header.
@@ -2871,12 +2874,13 @@ const printPrefactura = async () => {
     document.body.classList.remove('printing-prefactura')
     window.removeEventListener('afterprint', cleanup)
   }
+  // Register before printElement — browser fallback calls window.print inside helper.
   window.addEventListener('afterprint', cleanup)
   // Defensive fallback for browsers where afterprint may not fire on cancel.
   setTimeout(cleanup, 2000)
 
   await nextTick()
-  window.print()
+  await printTicketElement('pos-prefactura')
 }
 
 // Re-emit after a recoverable failure (e.g. Matias 401) — skips fiscal wizard.

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -14,8 +14,8 @@ import {
   mapComandasForPrint,
   orderItemIdsFromComandas,
   parseFireTableResponse,
-  printComandaTickets,
 } from '~/composables/useComandaPrint'
+import { useStationTicketPrint } from '~/composables/useStationTicketPrint'
 import { isStarterAccessLevel, isStarterPlanSlug } from '~/composables/useBilling'
 import { promoBadgeForProduct } from '~/utils/promoProductMatch'
 import { usePosOrderPromoTotals } from '~/composables/usePosOrderPromoTotals'
@@ -375,6 +375,7 @@ const selectedComandaIds = ref<string[]>([])
 const lastFiredComandaSessionKey = ref<string | null>(null)
 const persistedComandasLoading = ref(false)
 const showComandasReprintPanel = ref(false)
+const { printComandas: printComandasRouted } = useStationTicketPrint()
 const posBusinessName = computed(
   () => settingsData.value?.data?.business_name
     ?? settingsData.value?.data?.display_name
@@ -565,20 +566,37 @@ async function openComandasReprintPanel() {
   await refreshPersistedComandas(undefined, tableSessionFetchGen, false)
 }
 
+async function runComandaPrint(queue: ComandaPrintPayload[]) {
+  if (!queue.length) return
+  document.body.classList.add('printing-comanda')
+  void document.body.offsetHeight
+  const cleanup = () => {
+    document.body.classList.remove('printing-comanda')
+    window.removeEventListener('afterprint', cleanup)
+  }
+  const mode = await printComandasRouted(queue, {
+    setQueue: (c) => { printQueueComandas.value = c },
+    browserPrint: () => {},
+  })
+  if (mode === 'bridge') {
+    cleanup()
+    return
+  }
+  window.addEventListener('afterprint', cleanup, { once: true })
+  setTimeout(cleanup, 4000)
+  window.print()
+}
+
 async function printLatestComanda() {
   if (!comandaPrintEnabled.value || !canPrintLatestComanda.value) return
   const queue = mapComandasForPrint(lastFiredComandasRaw.value)
   if (!queue.length) return
-  printQueueComandas.value = queue
-  await nextTick()
-  printComandaTickets()
+  await runComandaPrint(queue)
 }
 
 async function printSelectedPersistedComandas() {
   if (!persistedComandasForPrintDisplay.value.length) return
-  printQueueComandas.value = persistedComandasForPrintDisplay.value
-  await nextTick()
-  printComandaTickets()
+  await runComandaPrint(persistedComandasForPrintDisplay.value)
 }
 
 // Issue warocol.com#708 — invalidate in-flight GET /current responses after tab mutations.

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -11,6 +11,7 @@ import {
   buildCustomerIdentityPresentation,
   formatFiscalIdentityLabel,
 } from '~/utils/customerIdentityPresentation'
+import { useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
 
 definePageMeta({ layout: 'dashboard', module: 'ventas' })
 
@@ -18,6 +19,7 @@ useHead({ title: () => t('ventas.head.detail') })
 
 // Tenant reactivity
 const { currentTenant, businessProfile } = useTenantReactive()
+const { printElement: printTicketElement } = useCajaTicketPrint()
 const { singular: tableSingular } = useTableLabel()
 const {
   receiptPrintSettings,
@@ -823,6 +825,19 @@ const printReceipt = async () => {
   const cleanup = () => {
     document.body.classList.remove('printing-receipt-ticket')
     window.removeEventListener('afterprint', cleanup)
+  }
+  const mode = await printTicketElement('pos-receipt', {
+    browserPrint: () => {},
+    getElementHtml: () => {
+      if (typeof document === 'undefined') return null
+      const el = document.querySelector('.receipt-print-ticket')
+      const html = el?.outerHTML?.trim()
+      return html || null
+    },
+  })
+  if (mode === 'bridge') {
+    cleanup()
+    return
   }
   window.addEventListener('afterprint', cleanup)
   window.print()


### PR DESCRIPTION
## Summary
- Preserve `station_id` in comanda print mapper; group QZ HTML jobs by resolved station printer (else caja).
- Wire POS (latest + reprint), despacho mesa/domicilios, and `/ventas/[id]` Imprimir through bridge helpers with deferred browser fallback.
- Companion API: https://github.com/uno0uno/api-warolabs/pull/749 — widens GET `/operaciones/printers` for POS/Ventas/Despacho.

Closes #1951

Depends on #1954 (and prior print stack). Stacked on `wr-1950-caja-ticket-print`.

## Test plan
- [ ] Merge print stack (#1952→#748→#1953→#1954) + api-warolabs#749
- [ ] Assign cocina + barra printers; fire multi-station → two QZ jobs
- [ ] Unmapped station → caja; no assignments → browser print
- [ ] POS reprint panel + despacho print use same routing
- [ ] `/ventas/[id]` Imprimir → caja; QZ down → browser

## Validation evidence
```text
bun test composables/useComandaPrint.test.ts composables/useStationTicketPrint.test.ts composables/useCajaTicketPrint.test.ts
 14 pass
 0 fail
Ran 14 tests across 3 files.
```