### PR TITLE
fix(print): thermal $ for COP + logo proxy

### DIFF
--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -296,7 +296,7 @@ const printableItems = computed(() =>
       <div class="receipt-product-line receipt-small">
         <div class="receipt-product-name">{{ item.name }}</div>
         <div class="receipt-product-values">
-          <span>{{ item.quantity }} × {{ money(item.unitPrice) }}</span>
+          <span>{{ item.quantity }} x {{ money(item.unitPrice) }}</span>
           <strong>{{ money(item.total) }}</strong>
         </div>
       </div>
@@ -307,7 +307,7 @@ const printableItems = computed(() =>
       >
         <div class="receipt-product-name">{{ modifierDescription(modifier) }}</div>
         <div class="receipt-product-values">
-          <span>{{ Number(modifier.quantity) || 1 }} × {{ money(modifier.price) }}</span>
+          <span>{{ Number(modifier.quantity) || 1 }} x {{ money(modifier.price) }}</span>
           <span>{{ money(modifierTotal(modifier)) }}</span>
         </div>
       </div>

--- a/server/routes/thermal-logo.get.ts
+++ b/server/routes/thermal-logo.get.ts
@@ -1,0 +1,51 @@
+/**
+ * Same-origin image proxy for ESC/POS logo raster (#1965 follow-up).
+ * Avoids canvas CORS when receipt logos are on S3/CDN without ACAO.
+ * GET /thermal-logo?url=https%3A%2F%2F...
+ */
+export default defineEventHandler(async (event) => {
+  const raw = String(getQuery(event).url || '').trim()
+  if (!raw) {
+    throw createError({ statusCode: 400, message: 'url is required' })
+  }
+
+  let parsed: URL
+  try {
+    parsed = new URL(raw)
+  } catch {
+    throw createError({ statusCode: 400, message: 'invalid url' })
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw createError({ statusCode: 400, message: 'only http(s) urls allowed' })
+  }
+
+  let upstream: Response
+  try {
+    upstream = await fetch(parsed.toString(), {
+      redirect: 'follow',
+      headers: { Accept: 'image/*,*/*;q=0.8' },
+    })
+  } catch {
+    throw createError({ statusCode: 502, message: 'logo fetch failed' })
+  }
+
+  if (!upstream.ok) {
+    throw createError({ statusCode: 502, message: `logo upstream ${upstream.status}` })
+  }
+
+  const contentType = upstream.headers.get('content-type') || 'application/octet-stream'
+  if (!contentType.startsWith('image/')) {
+    throw createError({ statusCode: 415, message: 'upstream is not an image' })
+  }
+
+  const buf = Buffer.from(await upstream.arrayBuffer())
+  // Cap ~1.5MB — thermal logos are small
+  if (buf.length > 1_500_000) {
+    throw createError({ statusCode: 413, message: 'logo too large' })
+  }
+
+  setHeader(event, 'Content-Type', contentType)
+  setHeader(event, 'Cache-Control', 'private, max-age=300')
+  return buf
+})

--- a/utils/currencyDisplay.test.ts
+++ b/utils/currencyDisplay.test.ts
@@ -158,13 +158,13 @@ describe('normalizeMinorUnits', () => {
 })
 
 describe('formatMoneyThermal', () => {
-  it('formats COP with ISO code and ASCII-only output', () => {
+  it('formats COP with ASCII peso sign and digits', () => {
     const out = formatMoneyThermal(1100, { currency: 'COP', locale: 'es', minorUnits: 0 })
-    assert.equal(out, 'COP 1.100')
+    assert.equal(out, '$ 1.100')
     assert.match(out, /^[\x20-\x7E]+$/)
   })
 
-  it('formats USD with decimals and ASCII-only output', () => {
+  it('formats USD with ISO code and ASCII-only output', () => {
     const out = formatMoneyThermal(12.5, { currency: 'USD', locale: 'en', minorUnits: 2 })
     assert.equal(out, 'USD 12.50')
     assert.match(out, /^[\x20-\x7E]+$/)

--- a/utils/currencyDisplay.ts
+++ b/utils/currencyDisplay.ts
@@ -93,8 +93,8 @@ export function formatMoney(
 
 /**
  * ASCII-safe money for ESC/POS / thermal tickets (#1965).
- * Prefers ISO code + locale number punctuation (no currency glyphs / NBSP).
- * Example: "COP 1.100", "USD 12.50"
+ * COP uses `$` (ASCII peso) + locale digits — matches Colombian tickets.
+ * Other currencies use ISO code (e.g. `USD 12.50`, `EUR 10,00`).
  */
 export function formatMoneyThermal(
   value: number | string | null | undefined,
@@ -117,6 +117,8 @@ export function formatMoneyThermal(
     .replace(/[\u00a0\u202f\u2007\u2009\u200a\ufeff]/g, ' ')
     .trim()
 
+  // COP → `$` (peso sign is ASCII on thermal); others keep ISO code
+  if (currency === 'COP') return `$ ${asciiAmount}`
   return `${currency} ${asciiAmount}`
 }
 import { toNumberLocaleTag } from './appLocales.ts'

--- a/utils/escPosTicket.test.ts
+++ b/utils/escPosTicket.test.ts
@@ -43,6 +43,10 @@ describe('normalizeEscPosAscii', () => {
     expect(normalizeEscPosAscii('FEV-73 · Factura')).toBe('FEV-73 - Factura')
     expect(normalizeEscPosAscii('Datafono · bold')).toBe('Datafono - bold')
   })
+
+  it('keeps ASCII peso sign', () => {
+    expect(normalizeEscPosAscii('$ 45.000')).toBe('$ 45.000')
+  })
 })
 
 describe('extractDianQrPayload', () => {

--- a/utils/escPosTicket.ts
+++ b/utils/escPosTicket.ts
@@ -312,6 +312,16 @@ function rasterFromLoadedImage(
   }
 }
 
+/** Same-origin proxy URL so canvas can read CDN logos without CORS. */
+export function thermalLogoProxyUrl(remoteUrl: string): string {
+  const u = remoteUrl.trim()
+  if (!u) return ''
+  if (u.startsWith('data:') || u.startsWith('blob:')) return u
+  // Already proxied
+  if (u.includes('/thermal-logo?')) return u
+  return `/thermal-logo?url=${encodeURIComponent(u)}`
+}
+
 /** Load logo URL / DOM img → ESC/POS raster (best-effort). */
 export async function loadEscPosLogoRasterFromUrl(
   url: string,
@@ -321,18 +331,18 @@ export async function loadEscPosLogoRasterFromUrl(
   const maxW = options?.maxWidthPx ?? DEFAULT_LOGO_MAX_WIDTH
   const maxH = options?.maxHeightPx ?? DEFAULT_LOGO_MAX_HEIGHT
 
-  // 1) Prefer already-decoded DOM logo (same paint path as browser print)
-  const domImg = findReceiptLogoImage(options?.elementId)
-  if (domImg && (domImg.complete || domImg.naturalWidth > 0)) {
-    const fromDom = rasterFromLoadedImage(domImg, maxW, maxH)
-    if (fromDom?.length) return fromDom
-  }
+  // Prefer same-origin proxy (bypasses CDN CORS + display:none unload issues)
+  const candidates = [
+    thermalLogoProxyUrl(url),
+    url,
+  ].filter((u, i, arr) => u && arr.indexOf(u) === i)
 
-  // 2) fetch → blob (works when CDN sends Access-Control-Allow-Origin)
-  try {
-    const res = await fetch(url, { mode: 'cors', credentials: 'omit', cache: 'force-cache' })
-    if (res.ok) {
+  for (const candidate of candidates) {
+    try {
+      const res = await fetch(candidate, { credentials: 'same-origin', cache: 'force-cache' })
+      if (!res.ok) continue
       const blob = await res.blob()
+      if (!blob.type.startsWith('image/') && !candidate.startsWith('data:')) continue
       const objectUrl = URL.createObjectURL(blob)
       try {
         const img = await new Promise<HTMLImageElement>((resolve, reject) => {
@@ -346,12 +356,19 @@ export async function loadEscPosLogoRasterFromUrl(
       } finally {
         URL.revokeObjectURL(objectUrl)
       }
+    } catch {
+      /* try next */
     }
-  } catch {
-    /* fall through */
   }
 
-  // 3) Image + crossOrigin anonymous
+  // DOM img (may be tainted / not loaded under display:none)
+  const domImg = findReceiptLogoImage(options?.elementId)
+  if (domImg && (domImg.complete || domImg.naturalWidth > 0)) {
+    const fromDom = rasterFromLoadedImage(domImg, maxW, maxH)
+    if (fromDom?.length) return fromDom
+  }
+
+  // Last resort: Image + crossOrigin anonymous
   try {
     const img = await new Promise<HTMLImageElement>((resolve, reject) => {
       const i = new Image()


### PR DESCRIPTION
## Summary
- COP thermal amounts print as `$ 45.000` (ASCII peso), not `COP …`.
- New `/thermal-logo?url=` same-origin proxy so ESC/POS can rasterize CDN logos without CORS.
- Logo load prefers proxy over DOM/`display:none` images.

## Test plan
- [ ] Restart Nuxt, reprint factura → amounts like `$ 45.000`, no `?`
- [ ] Logo appears on thermal when `logo_url` is set
- [ ] USD tenant still shows `USD 12.50`

## Validation evidence
```
$ bun test utils/escPosTicket.test.ts composables/useCajaTicketPrint.test.ts
24 pass

$ node --test utils/currencyDisplay.test.ts
14 pass
```

Made with [Cursor](https://cursor.com)