### PR TITLE
fix(pos): omit modifier prices on comanda tickets

### DIFF
--- a/.wr/1977.yaml
+++ b/.wr/1977.yaml
@@ -1,0 +1,40 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1977
+title: "Omit modifier prices on all comanda prints"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1977-comanda-no-prices
+
+paths:
+  - components/pos/ComandaPrintTickets.vue
+  - composables/useAutoComandaPrint.ts
+  - composables/useAutoComandaPrint.test.ts
+  - composables/useComandaPrint.test.ts
+
+ac:
+  - Auto ESC/POS omits modifier prices
+  - Manual ComandaPrintTickets omits modifier prices
+  - Mods still show name/qty; notes unchanged
+  - Receipt/prefactura untouched
+  - Tests updated
+
+out_of_scope:
+  - Prefactura/factura redesign
+  - API changes
+
+hints:
+  entry: "includeModifierPrices off in ticket callers"
+  pattern: "default false; helper still supports true"
+  tests: "bunx vitest run composables/useAutoComandaPrint.test.ts && bun test composables/useComandaPrint.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "smoke print comanda with modifiers"

--- a/components/pos/ComandaPrintTickets.vue
+++ b/components/pos/ComandaPrintTickets.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
   businessName?: string
 }>()
 
-const { formatCurrencyThermal, formatDateTime } = useFormatters()
+const { formatDateTime } = useFormatters()
 
 const ticketPlainText = computed(() => {
   if (!props.comandas.length) return ''
@@ -20,8 +20,7 @@ const ticketPlainText = computed(() => {
     stationLabel: (name) => t('pos.printTicket.station', { name }),
     noStationLabel: t('pos.printTicket.noStation'),
     specialNotesLabel: t('pos.printTicket.specialNotes'),
-    includeModifierPrices: true,
-    formatPrice: formatCurrencyThermal,
+    // Kitchen tickets: name/qty only — no modifier prices (#1977)
     formatTime: (firedAt) => formatDateTime(firedAt ?? new Date().toISOString()),
   })
 })

--- a/composables/useAutoComandaPrint.test.ts
+++ b/composables/useAutoComandaPrint.test.ts
@@ -119,7 +119,8 @@ describe('buildComandaPlainText', () => {
     expect(text).toContain('Comanda #5')
     expect(text).toContain('Estacion: Cocina')
     expect(text).toContain('2x Burger')
-    expect(text).toContain('  - Extra queso - 2000')
+    expect(text).toContain('  - Extra queso')
+    expect(text).not.toContain('2000')
     expect(text).toContain('  * Notas especiales: sin cebolla')
     // Rows must not mash meta into one line
     expect(text).not.toMatch(/Mesa 2Comanda/)

--- a/composables/useAutoComandaPrint.ts
+++ b/composables/useAutoComandaPrint.ts
@@ -105,11 +105,10 @@ export function markComandasPrinted(comandas: ComandaPrintPayload[], orderId?: s
   }
 }
 
-/** Same layout as manual ComandaPrintTickets (#1975); fallback tickets last. */
+/** Same layout as manual ComandaPrintTickets (#1975); no modifier prices (#1977). */
 export function buildComandaPlainText(comandas: ComandaPrintWithFallback[]): string {
   return buildComandaTicketPlainText(comandas, {
     orderComandas: (list) => orderComandasForPrint(list as ComandaPrintWithFallback[]),
-    includeModifierPrices: true,
   })
 }
 

--- a/composables/useComandaPrint.test.ts
+++ b/composables/useComandaPrint.test.ts
@@ -34,7 +34,7 @@ describe('mapComandasForPrint', () => {
 })
 
 describe('buildComandaTicketPlainText', () => {
-  it('keeps meta rows and item details on separate lines', () => {
+  it('keeps meta rows and omits modifier prices by default (kitchen)', () => {
     const text = buildComandaTicketPlainText(
       [
         {
@@ -57,8 +57,6 @@ describe('buildComandaTicketPlainText', () => {
       ],
       {
         businessName: 'Waro Colombia',
-        includeModifierPrices: true,
-        formatPrice: (n) => `$${n}`,
         formatTime: () => '31/07/26, 19:05',
       },
     )
@@ -72,12 +70,36 @@ describe('buildComandaTicketPlainText', () => {
       '--------------------------------',
       'Estacion: Cocina',
       '1x Santa inquisicion',
-      '  - Papas Fritas - $5000',
-      '  - Tocineta x2 - $8000',
+      '  - Papas Fritas',
+      '  - Tocineta x2',
       '  * Notas especiales: GRATIS (HORA FELIZ)',
     ])
-    expect(text).not.toContain('?')
+    expect(text).not.toContain('$')
+    expect(text).not.toContain('5000')
     expect(text).not.toMatch(/19:05Mesa/)
+  })
+
+  it('can still include modifier prices when explicitly requested', () => {
+    const text = buildComandaTicketPlainText(
+      [
+        {
+          comanda_number: 1,
+          items: [
+            {
+              kitchen_name: 'X',
+              quantity: 1,
+              modifiers_snapshot: [{ name: 'Extra', price: 1000, quantity: 1 }],
+            },
+          ],
+        },
+      ],
+      {
+        includeModifierPrices: true,
+        formatPrice: (n) => `$${n}`,
+        formatTime: () => 't',
+      },
+    )
+    expect(text).toContain('  - Extra - $1000')
   })
 })
 


### PR DESCRIPTION
## Summary
- Kitchen comanda prints (auto ESC/POS + manual) no longer show modifier prices
- Modifiers still print name/qty; notes unchanged
- Receipt/prefactura/factura paths untouched

Closes #1977

## Test plan
- [ ] Print comanda with priced modifiers → names only, no \$ amounts
- [ ] Prefactura/factura still show prices

## Validation evidence
```
bunx vitest run composables/useAutoComandaPrint.test.ts
✓ 13 tests

bun test composables/useComandaPrint.test.ts
5 pass, 0 fail
```

## wr-context
See `.wr/1977.yaml` on this branch.

Made with [Cursor](https://cursor.com)