### PR TITLE
fix(pos): print fallback comanda last when no station

### DIFF
--- a/.wr/1973.yaml
+++ b/.wr/1973.yaml
@@ -1,0 +1,38 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1973
+title: "Always print fallback comanda last when no kitchen stations"
+repo: both
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-1973-fallback-comanda-print
+
+paths:
+  - composables/useAutoComandaPrint.ts
+  - composables/useAutoComandaPrint.test.ts
+  - app/services/notifications_service.py
+  - tests/test_comanda_fired_notification.py
+  - tests/test_comanda_item_notes.py
+
+ac:
+  - Auto-print accepts station_id null / print_fallback
+  - Fallback ticket text last with Sin cocina asignada label
+
+out_of_scope:
+  - Header logo changes
+  - Station routing redesign
+
+hints:
+  entry: "orderComandasForPrint + autoPrintComandaFired"
+  pattern: "fallback last"
+  tests: "bunx vitest run composables/useAutoComandaPrint.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "depends on api companion for full E2E"

--- a/composables/useAutoComandaPrint.test.ts
+++ b/composables/useAutoComandaPrint.test.ts
@@ -113,6 +113,32 @@ describe('buildComandaPlainText', () => {
     expect(text).toContain('2x Burger')
     expect(text).toContain('sin cebolla')
   })
+
+  it('prints fallback last and labels Sin cocina asignada', () => {
+    const text = buildComandaPlainText([
+      {
+        id: undefined,
+        comanda_number: 10,
+        station_id: null,
+        station_name: 'Sin cocina asignada',
+        print_fallback: true,
+        items: [{ kitchen_name: 'PASSION', quantity: 1, notes: 'CON PEPINILLOS' }],
+      },
+      {
+        id: 'st-1',
+        comanda_number: 10,
+        station_id: 'st-1',
+        station_name: 'Parrilla',
+        items: [{ kitchen_name: 'Burger', quantity: 1 }],
+      },
+    ])
+    const parrillaAt = text.indexOf('Parrilla')
+    const fallbackAt = text.indexOf('Sin cocina asignada')
+    expect(parrillaAt).toBeGreaterThanOrEqual(0)
+    expect(fallbackAt).toBeGreaterThan(parrillaAt)
+    expect(text).toContain('PASSION')
+    expect(text).toContain('CON PEPINILLOS')
+  })
 })
 
 describe('autoPrintComandaFired', () => {
@@ -204,6 +230,36 @@ describe('autoPrintComandaFired', () => {
     }
     expect(await autoPrintComandaFired(payload, deps)).toBe('printed')
     expect(await autoPrintComandaFired(payload, deps)).toBe('skipped')
+    expect(bridge.printRawEscPos).toHaveBeenCalledOnce()
+  })
+
+  it('prints fallback-only payload to caja for mesa', async () => {
+    const bridge = fakeBridge()
+    const result = await autoPrintComandaFired(
+      {
+        type: 'comanda_fired',
+        source_type: 'table',
+        table_display_name: 'Mesa 1',
+        auto_print_target: 'caja',
+        order_id: 'o-fb',
+        comandas: [
+          {
+            id: null,
+            comanda_number: 3,
+            station_id: null,
+            station_name: 'Sin cocina asignada',
+            print_fallback: true,
+            items: [{ kitchen_name: 'poker 330', quantity: 2 }],
+          },
+        ],
+      },
+      {
+        bridge,
+        getCajaPrinterName: async () => 'CAJA_1',
+        getUserId: () => 'u1',
+      },
+    )
+    expect(result).toBe('printed')
     expect(bridge.printRawEscPos).toHaveBeenCalledOnce()
   })
 })

--- a/composables/useAutoComandaPrint.ts
+++ b/composables/useAutoComandaPrint.ts
@@ -23,11 +23,26 @@ export type ComandaFiredSsePayload = {
   comandas?: unknown[]
 }
 
+export type ComandaPrintWithFallback = ComandaPrintPayload & {
+  print_fallback?: boolean
+}
+
 const printedIds = new Set<string>()
 const PRINTED_CAP = 200
 
 export function __resetAutoComandaPrintDedupeForTests(): void {
   printedIds.clear()
+}
+
+/** Station tickets first; print_fallback / null station last (#1973). */
+export function orderComandasForPrint(
+  comandas: ComandaPrintWithFallback[],
+): ComandaPrintWithFallback[] {
+  return [...comandas].sort((a, b) => {
+    const aFb = a.print_fallback || !a.station_id ? 1 : 0
+    const bFb = b.print_fallback || !b.station_id ? 1 : 0
+    return aFb - bFb
+  })
 }
 
 export function resolveAutoPrintPrinterName(opts: {
@@ -87,13 +102,15 @@ export function markComandasPrinted(comandas: ComandaPrintPayload[], orderId?: s
   }
 }
 
-export function buildComandaPlainText(comandas: ComandaPrintPayload[]): string {
+export function buildComandaPlainText(comandas: ComandaPrintWithFallback[]): string {
   const blocks: string[] = []
-  for (const c of comandas) {
+  for (const c of orderComandasForPrint(comandas)) {
+    const stationLabel = c.station_name
+      || (c.print_fallback || !c.station_id ? 'Sin cocina asignada' : '')
     const lines: string[] = [
       `COMANDA #${c.comanda_number}`,
       c.table_display_name ? String(c.table_display_name) : '',
-      c.station_name ? `Estacion: ${c.station_name}` : '',
+      stationLabel ? `Estacion: ${stationLabel}` : '',
       '----------------',
     ]
     for (const item of c.items) {
@@ -126,8 +143,23 @@ export async function autoPrintComandaFired(
 ): Promise<'printed' | 'skipped'> {
   if (payload?.type && payload.type !== 'comanda_fired') return 'skipped'
 
-  const mapped = mapComandasForPrint(payload.comandas || [])
-  const pending = filterUnprintedComandas(mapped, payload.order_id)
+  const rawList = (payload.comandas || []) as Record<string, unknown>[]
+  const mapped: ComandaPrintWithFallback[] = mapComandasForPrint(rawList).map((c) => {
+    const raw = rawList.find((r) => {
+      if (c.id != null && r.id != null) return String(r.id) === c.id
+      return r.id == null
+        && String(r.comanda_number ?? '') === String(c.comanda_number)
+        && String(r.station_name ?? '') === String(c.station_name ?? '')
+    })
+    return {
+      ...c,
+      print_fallback: Boolean(raw?.print_fallback) || !c.station_id,
+    }
+  })
+  const pending = filterUnprintedComandas(
+    orderComandasForPrint(mapped),
+    payload.order_id,
+  )
   if (!pending.length) return 'skipped'
 
   let caja: string | null = null


### PR DESCRIPTION
## Summary
- Order auto-print tickets so `print_fallback` / null-station come **last**
- Label fallback as “Sin cocina asignada”; print no-station payloads to caja
- Companion API: sorts SSE payload the same way

Closes #1973

## Test plan
- [ ] No stations: Agregar y enviar → fallback prints on caja
- [ ] Mixed: station ticket then fallback
- [ ] Without PrintBridge: items still sent (no silent rollback)

## Validation evidence
```
bunx vitest run composables/useAutoComandaPrint.test.ts
13 passed
```

## wr-context
See `.wr/1973.yaml` on this branch.

Made with [Cursor](https://cursor.com)