### PR TITLE
feat(print): thermal money formatting + ESC/POS logo

### DIFF
--- a/.wr/1965.yaml
+++ b/.wr/1965.yaml
@@ -1,0 +1,46 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1965
+title: "Thermal-safe international money formatting for POS print tickets"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1965-thermal-money
+
+paths:
+  - utils/currencyDisplay.ts
+  - utils/currencyDisplay.test.ts
+  - composables/useFormatters.ts
+  - utils/escPosTicket.ts
+  - utils/escPosTicket.test.ts
+  - composables/useCajaTicketPrint.ts
+  - pages/pos/checkout.vue
+  - components/pos/ReceiptPrintTicket.vue
+  - components/pos/ComandaPrintTickets.vue
+
+ac:
+  - formatMoneyThermal ASCII ISO amounts (COP + USD)
+  - formatCurrencyThermal on print tickets (prefactura/factura/comandas)
+  - ESC/POS logo raster when img.receipt-logo present
+  - window.print fallback unchanged on bridge miss
+  - unit tests money + raster marker
+
+out_of_scope:
+  - FX / Matias currency
+  - PrintBridge HTML
+  - renaming all UI formatCurrency call sites
+
+hints:
+  entry: "formatMoneyThermal + buildEscPosRasterBytes + useCajaTicketPrint logo"
+  pattern: "ReceiptPrintTicket money() was hardcoded COP; checkout print DOM uses formatCurrencyThermal"
+  tests: "bun test utils/escPosTicket.test.ts composables/useCajaTicketPrint.test.ts && node --test utils/currencyDisplay.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "manual prefactura money+logo on STAR"

--- a/components/pos/ComandaPrintTickets.vue
+++ b/components/pos/ComandaPrintTickets.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
   businessName?: string
 }>()
 
-const { formatCurrency, formatDateTime } = useFormatters()
+const { formatCurrencyThermal, formatDateTime } = useFormatters()
 
 function modifierLines(item: ComandaPrintPayload['items'][0]) {
   return item.modifiers_snapshot ?? []
@@ -94,7 +94,7 @@ const printTicket = computed(() => {
               :key="`${section.key}-${i}-${mi}`"
               class="receipt-row receipt-small item-detail"
             >
-              ↳ {{ formatComandaModifierLabel(mod, { includePrice: true, formatPrice: formatCurrency }) }}
+              ↳ {{ formatComandaModifierLabel(mod, { includePrice: true, formatPrice: formatCurrencyThermal }) }}
             </div>
             <div v-if="item.notes" class="receipt-row receipt-small item-detail">
               {{ t('pos.printTicket.specialNotes') }}: {{ item.notes }}

--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const { t, locale } = useI18n({ useScope: 'global' })
+const { t } = useI18n({ useScope: 'global' })
 import { consolidateReceiptPrintLines } from '~/utils/receiptPrintLines'
 
 interface ReceiptItemModifier {
@@ -110,14 +110,9 @@ const props = defineProps<{
   } | null
 }>()
 
-const money = (value: number | string | null | undefined) => {
-  const n = Number(value) || 0
-  return new Intl.NumberFormat(toNumberLocaleTag(locale.value), {
-    style: 'currency',
-    currency: 'COP',
-    minimumFractionDigits: 0,
-  }).format(n)
-}
+const { formatCurrencyThermal } = useFormatters()
+
+const money = (value: number | string | null | undefined) => formatCurrencyThermal(value)
 
 const modifierTotal = (modifier: ReceiptItemModifier) => {
   const explicitTotal = Number(modifier.total)

--- a/composables/useCajaTicketPrint.ts
+++ b/composables/useCajaTicketPrint.ts
@@ -1,12 +1,16 @@
 /**
- * Prefactura/factura → configured caja printer via PrintBridge ESC/POS raw (#1960).
+ * Prefactura/factura → configured caja printer via PrintBridge ESC/POS raw (#1960/#1965).
  * Falls back to window.print when bridge or caja assignment is missing.
  */
 import {
   useLocalPrintBridge,
   type LocalPrintBridge,
 } from '~/composables/useLocalPrintBridge'
-import { buildEscPosTicketBytes } from '~/utils/escPosTicket'
+import {
+  buildEscPosTicketBytes,
+  findReceiptLogoSrc,
+  loadEscPosLogoRasterFromUrl,
+} from '~/utils/escPosTicket'
 
 export type CajaTicketPrintResult = 'bridge' | 'browser'
 
@@ -16,6 +20,8 @@ export type CajaTicketPrintDeps = {
   /** DOM/HTML content for the ticket; converted to ESC/POS text. */
   getElementHtml?: (elementId: string) => string | null
   browserPrint?: () => void
+  /** Optional logo URL override; default discovers img.receipt-logo in print DOM. */
+  getLogoSrc?: (elementId: string) => string | null
 }
 
 function defaultGetElementContent(elementId: string): string | null {
@@ -61,10 +67,21 @@ export async function printTicketViaCajaOrBrowser(
     return 'browser'
   }
 
+  let logoRaster: Uint8Array | null = null
+  try {
+    const logoSrc = deps.getLogoSrc?.(elementId) ?? findReceiptLogoSrc(elementId)
+    if (logoSrc) logoRaster = await loadEscPosLogoRasterFromUrl(logoSrc)
+  } catch {
+    logoRaster = null
+  }
+
   const bridge = deps.bridge ?? useLocalPrintBridge()
   try {
     await bridge.connect()
-    await bridge.printRawEscPos(printerName, buildEscPosTicketBytes(content))
+    await bridge.printRawEscPos(
+      printerName,
+      buildEscPosTicketBytes(content, { logoRaster }),
+    )
     return 'bridge'
   } catch {
     browserPrint()
@@ -93,6 +110,7 @@ export function useCajaTicketPrint() {
     options?: {
       browserPrint?: () => void
       getElementHtml?: (elementId: string) => string | null
+      getLogoSrc?: (elementId: string) => string | null
     },
   ): Promise<CajaTicketPrintResult> {
     return printTicketViaCajaOrBrowser(elementId, {
@@ -100,6 +118,7 @@ export function useCajaTicketPrint() {
       bridge,
       browserPrint: options?.browserPrint,
       getElementHtml: options?.getElementHtml,
+      getLogoSrc: options?.getLogoSrc,
     })
   }
 

--- a/composables/useFormatters.ts
+++ b/composables/useFormatters.ts
@@ -1,5 +1,10 @@
 import { computed } from 'vue'
-import { formatMoney, normalizeCurrencyCode, type FormatMoneyOptions } from '~/utils/currencyDisplay'
+import {
+  formatMoney,
+  formatMoneyThermal,
+  normalizeCurrencyCode,
+  type FormatMoneyOptions,
+} from '~/utils/currencyDisplay'
 import { toNumberLocaleTag } from '~/utils/appLocales'
 import {
   DEFAULT_UI_LOCALE,
@@ -85,6 +90,17 @@ export const useFormatters = () => {
     })
   }
 
+  /** Thermal / ESC/POS tickets — ISO code + ASCII amount (#1965). */
+  const formatCurrencyThermal = (
+    value: number | string | null | undefined,
+  ): string => {
+    return formatMoneyThermal(value, {
+      currency: currencyCode.value,
+      locale: uiLocale.value,
+      minorUnits: currencyMinorUnits.value,
+    })
+  }
+
   const formatNumber = (
     value: number | null | undefined,
     options?: { minimumFractionDigits?: number; maximumFractionDigits?: number },
@@ -121,6 +137,7 @@ export const useFormatters = () => {
     formatCalendarDate,
     formatDateShort,
     formatCurrency,
+    formatCurrencyThermal,
     formatNumber,
     formatDateTime,
     formatRelativeDate,

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1654,7 +1654,7 @@ watch(selectedCustomer, async (customer) => {
 })
 
 // Methods — display currency from tenant prefs (default COP); see display-currency.md
-const { formatCurrency, currencyCode } = useFormatters()
+const { formatCurrency, formatCurrencyThermal, currencyCode } = useFormatters()
 
 const getItemTotal = (item: any) => {
   const basePrice = Number(item.product.price) || 0
@@ -5354,8 +5354,8 @@ onUnmounted(() => {
           {{ item.product?.name || item.name }}<span v-if="isKitchenServiceMode && item.fired === false"> *</span>
         </div>
         <div class="receipt-product-values">
-          <span>{{ item.quantity }} × {{ formatCurrency(getItemUnitPrice(item)) }}</span>
-          <strong>{{ formatCurrency(getItemTotal(item)) }}</strong>
+          <span>{{ item.quantity }} × {{ formatCurrencyThermal(getItemUnitPrice(item)) }}</span>
+          <strong>{{ formatCurrencyThermal(getItemTotal(item)) }}</strong>
         </div>
       </div>
       <div
@@ -5365,8 +5365,8 @@ onUnmounted(() => {
       >
         <div class="receipt-product-name">{{ formatModifierPrintDesc(mod) }}</div>
         <div class="receipt-product-values">
-          <span>{{ (Number(mod.quantity) || 1) > 1 ? `${mod.quantity} × ` : '' }}{{ formatCurrency(Number(mod.price) || 0) }}</span>
-          <span>{{ formatCurrency(getModifierLineTotal(mod)) }}</span>
+          <span>{{ (Number(mod.quantity) || 1) > 1 ? `${mod.quantity} × ` : '' }}{{ formatCurrencyThermal(Number(mod.price) || 0) }}</span>
+          <span>{{ formatCurrencyThermal(getModifierLineTotal(mod)) }}</span>
         </div>
       </div>
     </template>
@@ -5374,7 +5374,7 @@ onUnmounted(() => {
 
     <div v-if="prefacturaPrintData.promoSavings > 0 || prefacturaPrintData.manualDiscountAmount > 0 || prefacturaPrintData.waroDiscountCop > 0" class="receipt-item">
       <span>{{ t('pos.receipt.subtotal') }}</span>
-      <span>{{ formatCurrency(prefacturaPrintData.cartSubtotal) }}</span>
+      <span>{{ formatCurrencyThermal(prefacturaPrintData.cartSubtotal) }}</span>
     </div>
     <div
       v-for="promo in prefacturaPrintData.promoBreakdown"
@@ -5382,50 +5382,50 @@ onUnmounted(() => {
       class="receipt-item"
     >
       <span>{{ promo.promotion_name }}</span>
-      <span>-{{ formatCurrency(promo.savings) }}</span>
+      <span>-{{ formatCurrencyThermal(promo.savings) }}</span>
     </div>
     <div v-if="prefacturaPrintData.manualDiscountAmount > 0" class="receipt-item">
       <span>{{ t('pos.receipt.manualDiscount') }}</span>
-      <span>-{{ formatCurrency(prefacturaPrintData.manualDiscountAmount) }}</span>
+      <span>-{{ formatCurrencyThermal(prefacturaPrintData.manualDiscountAmount) }}</span>
     </div>
     <div v-if="prefacturaPrintData.waroDiscountCop > 0" class="receipt-item">
       <span>{{ prefacturaPrintData.waroRewardName ? `WaRo: ${prefacturaPrintData.waroRewardName}` : t('pos.receipt.waroRedeem') }}</span>
-      <span>-{{ formatCurrency(prefacturaPrintData.waroDiscountCop) }}</span>
+      <span>-{{ formatCurrencyThermal(prefacturaPrintData.waroDiscountCop) }}</span>
     </div>
     <div v-if="taxPreview && taxPreview.standard_tax > 0" class="receipt-item">
       <span>{{ localizedInternalTaxLabel(taxPreview.standard_tax_label) }}</span>
-      <span>{{ formatCurrency(taxPreview.standard_tax) }}</span>
+      <span>{{ formatCurrencyThermal(taxPreview.standard_tax) }}</span>
     </div>
     <div v-if="taxPreview && taxPreview.liquor_tax > 0" class="receipt-item">
       <span>{{ taxPreview.liquor_tax_label || t('pos.receipt.liquorVat') }}</span>
-      <span>{{ formatCurrency(taxPreview.liquor_tax) }}</span>
+      <span>{{ formatCurrencyThermal(taxPreview.liquor_tax) }}</span>
     </div>
     <!-- warocol.com#739 + #939 — pre-bill totals include tip, advance, and split settlement when applicable -->
     <template v-if="prefacturaPrintData.tipAmount > 0 || prefacturaPrintData.advanceApplied > 0">
       <div class="receipt-item">
         <span>{{ t('pos.receipt.orderTotal') }}</span>
-        <span>{{ formatCurrency(prefacturaPrintData.orderTotal) }}</span>
+        <span>{{ formatCurrencyThermal(prefacturaPrintData.orderTotal) }}</span>
       </div>
       <div class="receipt-item">
         <span>{{ receiptTipLabel }}</span>
-        <span>{{ formatCurrency(prefacturaPrintData.tipAmount) }}</span>
+        <span>{{ formatCurrencyThermal(prefacturaPrintData.tipAmount) }}</span>
       </div>
       <div v-if="prefacturaPrintData.tipTaxAmount > 0" class="receipt-item">
         <span>{{ prefacturaPrintData.tipTaxLabel }}</span>
-        <span>{{ formatCurrency(prefacturaPrintData.tipTaxAmount) }}</span>
+        <span>{{ formatCurrencyThermal(prefacturaPrintData.tipTaxAmount) }}</span>
       </div>
       <div v-if="prefacturaPrintData.advanceApplied > 0" class="receipt-item">
         <span>{{ t('pos.receipt.tableAdvance') }}</span>
-        <span>-{{ formatCurrency(prefacturaPrintData.advanceApplied) }}</span>
+        <span>-{{ formatCurrencyThermal(prefacturaPrintData.advanceApplied) }}</span>
       </div>
       <div class="receipt-total">
         <span>{{ t('pos.receipt.totalDue') }}</span>
-        <span>{{ formatCurrency(prefacturaPrintData.amountDue) }}</span>
+        <span>{{ formatCurrencyThermal(prefacturaPrintData.amountDue) }}</span>
       </div>
     </template>
     <div v-else class="receipt-total">
       <span>{{ t('pos.receipt.totalUpper') }}</span>
-      <span>{{ formatCurrency(prefacturaPrintData.orderTotal) }}</span>
+      <span>{{ formatCurrencyThermal(prefacturaPrintData.orderTotal) }}</span>
     </div>
     <template v-if="prefacturaPrintData.splitPayments.length > 0">
       <div class="receipt-divider">--------------------------------</div>
@@ -5436,11 +5436,11 @@ onUnmounted(() => {
         class="receipt-item receipt-small"
       >
         <span>#{{ idx + 1 }} · {{ p.payment_method_name }}</span>
-        <span>{{ formatCurrency(p.amount) }}</span>
+        <span>{{ formatCurrencyThermal(p.amount) }}</span>
       </div>
       <div class="receipt-item">
         <span>{{ prefacturaPrintData.splitIsComplete ? t('pos.receipt.paymentComplete') : t('pos.receipt.balancePending') }}</span>
-        <span>{{ formatCurrency(prefacturaPrintData.splitRemaining) }}</span>
+        <span>{{ formatCurrencyThermal(prefacturaPrintData.splitRemaining) }}</span>
       </div>
     </template>
 
@@ -5513,8 +5513,8 @@ onUnmounted(() => {
       <div class="receipt-grid-row receipt-small">
         <span class="receipt-col-desc">{{ item.product?.name || item.name }}</span>
         <span class="receipt-col-qty">{{ item.quantity }}</span>
-        <span class="receipt-col-price">{{ formatCurrency(getItemUnitPrice(item)) }}</span>
-        <span class="receipt-col-total">{{ formatCurrency(getItemTotal(item)) }}</span>
+        <span class="receipt-col-price">{{ formatCurrencyThermal(getItemUnitPrice(item)) }}</span>
+        <span class="receipt-col-total">{{ formatCurrencyThermal(getItemTotal(item)) }}</span>
       </div>
       <div
         v-for="mod in (item.modifiers ?? [])"
@@ -5523,8 +5523,8 @@ onUnmounted(() => {
       >
         <span class="receipt-col-desc">{{ formatModifierPrintDesc(mod) }}</span>
         <span class="receipt-col-qty">{{ (Number(mod.quantity) || 1) > 1 ? mod.quantity : '' }}</span>
-        <span class="receipt-col-price">{{ formatCurrency(Number(mod.price) || 0) }}</span>
-        <span class="receipt-col-total">{{ formatCurrency(getModifierLineTotal(mod)) }}</span>
+        <span class="receipt-col-price">{{ formatCurrencyThermal(Number(mod.price) || 0) }}</span>
+        <span class="receipt-col-total">{{ formatCurrencyThermal(getModifierLineTotal(mod)) }}</span>
       </div>
     </template>
     <div class="receipt-divider">--------------------------------</div>
@@ -5534,7 +5534,7 @@ onUnmounted(() => {
       class="receipt-item"
     >
       <span>Subtotal</span>
-      <span>{{ formatCurrency(orderResult.subtotal) }}</span>
+      <span>{{ formatCurrencyThermal(orderResult.subtotal) }}</span>
     </div>
     <div
       v-for="promo in receiptPromoBreakdown"
@@ -5542,49 +5542,49 @@ onUnmounted(() => {
       class="receipt-item"
     >
       <span>{{ promo.promotion_name }}</span>
-      <span>-{{ formatCurrency(promo.savings) }}</span>
+      <span>-{{ formatCurrencyThermal(promo.savings) }}</span>
     </div>
     <div v-if="orderResult?.discount_amount" class="receipt-item">
 	      <span>{{ t('pos.receipt.manualDiscount') }}</span>
-      <span>-{{ formatCurrency(orderResult.discount_amount) }}</span>
+      <span>-{{ formatCurrencyThermal(orderResult.discount_amount) }}</span>
     </div>
     <div v-if="orderResultWaroDiscountCop > 0" class="receipt-item">
       <span>{{ orderResultWaroLineLabel }}</span>
-      <span>-{{ formatCurrency(orderResultWaroDiscountCop) }}</span>
+      <span>-{{ formatCurrencyThermal(orderResultWaroDiscountCop) }}</span>
     </div>
     <template v-if="orderResult?.standard_tax && orderResult.standard_tax > 0 || orderResult?.liquor_tax && orderResult.liquor_tax > 0">
 	      <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.taxDetail') }}</div>
       <div v-if="orderResult?.standard_tax && orderResult.standard_tax > 0" class="receipt-item receipt-small">
         <span>{{ localizedInternalTaxLabel(orderResult.standard_tax_label) }}</span>
-        <span>{{ formatCurrency(orderResult.standard_tax) }}</span>
+        <span>{{ formatCurrencyThermal(orderResult.standard_tax) }}</span>
       </div>
       <div v-if="orderResult?.liquor_tax && orderResult.liquor_tax > 0" class="receipt-item receipt-small">
 	        <span>{{ localizedInternalTaxLabel(orderResult.liquor_tax_label) || t('pos.receipt.liquorVat') }}</span>
-        <span>{{ formatCurrency(orderResult.liquor_tax) }}</span>
+        <span>{{ formatCurrencyThermal(orderResult.liquor_tax) }}</span>
       </div>
     </template>
     <!-- warocol.com#739 — printed receipt mirrors success modal + split payments -->
     <template v-if="(orderResult?.tip_amount && orderResult.tip_amount > 0) || (orderResult?.advance_applied && orderResult.advance_applied > 0)">
       <div class="receipt-item">
 	        <span>{{ t('pos.receipt.orderTotal') }}</span>
-        <span>{{ formatCurrency(orderResult?.total_amount ?? 0) }}</span>
+        <span>{{ formatCurrencyThermal(orderResult?.total_amount ?? 0) }}</span>
       </div>
       <div v-if="orderResult?.tip_amount && orderResult.tip_amount > 0" class="receipt-item">
         <span>{{ receiptTipLabel }}</span>
-        <span>{{ formatCurrency(orderResult.tip_amount) }}</span>
+        <span>{{ formatCurrencyThermal(orderResult.tip_amount) }}</span>
       </div>
       <div v-if="orderResult?.advance_applied && orderResult.advance_applied > 0" class="receipt-item">
 	        <span>{{ t('pos.receipt.tableAdvance') }}</span>
-        <span>-{{ formatCurrency(orderResult.advance_applied) }}</span>
+        <span>-{{ formatCurrencyThermal(orderResult.advance_applied) }}</span>
       </div>
       <div class="receipt-total">
 	        <span>{{ t('pos.receipt.totalChargedUpper') }}</span>
-        <span>{{ formatCurrency(orderResultChargedAmount) }}</span>
+        <span>{{ formatCurrencyThermal(orderResultChargedAmount) }}</span>
       </div>
     </template>
     <div v-else class="receipt-total">
       <span>TOTAL</span>
-      <span>{{ formatCurrency(orderResult?.total_amount ?? 0) }}</span>
+      <span>{{ formatCurrencyThermal(orderResult?.total_amount ?? 0) }}</span>
     </div>
     <div class="receipt-divider">--------------------------------</div>
 	    <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.paymentDetail') }}</div>
@@ -5592,11 +5592,11 @@ onUnmounted(() => {
       <template v-for="(p, idx) in splitPaymentsSnapshot" :key="p.id">
         <div class="receipt-item receipt-small">
           <span>#{{ idx + 1 }} · {{ p.payment_method_name }}</span>
-          <span>{{ formatCurrency(p.amount) }}</span>
+          <span>{{ formatCurrencyThermal(p.amount) }}</span>
         </div>
         <div v-if="p.change && p.change > 0" class="receipt-item receipt-small">
 	          <span>{{ t('pos.receipt.changeNumber', { number: idx + 1 }) }}</span>
-          <span>{{ formatCurrency(p.change) }}</span>
+          <span>{{ formatCurrencyThermal(p.change) }}</span>
         </div>
       </template>
     </template>
@@ -5609,14 +5609,14 @@ onUnmounted(() => {
                 : getPaymentMethodLabel(orderResult.payment_method))
 	            : t('pos.checkout.summary.pendingPayment')
         }}</span>
-        <span>{{ formatCurrency(orderResultChargedAmount) }}</span>
+        <span>{{ formatCurrencyThermal(orderResultChargedAmount) }}</span>
       </div>
       <div
         v-if="receiptPrintContext?.singlePaymentChange && receiptPrintContext.singlePaymentChange > 0"
         class="receipt-item receipt-small"
       >
 	        <span>{{ t('pos.receipt.change') }}</span>
-        <span>{{ formatCurrency(receiptPrintContext.singlePaymentChange) }}</span>
+        <span>{{ formatCurrencyThermal(receiptPrintContext.singlePaymentChange) }}</span>
       </div>
     </template>
     <div class="receipt-divider">================================</div>

--- a/utils/currencyDisplay.test.ts
+++ b/utils/currencyDisplay.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_NUMBER_LOCALE,
   coerceMoneyNumber,
   formatMoney,
+  formatMoneyThermal,
   localeToNumberFormatTag,
   normalizeCurrencyCode,
   normalizeMinorUnits,
@@ -153,5 +154,19 @@ describe('normalizeMinorUnits', () => {
     assert.equal(normalizeMinorUnits(-1, 0), 0)
     assert.equal(normalizeMinorUnits(4, 0), 0)
     assert.equal(normalizeMinorUnits(null, 0), 0)
+  })
+})
+
+describe('formatMoneyThermal', () => {
+  it('formats COP with ISO code and ASCII-only output', () => {
+    const out = formatMoneyThermal(1100, { currency: 'COP', locale: 'es', minorUnits: 0 })
+    assert.equal(out, 'COP 1.100')
+    assert.match(out, /^[\x20-\x7E]+$/)
+  })
+
+  it('formats USD with decimals and ASCII-only output', () => {
+    const out = formatMoneyThermal(12.5, { currency: 'USD', locale: 'en', minorUnits: 2 })
+    assert.equal(out, 'USD 12.50')
+    assert.match(out, /^[\x20-\x7E]+$/)
   })
 })

--- a/utils/currencyDisplay.ts
+++ b/utils/currencyDisplay.ts
@@ -90,4 +90,33 @@ export function formatMoney(
     maximumFractionDigits: minorUnits,
   }).format(numericValue)
 }
+
+/**
+ * ASCII-safe money for ESC/POS / thermal tickets (#1965).
+ * Prefers ISO code + locale number punctuation (no currency glyphs / NBSP).
+ * Example: "COP 1.100", "USD 12.50"
+ */
+export function formatMoneyThermal(
+  value: number | string | null | undefined,
+  options?: Omit<FormatMoneyOptions, 'notation'>,
+): string {
+  const currency = normalizeCurrencyCode(options?.currency)
+  const localeTag = localeToNumberFormatTag(options?.locale)
+  const minorUnits = normalizeMinorUnits(options?.minorUnits, 0)
+  const numericValue = coerceMoneyNumber(value) ?? 0
+
+  const amount = new Intl.NumberFormat(localeTag, {
+    style: 'decimal',
+    minimumFractionDigits: minorUnits,
+    maximumFractionDigits: minorUnits,
+    useGrouping: true,
+  }).format(numericValue)
+
+  // Normalize any exotic grouping spaces Intl may still emit
+  const asciiAmount = amount
+    .replace(/[\u00a0\u202f\u2007\u2009\u200a\ufeff]/g, ' ')
+    .trim()
+
+  return `${currency} ${asciiAmount}`
+}
 import { toNumberLocaleTag } from './appLocales.ts'

--- a/utils/escPosTicket.test.ts
+++ b/utils/escPosTicket.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'bun:test'
 import {
   buildDianQrUrl,
   buildEscPosQrCodeBytes,
+  buildEscPosRasterBytes,
   buildEscPosTicketBytes,
   extractDianQrPayload,
   hasEscPosQrMarker,
+  hasEscPosRasterMarker,
   normalizeEscPosAscii,
   ticketHtmlToPlainText,
 } from './escPosTicket'
@@ -103,5 +105,35 @@ describe('buildEscPosTicketBytes', () => {
     expect(hasEscPosQrMarker(withQr)).toBe(true)
     const without = buildEscPosTicketBytes(`CUFE: ${SAMPLE_CUFE}`, { qrPayload: null })
     expect(hasEscPosQrMarker(without)).toBe(false)
+  })
+
+  it('embeds logo raster when provided', () => {
+    // 8x1 black pixels
+    const data = new Uint8ClampedArray(8 * 1 * 4)
+    for (let i = 0; i < 8; i++) {
+      data[i * 4] = 0
+      data[i * 4 + 1] = 0
+      data[i * 4 + 2] = 0
+      data[i * 4 + 3] = 255
+    }
+    const logo = buildEscPosRasterBytes({ width: 8, height: 1, data })
+    expect(hasEscPosRasterMarker(logo)).toBe(true)
+    const bytes = buildEscPosTicketBytes('Ticket', { logoRaster: logo })
+    expect(hasEscPosRasterMarker(bytes)).toBe(true)
+  })
+})
+
+describe('buildEscPosRasterBytes', () => {
+  it('emits GS v 0 header for black pixels', () => {
+    const data = new Uint8ClampedArray(16 * 2 * 4)
+    for (let i = 0; i < data.length; i += 4) {
+      data[i] = 0
+      data[i + 1] = 0
+      data[i + 2] = 0
+      data[i + 3] = 255
+    }
+    const bytes = buildEscPosRasterBytes({ width: 16, height: 2, data })
+    expect(hasEscPosRasterMarker(bytes)).toBe(true)
+    expect(bytes.length).toBeGreaterThan(8)
   })
 })

--- a/utils/escPosTicket.ts
+++ b/utils/escPosTicket.ts
@@ -2,9 +2,12 @@
  * ESC/POS helpers for thermal tickets without PrintBridge HTML/Chromium.
  * Plain text → raw bytes (58mm ≈ 32 cols). Accents folded to ASCII for CP437-less queues.
  * Optional DIAN QR via native GS ( k when CUFE / search URL is present (#1962).
+ * Optional logo via GS v 0 raster (#1965).
  */
 
 const DEFAULT_COLS = 32
+const DEFAULT_LOGO_MAX_WIDTH = 384 // ~58mm @ 203dpi
+const DEFAULT_LOGO_MAX_HEIGHT = 120
 
 export const DIAN_SEARCH_QR_PREFIX =
   'https://catalogo-vpfe.dian.gov.co/document/searchqr?documentkey='
@@ -188,10 +191,121 @@ export function hasEscPosQrMarker(bytes: Uint8Array): boolean {
     && bytesIncludeSubsequence(bytes, [0x31, 0x50, 0x30])
 }
 
-/** Build ESC/POS raw ticket: init + left + lines + optional QR + feed + partial cut. */
+/** True when buffer contains GS v 0 raster header. */
+export function hasEscPosRasterMarker(bytes: Uint8Array): boolean {
+  return bytesIncludeSubsequence(bytes, [0x1d, 0x76, 0x30])
+}
+
+export type EscPosImageDataLike = {
+  width: number
+  height: number
+  data: ArrayLike<number>
+}
+
+/**
+ * Pack RGBA image data into ESC/POS GS v 0 raster (1-bit, centered).
+ * Width is floored to a multiple of 8.
+ */
+export function buildEscPosRasterBytes(imageData: EscPosImageDataLike): Uint8Array {
+  const width = Math.floor(imageData.width) & ~7
+  const height = Math.floor(imageData.height)
+  if (width < 8 || height < 1) return new Uint8Array(0)
+
+  const widthBytes = width / 8
+  const raster: number[] = []
+  for (let y = 0; y < height; y++) {
+    for (let xb = 0; xb < widthBytes; xb++) {
+      let byte = 0
+      for (let bit = 0; bit < 8; bit++) {
+        const x = xb * 8 + bit
+        const i = (y * imageData.width + x) * 4
+        const r = Number(imageData.data[i] ?? 255)
+        const g = Number(imageData.data[i + 1] ?? 255)
+        const b = Number(imageData.data[i + 2] ?? 255)
+        const a = Number(imageData.data[i + 3] ?? 255)
+        const lum = (r * 299 + g * 587 + b * 114) / 1000
+        if (a > 64 && lum < 180) byte |= 0x80 >> bit
+      }
+      raster.push(byte)
+    }
+  }
+
+  return Uint8Array.from([
+    0x1b, 0x61, 0x01, // center
+    0x1d, 0x76, 0x30, 0x00,
+    widthBytes & 0xff,
+    (widthBytes >> 8) & 0xff,
+    height & 0xff,
+    (height >> 8) & 0xff,
+    ...raster,
+    0x0a,
+    0x1b, 0x61, 0x00, // left
+  ])
+}
+
+/** Find receipt logo URL from print DOM (#pos-* or teleported .receipt-print-ticket). */
+export function findReceiptLogoSrc(elementId?: string | null): string | null {
+  if (typeof document === 'undefined') return null
+  const roots: Element[] = []
+  if (elementId) {
+    const el = document.getElementById(elementId)
+    if (el) roots.push(el)
+  }
+  const teleported = document.querySelector('.receipt-print-ticket')
+  if (teleported) roots.push(teleported)
+  for (const root of roots) {
+    const img = root.querySelector('img.receipt-logo') as HTMLImageElement | null
+    const src = (img?.currentSrc || img?.src || '').trim()
+    if (src) return src
+  }
+  return null
+}
+
+/** Load logo URL → ESC/POS raster bytes (best-effort; CORS may skip remote logos). */
+export async function loadEscPosLogoRasterFromUrl(
+  url: string,
+  options?: { maxWidthPx?: number; maxHeightPx?: number },
+): Promise<Uint8Array | null> {
+  if (typeof document === 'undefined' || !url?.trim()) return null
+  const maxW = options?.maxWidthPx ?? DEFAULT_LOGO_MAX_WIDTH
+  const maxH = options?.maxHeightPx ?? DEFAULT_LOGO_MAX_HEIGHT
+
+  try {
+    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const i = new Image()
+      i.crossOrigin = 'anonymous'
+      i.onload = () => resolve(i)
+      i.onerror = () => reject(new Error('logo load failed'))
+      i.src = url
+    })
+    let w = img.naturalWidth || img.width
+    let h = img.naturalHeight || img.height
+    if (!w || !h) return null
+    const scale = Math.min(maxW / w, maxH / h, 1)
+    w = Math.max(8, Math.floor(w * scale) & ~7)
+    h = Math.max(1, Math.floor(h * scale))
+    const canvas = document.createElement('canvas')
+    canvas.width = w
+    canvas.height = h
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return null
+    ctx.fillStyle = '#ffffff'
+    ctx.fillRect(0, 0, w, h)
+    ctx.drawImage(img, 0, 0, w, h)
+    return buildEscPosRasterBytes(ctx.getImageData(0, 0, w, h))
+  } catch {
+    return null
+  }
+}
+
+/** Build ESC/POS raw ticket: init + optional logo + lines + optional QR + feed + partial cut. */
 export function buildEscPosTicketBytes(
   text: string,
-  options?: { cols?: number; qrPayload?: string | null },
+  options?: {
+    cols?: number
+    qrPayload?: string | null
+    logoRaster?: Uint8Array | null
+  },
 ): Uint8Array {
   const cols = options?.cols ?? DEFAULT_COLS
   const plain = ticketHtmlToPlainText(text)
@@ -207,6 +321,13 @@ export function buildEscPosTicketBytes(
     0x1b, 0x40, // ESC @ init
     0x1b, 0x61, 0x00, // left align
   ]
+
+  const logo = options?.logoRaster
+  if (logo?.length) {
+    for (let i = 0; i < logo.length; i++) parts.push(logo[i]!)
+    parts.push(0x0a)
+  }
+
   for (const line of lines) {
     for (let i = 0; i < line.length; i++) parts.push(line.charCodeAt(i) & 0xff)
     parts.push(0x0a)


### PR DESCRIPTION
## Summary
- Print tickets use `formatMoneyThermal` / `formatCurrencyThermal` (`COP 1.100`, `USD 12.50`) instead of Intl currency glyphs that became `?` on ESC/POS.
- Caja thermal path rasterizes `img.receipt-logo` via GS `v 0` when loadable (CORS best-effort).
- ReceiptPrintTicket no longer hardcodes COP for money lines.

Closes #1965

## Test plan
- [ ] Prefactura amounts show `COP …` / tenant ISO without `?`
- [ ] Prefactura/factura with logo prints logo on Star (same-origin or CORS-ok URL)
- [ ] Comanda modifier prices use thermal formatter when shown
- [ ] No printer → browser print still works

## Validation evidence
```
$ bun test utils/escPosTicket.test.ts composables/useCajaTicketPrint.test.ts
22 pass 0 fail

$ node --test utils/currencyDisplay.test.ts
# tests 14 # pass 14 # fail 0
```

## wr-context
See `.wr/1965.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)