### PR TITLE
fix(print): thermal $ CODE amount for all currencies

### DIFF
--- a/utils/currencyDisplay.test.ts
+++ b/utils/currencyDisplay.test.ts
@@ -158,15 +158,21 @@ describe('normalizeMinorUnits', () => {
 })
 
 describe('formatMoneyThermal', () => {
-  it('formats COP with ASCII peso sign and digits', () => {
+  it('formats COP with peso sign and ISO code', () => {
     const out = formatMoneyThermal(1100, { currency: 'COP', locale: 'es', minorUnits: 0 })
-    assert.equal(out, '$ 1.100')
+    assert.equal(out, '$ COP 1.100')
     assert.match(out, /^[\x20-\x7E]+$/)
   })
 
-  it('formats USD with ISO code and ASCII-only output', () => {
+  it('formats USD with peso/dollar sign and ISO code', () => {
     const out = formatMoneyThermal(12.5, { currency: 'USD', locale: 'en', minorUnits: 2 })
-    assert.equal(out, 'USD 12.50')
+    assert.equal(out, '$ USD 12.50')
+    assert.match(out, /^[\x20-\x7E]+$/)
+  })
+
+  it('formats EUR with sign and ISO code', () => {
+    const out = formatMoneyThermal(10, { currency: 'EUR', locale: 'es', minorUnits: 2 })
+    assert.equal(out, '$ EUR 10,00')
     assert.match(out, /^[\x20-\x7E]+$/)
   })
 })

--- a/utils/currencyDisplay.ts
+++ b/utils/currencyDisplay.ts
@@ -93,8 +93,8 @@ export function formatMoney(
 
 /**
  * ASCII-safe money for ESC/POS / thermal tickets (#1965).
- * COP uses `$` (ASCII peso) + locale digits — matches Colombian tickets.
- * Other currencies use ISO code (e.g. `USD 12.50`, `EUR 10,00`).
+ * Always: `$ {CODE} {amount}` so Colombia keeps peso sign + ISO for every currency.
+ * Example: "$ COP 1.100", "$ USD 12.50", "$ EUR 10,00"
  */
 export function formatMoneyThermal(
   value: number | string | null | undefined,
@@ -117,8 +117,6 @@ export function formatMoneyThermal(
     .replace(/[\u00a0\u202f\u2007\u2009\u200a\ufeff]/g, ' ')
     .trim()
 
-  // COP → `$` (peso sign is ASCII on thermal); others keep ISO code
-  if (currency === 'COP') return `$ ${asciiAmount}`
-  return `${currency} ${asciiAmount}`
+  return `$ ${currency} ${asciiAmount}`
 }
 import { toNumberLocaleTag } from './appLocales.ts'


### PR DESCRIPTION
## Summary
- Thermal money format is always `$ {ISO} {amount}` (e.g. `$ COP 45.000`, `$ USD 12.50`).

## Test plan
- [ ] Prefactura/factura shows `$ COP …`
- [ ] Non-COP tenant shows `$ USD …` (or other code)

## Validation evidence
```
$ node --test utils/currencyDisplay.test.ts
# pass (formatMoneyThermal cases)
```

Made with [Cursor](https://cursor.com)