### PR TITLE
feat(pos): auto-print fired comandas via SSE + PrintBridge

### DIFF
--- a/.wr/1971.yaml
+++ b/.wr/1971.yaml
@@ -1,0 +1,42 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1971
+title: "Auto-print comandas to caja / user printer on add-to-table and counter-bar send"
+repo: both
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-1971-auto-print-comandas
+
+paths:
+  - composables/useAutoComandaPrint.ts
+  - composables/useAutoComandaPrint.test.ts
+  - composables/useUserPrinterPreference.ts
+  - composables/useNotifications.ts
+  - pages/operaciones/impresoras.vue
+  - app/services/notifications_service.py
+  - app/services/comandas_service.py
+  - tests/test_comanda_fired_notification.py
+
+ac:
+  - Client gate PrintBridge + caja/user printer
+  - Mi impresora (1) on Operaciones → Impresoras
+  - SSE comanda_fired handler without toast noise
+
+out_of_scope:
+  - Multi-station auto routing
+  - Cloud print queue
+
+hints:
+  entry: "useNotifications SSE → autoPrintComandaFired"
+  pattern: "silent skip without bridge"
+  tests: "bunx vitest run composables/useAutoComandaPrint.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "pair with api-warolabs companion PR"

--- a/composables/useAutoComandaPrint.test.ts
+++ b/composables/useAutoComandaPrint.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import {
+  __resetAutoComandaPrintDedupeForTests,
+  autoPrintComandaFired,
+  buildComandaPlainText,
+  filterUnprintedComandas,
+  markComandasPrinted,
+  resolveAutoPrintPrinterName,
+} from './useAutoComandaPrint'
+import type { LocalPrintBridge } from './useLocalPrintBridge'
+import { LocalPrintBridgeError } from './useLocalPrintBridge'
+
+function fakeBridge(overrides: Partial<LocalPrintBridge> = {}): LocalPrintBridge {
+  return {
+    isAvailable: () => true,
+    connect: vi.fn(async () => {}),
+    listPrinters: vi.fn(async () => ['CAJA']),
+    printRawEscPos: vi.fn(async () => {}),
+    printEscPosTestTicket: vi.fn(async () => {}),
+    printHtml: vi.fn(async () => {}),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  __resetAutoComandaPrintDedupeForTests()
+})
+
+describe('resolveAutoPrintPrinterName', () => {
+  it('uses caja for table / mesa', () => {
+    expect(
+      resolveAutoPrintPrinterName({
+        sourceType: 'table',
+        tableDisplayName: 'Mesa 5',
+        cajaPrinterName: 'CAJA',
+        userPrinterName: 'USER',
+      }),
+    ).toBe('CAJA')
+  })
+
+  it('uses user printer for barra even with source table', () => {
+    expect(
+      resolveAutoPrintPrinterName({
+        sourceType: 'table',
+        tableDisplayName: 'Barra',
+        cajaPrinterName: 'CAJA',
+        userPrinterName: 'BARRA',
+      }),
+    ).toBe('BARRA')
+  })
+
+  it('uses user printer for pos / counter', () => {
+    expect(
+      resolveAutoPrintPrinterName({
+        sourceType: 'pos',
+        cajaPrinterName: 'CAJA',
+        userPrinterName: 'BARRA',
+      }),
+    ).toBe('BARRA')
+  })
+
+  it('honors explicit auto_print_target', () => {
+    expect(
+      resolveAutoPrintPrinterName({
+        sourceType: 'table',
+        autoPrintTarget: 'user',
+        cajaPrinterName: 'CAJA',
+        userPrinterName: 'MINE',
+      }),
+    ).toBe('MINE')
+  })
+
+  it('returns null when required printer missing', () => {
+    expect(
+      resolveAutoPrintPrinterName({
+        sourceType: 'table',
+        tableDisplayName: 'Mesa 1',
+        cajaPrinterName: null,
+        userPrinterName: 'BARRA',
+      }),
+    ).toBeNull()
+    expect(
+      resolveAutoPrintPrinterName({
+        sourceType: 'pos',
+        cajaPrinterName: 'CAJA',
+        userPrinterName: null,
+      }),
+    ).toBeNull()
+  })
+})
+
+describe('dedupe', () => {
+  it('skips already printed comanda ids', () => {
+    const comandas = [
+      { comanda_number: 1, items: [{ kitchen_name: 'A', quantity: 1 }], id: 'c1' },
+    ]
+    markComandasPrinted(comandas)
+    expect(filterUnprintedComandas(comandas)).toEqual([])
+  })
+})
+
+describe('buildComandaPlainText', () => {
+  it('includes qty and kitchen name', () => {
+    const text = buildComandaPlainText([
+      {
+        comanda_number: 5,
+        table_display_name: 'Mesa 2',
+        station_name: 'Cocina',
+        items: [{ kitchen_name: 'Burger', quantity: 2, notes: 'sin cebolla' }],
+      },
+    ])
+    expect(text).toContain('COMANDA #5')
+    expect(text).toContain('2x Burger')
+    expect(text).toContain('sin cebolla')
+  })
+})
+
+describe('autoPrintComandaFired', () => {
+  it('prints to caja for table when bridge ok', async () => {
+    const bridge = fakeBridge()
+    const result = await autoPrintComandaFired(
+      {
+        type: 'comanda_fired',
+        source_type: 'table',
+        order_id: 'o1',
+        comandas: [
+          {
+            id: 'c-a',
+            comanda_number: 1,
+            items: [{ kitchen_name: 'Soup', quantity: 1 }],
+          },
+        ],
+      },
+      {
+        bridge,
+        getCajaPrinterName: async () => 'CAJA_1',
+        getUserId: () => 'u1',
+        getUserPrinter: () => null,
+      },
+    )
+    expect(result).toBe('printed')
+    expect(bridge.printRawEscPos).toHaveBeenCalledOnce()
+    expect(bridge.printRawEscPos).toHaveBeenCalledWith('CAJA_1', expect.any(Uint8Array))
+  })
+
+  it('skips when PrintBridge unavailable', async () => {
+    const bridge = fakeBridge({
+      connect: vi.fn(async () => {
+        throw new LocalPrintBridgeError('UNAVAILABLE', 'down')
+      }),
+    })
+    const result = await autoPrintComandaFired(
+      {
+        type: 'comanda_fired',
+        source_type: 'table',
+        comandas: [
+          { id: 'c-b', comanda_number: 1, items: [{ kitchen_name: 'X', quantity: 1 }] },
+        ],
+      },
+      {
+        bridge,
+        getCajaPrinterName: async () => 'CAJA',
+        getUserId: () => 'u1',
+      },
+    )
+    expect(result).toBe('skipped')
+    expect(bridge.printRawEscPos).not.toHaveBeenCalled()
+  })
+
+  it('skips pos without user printer', async () => {
+    const bridge = fakeBridge()
+    const result = await autoPrintComandaFired(
+      {
+        type: 'comanda_fired',
+        source_type: 'pos',
+        comandas: [
+          { id: 'c-c', comanda_number: 1, items: [{ kitchen_name: 'X', quantity: 1 }] },
+        ],
+      },
+      {
+        bridge,
+        getCajaPrinterName: async () => 'CAJA',
+        getUserId: () => 'u1',
+        getUserPrinter: () => null,
+      },
+    )
+    expect(result).toBe('skipped')
+  })
+
+  it('dedupes second SSE for same comanda', async () => {
+    const bridge = fakeBridge()
+    const payload = {
+      type: 'comanda_fired' as const,
+      source_type: 'table',
+      order_id: 'o1',
+      comandas: [
+        { id: 'c-dup', comanda_number: 1, items: [{ kitchen_name: 'X', quantity: 1 }] },
+      ],
+    }
+    const deps = {
+      bridge,
+      getCajaPrinterName: async () => 'CAJA',
+      getUserId: () => 'u1',
+    }
+    expect(await autoPrintComandaFired(payload, deps)).toBe('printed')
+    expect(await autoPrintComandaFired(payload, deps)).toBe('skipped')
+    expect(bridge.printRawEscPos).toHaveBeenCalledOnce()
+  })
+})

--- a/composables/useAutoComandaPrint.ts
+++ b/composables/useAutoComandaPrint.ts
@@ -1,0 +1,169 @@
+/**
+ * Auto-print fired comandas when PrintBridge is connected (warocol.com#1971).
+ * Mesa (source_type=table) → caja. Mostrador/barra (pos) → user's single printer.
+ * Never falls back to window.print — silent no-op without bridge/printer.
+ */
+import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
+import { mapComandasForPrint } from '~/composables/useComandaPrint'
+import { getUserPrinterName } from '~/composables/useUserPrinterPreference'
+import {
+  LocalPrintBridgeError,
+  useLocalPrintBridge,
+  type LocalPrintBridge,
+} from '~/composables/useLocalPrintBridge'
+import { buildEscPosTicketBytes } from '~/utils/escPosTicket'
+
+export type ComandaFiredSsePayload = {
+  type?: string
+  order_id?: string
+  source_type?: string
+  table_display_name?: string | null
+  /** Explicit target from API: caja (mesa) | user (mostrador/barra) */
+  auto_print_target?: 'caja' | 'user' | string
+  comandas?: unknown[]
+}
+
+const printedIds = new Set<string>()
+const PRINTED_CAP = 200
+
+export function __resetAutoComandaPrintDedupeForTests(): void {
+  printedIds.clear()
+}
+
+export function resolveAutoPrintPrinterName(opts: {
+  sourceType: string | null | undefined
+  tableDisplayName?: string | null
+  autoPrintTarget?: string | null
+  cajaPrinterName: string | null | undefined
+  userPrinterName: string | null | undefined
+}): string | null {
+  const explicit = (opts.autoPrintTarget || '').trim().toLowerCase()
+  const source = (opts.sourceType || '').trim().toLowerCase()
+  const label = (opts.tableDisplayName || '').trim().toLowerCase()
+
+  let target: 'caja' | 'user'
+  if (explicit === 'caja' || explicit === 'user') {
+    target = explicit
+  } else if (source === 'table' && label !== 'barra' && label !== 'bar') {
+    target = 'caja'
+  } else {
+    target = 'user'
+  }
+
+  if (target === 'caja') {
+    const caja = (opts.cajaPrinterName || '').trim()
+    return caja || null
+  }
+  const user = (opts.userPrinterName || '').trim()
+  return user || null
+}
+
+export function comandaDedupeKey(comanda: ComandaPrintPayload, orderId?: string): string {
+  if (comanda.id) return String(comanda.id)
+  return `fallback:${orderId || 'x'}:${comanda.comanda_number}:${comanda.station_name || ''}`
+}
+
+export function filterUnprintedComandas(
+  comandas: ComandaPrintPayload[],
+  orderId?: string,
+): ComandaPrintPayload[] {
+  const out: ComandaPrintPayload[] = []
+  for (const c of comandas) {
+    const key = comandaDedupeKey(c, orderId)
+    if (printedIds.has(key)) continue
+    out.push(c)
+  }
+  return out
+}
+
+export function markComandasPrinted(comandas: ComandaPrintPayload[], orderId?: string): void {
+  for (const c of comandas) {
+    printedIds.add(comandaDedupeKey(c, orderId))
+  }
+  while (printedIds.size > PRINTED_CAP) {
+    const first = printedIds.values().next().value
+    if (first == null) break
+    printedIds.delete(first)
+  }
+}
+
+export function buildComandaPlainText(comandas: ComandaPrintPayload[]): string {
+  const blocks: string[] = []
+  for (const c of comandas) {
+    const lines: string[] = [
+      `COMANDA #${c.comanda_number}`,
+      c.table_display_name ? String(c.table_display_name) : '',
+      c.station_name ? `Estacion: ${c.station_name}` : '',
+      '----------------',
+    ]
+    for (const item of c.items) {
+      lines.push(`${item.quantity}x ${item.kitchen_name}`)
+      for (const mod of item.modifiers_snapshot || []) {
+        const qty = Number(mod.quantity) || 1
+        lines.push(`  + ${mod.name}${qty > 1 ? ` x${qty}` : ''}`)
+      }
+      if (item.notes?.trim()) lines.push(`  * ${item.notes.trim()}`)
+    }
+    blocks.push(lines.filter(Boolean).join('\n'))
+  }
+  return blocks.join('\n\n')
+}
+
+export type AutoPrintDeps = {
+  bridge?: LocalPrintBridge
+  getCajaPrinterName: () => Promise<string | null>
+  getUserId: () => string
+  /** Injected for tests — default uses getUserPrinterName */
+  getUserPrinter?: (userId: string) => string | null
+}
+
+/**
+ * Gate + print. Returns 'printed' | 'skipped'. Never throws to callers.
+ */
+export async function autoPrintComandaFired(
+  payload: ComandaFiredSsePayload,
+  deps: AutoPrintDeps,
+): Promise<'printed' | 'skipped'> {
+  if (payload?.type && payload.type !== 'comanda_fired') return 'skipped'
+
+  const mapped = mapComandasForPrint(payload.comandas || [])
+  const pending = filterUnprintedComandas(mapped, payload.order_id)
+  if (!pending.length) return 'skipped'
+
+  let caja: string | null = null
+  try {
+    caja = await deps.getCajaPrinterName()
+  } catch {
+    caja = null
+  }
+
+  const userId = deps.getUserId()
+  const userPrinter = (deps.getUserPrinter || getUserPrinterName)(userId)
+  const printerName = resolveAutoPrintPrinterName({
+    sourceType: payload.source_type,
+    tableDisplayName: payload.table_display_name,
+    autoPrintTarget: payload.auto_print_target,
+    cajaPrinterName: caja,
+    userPrinterName: userPrinter,
+  })
+  if (!printerName) return 'skipped'
+
+  const bridge = deps.bridge ?? useLocalPrintBridge()
+  try {
+    await bridge.connect()
+  } catch {
+    return 'skipped'
+  }
+
+  const plain = buildComandaPlainText(pending)
+  if (!plain.trim()) return 'skipped'
+
+  try {
+    await bridge.printRawEscPos(printerName, buildEscPosTicketBytes(plain))
+    markComandasPrinted(pending, payload.order_id)
+    return 'printed'
+  } catch (err) {
+    if (err instanceof LocalPrintBridgeError) return 'skipped'
+    return 'skipped'
+  }
+}

--- a/composables/useNotifications.ts
+++ b/composables/useNotifications.ts
@@ -79,6 +79,39 @@ export const useNotifications = () => {
 
     eventSource.onmessage = async (event) => {
       if (!event.data || event.data.startsWith(':')) return // ignore heartbeat comments
+
+      // warocol.com#1971 — SSE-only comanda_fired (no DB row); auto-print if PrintBridge up
+      try {
+        const payload = JSON.parse(event.data) as Record<string, unknown>
+        if (payload?.type === 'comanda_fired') {
+          const { autoPrintComandaFired } = await import('~/composables/useAutoComandaPrint')
+          const authStore = useAuthStore()
+          const userId = String(
+            authStore.user?.id
+            || authStore.session?.user?.id
+            || authStore.profile?.id
+            || 'anon',
+          )
+          void autoPrintComandaFired(payload as import('~/composables/useAutoComandaPrint').ComandaFiredSsePayload, {
+            getUserId: () => userId,
+            getCajaPrinterName: async () => {
+              try {
+                const res = await $fetch<{ success: boolean; data: { caja_printer_name?: string | null; resolved_caja?: string | null } }>(
+                  '/api/operaciones/printers',
+                )
+                return res.data?.resolved_caja || res.data?.caja_printer_name || null
+              } catch {
+                return null
+              }
+            },
+          })
+          // No notifications row for this type — skip list invalidation churn
+          return
+        }
+      } catch {
+        /* non-JSON heartbeat or unrelated — fall through */
+      }
+
       // Invalidate cache — Pinia Colada refetches automatically
       // Toast + chime are handled by MobileOrderToast.vue via its length watcher
       await _queryCache?.invalidateQueries({ key: ['notifications'] })

--- a/composables/useUserPrinterPreference.ts
+++ b/composables/useUserPrinterPreference.ts
@@ -1,0 +1,33 @@
+/**
+ * Per-user single printer preference for auto-comanda print (warocol.com#1971).
+ * localStorage only — max one printer name per profile id.
+ */
+const STORAGE_PREFIX = 'waro:user-printer:'
+
+export function userPrinterStorageKey(userId: string): string {
+  return `${STORAGE_PREFIX}${userId || 'anon'}`
+}
+
+export function getUserPrinterName(userId: string): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = localStorage.getItem(userPrinterStorageKey(userId))
+    const name = (raw || '').trim()
+    return name || null
+  } catch {
+    return null
+  }
+}
+
+/** Persist at most one printer; empty/null clears. */
+export function setUserPrinterName(userId: string, printerName: string | null | undefined): void {
+  if (typeof window === 'undefined') return
+  const key = userPrinterStorageKey(userId)
+  const name = (printerName || '').trim()
+  try {
+    if (!name) localStorage.removeItem(key)
+    else localStorage.setItem(key, name)
+  } catch {
+    /* ignore quota / private mode */
+  }
+}

--- a/pages/operaciones/impresoras.vue
+++ b/pages/operaciones/impresoras.vue
@@ -3,10 +3,14 @@
  * Operaciones → Impresoras (warocol.com#1949 / #1958).
  * Compact tables + per-row test print + PrintBridge download modal.
  */
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watch, onMounted } from 'vue'
 import { ArrowDownTrayIcon, PrinterIcon, QueueListIcon } from '@heroicons/vue/24/outline'
 import { LocalPrintBridgeError, useLocalPrintBridge } from '~/composables/useLocalPrintBridge'
 import { usePrinterAssignments } from '~/composables/usePrinterAssignments'
+import {
+  getUserPrinterName,
+  setUserPrinterName,
+} from '~/composables/useUserPrinterPreference'
 import {
   PRINTBRIDGE_DOWNLOADS,
   PRINTBRIDGE_RELEASES_PAGE,
@@ -16,6 +20,7 @@ import {
 } from '~/utils/printBridgeDownloads'
 
 const { t } = useI18n({ useScope: 'global' })
+const authStore = useAuthStore()
 
 definePageMeta({
   layout: 'dashboard',
@@ -47,6 +52,29 @@ const showDownloadCta = ref(false)
 const cajaPrinter = ref<string>('')
 /** station_id → printer name (empty = use caja) */
 const stationPrinters = ref<Record<string, string>>({})
+/** One printer per user for mostrador/barra auto-print (#1971) */
+const myPrinter = ref<string>('')
+
+const currentUserId = computed(() =>
+  String(
+    authStore.user?.id
+    || authStore.session?.user?.id
+    || authStore.profile?.id
+    || 'anon',
+  ),
+)
+
+onMounted(() => {
+  myPrinter.value = getUserPrinterName(currentUserId.value) || ''
+})
+
+watch(currentUserId, (id) => {
+  myPrinter.value = getUserPrinterName(id) || ''
+})
+
+watch(myPrinter, (name) => {
+  setUserPrinterName(currentUserId.value, name)
+})
 
 const preferredDownloadId = preferredPrintBridgeDownloadId()
 
@@ -78,6 +106,7 @@ watch(
 const printerOptions = computed(() => {
   const names = new Set<string>(discovered.value)
   if (cajaPrinter.value) names.add(cajaPrinter.value)
+  if (myPrinter.value) names.add(myPrinter.value)
   for (const v of Object.values(stationPrinters.value)) {
     if (v) names.add(v)
   }
@@ -352,6 +381,25 @@ async function onSave() {
             </button>
           </template>
         </UiResponsiveDataView>
+
+        <!-- Mi impresora — 1 por usuario (auto-print mostrador/barra) #1971 -->
+        <div class="mt-5 rounded-xl border border-border bg-background/50 p-4">
+          <p class="text-sm font-semibold text-text-primary">Mi impresora</p>
+          <p class="mt-1 text-xs text-text-secondary">
+            Una sola impresora por usuario. Se usa al enviar a cocina desde mostrador o barra (auto-impresión con PrintBridge).
+          </p>
+          <select
+            v-model="myPrinter"
+            class="input-base mt-3 min-h-[44px] w-full max-w-md rounded-lg border border-border bg-background px-3 py-2 text-sm"
+          >
+            <option value="">
+              {{ t('operaciones.impresoras.none') }}
+            </option>
+            <option v-for="name in printerOptions" :key="`my-${name}`" :value="name">
+              {{ name }}
+            </option>
+          </select>
+        </div>
       </div>
 
       <!-- ══════ ESTACIONES ══════ -->


### PR DESCRIPTION
## Summary
- On SSE `comanda_fired`, auto-print only if PrintBridge connects (silent otherwise)
- Mesa → tenant caja printer; mostrador/barra → user’s single “Mi impresora”
- Operaciones → Impresoras: configure one printer per user (localStorage)
- Companion API: https://github.com/uno0uno/api-warolabs/pull/753

Closes #1971

## Test plan
- [ ] Caja PC with PrintBridge + caja assigned: agregar a mesa prints to caja
- [ ] User sets Mi impresora; send from mostrador/barra prints there
- [ ] Device without PrintBridge: no print dialog / no error toast
- [ ] Duplicate SSE does not double-print

## Validation evidence
```
bunx vitest run composables/useAutoComandaPrint.test.ts
✓ composables/useAutoComandaPrint.test.ts (11 tests)
Test Files  1 passed (1)
Tests  11 passed (11)
```

## wr-context
See `.wr/1971.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)