### PR TITLE
feat(crm): show fiscal data in Clients when present

### DIFF
--- a/.wr/751.yaml
+++ b/.wr/751.yaml
@@ -1,0 +1,42 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 751
+title: "Show customer fiscal data in CRM Clients when present"
+repo: both
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-751-crm-fiscal-clients
+
+paths:
+  - pages/crm/clientes/index.vue
+  - pages/crm/clientes/[id].vue
+  - i18n/locales/es/analitica.json
+  - i18n/locales/en/analitica.json
+  - app/services/orders_service.py
+  - tests/test_customers_list.py
+  - tests/test_customer_detail.py
+
+ac:
+  - CRM detail shows fiscal block only when any fiscal field present
+  - CRM list shows compact fiscal signal when present; no empty noise
+  - Relies on API fiscal_* fields from GET /orders/customers*
+
+out_of_scope:
+  - Editing fiscal from CRM
+  - POS capture flow changes
+  - Matías / electronic invoicing
+
+hints:
+  entry: "pages/crm/clientes/index.vue + [id].vue"
+  pattern: "show fiscal only when hasFiscalData / hasFiscalInfo"
+  tests: "API: ./venv/bin/pytest tests/test_customers_list.py tests/test_customer_detail.py -q"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "depends on api-warolabs PR exposing fiscal_*"

--- a/i18n/locales/en/analitica.json
+++ b/i18n/locales/en/analitica.json
@@ -257,7 +257,9 @@
       "showingRange": "Showing {start} to {end} of {total} customers",
       "prev": "Previous",
       "next": "Next",
-      "noPhone": "No phone"
+      "noPhone": "No phone",
+      "fiscal": "Fiscal",
+      "fiscalDocument": "{type} {id}"
     },
     "customerDetail": {
       "notFound": "Customer not found",
@@ -270,6 +272,10 @@
       "editError": "Error saving changes",
       "firstPurchase": "First purchase",
       "lastPurchase": "Last purchase",
+      "fiscalInfo": "Fiscal information",
+      "fiscalDocument": "Document",
+      "fiscalBusinessName": "Business / legal name",
+      "fiscalEmail": "Fiscal email",
       "totalOrders": "Total orders",
       "orderNumber": "Order #",
       "orderNumberAlt": "Order #",

--- a/i18n/locales/es/analitica.json
+++ b/i18n/locales/es/analitica.json
@@ -257,7 +257,9 @@
       "showingRange": "Mostrando {start} a {end} de {total} clientes",
       "prev": "Anterior",
       "next": "Siguiente",
-      "noPhone": "Sin teléfono"
+      "noPhone": "Sin teléfono",
+      "fiscal": "Fiscal",
+      "fiscalDocument": "{type} {id}"
     },
     "customerDetail": {
       "notFound": "Cliente no encontrado",
@@ -270,6 +272,10 @@
       "editError": "Error al guardar los cambios",
       "firstPurchase": "Primera compra",
       "lastPurchase": "Última compra",
+      "fiscalInfo": "Información fiscal",
+      "fiscalDocument": "Documento",
+      "fiscalBusinessName": "Razón social / nombre",
+      "fiscalEmail": "Correo fiscal",
       "totalOrders": "Total pedidos",
       "orderNumber": "# Pedido",
       "orderNumberAlt": "# Orden",

--- a/pages/crm/clientes/[id].vue
+++ b/pages/crm/clientes/[id].vue
@@ -75,6 +75,16 @@ const realEmail = computed(() => {
   if (!email || email.endsWith('@customer.temp')) return null
   return email
 })
+const hasFiscalInfo = computed(() => {
+  const c = customer.value
+  if (!c) return false
+  return !!(c.fiscal_id_type || c.fiscal_id || c.fiscal_business_name || c.fiscal_email)
+})
+const fiscalDocumentLabel = computed(() => {
+  const c = customer.value
+  if (!c?.fiscal_id_type || !c?.fiscal_id) return null
+  return `${c.fiscal_id_type} ${c.fiscal_id}`
+})
 const avgTicket = computed(() => {
   const c = customer.value
   if (!c || !c.total_orders) return 0
@@ -558,6 +568,25 @@ onUnmounted(() => {
               <p class="text-xs text-text-secondary uppercase tracking-wider font-medium">{{ t('analitica.customerDetail.lastPurchase') }}</p>
             </div>
             <p class="text-sm font-semibold text-text-primary">{{ formatDate(customer.last_purchase) }}</p>
+          </div>
+        </div>
+
+        <!-- Fiscal info (only when present) -->
+        <div v-if="hasFiscalInfo" class="border-t border-border px-5 py-4">
+          <p class="text-xs text-text-secondary uppercase tracking-wider font-medium mb-3">{{ t('analitica.customerDetail.fiscalInfo') }}</p>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div v-if="fiscalDocumentLabel">
+              <p class="text-xs text-text-secondary mb-0.5">{{ t('analitica.customerDetail.fiscalDocument') }}</p>
+              <p class="text-sm font-semibold text-text-primary">{{ fiscalDocumentLabel }}</p>
+            </div>
+            <div v-if="customer.fiscal_business_name">
+              <p class="text-xs text-text-secondary mb-0.5">{{ t('analitica.customerDetail.fiscalBusinessName') }}</p>
+              <p class="text-sm font-semibold text-text-primary">{{ customer.fiscal_business_name }}</p>
+            </div>
+            <div v-if="customer.fiscal_email">
+              <p class="text-xs text-text-secondary mb-0.5">{{ t('analitica.customerDetail.fiscalEmail') }}</p>
+              <p class="text-sm font-semibold text-text-primary truncate">{{ customer.fiscal_email }}</p>
+            </div>
           </div>
         </div>
 

--- a/pages/crm/clientes/[id].vue
+++ b/pages/crm/clientes/[id].vue
@@ -78,7 +78,8 @@ const realEmail = computed(() => {
 const hasFiscalInfo = computed(() => {
   const c = customer.value
   if (!c) return false
-  return !!(c.fiscal_id_type || c.fiscal_id || c.fiscal_business_name || c.fiscal_email)
+  const hasDocument = !!(c.fiscal_id_type && c.fiscal_id)
+  return !!(hasDocument || c.fiscal_business_name || c.fiscal_email)
 })
 const fiscalDocumentLabel = computed(() => {
   const c = customer.value

--- a/pages/crm/clientes/index.vue
+++ b/pages/crm/clientes/index.vue
@@ -158,11 +158,12 @@ const formatFiscalLabel = (row: {
   fiscal_id_type?: string | null
   fiscal_id?: string | null
   fiscal_business_name?: string | null
+  fiscal_email?: string | null
 }) => {
   if (row.fiscal_id_type && row.fiscal_id) {
     return t('analitica.clientes.fiscalDocument', { type: row.fiscal_id_type, id: row.fiscal_id })
   }
-  return row.fiscal_business_name || null
+  return row.fiscal_business_name || row.fiscal_email || null
 }
 
 const hasFiscalData = (row: {
@@ -170,7 +171,11 @@ const hasFiscalData = (row: {
   fiscal_id?: string | null
   fiscal_business_name?: string | null
   fiscal_email?: string | null
-}) => !!(row.fiscal_id_type || row.fiscal_id || row.fiscal_business_name || row.fiscal_email)
+}) => !!(
+  (row.fiscal_id_type && row.fiscal_id)
+  || row.fiscal_business_name
+  || row.fiscal_email
+)
 
 const router = useRouter()
 const showCreateModal = ref(false)

--- a/pages/crm/clientes/index.vue
+++ b/pages/crm/clientes/index.vue
@@ -154,6 +154,24 @@ const formatWaros = (value: number) => formatNumber(value || 0, { maximumFractio
 const formatOrderCount = (count: number) =>
   t(count === 1 ? 'analitica.clientes.orderCountOne' : 'analitica.clientes.orderCountMany', { count })
 
+const formatFiscalLabel = (row: {
+  fiscal_id_type?: string | null
+  fiscal_id?: string | null
+  fiscal_business_name?: string | null
+}) => {
+  if (row.fiscal_id_type && row.fiscal_id) {
+    return t('analitica.clientes.fiscalDocument', { type: row.fiscal_id_type, id: row.fiscal_id })
+  }
+  return row.fiscal_business_name || null
+}
+
+const hasFiscalData = (row: {
+  fiscal_id_type?: string | null
+  fiscal_id?: string | null
+  fiscal_business_name?: string | null
+  fiscal_email?: string | null
+}) => !!(row.fiscal_id_type || row.fiscal_id || row.fiscal_business_name || row.fiscal_email)
+
 const router = useRouter()
 const showCreateModal = ref(false)
 
@@ -296,6 +314,9 @@ onUnmounted(() => {
                 <p class="text-xs text-text-secondary mt-0.5">
                   {{ item.phone || t('analitica.clientes.noPhone') }} · {{ formatOrderCount(item.order_count) }}<template v-if="item.last_order_date"> · {{ formatDate(item.last_order_date) }}</template>
                 </p>
+                <p v-if="hasFiscalData(item) && formatFiscalLabel(item)" class="text-xs text-text-secondary mt-0.5 truncate">
+                  {{ t('analitica.clientes.fiscal') }}: {{ formatFiscalLabel(item) }}
+                </p>
               </div>
               <div class="flex flex-col items-end gap-1 flex-shrink-0">
                 <span class="text-sm font-bold text-text-primary">{{ formatCurrency(item.total_spent) }}</span>
@@ -321,7 +342,12 @@ onUnmounted(() => {
           </template>
 
           <template #cell-name="{ row }">
-            <span class="text-sm font-bold text-text-primary">{{ row.name }}</span>
+            <div class="min-w-0">
+              <span class="text-sm font-bold text-text-primary">{{ row.name }}</span>
+              <p v-if="hasFiscalData(row) && formatFiscalLabel(row)" class="text-xs text-text-secondary mt-0.5 truncate">
+                {{ formatFiscalLabel(row) }}
+              </p>
+            </div>
           </template>
 
           <template #cell-phone="{ value }">


### PR DESCRIPTION
## Summary
- CRM customer detail shows a fiscal block when any fiscal field is present
- CRM customers list shows a compact fiscal document/name signal under the customer name
- Relies on API PR https://github.com/uno0uno/api-warolabs/pull/752 for fiscal_* payload fields

Related: uno0uno/api-warolabs#751

## Test plan
- [ ] Customer with NIT/CC fiscal data shows document + business name (+ fiscal email if set) on detail
- [ ] Same customer shows fiscal line under name on list (mobile card + desktop table)
- [ ] Customer without fiscal data looks unchanged (no empty fiscal UI)

## Validation evidence
```
API (companion): ./venv/bin/pytest tests/test_customers_list.py tests/test_customer_detail.py -q
9 passed in 0.19s
Front: no project unit tests for these pages; UI validated against AC (display-only).
```

## wr-context
See `.wr/751.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)