### PR TITLE
feat(print): DIAN QR on ESC/POS thermal tickets

### DIFF
--- a/.wr/1962.yaml
+++ b/.wr/1962.yaml
@@ -1,0 +1,40 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1962
+title: "Print DIAN QR on thermal ESC/POS tickets"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1962-escpos-dian-qr
+
+paths:
+  - utils/escPosTicket.ts
+  - utils/escPosTicket.test.ts
+
+ac:
+  - Fiscal receipt with CUFE prints scannable DIAN QR via ESC/POS GS ( k
+  - Prefactura / no CUFE stays text-only (no QR block)
+  - window.print fallback unchanged (caja path untouched)
+  - Unit tests: QR marker with CUFE; absent without
+  - Manual: factura on Star shows QR opening DIAN search URL
+
+out_of_scope:
+  - logo
+  - PrintBridge HTML/Chromium
+  - API / PrintBridge app
+  - station comandas
+
+hints:
+  entry: "buildEscPosTicketBytes + extractDianQrPayload"
+  pattern: "CUFE line on #pos-receipt → catalogo-vpfe searchqr URL → GS ( k"
+  tests: "bun test utils/escPosTicket.test.ts composables/useCajaTicketPrint.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "manual factura térmica QR on STAR"

--- a/utils/escPosTicket.test.ts
+++ b/utils/escPosTicket.test.ts
@@ -32,6 +32,10 @@ describe('extractDianQrPayload', () => {
     expect(extractDianQrPayload(`Total\nCUFE: ${SAMPLE_CUFE}\n`)).toBe(buildDianQrUrl(SAMPLE_CUFE))
   })
 
+  it('accepts French-style CUFE with space before colon', () => {
+    expect(extractDianQrPayload(`CUFE : ${SAMPLE_CUFE}`)).toBe(buildDianQrUrl(SAMPLE_CUFE))
+  })
+
   it('extracts from catalogo-vpfe URL', () => {
     const url = buildDianQrUrl(SAMPLE_CUFE)
     expect(extractDianQrPayload(`<div>${url}</div>`)).toBe(url)

--- a/utils/escPosTicket.test.ts
+++ b/utils/escPosTicket.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'bun:test'
 import {
+  buildDianQrUrl,
+  buildEscPosQrCodeBytes,
   buildEscPosTicketBytes,
+  extractDianQrPayload,
+  hasEscPosQrMarker,
   normalizeEscPosAscii,
   ticketHtmlToPlainText,
 } from './escPosTicket'
+
+const SAMPLE_CUFE = 'a'.repeat(48)
 
 describe('ticketHtmlToPlainText', () => {
   it('strips tags and keeps text', () => {
@@ -18,6 +24,31 @@ describe('ticketHtmlToPlainText', () => {
 describe('normalizeEscPosAscii', () => {
   it('folds Spanish accents', () => {
     expect(normalizeEscPosAscii('Café Niño')).toBe('Cafe Nino')
+  })
+})
+
+describe('extractDianQrPayload', () => {
+  it('builds URL from CUFE label', () => {
+    expect(extractDianQrPayload(`Total\nCUFE: ${SAMPLE_CUFE}\n`)).toBe(buildDianQrUrl(SAMPLE_CUFE))
+  })
+
+  it('extracts from catalogo-vpfe URL', () => {
+    const url = buildDianQrUrl(SAMPLE_CUFE)
+    expect(extractDianQrPayload(`<div>${url}</div>`)).toBe(url)
+  })
+
+  it('returns null without CUFE (prefactura)', () => {
+    expect(extractDianQrPayload('<div id="pos-prefactura">Prefactura</div>')).toBeNull()
+  })
+})
+
+describe('buildEscPosQrCodeBytes', () => {
+  it('emits GS ( k store/print sequence with payload', () => {
+    const url = buildDianQrUrl(SAMPLE_CUFE)
+    const bytes = buildEscPosQrCodeBytes(url)
+    expect(hasEscPosQrMarker(bytes)).toBe(true)
+    const asText = String.fromCharCode(...bytes)
+    expect(asText).toContain(SAMPLE_CUFE)
   })
 })
 
@@ -38,5 +69,25 @@ describe('buildEscPosTicketBytes', () => {
     const bytes = buildEscPosTicketBytes('<div id="pos-receipt">Total $10</div>')
     const asText = String.fromCharCode(...bytes)
     expect(asText).toContain('Total $10')
+  })
+
+  it('embeds native QR when CUFE present', () => {
+    const bytes = buildEscPosTicketBytes(`Factura\nCUFE: ${SAMPLE_CUFE}\n`)
+    expect(hasEscPosQrMarker(bytes)).toBe(true)
+    const asText = String.fromCharCode(...bytes)
+    expect(asText).toContain(SAMPLE_CUFE)
+  })
+
+  it('omits QR when no CUFE', () => {
+    const bytes = buildEscPosTicketBytes('<div id="pos-prefactura">Prefactura OK</div>')
+    expect(hasEscPosQrMarker(bytes)).toBe(false)
+  })
+
+  it('respects explicit qrPayload override', () => {
+    const url = buildDianQrUrl(SAMPLE_CUFE)
+    const withQr = buildEscPosTicketBytes('Solo texto', { qrPayload: url })
+    expect(hasEscPosQrMarker(withQr)).toBe(true)
+    const without = buildEscPosTicketBytes(`CUFE: ${SAMPLE_CUFE}`, { qrPayload: null })
+    expect(hasEscPosQrMarker(without)).toBe(false)
   })
 })

--- a/utils/escPosTicket.ts
+++ b/utils/escPosTicket.ts
@@ -1,9 +1,13 @@
 /**
  * ESC/POS helpers for thermal tickets without PrintBridge HTML/Chromium.
  * Plain text → raw bytes (58mm ≈ 32 cols). Accents folded to ASCII for CP437-less queues.
+ * Optional DIAN QR via native GS ( k when CUFE / search URL is present (#1962).
  */
 
 const DEFAULT_COLS = 32
+
+export const DIAN_SEARCH_QR_PREFIX =
+  'https://catalogo-vpfe.dian.gov.co/document/searchqr?documentkey='
 
 const ACCENT_MAP: Record<string, string> = {
   'á': 'a',
@@ -85,15 +89,104 @@ function wrapLine(line: string, cols: number): string[] {
   return parts
 }
 
-/** Build ESC/POS raw ticket: init + left + lines + feed + partial cut. */
+export function buildDianQrUrl(cufe: string): string {
+  return `${DIAN_SEARCH_QR_PREFIX}${cufe.trim()}`
+}
+
+/**
+ * Resolve DIAN verify URL from ticket HTML/text (CUFE line or searchqr URL).
+ * Prefactura without CUFE → null.
+ */
+export function extractDianQrPayload(htmlOrText: string): string | null {
+  const raw = htmlOrText || ''
+  if (!raw.trim()) return null
+
+  const urlMatch = raw.match(
+    /https?:\/\/catalogo-vpfe\.dian\.gov\.co\/document\/searchqr\?documentkey=([A-Za-z0-9]+)/i,
+  )
+  if (urlMatch?.[1]) return buildDianQrUrl(urlMatch[1])
+
+  const keyMatch = raw.match(/documentkey=([A-Za-z0-9]{20,})/i)
+  if (keyMatch?.[1]) return buildDianQrUrl(keyMatch[1])
+
+  const cufeMatch = raw.match(/CUFE:\s*([A-Za-z0-9]{20,})/i)
+  if (cufeMatch?.[1]) return buildDianQrUrl(cufeMatch[1])
+
+  return null
+}
+
+/**
+ * Epson / Star-compatible QR Code via GS ( k (model 2).
+ * @see ESC/POS QR: functions 165/167/169/180/181
+ */
+export function buildEscPosQrCodeBytes(
+  data: string,
+  options?: { moduleSize?: number },
+): Uint8Array {
+  const payload = new TextEncoder().encode(data)
+  if (!payload.length) return new Uint8Array(0)
+
+  const size = Math.min(16, Math.max(3, options?.moduleSize ?? 5))
+  const parts: number[] = []
+
+  // Center
+  parts.push(0x1b, 0x61, 0x01)
+
+  // Select model 2: GS ( k 04 00 31 41 32 00
+  parts.push(0x1d, 0x28, 0x6b, 0x04, 0x00, 0x31, 0x41, 0x32, 0x00)
+
+  // Module size: GS ( k 03 00 31 43 n
+  parts.push(0x1d, 0x28, 0x6b, 0x03, 0x00, 0x31, 0x43, size)
+
+  // Error correction level M (0x31): GS ( k 03 00 31 45 31
+  parts.push(0x1d, 0x28, 0x6b, 0x03, 0x00, 0x31, 0x45, 0x31)
+
+  // Store symbol data: GS ( k pL pH 31 50 30 + data
+  const storeLen = payload.length + 3
+  parts.push(0x1d, 0x28, 0x6b, storeLen & 0xff, (storeLen >> 8) & 0xff, 0x31, 0x50, 0x30)
+  for (let i = 0; i < payload.length; i++) parts.push(payload[i]!)
+
+  // Print symbol: GS ( k 03 00 31 51 30
+  parts.push(0x1d, 0x28, 0x6b, 0x03, 0x00, 0x31, 0x51, 0x30)
+
+  // Left + feed
+  parts.push(0x1b, 0x61, 0x00, 0x0a)
+
+  return Uint8Array.from(parts)
+}
+
+function bytesIncludeSubsequence(haystack: Uint8Array, needle: number[]): boolean {
+  if (needle.length > haystack.length) return false
+  outer: for (let i = 0; i <= haystack.length - needle.length; i++) {
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) continue outer
+    }
+    return true
+  }
+  return false
+}
+
+/** True when buffer contains GS ( k QR store/print sequence marker. */
+export function hasEscPosQrMarker(bytes: Uint8Array): boolean {
+  // GS ( k … 31 50 30 = store QR data
+  return bytesIncludeSubsequence(bytes, [0x1d, 0x28, 0x6b])
+    && bytesIncludeSubsequence(bytes, [0x31, 0x50, 0x30])
+}
+
+/** Build ESC/POS raw ticket: init + left + lines + optional QR + feed + partial cut. */
 export function buildEscPosTicketBytes(
   text: string,
-  options?: { cols?: number },
+  options?: { cols?: number; qrPayload?: string | null },
 ): Uint8Array {
   const cols = options?.cols ?? DEFAULT_COLS
   const plain = ticketHtmlToPlainText(text)
   const normalized = normalizeEscPosAscii(plain)
   const lines = normalized.split(/\n/).flatMap((line) => wrapLine(line, cols))
+
+  const qrUrl =
+    options && 'qrPayload' in options
+      ? (options.qrPayload?.trim() || null)
+      : extractDianQrPayload(text)
 
   const parts: number[] = [
     0x1b, 0x40, // ESC @ init
@@ -103,7 +196,14 @@ export function buildEscPosTicketBytes(
     for (let i = 0; i < line.length; i++) parts.push(line.charCodeAt(i) & 0xff)
     parts.push(0x0a)
   }
-  parts.push(0x0a, 0x0a, 0x0a)
+  parts.push(0x0a)
+
+  if (qrUrl) {
+    const qr = buildEscPosQrCodeBytes(qrUrl)
+    for (let i = 0; i < qr.length; i++) parts.push(qr[i]!)
+  }
+
+  parts.push(0x0a, 0x0a)
   parts.push(0x1d, 0x56, 0x01) // GS V partial cut
   return Uint8Array.from(parts)
 }

--- a/utils/escPosTicket.ts
+++ b/utils/escPosTicket.ts
@@ -109,7 +109,7 @@ export function extractDianQrPayload(htmlOrText: string): string | null {
   const keyMatch = raw.match(/documentkey=([A-Za-z0-9]{20,})/i)
   if (keyMatch?.[1]) return buildDianQrUrl(keyMatch[1])
 
-  const cufeMatch = raw.match(/CUFE:\s*([A-Za-z0-9]{20,})/i)
+  const cufeMatch = raw.match(/CUFE\s*:\s*([A-Za-z0-9]{20,})/i)
   if (cufeMatch?.[1]) return buildDianQrUrl(cufeMatch[1])
 
   return null
@@ -196,14 +196,14 @@ export function buildEscPosTicketBytes(
     for (let i = 0; i < line.length; i++) parts.push(line.charCodeAt(i) & 0xff)
     parts.push(0x0a)
   }
-  parts.push(0x0a)
+  parts.push(0x0a, 0x0a)
 
   if (qrUrl) {
     const qr = buildEscPosQrCodeBytes(qrUrl)
     for (let i = 0; i < qr.length; i++) parts.push(qr[i]!)
   }
 
-  parts.push(0x0a, 0x0a)
+  parts.push(0x0a, 0x0a, 0x0a)
   parts.push(0x1d, 0x56, 0x01) // GS V partial cut
   return Uint8Array.from(parts)
 }


### PR DESCRIPTION
## Summary
- Fiscal caja tickets with `CUFE:` (or DIAN search URL) now append a native ESC/POS QR (`GS ( k`) pointing at catalogo-vpfe.
- Prefactura / tickets without CUFE stay text-only.
- No call-site changes: `buildEscPosTicketBytes` extracts the payload automatically.

Closes #1962

## Test plan
- [ ] Print factura with CUFE on Star ESC/POS → QR scans to DIAN search URL
- [ ] Prefactura still prints without QR garbage
- [ ] Unassigned printer → browser print unchanged

## Validation evidence
```
$ bun test utils/escPosTicket.test.ts composables/useCajaTicketPrint.test.ts
17 pass
0 fail
Ran 17 tests across 2 files. [264.00ms]
```

## wr-context
See `.wr/1962.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)