### PR TITLE
Batch 4: Comandas by station + ventas reprint routing

### DIFF
--- a/composables/useCajaTicketPrint.ts
+++ b/composables/useCajaTicketPrint.ts
@@ -86,12 +86,16 @@ export function useCajaTicketPrint() {
 
   async function printElement(
     elementId: string,
-    options?: { browserPrint?: () => void },
+    options?: {
+      browserPrint?: () => void
+      getElementHtml?: (elementId: string) => string | null
+    },
   ): Promise<CajaTicketPrintResult> {
     return printTicketViaCajaOrBrowser(elementId, {
       getCajaPrinterName,
       bridge,
       browserPrint: options?.browserPrint,
+      getElementHtml: options?.getElementHtml,
     })
   }
 

--- a/composables/useComandaPrint.test.ts
+++ b/composables/useComandaPrint.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'bun:test'
+import { mapComandasForPrint } from './useComandaPrint'
+
+describe('mapComandasForPrint', () => {
+  it('preserves station_id alongside station_name', () => {
+    const mapped = mapComandasForPrint([
+      {
+        id: 'c1',
+        comanda_number: 12,
+        station_id: '11111111-1111-1111-1111-111111111111',
+        station_name: 'Barra',
+        items: [{ kitchen_name: 'Café', quantity: 1 }],
+      },
+    ])
+    expect(mapped).toHaveLength(1)
+    expect(mapped[0]!.station_id).toBe('11111111-1111-1111-1111-111111111111')
+    expect(mapped[0]!.station_name).toBe('Barra')
+  })
+
+  it('sets station_id null when missing', () => {
+    const mapped = mapComandasForPrint([
+      {
+        comanda_number: 1,
+        station_name: 'Sin id',
+        items: [{ kitchen_name: 'X', quantity: 2 }],
+      },
+    ])
+    expect(mapped[0]!.station_id).toBeNull()
+  })
+})

--- a/composables/useComandaPrint.ts
+++ b/composables/useComandaPrint.ts
@@ -1,5 +1,6 @@
 /**
  * Kitchen comanda ticket printing (#753) — browser print via hidden DOM + body class.
+ * Prefer printComandasViaBridgeOrBrowser (warocol.com#1951) for station routing.
  */
 
 import { DEFAULT_TENANT_TIMEZONE, normalizeTimezone } from '~/utils/bogotaDate'
@@ -36,6 +37,7 @@ export function formatComandaModifierLabel(
 export type ComandaPrintPayload = {
   id?: string
   comanda_number: number | string
+  station_id?: string | null
   station_name?: string | null
   table_display_name?: string | null
   fired_at?: string | null
@@ -91,6 +93,7 @@ export function mapComandasForPrint(rawComandas: unknown[]): ComandaPrintPayload
     .map((c) => ({
     id: c.id != null ? String(c.id) : undefined,
     comanda_number: (c.comanda_number as number | string) ?? '—',
+    station_id: c.station_id != null ? String(c.station_id) : null,
     station_name: (c.station_name as string) ?? null,
     table_display_name: (c.table_display_name as string) ?? null,
     fired_at: c.fired_at != null ? String(c.fired_at) : null,

--- a/composables/useStationTicketPrint.test.ts
+++ b/composables/useStationTicketPrint.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, mock } from 'bun:test'
+import {
+  groupComandasByPrinter,
+  printComandasViaBridgeOrBrowser,
+  resolveComandaPrinterName,
+} from './useStationTicketPrint'
+import type { ComandaPrintPayload } from './useComandaPrint'
+import type { LocalPrintBridge } from './useLocalPrintBridge'
+
+const STATION_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+const STATION_B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+
+function comanda(
+  stationId: string | null,
+  number: number,
+): ComandaPrintPayload {
+  return {
+    comanda_number: number,
+    station_id: stationId,
+    station_name: stationId ? `S-${number}` : null,
+    items: [{ kitchen_name: 'Item', quantity: 1 }],
+  }
+}
+
+function fakeBridge(overrides: Partial<LocalPrintBridge> = {}): LocalPrintBridge {
+  return {
+    isAvailable: () => true,
+    connect: mock(() => Promise.resolve()),
+    listPrinters: mock(() => Promise.resolve([])),
+    printRawEscPos: mock(() => Promise.resolve()),
+    printEscPosTestTicket: mock(() => Promise.resolve()),
+    printHtml: mock(() => Promise.resolve()),
+    ...overrides,
+  }
+}
+
+describe('resolveComandaPrinterName', () => {
+  it('uses station mapping when present', () => {
+    expect(
+      resolveComandaPrinterName(STATION_A, {
+        resolved: { [STATION_A]: 'BAR' },
+        resolved_caja: 'CAJA',
+      }),
+    ).toBe('BAR')
+  })
+
+  it('falls back to caja when station unmapped', () => {
+    expect(
+      resolveComandaPrinterName(STATION_A, {
+        resolved: { [STATION_A]: null },
+        resolved_caja: 'CAJA',
+      }),
+    ).toBe('CAJA')
+  })
+})
+
+describe('groupComandasByPrinter', () => {
+  it('groups by resolved printer and merges shared printers', () => {
+    const groups = groupComandasByPrinter(
+      [comanda(STATION_A, 1), comanda(STATION_B, 2), comanda(STATION_A, 3)],
+      {
+        resolved: { [STATION_A]: 'BAR', [STATION_B]: 'BAR' },
+        resolved_caja: 'CAJA',
+      },
+    )
+    expect(groups).toHaveLength(1)
+    expect(groups[0]!.printerName).toBe('BAR')
+    expect(groups[0]!.comandas.map((c) => c.comanda_number)).toEqual([1, 2, 3])
+  })
+
+  it('sends unmapped stations to caja', () => {
+    const groups = groupComandasByPrinter(
+      [comanda(STATION_A, 1), comanda(STATION_B, 2)],
+      {
+        resolved: { [STATION_A]: 'COCINA', [STATION_B]: null },
+        resolved_caja: 'CAJA',
+      },
+    )
+    expect(groups).toHaveLength(2)
+    const cocina = groups.find((g) => g.printerName === 'COCINA')
+    const caja = groups.find((g) => g.printerName === 'CAJA')
+    expect(cocina?.comandas).toHaveLength(1)
+    expect(caja?.comandas).toHaveLength(1)
+  })
+})
+
+describe('printComandasViaBridgeOrBrowser', () => {
+  it('prints one HTML job per printer via bridge', async () => {
+    const printHtml = mock(() => Promise.resolve())
+    const setQueue = mock((_c: ComandaPrintPayload[]) => {})
+    const browserPrint = mock(() => {})
+
+    const result = await printComandasViaBridgeOrBrowser(
+      [comanda(STATION_A, 1), comanda(STATION_B, 2)],
+      {
+        setQueue,
+        getResolveMap: async () => ({
+          resolved: { [STATION_A]: 'BAR', [STATION_B]: 'COCINA' },
+          resolved_caja: 'CAJA',
+        }),
+        bridge: fakeBridge({ printHtml }),
+        getElementHtml: () => '<div id="pos-comanda-print">ok</div>',
+        browserPrint,
+        waitForDom: async () => {},
+      },
+    )
+
+    expect(result).toBe('bridge')
+    expect(printHtml).toHaveBeenCalledTimes(2)
+    expect(browserPrint).toHaveBeenCalledTimes(0)
+    expect(setQueue.mock.calls.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('falls back to browser when no printers resolved', async () => {
+    const printHtml = mock(() => Promise.resolve())
+    const browserPrint = mock(() => {})
+    const setQueue = mock((_c: ComandaPrintPayload[]) => {})
+
+    const result = await printComandasViaBridgeOrBrowser([comanda(null, 1)], {
+      setQueue,
+      getResolveMap: async () => ({ resolved: {}, resolved_caja: null }),
+      bridge: fakeBridge({ printHtml }),
+      getElementHtml: () => '<div/>',
+      browserPrint,
+      waitForDom: async () => {},
+    })
+
+    expect(result).toBe('browser')
+    expect(printHtml).toHaveBeenCalledTimes(0)
+    expect(browserPrint).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to browser when bridge fails', async () => {
+    const browserPrint = mock(() => {})
+    const result = await printComandasViaBridgeOrBrowser([comanda(STATION_A, 1)], {
+      setQueue: mock(() => {}),
+      getResolveMap: async () => ({
+        resolved: { [STATION_A]: 'BAR' },
+        resolved_caja: 'CAJA',
+      }),
+      bridge: fakeBridge({
+        connect: mock(() => Promise.reject(new Error('down'))),
+      }),
+      getElementHtml: () => '<div/>',
+      browserPrint,
+      waitForDom: async () => {},
+    })
+    expect(result).toBe('browser')
+    expect(browserPrint).toHaveBeenCalledTimes(1)
+  })
+})

--- a/composables/useStationTicketPrint.test.ts
+++ b/composables/useStationTicketPrint.test.ts
@@ -148,4 +148,31 @@ describe('printComandasViaBridgeOrBrowser', () => {
     expect(result).toBe('browser')
     expect(browserPrint).toHaveBeenCalledTimes(1)
   })
+
+  it('leaves queue as leftovers only when some groups lack a printer', async () => {
+    const printHtml = mock(() => Promise.resolve())
+    const queued: ComandaPrintPayload[][] = []
+    const setQueue = mock((c: ComandaPrintPayload[]) => { queued.push(c) })
+    const browserPrint = mock(() => {})
+
+    const result = await printComandasViaBridgeOrBrowser(
+      [comanda(STATION_A, 1), comanda(null, 2)],
+      {
+        setQueue,
+        getResolveMap: async () => ({
+          resolved: { [STATION_A]: 'BAR' },
+          resolved_caja: null,
+        }),
+        bridge: fakeBridge({ printHtml }),
+        getElementHtml: () => '<div id="pos-comanda-print">ok</div>',
+        browserPrint,
+        waitForDom: async () => {},
+      },
+    )
+
+    expect(result).toBe('browser')
+    expect(printHtml).toHaveBeenCalledTimes(1)
+    const lastQueue = queued[queued.length - 1]!
+    expect(lastQueue.map((c) => c.comanda_number)).toEqual([2])
+  })
 })

--- a/composables/useStationTicketPrint.ts
+++ b/composables/useStationTicketPrint.ts
@@ -1,0 +1,187 @@
+/**
+ * Station-routed comanda printing via QZ HTML (warocol.com#1951).
+ * Groups by resolved station printer (else caja); falls back to window.print.
+ */
+import {
+  useLocalPrintBridge,
+  type LocalPrintBridge,
+} from '~/composables/useLocalPrintBridge'
+import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
+import { nextTick } from 'vue'
+
+export type StationTicketPrintResult = 'bridge' | 'browser'
+
+export type PrinterResolveMap = {
+  resolved: Record<string, string | null>
+  resolved_caja: string | null
+}
+
+export type ComandaPrinterGroup = {
+  printerName: string | null
+  comandas: ComandaPrintPayload[]
+}
+
+export function resolveComandaPrinterName(
+  stationId: string | null | undefined,
+  map: PrinterResolveMap,
+): string | null {
+  const sid = (stationId || '').trim()
+  if (sid) {
+    const mapped = map.resolved[sid]
+    if (mapped != null && String(mapped).trim()) return String(mapped).trim()
+  }
+  const caja = map.resolved_caja || null
+  return caja?.trim() || null
+}
+
+/** Group comandas by resolved printer name (shared printers → one job). */
+export function groupComandasByPrinter(
+  comandas: ComandaPrintPayload[],
+  map: PrinterResolveMap,
+): ComandaPrinterGroup[] {
+  const order: string[] = []
+  const byKey = new Map<string, ComandaPrintPayload[]>()
+  for (const comanda of comandas) {
+    const printerName = resolveComandaPrinterName(comanda.station_id, map)
+    const key = printerName ?? ''
+    if (!byKey.has(key)) {
+      byKey.set(key, [])
+      order.push(key)
+    }
+    byKey.get(key)!.push(comanda)
+  }
+  return order.map((key) => ({
+    printerName: key || null,
+    comandas: byKey.get(key)!,
+  }))
+}
+
+function defaultGetElementHtml(elementId: string): string | null {
+  if (typeof document === 'undefined') return null
+  const el = document.getElementById(elementId)
+  if (!el) return null
+  const html = el.outerHTML?.trim()
+  return html || null
+}
+
+export type PrintComandasViaBridgeDeps = {
+  setQueue: (comandas: ComandaPrintPayload[]) => void
+  getResolveMap: () => Promise<PrinterResolveMap | null>
+  bridge?: LocalPrintBridge
+  elementId?: string
+  getElementHtml?: (elementId: string) => string | null
+  browserPrint?: () => void
+  waitForDom?: () => Promise<void>
+}
+
+/**
+ * Print comandas grouped by station→printer (else caja).
+ * Never throws — browser fallback on missing assignment / bridge errors.
+ */
+export async function printComandasViaBridgeOrBrowser(
+  comandas: ComandaPrintPayload[],
+  deps: PrintComandasViaBridgeDeps,
+): Promise<StationTicketPrintResult> {
+  const browserPrint = deps.browserPrint ?? (() => {
+    if (typeof window !== 'undefined') window.print()
+  })
+  const elementId = deps.elementId ?? 'pos-comanda-print'
+  const getHtml = deps.getElementHtml ?? defaultGetElementHtml
+  const waitForDom = deps.waitForDom ?? (() => nextTick())
+
+  if (!comandas.length) {
+    return 'browser'
+  }
+
+  let map: PrinterResolveMap | null
+  try {
+    map = await deps.getResolveMap()
+  } catch {
+    deps.setQueue(comandas)
+    await waitForDom()
+    browserPrint()
+    return 'browser'
+  }
+
+  if (!map) {
+    deps.setQueue(comandas)
+    await waitForDom()
+    browserPrint()
+    return 'browser'
+  }
+
+  const groups = groupComandasByPrinter(comandas, map)
+  const withPrinter = groups.filter((g) => g.printerName)
+  if (!withPrinter.length) {
+    deps.setQueue(comandas)
+    await waitForDom()
+    browserPrint()
+    return 'browser'
+  }
+
+  const bridge = deps.bridge ?? useLocalPrintBridge()
+  try {
+    await bridge.connect()
+    for (const group of withPrinter) {
+      deps.setQueue(group.comandas)
+      await waitForDom()
+      const html = getHtml(elementId)
+      if (!html) throw new Error('Missing comanda print DOM')
+      await bridge.printHtml(group.printerName!, html)
+    }
+    // Unmapped leftovers (no caja) — rare; browser once for those.
+    const without = groups.filter((g) => !g.printerName).flatMap((g) => g.comandas)
+    if (without.length) {
+      deps.setQueue(without)
+      await waitForDom()
+      browserPrint()
+      deps.setQueue(comandas)
+      return 'browser'
+    }
+    deps.setQueue(comandas)
+    return 'bridge'
+  } catch {
+    deps.setQueue(comandas)
+    await waitForDom()
+    browserPrint()
+    return 'browser'
+  }
+}
+
+export function useStationTicketPrint() {
+  const { assignments, refetch } = usePrinterAssignments()
+  const bridge = useLocalPrintBridge()
+
+  async function getResolveMap(): Promise<PrinterResolveMap | null> {
+    if (!assignments.value) {
+      try {
+        await refetch()
+      } catch {
+        /* fall through */
+      }
+    }
+    const data = assignments.value
+    if (!data) return null
+    return {
+      resolved: data.resolved ?? {},
+      resolved_caja: data.resolved_caja ?? data.caja_printer_name ?? null,
+    }
+  }
+
+  async function printComandas(
+    comandas: ComandaPrintPayload[],
+    options: {
+      setQueue: (comandas: ComandaPrintPayload[]) => void
+      browserPrint?: () => void
+    },
+  ): Promise<StationTicketPrintResult> {
+    return printComandasViaBridgeOrBrowser(comandas, {
+      setQueue: options.setQueue,
+      getResolveMap,
+      bridge,
+      browserPrint: options.browserPrint,
+    })
+  }
+
+  return { printComandas, getResolveMap }
+}

--- a/composables/useStationTicketPrint.ts
+++ b/composables/useStationTicketPrint.ts
@@ -129,13 +129,13 @@ export async function printComandasViaBridgeOrBrowser(
       if (!html) throw new Error('Missing comanda print DOM')
       await bridge.printHtml(group.printerName!, html)
     }
-    // Unmapped leftovers (no caja) — rare; browser once for those.
+    // Unmapped leftovers (no caja) — leave queue as leftovers so deferred
+    // callers' window.print only reprints those, not bridge-printed groups.
     const without = groups.filter((g) => !g.printerName).flatMap((g) => g.comandas)
     if (without.length) {
       deps.setQueue(without)
       await waitForDom()
       browserPrint()
-      deps.setQueue(comandas)
       return 'browser'
     }
     deps.setQueue(comandas)

--- a/pages/despacho/domicilios/[id].vue
+++ b/pages/despacho/domicilios/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { inject, watch, nextTick, onMounted, onUnmounted } from 'vue'
+import { inject, watch, onMounted, onUnmounted } from 'vue'
 import { Printer } from 'lucide-vue-next'
 import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
 import { useStationTicketPrint } from '~/composables/useStationTicketPrint'

--- a/pages/despacho/domicilios/[id].vue
+++ b/pages/despacho/domicilios/[id].vue
@@ -2,7 +2,7 @@
 import { inject, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import { Printer } from 'lucide-vue-next'
 import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
-import { printComandaTickets } from '~/composables/useComandaPrint'
+import { useStationTicketPrint } from '~/composables/useStationTicketPrint'
 
 definePageMeta({ layout: 'dashboard', module: 'despacho' })
 const { t } = useI18n({ useScope: 'global' })
@@ -186,10 +186,33 @@ const canPrintComanda = computed(() =>
   !!order.value && comandaPrintPayload.value.some(comanda => comanda.items.length > 0),
 )
 
+const comandaPrintQueueOverride = ref<ComandaPrintPayload[] | null>(null)
+const comandaTicketsForPrint = computed(
+  () => comandaPrintQueueOverride.value ?? comandaPrintPayload.value,
+)
+const { printComandas: printComandasRouted } = useStationTicketPrint()
+
 async function printOrderComanda() {
   if (!canPrintComanda.value) return
-  await nextTick()
-  printComandaTickets()
+  const queue = comandaPrintPayload.value
+  document.body.classList.add('printing-comanda')
+  void document.body.offsetHeight
+  const cleanup = () => {
+    document.body.classList.remove('printing-comanda')
+    window.removeEventListener('afterprint', cleanup)
+    comandaPrintQueueOverride.value = null
+  }
+  const mode = await printComandasRouted(queue, {
+    setQueue: (c) => { comandaPrintQueueOverride.value = c },
+    browserPrint: () => {},
+  })
+  if (mode === 'bridge') {
+    cleanup()
+    return
+  }
+  window.addEventListener('afterprint', cleanup, { once: true })
+  setTimeout(cleanup, 4000)
+  window.print()
 }
 
 // Dashboard layout inject — dynamic back button
@@ -646,7 +669,7 @@ onUnmounted(() => {
     </Teleport>
 
     <PosComandaPrintTickets
-      :comandas="comandaPrintPayload"
+      :comandas="comandaTicketsForPrint"
       :business-name="businessName"
     />
   </div>

--- a/pages/despacho/en-mesa/[id].vue
+++ b/pages/despacho/en-mesa/[id].vue
@@ -2,7 +2,7 @@
 import { inject, watch, nextTick, onMounted, onUnmounted } from 'vue'
 import { Printer } from 'lucide-vue-next'
 import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
-import { printComandaTickets } from '~/composables/useComandaPrint'
+import { useStationTicketPrint } from '~/composables/useStationTicketPrint'
 import { formatTableQrPayment } from '~/composables/formatTableQrPayment'
 import { notifyTableSessionUpdated, storeTableQrPaymentIntent } from '~/composables/useTableSessionSync'
 import { useNotifications } from '~/composables/useNotifications'
@@ -250,10 +250,33 @@ const canPrintComanda = computed(() =>
   !!request.value && comandaPrintPayload.value.some(comanda => comanda.items.length > 0),
 )
 
+const comandaPrintQueueOverride = ref<ComandaPrintPayload[] | null>(null)
+const comandaTicketsForPrint = computed(
+  () => comandaPrintQueueOverride.value ?? comandaPrintPayload.value,
+)
+const { printComandas: printComandasRouted } = useStationTicketPrint()
+
 async function printQrComanda() {
   if (!canPrintComanda.value) return
-  await nextTick()
-  printComandaTickets()
+  const queue = comandaPrintPayload.value
+  document.body.classList.add('printing-comanda')
+  void document.body.offsetHeight
+  const cleanup = () => {
+    document.body.classList.remove('printing-comanda')
+    window.removeEventListener('afterprint', cleanup)
+    comandaPrintQueueOverride.value = null
+  }
+  const mode = await printComandasRouted(queue, {
+    setQueue: (c) => { comandaPrintQueueOverride.value = c },
+    browserPrint: () => {},
+  })
+  if (mode === 'bridge') {
+    cleanup()
+    return
+  }
+  window.addEventListener('afterprint', cleanup, { once: true })
+  setTimeout(cleanup, 4000)
+  window.print()
 }
 </script>
 
@@ -428,7 +451,7 @@ async function printQrComanda() {
     </div>
 
     <PosComandaPrintTickets
-      :comandas="comandaPrintPayload"
+      :comandas="comandaTicketsForPrint"
       :business-name="businessName"
     />
   </div>

--- a/pages/despacho/en-mesa/[id].vue
+++ b/pages/despacho/en-mesa/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { inject, watch, nextTick, onMounted, onUnmounted } from 'vue'
+import { inject, watch, onMounted, onUnmounted } from 'vue'
 import { Printer } from 'lucide-vue-next'
 import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
 import { useStationTicketPrint } from '~/composables/useStationTicketPrint'

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -14,8 +14,8 @@ import {
   mapComandasForPrint,
   orderItemIdsFromComandas,
   parseFireTableResponse,
-  printComandaTickets,
 } from '~/composables/useComandaPrint'
+import { useStationTicketPrint } from '~/composables/useStationTicketPrint'
 import { isStarterAccessLevel, isStarterPlanSlug } from '~/composables/useBilling'
 import { promoBadgeForProduct } from '~/utils/promoProductMatch'
 import { usePosOrderPromoTotals } from '~/composables/usePosOrderPromoTotals'
@@ -375,6 +375,7 @@ const selectedComandaIds = ref<string[]>([])
 const lastFiredComandaSessionKey = ref<string | null>(null)
 const persistedComandasLoading = ref(false)
 const showComandasReprintPanel = ref(false)
+const { printComandas: printComandasRouted } = useStationTicketPrint()
 const posBusinessName = computed(
   () => settingsData.value?.data?.business_name
     ?? settingsData.value?.data?.display_name
@@ -565,20 +566,37 @@ async function openComandasReprintPanel() {
   await refreshPersistedComandas(undefined, tableSessionFetchGen, false)
 }
 
+async function runComandaPrint(queue: ComandaPrintPayload[]) {
+  if (!queue.length) return
+  document.body.classList.add('printing-comanda')
+  void document.body.offsetHeight
+  const cleanup = () => {
+    document.body.classList.remove('printing-comanda')
+    window.removeEventListener('afterprint', cleanup)
+  }
+  const mode = await printComandasRouted(queue, {
+    setQueue: (c) => { printQueueComandas.value = c },
+    browserPrint: () => {},
+  })
+  if (mode === 'bridge') {
+    cleanup()
+    return
+  }
+  window.addEventListener('afterprint', cleanup, { once: true })
+  setTimeout(cleanup, 4000)
+  window.print()
+}
+
 async function printLatestComanda() {
   if (!comandaPrintEnabled.value || !canPrintLatestComanda.value) return
   const queue = mapComandasForPrint(lastFiredComandasRaw.value)
   if (!queue.length) return
-  printQueueComandas.value = queue
-  await nextTick()
-  printComandaTickets()
+  await runComandaPrint(queue)
 }
 
 async function printSelectedPersistedComandas() {
   if (!persistedComandasForPrintDisplay.value.length) return
-  printQueueComandas.value = persistedComandasForPrintDisplay.value
-  await nextTick()
-  printComandaTickets()
+  await runComandaPrint(persistedComandasForPrintDisplay.value)
 }
 
 // Issue warocol.com#708 — invalidate in-flight GET /current responses after tab mutations.

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -11,6 +11,7 @@ import {
   buildCustomerIdentityPresentation,
   formatFiscalIdentityLabel,
 } from '~/utils/customerIdentityPresentation'
+import { useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
 
 definePageMeta({ layout: 'dashboard', module: 'ventas' })
 
@@ -18,6 +19,7 @@ useHead({ title: () => t('ventas.head.detail') })
 
 // Tenant reactivity
 const { currentTenant, businessProfile } = useTenantReactive()
+const { printElement: printTicketElement } = useCajaTicketPrint()
 const { singular: tableSingular } = useTableLabel()
 const {
   receiptPrintSettings,
@@ -823,6 +825,19 @@ const printReceipt = async () => {
   const cleanup = () => {
     document.body.classList.remove('printing-receipt-ticket')
     window.removeEventListener('afterprint', cleanup)
+  }
+  const mode = await printTicketElement('pos-receipt', {
+    browserPrint: () => {},
+    getElementHtml: () => {
+      if (typeof document === 'undefined') return null
+      const el = document.querySelector('.receipt-print-ticket')
+      const html = el?.outerHTML?.trim()
+      return html || null
+    },
+  })
+  if (mode === 'bridge') {
+    cleanup()
+    return
   }
   window.addEventListener('afterprint', cleanup)
   window.print()


### PR DESCRIPTION
## Summary
- Preserve `station_id` in comanda print mapper; group QZ HTML jobs by resolved station printer (else caja).
- Wire POS (latest + reprint), despacho mesa/domicilios, and `/ventas/[id]` Imprimir through bridge helpers with deferred browser fallback.
- Companion API merged as https://github.com/uno0uno/api-warolabs/pull/750

Closes #1951

Replaces closed stacked PR #1955 (base branch deleted when #1956 merged).

## Test plan
- [ ] Multi-station fire → correct printers
- [ ] Unmapped → caja; no assignment → browser
- [ ] Ventas Imprimir → caja

## Validation evidence
```text
bun test composables/useComandaPrint.test.ts composables/useStationTicketPrint.test.ts composables/useCajaTicketPrint.test.ts
15 pass
```

Made with [Cursor](https://cursor.com)