### PR TITLE
fix(pos): unify comanda thermal print layout

### DIFF
--- a/.wr/1975.yaml
+++ b/.wr/1975.yaml
@@ -1,0 +1,42 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1975
+title: "Unify comanda thermal print layout; no auto-print without PrintBridge"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1975-comanda-print-layout
+
+paths:
+  - composables/useComandaPrint.ts
+  - composables/useComandaPrint.test.ts
+  - composables/useAutoComandaPrint.ts
+  - composables/useAutoComandaPrint.test.ts
+  - components/pos/ComandaPrintTickets.vue
+
+ac:
+  - Auto-print skips without PrintBridge / printer (no window.print)
+  - Manual última/selected still browser-fallback when no bridge
+  - Shared plain-text layout for auto ESC/POS and manual print
+  - Thermal-readable newlines; ASCII mod separators
+  - Focused front tests for builder + auto skip
+
+out_of_scope:
+  - Prefactura/factura redesign
+  - Multi-station printer matrix
+  - API payload changes
+
+hints:
+  entry: "buildComandaTicketPlainText + ComandaPrintTickets pre"
+  pattern: "explicit \\n in pre; auto uses same builder"
+  tests: "bunx vitest run composables/useAutoComandaPrint.test.ts && bun test composables/useComandaPrint.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "manual thermal smoke: última without bridge; auto with PrintBridge"

--- a/components/pos/ComandaPrintTickets.vue
+++ b/components/pos/ComandaPrintTickets.vue
@@ -2,7 +2,7 @@
 const { t } = useI18n({ useScope: 'global' })
 import { computed } from 'vue'
 import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
-import { formatComandaModifierLabel } from '~/composables/useComandaPrint'
+import { buildComandaTicketPlainText } from '~/composables/useComandaPrint'
 
 const props = defineProps<{
   comandas: ComandaPrintPayload[]
@@ -11,97 +11,33 @@ const props = defineProps<{
 
 const { formatCurrencyThermal, formatDateTime } = useFormatters()
 
-function modifierLines(item: ComandaPrintPayload['items'][0]) {
-  return item.modifiers_snapshot ?? []
-}
-
-function formatTicketTime(firedAt?: string | null) {
-  return formatDateTime(firedAt ?? new Date().toISOString())
-}
-
-const printTicket = computed(() => {
-  const first = props.comandas[0]
-  if (!first) return null
-
-  const comandaNumbers = [
-    ...new Set(props.comandas.map(c => String(c.comanda_number ?? '—'))),
-  ]
-
-  const sections: Array<{
-    key: string
-    stationName: string
-    items: ComandaPrintPayload['items']
-  }> = []
-  const sectionByStation = new Map<string, (typeof sections)[number]>()
-
-  for (const comanda of props.comandas) {
-    const stationName = comanda.station_name || t('pos.printTicket.noStation')
-    let section = sectionByStation.get(stationName)
-    if (!section) {
-      section = {
-        key: `${stationName}-${sections.length}`,
-        stationName,
-        items: [],
-      }
-      sectionByStation.set(stationName, section)
-      sections.push(section)
-    }
-    section.items.push(...comanda.items)
-  }
-
-  return {
-    firedAt: first.fired_at,
-    tableDisplayName: first.table_display_name,
-    comandaNumbers,
-    sections,
-  }
+const ticketPlainText = computed(() => {
+  if (!props.comandas.length) return ''
+  return buildComandaTicketPlainText(props.comandas, {
+    businessName: props.businessName || 'WARO',
+    title: `*** ${t('pos.printTicket.title')} ***`,
+    comandaLabel: (numbers) => t('pos.printTicket.comanda', { numbers }),
+    stationLabel: (name) => t('pos.printTicket.station', { name }),
+    noStationLabel: t('pos.printTicket.noStation'),
+    specialNotesLabel: t('pos.printTicket.specialNotes'),
+    includeModifierPrices: true,
+    formatPrice: formatCurrencyThermal,
+    formatTime: (firedAt) => formatDateTime(firedAt ?? new Date().toISOString()),
+  })
 })
 </script>
 
 <template>
   <Teleport to="body">
     <div id="pos-comanda-print" aria-hidden="true">
-      <div
-        v-if="printTicket"
-        class="comanda-ticket"
-      >
-        <div class="receipt-header">{{ businessName || 'WARO' }}</div>
-        <div class="receipt-row receipt-small">*** {{ t('pos.printTicket.title') }} ***</div>
-        <div class="receipt-row receipt-small">{{ formatTicketTime(printTicket.firedAt) }}</div>
-        <div v-if="printTicket.tableDisplayName" class="receipt-row receipt-small">
-          {{ printTicket.tableDisplayName }}
-        </div>
-        <div class="receipt-row receipt-small">
-          {{ t('pos.printTicket.comanda', { numbers: printTicket.comandaNumbers.join(', ') }) }}
-        </div>
-        <div class="receipt-divider">--------------------------------</div>
-
-        <section
-          v-for="section in printTicket.sections"
-          :key="section.key"
-          class="comanda-station-section"
-        >
-          <div class="receipt-row receipt-small station-title">
-            {{ t('pos.printTicket.station', { name: section.stationName }) }}
-          </div>
-          <template v-for="(item, i) in section.items" :key="`${section.key}-${i}`">
-            <div class="receipt-item receipt-small">
-              <span class="comanda-item-qty">{{ item.quantity }}×</span>
-              <span class="comanda-item-name">{{ item.kitchen_name }}</span>
-            </div>
-            <div
-              v-for="(mod, mi) in modifierLines(item)"
-              :key="`${section.key}-${i}-${mi}`"
-              class="receipt-row receipt-small item-detail"
-            >
-              ↳ {{ formatComandaModifierLabel(mod, { includePrice: true, formatPrice: formatCurrencyThermal }) }}
-            </div>
-            <div v-if="item.notes" class="receipt-row receipt-small item-detail">
-              {{ t('pos.printTicket.specialNotes') }}: {{ item.notes }}
-            </div>
-          </template>
-        </section>
-      </div>
+      <!--
+        Plain <pre> with explicit newlines (#1975). Thermal Windows drivers often
+        concatenate adjacent HTML blocks (19:05Mesa) and turn ↳/× into "?".
+      -->
+      <pre
+        v-if="ticketPlainText"
+        class="comanda-ticket-pre"
+      >{{ ticketPlainText }}</pre>
     </div>
   </Teleport>
 </template>
@@ -111,51 +47,17 @@ const printTicket = computed(() => {
   display: none;
 }
 
-.comanda-ticket {
-  margin-bottom: 4mm;
-}
-
-.comanda-ticket .receipt-header { font-size: 1.1em; font-weight: bold; text-align: center; margin-bottom: 4px; }
-.comanda-ticket .receipt-row { text-align: center; margin: 2px 0; }
-.comanda-ticket .receipt-divider { letter-spacing: 0; margin: 4px 0; text-align: center; }
-.comanda-ticket .comanda-station-section {
-  margin-top: 7px;
-  padding-top: 5px;
-  border-top: 1px dashed #000;
-}
-.comanda-ticket .comanda-station-section:first-of-type {
-  margin-top: 0;
-  padding-top: 0;
-  border-top: 0;
-}
-.comanda-ticket .station-title {
-  font-weight: 900;
-  text-align: left;
-}
-.comanda-ticket .item-detail {
-  padding-left: 8px;
-}
-.comanda-ticket .receipt-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  margin: 6px 0;
-  font-size: 1.12em;
-  font-weight: 700;
-}
-.comanda-ticket .receipt-footer { text-align: center; margin-top: 6px; }
-.comanda-ticket .receipt-small { font-size: 0.9em; }
-.comanda-ticket .comanda-item-qty {
-  flex-shrink: 0;
-  min-width: 9mm;
-  font-size: 1.65em;
-  font-weight: 900;
-  line-height: 1;
-  text-align: right;
-}
-.comanda-ticket .comanda-item-name {
-  min-width: 0;
+.comanda-ticket-pre {
+  margin: 0;
+  padding: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
   overflow-wrap: anywhere;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 9pt;
+  line-height: 1.3;
+  color: #000;
+  background: #fff;
 }
 
 @media print {
@@ -175,14 +77,16 @@ const printTicket = computed(() => {
     position: fixed !important;
     top: 0 !important;
     left: 0 !important;
-    font-family: 'Courier New', Courier, monospace;
-    font-size: 9pt;
-    line-height: 1.25;
     width: 54mm;
     color: #000;
     background: #fff;
     padding: 2mm;
     margin: 0 !important;
+  }
+
+  #pos-comanda-print .comanda-ticket-pre {
+    display: block !important;
+    width: 100%;
   }
 
   @page {

--- a/composables/useAutoComandaPrint.test.ts
+++ b/composables/useAutoComandaPrint.test.ts
@@ -100,18 +100,30 @@ describe('dedupe', () => {
 })
 
 describe('buildComandaPlainText', () => {
-  it('includes qty and kitchen name', () => {
+  it('includes shared header, qty, mods, and special notes on separate lines', () => {
     const text = buildComandaPlainText([
       {
         comanda_number: 5,
         table_display_name: 'Mesa 2',
         station_name: 'Cocina',
-        items: [{ kitchen_name: 'Burger', quantity: 2, notes: 'sin cebolla' }],
+        items: [{
+          kitchen_name: 'Burger',
+          quantity: 2,
+          notes: 'sin cebolla',
+          modifiers_snapshot: [{ name: 'Extra queso', price: 2000, quantity: 1 }],
+        }],
       },
     ])
-    expect(text).toContain('COMANDA #5')
+    expect(text).toContain('*** COMANDA POS ***')
+    expect(text).toContain('Mesa 2')
+    expect(text).toContain('Comanda #5')
+    expect(text).toContain('Estacion: Cocina')
     expect(text).toContain('2x Burger')
-    expect(text).toContain('sin cebolla')
+    expect(text).toContain('  - Extra queso - 2000')
+    expect(text).toContain('  * Notas especiales: sin cebolla')
+    // Rows must not mash meta into one line
+    expect(text).not.toMatch(/Mesa 2Comanda/)
+    expect(text.indexOf('Mesa 2')).toBeLessThan(text.indexOf('Comanda #5'))
   })
 
   it('prints fallback last and labels Sin cocina asignada', () => {

--- a/composables/useAutoComandaPrint.ts
+++ b/composables/useAutoComandaPrint.ts
@@ -4,7 +4,10 @@
  * Never falls back to window.print — silent no-op without bridge/printer.
  */
 import type { ComandaPrintPayload } from '~/composables/useComandaPrint'
-import { mapComandasForPrint } from '~/composables/useComandaPrint'
+import {
+  buildComandaTicketPlainText,
+  mapComandasForPrint,
+} from '~/composables/useComandaPrint'
 import { getUserPrinterName } from '~/composables/useUserPrinterPreference'
 import {
   LocalPrintBridgeError,
@@ -102,28 +105,12 @@ export function markComandasPrinted(comandas: ComandaPrintPayload[], orderId?: s
   }
 }
 
+/** Same layout as manual ComandaPrintTickets (#1975); fallback tickets last. */
 export function buildComandaPlainText(comandas: ComandaPrintWithFallback[]): string {
-  const blocks: string[] = []
-  for (const c of orderComandasForPrint(comandas)) {
-    const stationLabel = c.station_name
-      || (c.print_fallback || !c.station_id ? 'Sin cocina asignada' : '')
-    const lines: string[] = [
-      `COMANDA #${c.comanda_number}`,
-      c.table_display_name ? String(c.table_display_name) : '',
-      stationLabel ? `Estacion: ${stationLabel}` : '',
-      '----------------',
-    ]
-    for (const item of c.items) {
-      lines.push(`${item.quantity}x ${item.kitchen_name}`)
-      for (const mod of item.modifiers_snapshot || []) {
-        const qty = Number(mod.quantity) || 1
-        lines.push(`  + ${mod.name}${qty > 1 ? ` x${qty}` : ''}`)
-      }
-      if (item.notes?.trim()) lines.push(`  * ${item.notes.trim()}`)
-    }
-    blocks.push(lines.filter(Boolean).join('\n'))
-  }
-  return blocks.join('\n\n')
+  return buildComandaTicketPlainText(comandas, {
+    orderComandas: (list) => orderComandasForPrint(list as ComandaPrintWithFallback[]),
+    includeModifierPrices: true,
+  })
 }
 
 export type AutoPrintDeps = {

--- a/composables/useComandaPrint.test.ts
+++ b/composables/useComandaPrint.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'bun:test'
-import { mapComandasForPrint } from './useComandaPrint'
+import {
+  buildComandaTicketPlainText,
+  formatComandaModifierLabel,
+  mapComandasForPrint,
+} from './useComandaPrint'
 
 describe('mapComandasForPrint', () => {
   it('preserves station_id alongside station_name', () => {
@@ -26,5 +30,64 @@ describe('mapComandasForPrint', () => {
       },
     ])
     expect(mapped[0]!.station_id).toBeNull()
+  })
+})
+
+describe('buildComandaTicketPlainText', () => {
+  it('keeps meta rows and item details on separate lines', () => {
+    const text = buildComandaTicketPlainText(
+      [
+        {
+          comanda_number: 173,
+          table_display_name: 'Mesa 15',
+          station_name: 'Cocina',
+          fired_at: '2026-07-31T19:05:00-05:00',
+          items: [
+            {
+              kitchen_name: 'Santa inquisicion',
+              quantity: 1,
+              notes: 'GRATIS (HORA FELIZ)',
+              modifiers_snapshot: [
+                { name: 'Papas Fritas', price: 5000, quantity: 1 },
+                { name: 'Tocineta', price: 4000, quantity: 2 },
+              ],
+            },
+          ],
+        },
+      ],
+      {
+        businessName: 'Waro Colombia',
+        includeModifierPrices: true,
+        formatPrice: (n) => `$${n}`,
+        formatTime: () => '31/07/26, 19:05',
+      },
+    )
+
+    expect(text.split('\n')).toEqual([
+      'Waro Colombia',
+      '*** COMANDA POS ***',
+      '31/07/26, 19:05',
+      'Mesa 15',
+      'Comanda #173',
+      '--------------------------------',
+      'Estacion: Cocina',
+      '1x Santa inquisicion',
+      '  - Papas Fritas - $5000',
+      '  - Tocineta x2 - $8000',
+      '  * Notas especiales: GRATIS (HORA FELIZ)',
+    ])
+    expect(text).not.toContain('?')
+    expect(text).not.toMatch(/19:05Mesa/)
+  })
+})
+
+describe('formatComandaModifierLabel', () => {
+  it('uses ASCII separators for thermal-safe labels', () => {
+    expect(
+      formatComandaModifierLabel(
+        { name: 'Extra', price: 1000, quantity: 2 },
+        { includePrice: true, formatPrice: (n) => `$${n}` },
+      ),
+    ).toBe('Extra x2 - $2000')
   })
 })

--- a/composables/useComandaPrint.ts
+++ b/composables/useComandaPrint.ts
@@ -26,12 +26,97 @@ export function formatComandaModifierLabel(
 ): string {
   const qty = Number(mod.quantity) || 1
   let label = mod.name
-  if (qty > 1) label += ` ×${qty}`
+  // ASCII separators — thermal Windows drivers often turn ×/· into "?"
+  if (qty > 1) label += ` x${qty}`
   if (options?.includePrice && mod.price != null) {
     const lineTotal = Number(mod.price) * qty
-    label += ` · ${options.formatPrice ? options.formatPrice(lineTotal) : String(lineTotal)}`
+    label += ` - ${options.formatPrice ? options.formatPrice(lineTotal) : String(lineTotal)}`
   }
   return label
+}
+
+export type ComandaTicketPlainTextOptions = {
+  businessName?: string
+  /** e.g. "*** COMANDA POS ***" */
+  title?: string
+  comandaLabel?: (numbers: string) => string
+  stationLabel?: (name: string) => string
+  noStationLabel?: string
+  specialNotesLabel?: string
+  includeModifierPrices?: boolean
+  formatPrice?: (amount: number) => string
+  formatTime?: (firedAt?: string | null) => string
+  orderComandas?: (comandas: ComandaPrintPayload[]) => ComandaPrintPayload[]
+}
+
+/**
+ * Shared plain-text comanda layout for ESC/POS auto-print and browser/thermal
+ * window.print (#1975). Explicit \\n so generic Windows drivers do not mash rows.
+ */
+export function buildComandaTicketPlainText(
+  comandas: ComandaPrintPayload[],
+  options: ComandaTicketPlainTextOptions = {},
+): string {
+  if (!comandas.length) return ''
+
+  const ordered = options.orderComandas
+    ? options.orderComandas(comandas)
+    : comandas
+  const first = ordered[0]!
+  const business = (options.businessName || 'WARO').trim() || 'WARO'
+  const title = options.title ?? '*** COMANDA POS ***'
+  const noStation = options.noStationLabel ?? 'Sin cocina asignada'
+  const specialNotes = options.specialNotesLabel ?? 'Notas especiales'
+  const stationLabel = options.stationLabel ?? ((name: string) => `Estacion: ${name}`)
+  const comandaLabel = options.comandaLabel ?? ((numbers: string) => `Comanda #${numbers}`)
+  const formatTime = options.formatTime ?? ((firedAt?: string | null) => formatComandaPrintTime(firedAt))
+
+  const numbers = [...new Set(ordered.map((c) => String(c.comanda_number ?? '—')))].join(', ')
+
+  type Section = { stationName: string; items: ComandaPrintItem[] }
+  const sections: Section[] = []
+  const byStation = new Map<string, Section>()
+  for (const comanda of ordered) {
+    const stationName = (comanda.station_name || '').trim() || noStation
+    let section = byStation.get(stationName)
+    if (!section) {
+      section = { stationName, items: [] }
+      byStation.set(stationName, section)
+      sections.push(section)
+    }
+    section.items.push(...comanda.items)
+  }
+
+  const lines: string[] = [
+    business,
+    title,
+    formatTime(first.fired_at),
+  ]
+  const table = (first.table_display_name || '').trim()
+  if (table) lines.push(table)
+  lines.push(comandaLabel(numbers))
+  lines.push('--------------------------------')
+
+  for (const section of sections) {
+    lines.push(stationLabel(section.stationName))
+    for (const item of section.items) {
+      const qty = Number(item.quantity) || 1
+      lines.push(`${qty}x ${item.kitchen_name}`)
+      for (const mod of item.modifiers_snapshot || []) {
+        lines.push(
+          `  - ${formatComandaModifierLabel(mod, {
+            includePrice: options.includeModifierPrices,
+            formatPrice: options.formatPrice,
+          })}`,
+        )
+      }
+      const notes = (item.notes || '').trim()
+      if (notes) lines.push(`  * ${specialNotes}: ${notes}`)
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n').replace(/\n{3,}/g, '\n\n').trim()
 }
 
 export type ComandaPrintPayload = {


### PR DESCRIPTION
## Summary
- Shared `buildComandaTicketPlainText` for auto ESC/POS and manual browser print
- Manual ticket renders as `<pre>` with explicit newlines (fixes mashed thermal Windows text)
- Auto-print stays PrintBridge-only (no `window.print` fallback)

Closes #1975

## Test plan
- [ ] Without PrintBridge: fire items → no auto print; use “última / manual” → Windows dialog with readable lines
- [ ] With PrintBridge + printer: auto and manual show same structure (header, mesa, comanda, station, items, mods, notes)
- [ ] Modifiers/notes no longer show `?` or `19:05Mesa`-style mash

## Validation evidence
```
bunx vitest run composables/useAutoComandaPrint.test.ts
✓ 13 tests

bun test composables/useComandaPrint.test.ts
4 pass, 0 fail
```

## wr-context
See `.wr/1975.yaml` on this branch.

Made with [Cursor](https://cursor.com)