### PR TITLE
fix(print): ESC/POS NBSP before amounts

### DIFF
--- a/utils/escPosTicket.test.ts
+++ b/utils/escPosTicket.test.ts
@@ -25,6 +25,16 @@ describe('normalizeEscPosAscii', () => {
   it('folds Spanish accents', () => {
     expect(normalizeEscPosAscii('Café Niño')).toBe('Cafe Nino')
   })
+
+  it('maps NBSP after peso sign to ASCII space', () => {
+    // es-CO Intl: "$" + U+00A0 + "1.100"
+    expect(normalizeEscPosAscii('$\u00a01.100')).toBe('$ 1.100')
+  })
+
+  it('maps narrow NBSP and unicode minus', () => {
+    expect(normalizeEscPosAscii('$\u202f500')).toBe('$ 500')
+    expect(normalizeEscPosAscii('\u2212$100')).toBe('-$100')
+  })
 })
 
 describe('extractDianQrPayload', () => {

--- a/utils/escPosTicket.ts
+++ b/utils/escPosTicket.ts
@@ -61,12 +61,27 @@ export function normalizeEscPosAscii(text: string): string {
       continue
     }
     const code = ch.charCodeAt(0)
-    if (code === 9) {
+    // Tab + Unicode spaces (NBSP, narrow NBSP, thin, etc.) → ASCII space
+    // so es-CO "$ 1.100" does not become "$?1.100" on thermal.
+    if (
+      code === 9
+      || code === 0xa0
+      || code === 0x202f
+      || code === 0x2007
+      || code === 0x2009
+      || code === 0x200a
+      || code === 0xfeff
+    ) {
       out += ' '
       continue
     }
     if (code === 10 || code === 13) {
       out += ch === '\r' ? '' : '\n'
+      continue
+    }
+    // Unicode minus / en-dash near amounts → ASCII hyphen
+    if (code === 0x2212 || code === 0x2013) {
+      out += '-'
       continue
     }
     // Printable ASCII only


### PR DESCRIPTION
## Summary
- Map Unicode spaces (NBSP / narrow NBSP) and unicode minus to ASCII so thermal tickets show `$ 1.100` instead of `$?1.100`.

## Test plan
- [ ] Prefactura/factura amounts print `$ 1.100` without `?`

## Validation evidence
```
$ bun test utils/escPosTicket.test.ts
(see CI / local pass)
```

Made with [Cursor](https://cursor.com)