### PR TITLE
fix(print): ESC/POS raw for POS thermal tickets

### DIFF
--- a/.wr/1960.yaml
+++ b/.wr/1960.yaml
@@ -1,0 +1,44 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1960
+title: "Print thermal tickets via ESC/POS raw instead of PrintBridge HTML"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1960-escpos-raw-tickets
+
+paths:
+  - utils/escPosTicket.ts
+  - utils/escPosTicket.test.ts
+  - composables/useCajaTicketPrint.ts
+  - composables/useCajaTicketPrint.test.ts
+  - composables/useStationTicketPrint.ts
+  - composables/useStationTicketPrint.test.ts
+
+ac:
+  - Caja tickets print via ESC/POS raw when PrintBridge + caja assigned
+  - Station/comanda tickets use same raw path when station printer assigned
+  - window.print only when no printer or bridge/raw fails
+  - Impresoras ESC/POS test path unchanged
+  - Unit tests cover raw success + browser fallback
+  - Manual: prefactura prints without Chrome
+
+out_of_scope:
+  - PrintBridge app / requiring Chrome
+  - API changes
+  - Full visual parity for QR/logo (best-effort text only)
+
+hints:
+  entry: "useCajaTicketPrint.printTicketViaCajaOrBrowser / useStationTicketPrint.printComandasViaBridgeOrBrowser"
+  pattern: "useLocalPrintBridge.printRawEscPos + Impresoras printEscPosTestTicket"
+  tests: "bun test composables/useCajaTicketPrint.test.ts composables/useStationTicketPrint.test.ts utils/escPosTicket.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "manual prefactura on STAR without Chrome"

--- a/composables/useCajaTicketPrint.test.ts
+++ b/composables/useCajaTicketPrint.test.ts
@@ -15,10 +15,10 @@ function fakeBridge(overrides: Partial<LocalPrintBridge> = {}): LocalPrintBridge
 }
 
 describe('printTicketViaCajaOrBrowser', () => {
-  it('prints HTML via bridge when caja is assigned', async () => {
-    const printHtml = mock(() => Promise.resolve())
+  it('prints ESC/POS raw via bridge when caja is assigned', async () => {
+    const printRawEscPos = mock(() => Promise.resolve())
     const browserPrint = mock(() => {})
-    const bridge = fakeBridge({ printHtml })
+    const bridge = fakeBridge({ printRawEscPos })
 
     const result = await printTicketViaCajaOrBrowser('pos-receipt', {
       getCajaPrinterName: async () => 'STAR_TP586',
@@ -28,15 +28,18 @@ describe('printTicketViaCajaOrBrowser', () => {
     })
 
     expect(result).toBe('bridge')
-    expect(printHtml).toHaveBeenCalledTimes(1)
-    expect(printHtml).toHaveBeenCalledWith('STAR_TP586', '<div id="pos-receipt">OK</div>')
+    expect(printRawEscPos).toHaveBeenCalledTimes(1)
+    const [printer, payload] = printRawEscPos.mock.calls[0]!
+    expect(printer).toBe('STAR_TP586')
+    expect(payload).toBeInstanceOf(Uint8Array)
+    expect((payload as Uint8Array).length).toBeGreaterThan(8)
     expect(browserPrint).toHaveBeenCalledTimes(0)
   })
 
   it('falls back to browser when caja assignment is missing', async () => {
-    const printHtml = mock(() => Promise.resolve())
+    const printRawEscPos = mock(() => Promise.resolve())
     const browserPrint = mock(() => {})
-    const bridge = fakeBridge({ printHtml })
+    const bridge = fakeBridge({ printRawEscPos })
 
     const result = await printTicketViaCajaOrBrowser('pos-prefactura', {
       getCajaPrinterName: async () => null,
@@ -46,15 +49,15 @@ describe('printTicketViaCajaOrBrowser', () => {
     })
 
     expect(result).toBe('browser')
-    expect(printHtml).toHaveBeenCalledTimes(0)
+    expect(printRawEscPos).toHaveBeenCalledTimes(0)
     expect(browserPrint).toHaveBeenCalledTimes(1)
   })
 
-  it('falls back to browser when bridge printHtml fails', async () => {
+  it('falls back to browser when bridge raw print fails', async () => {
     const browserPrint = mock(() => {})
     const bridge = fakeBridge({
       connect: mock(() => Promise.resolve()),
-      printHtml: mock(() => Promise.reject(new Error('QZ down'))),
+      printRawEscPos: mock(() => Promise.reject(new Error('bridge down'))),
     })
 
     const result = await printTicketViaCajaOrBrowser('pos-receipt', {
@@ -68,19 +71,19 @@ describe('printTicketViaCajaOrBrowser', () => {
     expect(browserPrint).toHaveBeenCalledTimes(1)
   })
 
-  it('falls back to browser when element HTML is missing', async () => {
-    const printHtml = mock(() => Promise.resolve())
+  it('falls back to browser when element content is missing', async () => {
+    const printRawEscPos = mock(() => Promise.resolve())
     const browserPrint = mock(() => {})
 
     const result = await printTicketViaCajaOrBrowser('missing', {
       getCajaPrinterName: async () => 'STAR_TP586',
-      bridge: fakeBridge({ printHtml }),
+      bridge: fakeBridge({ printRawEscPos }),
       getElementHtml: () => null,
       browserPrint,
     })
 
     expect(result).toBe('browser')
-    expect(printHtml).toHaveBeenCalledTimes(0)
+    expect(printRawEscPos).toHaveBeenCalledTimes(0)
     expect(browserPrint).toHaveBeenCalledTimes(1)
   })
 

--- a/composables/useCajaTicketPrint.ts
+++ b/composables/useCajaTicketPrint.ts
@@ -1,31 +1,35 @@
 /**
- * Prefactura/factura → configured caja printer via PrintBridge HTML (warocol.com#1950).
+ * Prefactura/factura → configured caja printer via PrintBridge ESC/POS raw (#1960).
  * Falls back to window.print when bridge or caja assignment is missing.
  */
 import {
   useLocalPrintBridge,
   type LocalPrintBridge,
 } from '~/composables/useLocalPrintBridge'
+import { buildEscPosTicketBytes } from '~/utils/escPosTicket'
 
 export type CajaTicketPrintResult = 'bridge' | 'browser'
 
 export type CajaTicketPrintDeps = {
   getCajaPrinterName: () => Promise<string | null | undefined>
   bridge?: LocalPrintBridge
+  /** DOM/HTML content for the ticket; converted to ESC/POS text. */
   getElementHtml?: (elementId: string) => string | null
   browserPrint?: () => void
 }
 
-function defaultGetElementHtml(elementId: string): string | null {
+function defaultGetElementContent(elementId: string): string | null {
   if (typeof document === 'undefined') return null
   const el = document.getElementById(elementId)
   if (!el) return null
+  const text = (el as HTMLElement).innerText?.trim()
+  if (text) return text
   const html = el.outerHTML?.trim()
   return html || null
 }
 
 /**
- * Try PrintBridge HTML print to the tenant caja printer; otherwise call browserPrint().
+ * Try PrintBridge raw ESC/POS to the tenant caja printer; otherwise call browserPrint().
  * Never throws — browser fallback absorbs bridge errors.
  */
 export async function printTicketViaCajaOrBrowser(
@@ -35,7 +39,7 @@ export async function printTicketViaCajaOrBrowser(
   const browserPrint = deps.browserPrint ?? (() => {
     if (typeof window !== 'undefined') window.print()
   })
-  const getHtml = deps.getElementHtml ?? defaultGetElementHtml
+  const getContent = deps.getElementHtml ?? defaultGetElementContent
 
   let caja: string | null | undefined
   try {
@@ -51,8 +55,8 @@ export async function printTicketViaCajaOrBrowser(
     return 'browser'
   }
 
-  const html = getHtml(elementId)
-  if (!html) {
+  const content = getContent(elementId)
+  if (!content?.trim()) {
     browserPrint()
     return 'browser'
   }
@@ -60,7 +64,7 @@ export async function printTicketViaCajaOrBrowser(
   const bridge = deps.bridge ?? useLocalPrintBridge()
   try {
     await bridge.connect()
-    await bridge.printHtml(printerName, html)
+    await bridge.printRawEscPos(printerName, buildEscPosTicketBytes(content))
     return 'bridge'
   } catch {
     browserPrint()

--- a/composables/useStationTicketPrint.test.ts
+++ b/composables/useStationTicketPrint.test.ts
@@ -85,8 +85,8 @@ describe('groupComandasByPrinter', () => {
 })
 
 describe('printComandasViaBridgeOrBrowser', () => {
-  it('prints one HTML job per printer via bridge', async () => {
-    const printHtml = mock(() => Promise.resolve())
+  it('prints one ESC/POS raw job per printer via bridge', async () => {
+    const printRawEscPos = mock(() => Promise.resolve())
     const setQueue = mock((_c: ComandaPrintPayload[]) => {})
     const browserPrint = mock(() => {})
 
@@ -98,7 +98,7 @@ describe('printComandasViaBridgeOrBrowser', () => {
           resolved: { [STATION_A]: 'BAR', [STATION_B]: 'COCINA' },
           resolved_caja: 'CAJA',
         }),
-        bridge: fakeBridge({ printHtml }),
+        bridge: fakeBridge({ printRawEscPos }),
         getElementHtml: () => '<div id="pos-comanda-print">ok</div>',
         browserPrint,
         waitForDom: async () => {},
@@ -106,27 +106,27 @@ describe('printComandasViaBridgeOrBrowser', () => {
     )
 
     expect(result).toBe('bridge')
-    expect(printHtml).toHaveBeenCalledTimes(2)
+    expect(printRawEscPos).toHaveBeenCalledTimes(2)
     expect(browserPrint).toHaveBeenCalledTimes(0)
     expect(setQueue.mock.calls.length).toBeGreaterThanOrEqual(2)
   })
 
   it('falls back to browser when no printers resolved', async () => {
-    const printHtml = mock(() => Promise.resolve())
+    const printRawEscPos = mock(() => Promise.resolve())
     const browserPrint = mock(() => {})
     const setQueue = mock((_c: ComandaPrintPayload[]) => {})
 
     const result = await printComandasViaBridgeOrBrowser([comanda(null, 1)], {
       setQueue,
       getResolveMap: async () => ({ resolved: {}, resolved_caja: null }),
-      bridge: fakeBridge({ printHtml }),
+      bridge: fakeBridge({ printRawEscPos }),
       getElementHtml: () => '<div/>',
       browserPrint,
       waitForDom: async () => {},
     })
 
     expect(result).toBe('browser')
-    expect(printHtml).toHaveBeenCalledTimes(0)
+    expect(printRawEscPos).toHaveBeenCalledTimes(0)
     expect(browserPrint).toHaveBeenCalledTimes(1)
   })
 
@@ -150,7 +150,7 @@ describe('printComandasViaBridgeOrBrowser', () => {
   })
 
   it('leaves queue as leftovers only when some groups lack a printer', async () => {
-    const printHtml = mock(() => Promise.resolve())
+    const printRawEscPos = mock(() => Promise.resolve())
     const queued: ComandaPrintPayload[][] = []
     const setQueue = mock((c: ComandaPrintPayload[]) => { queued.push(c) })
     const browserPrint = mock(() => {})
@@ -163,7 +163,7 @@ describe('printComandasViaBridgeOrBrowser', () => {
           resolved: { [STATION_A]: 'BAR' },
           resolved_caja: null,
         }),
-        bridge: fakeBridge({ printHtml }),
+        bridge: fakeBridge({ printRawEscPos }),
         getElementHtml: () => '<div id="pos-comanda-print">ok</div>',
         browserPrint,
         waitForDom: async () => {},
@@ -171,7 +171,7 @@ describe('printComandasViaBridgeOrBrowser', () => {
     )
 
     expect(result).toBe('browser')
-    expect(printHtml).toHaveBeenCalledTimes(1)
+    expect(printRawEscPos).toHaveBeenCalledTimes(1)
     const lastQueue = queued[queued.length - 1]!
     expect(lastQueue.map((c) => c.comanda_number)).toEqual([2])
   })

--- a/composables/useStationTicketPrint.ts
+++ b/composables/useStationTicketPrint.ts
@@ -1,5 +1,5 @@
 /**
- * Station-routed comanda printing via PrintBridge HTML (warocol.com#1951).
+ * Station-routed comanda printing via PrintBridge ESC/POS raw (warocol.com#1960).
  * Groups by resolved station printer (else caja); falls back to window.print.
  */
 import {
@@ -7,6 +7,7 @@ import {
   type LocalPrintBridge,
 } from '~/composables/useLocalPrintBridge'
 import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
+import { buildEscPosTicketBytes } from '~/utils/escPosTicket'
 import { nextTick } from 'vue'
 
 export type StationTicketPrintResult = 'bridge' | 'browser'
@@ -56,10 +57,12 @@ export function groupComandasByPrinter(
   }))
 }
 
-function defaultGetElementHtml(elementId: string): string | null {
+function defaultGetElementContent(elementId: string): string | null {
   if (typeof document === 'undefined') return null
   const el = document.getElementById(elementId)
   if (!el) return null
+  const text = (el as HTMLElement).innerText?.trim()
+  if (text) return text
   const html = el.outerHTML?.trim()
   return html || null
 }
@@ -86,7 +89,7 @@ export async function printComandasViaBridgeOrBrowser(
     if (typeof window !== 'undefined') window.print()
   })
   const elementId = deps.elementId ?? 'pos-comanda-print'
-  const getHtml = deps.getElementHtml ?? defaultGetElementHtml
+  const getContent = deps.getElementHtml ?? defaultGetElementContent
   const waitForDom = deps.waitForDom ?? (() => nextTick())
 
   if (!comandas.length) {
@@ -125,9 +128,9 @@ export async function printComandasViaBridgeOrBrowser(
     for (const group of withPrinter) {
       deps.setQueue(group.comandas)
       await waitForDom()
-      const html = getHtml(elementId)
-      if (!html) throw new Error('Missing comanda print DOM')
-      await bridge.printHtml(group.printerName!, html)
+      const content = getContent(elementId)
+      if (!content?.trim()) throw new Error('Missing comanda print content')
+      await bridge.printRawEscPos(group.printerName!, buildEscPosTicketBytes(content))
     }
     // Unmapped leftovers (no caja) — leave queue as leftovers so deferred
     // callers' window.print only reprints those, not bridge-printed groups.

--- a/docs/engineering/local-print-bridge.md
+++ b/docs/engineering/local-print-bridge.md
@@ -47,7 +47,8 @@ If PrintBridge is stopped: explicit error/toast — POS still falls back to `win
 - `listPrinters()` → `string[]`
 - `printRawEscPos(printerName, bytes | string)`
 - `printEscPosTestTicket(printerName)`
-- `printHtml(printerName, html)` → `raw-html` job (~58mm)
+- `printHtml(printerName, html)` → `raw-html` job (~58mm; needs local Chromium — prefer raw for POS tickets)
+- POS/caja/station tickets use `printRawEscPos` via `utils/escPosTicket` (no Chromium)
 
 Default agent: `ws://127.0.0.1:17890/ws`
 

--- a/utils/escPosTicket.test.ts
+++ b/utils/escPosTicket.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  buildEscPosTicketBytes,
+  normalizeEscPosAscii,
+  ticketHtmlToPlainText,
+} from './escPosTicket'
+
+describe('ticketHtmlToPlainText', () => {
+  it('strips tags and keeps text', () => {
+    expect(ticketHtmlToPlainText('<div>Hola<br/>Mundo</div>')).toBe('Hola\nMundo')
+  })
+
+  it('passes plain text through', () => {
+    expect(ticketHtmlToPlainText('Linea 1\nLinea 2')).toBe('Linea 1\nLinea 2')
+  })
+})
+
+describe('normalizeEscPosAscii', () => {
+  it('folds Spanish accents', () => {
+    expect(normalizeEscPosAscii('Café Niño')).toBe('Cafe Nino')
+  })
+})
+
+describe('buildEscPosTicketBytes', () => {
+  it('starts with ESC @ and ends with partial cut', () => {
+    const bytes = buildEscPosTicketBytes('WARO')
+    expect(bytes[0]).toBe(0x1b)
+    expect(bytes[1]).toBe(0x40)
+    const n = bytes.length
+    expect(bytes[n - 3]).toBe(0x1d)
+    expect(bytes[n - 2]).toBe(0x56)
+    expect(bytes[n - 1]).toBe(0x01)
+    const asText = String.fromCharCode(...bytes)
+    expect(asText).toContain('WARO')
+  })
+
+  it('accepts HTML ticket markup', () => {
+    const bytes = buildEscPosTicketBytes('<div id="pos-receipt">Total $10</div>')
+    const asText = String.fromCharCode(...bytes)
+    expect(asText).toContain('Total $10')
+  })
+})

--- a/utils/escPosTicket.ts
+++ b/utils/escPosTicket.ts
@@ -1,0 +1,109 @@
+/**
+ * ESC/POS helpers for thermal tickets without PrintBridge HTML/Chromium.
+ * Plain text → raw bytes (58mm ≈ 32 cols). Accents folded to ASCII for CP437-less queues.
+ */
+
+const DEFAULT_COLS = 32
+
+const ACCENT_MAP: Record<string, string> = {
+  'á': 'a',
+  'é': 'e',
+  'í': 'i',
+  'ó': 'o',
+  'ú': 'u',
+  'ü': 'u',
+  'ñ': 'n',
+  'Á': 'A',
+  'É': 'E',
+  'Í': 'I',
+  'Ó': 'O',
+  'Ú': 'U',
+  'Ü': 'U',
+  'Ñ': 'N',
+  '¿': '?',
+  '¡': '!',
+  '°': 'o',
+}
+
+/** Strip tags / entities from ticket HTML (or pass through plain text). */
+export function ticketHtmlToPlainText(htmlOrText: string): string {
+  const raw = (htmlOrText || '').trim()
+  if (!raw) return ''
+  if (!raw.includes('<')) return raw
+
+  return raw
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(p|div|tr|li|h[1-6]|section|article|header|footer)>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim()
+}
+
+export function normalizeEscPosAscii(text: string): string {
+  let out = ''
+  for (const ch of text) {
+    if (ACCENT_MAP[ch]) {
+      out += ACCENT_MAP[ch]
+      continue
+    }
+    const code = ch.charCodeAt(0)
+    if (code === 9) {
+      out += ' '
+      continue
+    }
+    if (code === 10 || code === 13) {
+      out += ch === '\r' ? '' : '\n'
+      continue
+    }
+    // Printable ASCII only
+    out += code >= 32 && code <= 126 ? ch : '?'
+  }
+  return out
+}
+
+function wrapLine(line: string, cols: number): string[] {
+  if (line.length <= cols) return [line]
+  const parts: string[] = []
+  let rest = line
+  while (rest.length > cols) {
+    let breakAt = rest.lastIndexOf(' ', cols)
+    if (breakAt < Math.floor(cols / 2)) breakAt = cols
+    parts.push(rest.slice(0, breakAt).trimEnd())
+    rest = rest.slice(breakAt).trimStart()
+  }
+  if (rest) parts.push(rest)
+  return parts
+}
+
+/** Build ESC/POS raw ticket: init + left + lines + feed + partial cut. */
+export function buildEscPosTicketBytes(
+  text: string,
+  options?: { cols?: number },
+): Uint8Array {
+  const cols = options?.cols ?? DEFAULT_COLS
+  const plain = ticketHtmlToPlainText(text)
+  const normalized = normalizeEscPosAscii(plain)
+  const lines = normalized.split(/\n/).flatMap((line) => wrapLine(line, cols))
+
+  const parts: number[] = [
+    0x1b, 0x40, // ESC @ init
+    0x1b, 0x61, 0x00, // left align
+  ]
+  for (const line of lines) {
+    for (let i = 0; i < line.length; i++) parts.push(line.charCodeAt(i) & 0xff)
+    parts.push(0x0a)
+  }
+  parts.push(0x0a, 0x0a, 0x0a)
+  parts.push(0x1d, 0x56, 0x01) // GS V partial cut
+  return Uint8Array.from(parts)
+}


### PR DESCRIPTION
## Summary
- POS caja tickets (prefactura/factura/ventas) and station comandas print via PrintBridge **ESC/POS raw** instead of HTML/`raw-html` (no Chromium required).
- `window.print()` only when no printer is assigned or bridge/raw fails.
- Shared helper `utils/escPosTicket` converts ticket DOM/HTML text to thermal bytes.

Closes #1960

## Test plan
- [ ] PrintBridge running, caja = STAR queue, **no Chrome** → POS prefactura prints thermally
- [ ] Same for ventas receipt + comanda station print
- [ ] Unassign caja printer → browser print dialog
- [ ] Operaciones → Impresoras test icon still works

## Validation evidence
```
$ bun test composables/useCajaTicketPrint.test.ts composables/useStationTicketPrint.test.ts utils/escPosTicket.test.ts
18 pass
0 fail
Ran 18 tests across 3 files. [208.00ms]
```

## wr-context
See `.wr/1960.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)