### PR TITLE
fix(pos): thermal-readable prefactura, factura, and ventas receipts

### DIFF
--- a/.wr/1979.yaml
+++ b/.wr/1979.yaml
@@ -27,8 +27,8 @@ out_of_scope:
   - Printer assignment UX
 
 hints:
-  entry: "padReceiptLine + ReceiptPrintTicket plain lines"
-  pattern: "explicit spaces in text; prefer innerText for ESC/POS"
+  entry: "padReceiptLine + collectThermalTicketText for hidden DOM"
+  pattern: "never rely on innerText of display:none; preserve pad spaces"
   tests: "bun test utils/receiptTicketPlainText.test.ts"
 
 risk:

--- a/.wr/1979.yaml
+++ b/.wr/1979.yaml
@@ -1,0 +1,42 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1979
+title: "Fix thermal layout for prefactura, factura, and ventas order print"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1979-receipt-thermal-layout
+
+paths:
+  - utils/receiptTicketPlainText.ts
+  - utils/receiptTicketPlainText.test.ts
+  - components/pos/ReceiptPrintTicket.vue
+  - pages/pos/checkout.vue
+  - pages/ventas/[id].vue
+
+ac:
+  - Prefactura thermal readable (no DescripcionTotal / Subtotal$)
+  - Factura checkout uses ReceiptPrintTicket plain layout
+  - ventas/[id] same layout via ReceiptPrintTicket
+  - Bridge + window.print both readable
+  - Focused tests for padReceiptLine / product blocks
+
+out_of_scope:
+  - Comanda tickets
+  - DIAN content changes
+  - Printer assignment UX
+
+hints:
+  entry: "padReceiptLine + ReceiptPrintTicket plain lines"
+  pattern: "explicit spaces in text; prefer innerText for ESC/POS"
+  tests: "bun test utils/receiptTicketPlainText.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "thermal smoke prefactura + ventas reprint"

--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -451,7 +451,11 @@ const printableItems = computed(() =>
           class="receipt-plain-line receipt-small"
         >
           {{ moneyLine(
-            `${line.label || t('pos.checkout.taxFallback')}${formatRate(line.rate) ? ` ${formatRate(line.rate)}` : ''}`,
+            [
+              line.label || t('pos.checkout.taxFallback'),
+              formatRate(line.rate),
+              Number(line.base) > 0 ? t('pos.receipt.taxBase', { amount: money(line.base) }) : null,
+            ].filter(Boolean).join(' '),
             line.amount,
           ) }}
         </div>

--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
 const { t } = useI18n({ useScope: 'global' })
 import { consolidateReceiptPrintLines } from '~/utils/receiptPrintLines'
+import {
+  formatReceiptModifierBlock,
+  formatReceiptProductBlock,
+  padReceiptLine,
+  receiptDivider,
+} from '~/utils/receiptTicketPlainText'
 
 interface ReceiptItemModifier {
   id?: string | number | null
@@ -124,6 +130,30 @@ const modifierDescription = (modifier: ReceiptItemModifier) => {
   const qty = Number(modifier.quantity) || 1
   return qty > 1 ? `+ ${modifier.name} x${qty}` : `+ ${modifier.name}`
 }
+
+const productBlock = (item: { name: string; quantity: number | string; unitPrice: number; total: number }) =>
+  formatReceiptProductBlock({
+    name: item.name,
+    quantity: item.quantity,
+    unitPriceLabel: money(item.unitPrice),
+    lineTotalLabel: money(item.total),
+  })
+
+const modifierBlock = (modifier: ReceiptItemModifier) =>
+  formatReceiptModifierBlock({
+    description: modifierDescription(modifier),
+    quantity: modifier.quantity ?? 1,
+    unitPriceLabel: money(modifier.price),
+    lineTotalLabel: money(modifierTotal(modifier)),
+  })
+
+const moneyLine = (label: string, amount: number | string | null | undefined, negative = false) => {
+  const amt = money(amount)
+  return padReceiptLine(label, negative ? `-${amt}` : amt)
+}
+
+const dashDivider = receiptDivider()
+const strongDivider = receiptDivider(32, '=')
 
 const hasBreakdownSubtotal = computed(() =>
   (props.promoBreakdown?.length ?? 0) > 0
@@ -261,16 +291,16 @@ const printableItems = computed(() =>
       :logo-url="logoUrl"
     />
 
-    <div class="receipt-divider receipt-divider--strong" aria-hidden="true" />
+    <div class="receipt-plain-line">{{ strongDivider }}</div>
     <div v-if="invoice" class="receipt-row receipt-document-title">
       {{ t('pos.receipt.electronicInvoiceSale') }}
     </div>
     <div class="receipt-row receipt-small" style="font-weight:bold;">
       <template v-if="invoiceNumberLabel">
-        {{ invoiceNumberLabel }}<span v-if="orderNumber"> · {{ documentLabel }} #{{ orderNumber }}</span>
+        {{ invoiceNumberLabel }}<template v-if="orderNumber"> · {{ documentLabel }} #{{ orderNumber }}</template>
       </template>
       <template v-else>
-        {{ documentLabel }}<span v-if="orderNumber"> #{{ orderNumber }}</span>
+        {{ documentLabel }}<template v-if="orderNumber"> #{{ orderNumber }}</template>
       </template>
     </div>
     <div v-if="soldAt" class="receipt-row receipt-small">{{ soldAt }}</div>
@@ -278,7 +308,7 @@ const printableItems = computed(() =>
     <div v-if="waiterName" class="receipt-row receipt-small">{{ t('pos.receipt.waiter', { name: waiterName }) }}</div>
 
     <template v-if="customerName || customerPhone || customerEmail">
-      <div class="receipt-divider" aria-hidden="true" />
+      <div class="receipt-plain-line">{{ dashDivider }}</div>
       <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.saleContact') }}</div>
       <div v-if="customerName" class="receipt-row receipt-small">{{ customerName }}</div>
       <div v-if="customerPhone" class="receipt-row receipt-small">{{ t('pos.receipt.phone', { phone: customerPhone }) }}</div>
@@ -286,121 +316,91 @@ const printableItems = computed(() =>
       <div v-if="!invoice && customerFiscalLabel" class="receipt-row receipt-small">{{ customerFiscalLabel }}</div>
     </template>
 
-    <div class="receipt-divider" aria-hidden="true" />
-    <div class="receipt-product-header receipt-small">
-      <span class="receipt-col-desc">{{ t('pos.receipt.description') }}</span>
-      <span class="receipt-col-total">{{ t('pos.receipt.total') }}</span>
-    </div>
+    <div class="receipt-plain-line">{{ dashDivider }}</div>
+    <div class="receipt-plain-line receipt-small">{{ padReceiptLine(t('pos.receipt.description'), t('pos.receipt.total')) }}</div>
 
     <template v-for="item in printableItems" :key="item.id ?? item.name">
-      <div class="receipt-product-line receipt-small">
-        <div class="receipt-product-name">{{ item.name }}</div>
-        <div class="receipt-product-values">
-          <span>{{ item.quantity }} x {{ money(item.unitPrice) }}</span>
-          <strong>{{ money(item.total) }}</strong>
-        </div>
-      </div>
-      <div
+      <pre class="receipt-plain-pre">{{ productBlock(item) }}</pre>
+      <pre
         v-for="modifier in (item.modifiers ?? [])"
         :key="`${item.id ?? item.name}-${modifier.id ?? modifier.name}`"
-        class="receipt-product-line receipt-small receipt-modifier-row"
-      >
-        <div class="receipt-product-name">{{ modifierDescription(modifier) }}</div>
-        <div class="receipt-product-values">
-          <span>{{ Number(modifier.quantity) || 1 }} x {{ money(modifier.price) }}</span>
-          <span>{{ money(modifierTotal(modifier)) }}</span>
-        </div>
-      </div>
+        class="receipt-plain-pre receipt-modifier-pre"
+      >{{ modifierBlock(modifier) }}</pre>
     </template>
 
-    <div class="receipt-divider" aria-hidden="true" />
+    <div class="receipt-plain-line">{{ dashDivider }}</div>
 
-    <div v-if="hasBreakdownSubtotal && subtotal != null" class="receipt-item">
-      <span>{{ t('pos.receipt.subtotal') }}</span>
-      <span>{{ money(subtotal) }}</span>
+    <div v-if="hasBreakdownSubtotal && subtotal != null" class="receipt-plain-line">
+      {{ moneyLine(t('pos.receipt.subtotal'), subtotal) }}
     </div>
     <div
       v-for="promo in (promoBreakdown ?? [])"
       :key="promo.promotion_id ?? promo.promotion_name"
-      class="receipt-item"
+      class="receipt-plain-line"
     >
-      <span>{{ promo.promotion_name || t('pos.receipt.promoFallback') }}</span>
-      <span>-{{ money(promo.savings) }}</span>
+      {{ moneyLine(promo.promotion_name || t('pos.receipt.promoFallback'), promo.savings, true) }}
     </div>
-    <div v-if="Number(discountAmount) > 0" class="receipt-item">
-      <span>{{ t('pos.receipt.manualDiscount') }}</span>
-      <span>-{{ money(discountAmount) }}</span>
+    <div v-if="Number(discountAmount) > 0" class="receipt-plain-line">
+      {{ moneyLine(t('pos.receipt.manualDiscount'), discountAmount, true) }}
     </div>
-    <div v-if="Number(waroDiscountAmount) > 0" class="receipt-item">
-      <span>{{ waroDiscountLabel || t('pos.receipt.waroRedeem') }}</span>
-      <span>-{{ money(waroDiscountAmount) }}</span>
+    <div v-if="Number(waroDiscountAmount) > 0" class="receipt-plain-line">
+      {{ moneyLine(waroDiscountLabel || t('pos.receipt.waroRedeem'), waroDiscountAmount, true) }}
     </div>
 
     <template v-if="hasTaxBreakdown">
       <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.taxDetail') }}</div>
-      <div v-if="Number(standardTax) > 0" class="receipt-item receipt-small">
-        <span>{{ displayStandardTaxLabel }}</span>
-        <span>{{ money(standardTax) }}</span>
+      <div v-if="Number(standardTax) > 0" class="receipt-plain-line receipt-small">
+        {{ moneyLine(displayStandardTaxLabel, standardTax) }}
       </div>
-      <div v-if="Number(liquorTax) > 0" class="receipt-item receipt-small">
-        <span>{{ displayLiquorTaxLabel }}</span>
-        <span>{{ money(liquorTax) }}</span>
+      <div v-if="Number(liquorTax) > 0" class="receipt-plain-line receipt-small">
+        {{ moneyLine(displayLiquorTaxLabel, liquorTax) }}
       </div>
     </template>
 
     <template v-if="hasSettlementBreakdown">
-      <div class="receipt-item">
-        <span>{{ t('pos.receipt.orderTotal') }}</span>
-        <span>{{ money(orderTotal) }}</span>
+      <div class="receipt-plain-line">
+        {{ moneyLine(t('pos.receipt.orderTotal'), orderTotal) }}
       </div>
-      <div v-if="Number(tipAmount) > 0" class="receipt-item">
-        <span>{{ tipLabel || t('pos.receipt.tipDefault') }}</span>
-        <span>{{ money(tipAmount) }}</span>
+      <div v-if="Number(tipAmount) > 0" class="receipt-plain-line">
+        {{ moneyLine(tipLabel || t('pos.receipt.tipDefault'), tipAmount) }}
       </div>
-      <div v-if="Number(tipTaxAmount) > 0" class="receipt-item">
-        <span>{{ t('pos.receipt.tipTax') }}</span>
-        <span>{{ money(tipTaxAmount) }}</span>
+      <div v-if="Number(tipTaxAmount) > 0" class="receipt-plain-line">
+        {{ moneyLine(t('pos.receipt.tipTax'), tipTaxAmount) }}
       </div>
-      <div v-if="Number(advanceApplied) > 0" class="receipt-item">
-        <span>{{ t('pos.receipt.tableAdvance') }}</span>
-        <span>-{{ money(advanceApplied) }}</span>
+      <div v-if="Number(advanceApplied) > 0" class="receipt-plain-line">
+        {{ moneyLine(t('pos.receipt.tableAdvance'), advanceApplied, true) }}
       </div>
-      <div class="receipt-total">
-        <span>{{ t('pos.receipt.totalChargedUpper') }}</span>
-        <span>{{ money(finalTotal) }}</span>
+      <div class="receipt-plain-line receipt-plain-total">
+        {{ moneyLine(t('pos.receipt.totalChargedUpper'), finalTotal) }}
       </div>
     </template>
-    <div v-else class="receipt-total">
-      <span>{{ t('pos.receipt.totalUpper') }}</span>
-      <span>{{ money(orderTotal) }}</span>
+    <div v-else class="receipt-plain-line receipt-plain-total">
+      {{ moneyLine(t('pos.receipt.totalUpper'), orderTotal) }}
     </div>
 
-    <div class="receipt-divider" aria-hidden="true" />
+    <div class="receipt-plain-line">{{ dashDivider }}</div>
     <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.paymentDetail') }}</div>
     <template v-if="(payments?.length ?? 0) > 0">
       <template v-for="(payment, idx) in payments" :key="payment.id ?? idx">
-        <div class="receipt-item receipt-small">
-          <span>#{{ idx + 1 }} · {{ payment.label }}</span>
-          <span>{{ money(payment.amount) }}</span>
+        <div class="receipt-plain-line receipt-small">
+          {{ moneyLine(`#${idx + 1} - ${payment.label}`, payment.amount) }}
         </div>
-        <div v-if="payment.change && payment.change > 0" class="receipt-item receipt-small">
-          <span>{{ t('pos.receipt.changeNumber', { number: idx + 1 }) }}</span>
-          <span>{{ money(payment.change) }}</span>
+        <div v-if="payment.change && payment.change > 0" class="receipt-plain-line receipt-small">
+          {{ moneyLine(t('pos.receipt.changeNumber', { number: idx + 1 }), payment.change) }}
         </div>
       </template>
     </template>
     <template v-else>
-      <div class="receipt-item receipt-small">
-        <span>{{ singlePaymentLabel || t('pos.checkout.summary.pendingPayment') }}</span>
-        <span>{{ money(finalTotal) }}</span>
+      <div class="receipt-plain-line receipt-small">
+        {{ moneyLine(singlePaymentLabel || t('pos.checkout.summary.pendingPayment'), finalTotal) }}
       </div>
     </template>
 
     <!-- Venta sin FE: comprobante del establecimiento (DIAN disclaimer only for CO FE tenants) -->
     <template v-if="!invoice">
-      <div class="receipt-divider receipt-divider--strong" aria-hidden="true" />
+      <div class="receipt-plain-line">{{ strongDivider }}</div>
       <div class="receipt-footer">{{ t('pos.receipt.thanks') }}</div>
-      <div class="receipt-divider" aria-hidden="true" />
+      <div class="receipt-plain-line">{{ dashDivider }}</div>
       <div class="receipt-row receipt-small" style="font-weight:bold;">
         {{ t('pos.receipt.saleReceipt') }}
       </div>
@@ -423,7 +423,7 @@ const printableItems = computed(() =>
     </template>
 
     <template v-else>
-      <div class="receipt-divider receipt-divider--strong" aria-hidden="true" />
+      <div class="receipt-plain-line">{{ strongDivider }}</div>
       <div class="receipt-fe-details">
         <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.printedElectronicInvoice') }}</div>
         <div v-if="invoice.issuedAt" class="receipt-row receipt-row--start receipt-small">{{ t('pos.receipt.dianIssueDate', { date: invoice.issuedAt }) }}</div>
@@ -443,16 +443,17 @@ const printableItems = computed(() =>
         <div v-if="invoicePaymentLabel" class="receipt-row receipt-row--start receipt-small">{{ t('pos.receipt.paymentForm', { label: invoicePaymentLabel }) }}</div>
       </div>
       <template v-if="invoiceTaxLines.length > 0">
-        <div class="receipt-divider" aria-hidden="true" />
+        <div class="receipt-plain-line">{{ dashDivider }}</div>
         <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.taxTributaryDetail') }}</div>
         <div
           v-for="(line, idx) in invoiceTaxLines"
           :key="`${line.label ?? 'tax'}-${idx}`"
-          class="receipt-tax-line receipt-small"
+          class="receipt-plain-line receipt-small"
         >
-          <span>{{ line.label || t('pos.checkout.taxFallback') }}<template v-if="formatRate(line.rate)"> {{ formatRate(line.rate) }}</template></span>
-          <span v-if="Number(line.base) > 0">{{ t('pos.receipt.taxBase', { amount: money(line.base) }) }}</span>
-          <span>{{ money(line.amount) }}</span>
+          {{ moneyLine(
+            `${line.label || t('pos.checkout.taxFallback')}${formatRate(line.rate) ? ` ${formatRate(line.rate)}` : ''}`,
+            line.amount,
+          ) }}
         </div>
       </template>
       <div v-if="invoice.cufe" class="receipt-row receipt-row--start receipt-small receipt-cufe">
@@ -465,7 +466,7 @@ const printableItems = computed(() =>
         class="receipt-qr"
       >
       <div v-if="invoiceDianUrl" class="receipt-row receipt-small">{{ t('pos.receipt.verifyDian') }}</div>
-      <div class="receipt-divider receipt-divider--strong" aria-hidden="true" />
+      <div class="receipt-plain-line">{{ strongDivider }}</div>
       <div class="receipt-footer">{{ t('pos.receipt.thanks') }}</div>
       <PosReceiptPlatformFooter document-kind="fe" :platform-legal="platformLegal" :matias-dian="true" />
     </template>
@@ -568,6 +569,33 @@ const printableItems = computed(() =>
   height: 30mm;
   margin: 4px auto;
   display: block;
+}
+
+.receipt-print-ticket .receipt-plain-line,
+.receipt-print-ticket .receipt-plain-pre {
+  display: block;
+  margin: 2px 0;
+  padding: 0;
+  white-space: pre;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.9em;
+  line-height: 1.25;
+  text-align: left;
+  overflow: hidden;
+}
+
+.receipt-print-ticket .receipt-plain-pre {
+  margin: 4px 0;
+}
+
+.receipt-print-ticket .receipt-modifier-pre {
+  margin-top: 0;
+  padding-left: 0;
+}
+
+.receipt-print-ticket .receipt-plain-total {
+  font-weight: 700;
+  margin-top: 4px;
 }
 
 .receipt-print-ticket .receipt-footer {

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -24,6 +24,7 @@ import {
   formatReceiptProductBlock,
   padReceiptLine,
   receiptDivider,
+  collectThermalTicketText,
 } from '~/utils/receiptTicketPlainText'
 import { useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
 import { modifierLineTotal } from '~/utils/saleModifierOption'
@@ -2579,10 +2580,8 @@ const printReceipt = async () => {
     browserPrint: () => {},
     getElementHtml: () => {
       if (typeof document === 'undefined') return null
-      const el = document.querySelector('.receipt-print-ticket') as HTMLElement | null
-      const text = el?.innerText?.trim()
-      if (text) return text
-      return el?.outerHTML?.trim() || null
+      const el = document.querySelector('.receipt-print-ticket')
+      return collectThermalTicketText(el) || null
     },
   })
   if (mode === 'bridge') {
@@ -2926,10 +2925,7 @@ const printPrefactura = async () => {
     browserPrint: () => {},
     getElementHtml: () => {
       if (typeof document === 'undefined') return null
-      const el = document.getElementById('pos-prefactura')
-      const text = (el as HTMLElement | null)?.innerText?.trim()
-      if (text) return text
-      return el?.outerHTML?.trim() || null
+      return collectThermalTicketText(document.getElementById('pos-prefactura')) || null
     },
   })
   if (mode === 'bridge') {

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -19,6 +19,12 @@ import { computePromoEligibleSubtotal, linePromoSavingsForProduct } from '~/util
 import { normalizeFiscalDocumentId } from '~/utils/fiscalDocument'
 import { posDebugLog, posDebugSerializeError } from '~/utils/posDebugLog'
 import { buildReceiptTicketItems, consolidateReceiptPrintLines } from '~/utils/receiptPrintLines'
+import {
+  formatReceiptModifierBlock,
+  formatReceiptProductBlock,
+  padReceiptLine,
+  receiptDivider,
+} from '~/utils/receiptTicketPlainText'
 import { useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
 import { modifierLineTotal } from '~/utils/saleModifierOption'
 import {
@@ -1812,8 +1818,32 @@ const getModifierLineTotal = (mod: PrintModifier) =>
 
 const formatModifierPrintDesc = (mod: PrintModifier) => {
   const qty = Number(mod.quantity) || 1
-  return qty > 1 ? `+ ${mod.name} ×${qty}` : `+ ${mod.name}`
+  return qty > 1 ? `+ ${mod.name} x${qty}` : `+ ${mod.name}`
 }
+
+const prefacturaDash = receiptDivider()
+const prefacturaStrong = receiptDivider(32, '=')
+
+const prefacturaMoneyLine = (label: string, amount: number | string, negative = false) => {
+  const amt = formatCurrencyThermal(amount)
+  return padReceiptLine(label, negative ? `-${amt}` : amt)
+}
+
+const prefacturaProductBlock = (item: any) =>
+  formatReceiptProductBlock({
+    name: `${item.product?.name || item.name || 'Item'}${isKitchenServiceMode.value && item.fired === false ? ' *' : ''}`,
+    quantity: item.quantity,
+    unitPriceLabel: formatCurrencyThermal(getItemUnitPrice(item)),
+    lineTotalLabel: formatCurrencyThermal(getItemTotal(item)),
+  })
+
+const prefacturaModifierBlock = (mod: PrintModifier) =>
+  formatReceiptModifierBlock({
+    description: formatModifierPrintDesc(mod),
+    quantity: mod.quantity ?? 1,
+    unitPriceLabel: formatCurrencyThermal(Number(mod.price) || 0),
+    lineTotalLabel: formatCurrencyThermal(getModifierLineTotal(mod)),
+  })
 
 const receiptPrintLineGuards = (item: any) => [
   item.promo_opt_out,
@@ -2544,7 +2574,17 @@ const printReceipt = async () => {
     window.removeEventListener('afterprint', cleanup)
   }
   // Defer window.print until after await so body print classes stay until fallback.
-  const mode = await printTicketElement('pos-receipt', { browserPrint: () => {} })
+  // Prefer teleported ReceiptPrintTicket (plain-text layout #1979), not flex #pos-receipt.
+  const mode = await printTicketElement('pos-receipt', {
+    browserPrint: () => {},
+    getElementHtml: () => {
+      if (typeof document === 'undefined') return null
+      const el = document.querySelector('.receipt-print-ticket') as HTMLElement | null
+      const text = el?.innerText?.trim()
+      if (text) return text
+      return el?.outerHTML?.trim() || null
+    },
+  })
   if (mode === 'bridge') {
     cleanup()
     return
@@ -2882,7 +2922,16 @@ const printPrefactura = async () => {
 
   await nextTick()
   // Defer window.print until after await so body print classes stay until fallback.
-  const mode = await printTicketElement('pos-prefactura', { browserPrint: () => {} })
+  const mode = await printTicketElement('pos-prefactura', {
+    browserPrint: () => {},
+    getElementHtml: () => {
+      if (typeof document === 'undefined') return null
+      const el = document.getElementById('pos-prefactura')
+      const text = (el as HTMLElement | null)?.innerText?.trim()
+      if (text) return text
+      return el?.outerHTML?.trim() || null
+    },
+  })
   if (mode === 'bridge') {
     cleanup()
     return
@@ -5342,105 +5391,74 @@ onUnmounted(() => {
         </div>
       </template>
     </template>
-    <div class="receipt-divider">--------------------------------</div>
+    <div class="receipt-plain-line">{{ prefacturaDash }}</div>
 
-    <div class="receipt-product-header receipt-small">
-      <span class="receipt-col-desc">{{ t('pos.receipt.description') }}</span>
-      <span class="receipt-col-total">{{ t('pos.receipt.total') }}</span>
-    </div>
+    <div class="receipt-plain-line receipt-small">{{ padReceiptLine(t('pos.receipt.description'), t('pos.receipt.total')) }}</div>
     <template v-for="item in printablePrefacturaItems" :key="item.id ?? item.orderItemId">
-      <div class="receipt-product-line receipt-small">
-        <div class="receipt-product-name">
-          {{ item.product?.name || item.name }}<span v-if="isKitchenServiceMode && item.fired === false"> *</span>
-        </div>
-        <div class="receipt-product-values">
-          <span>{{ item.quantity }} × {{ formatCurrencyThermal(getItemUnitPrice(item)) }}</span>
-          <strong>{{ formatCurrencyThermal(getItemTotal(item)) }}</strong>
-        </div>
-      </div>
-      <div
+      <pre class="receipt-plain-pre">{{ prefacturaProductBlock(item) }}</pre>
+      <pre
         v-for="mod in (item.modifiers ?? [])"
         :key="`${item.id ?? item.orderItemId}-${mod.id}`"
-        class="receipt-product-line receipt-small receipt-modifier-row"
-      >
-        <div class="receipt-product-name">{{ formatModifierPrintDesc(mod) }}</div>
-        <div class="receipt-product-values">
-          <span>{{ (Number(mod.quantity) || 1) > 1 ? `${mod.quantity} × ` : '' }}{{ formatCurrencyThermal(Number(mod.price) || 0) }}</span>
-          <span>{{ formatCurrencyThermal(getModifierLineTotal(mod)) }}</span>
-        </div>
-      </div>
+        class="receipt-plain-pre"
+      >{{ prefacturaModifierBlock(mod) }}</pre>
     </template>
-    <div class="receipt-divider">--------------------------------</div>
+    <div class="receipt-plain-line">{{ prefacturaDash }}</div>
 
-    <div v-if="prefacturaPrintData.promoSavings > 0 || prefacturaPrintData.manualDiscountAmount > 0 || prefacturaPrintData.waroDiscountCop > 0" class="receipt-item">
-      <span>{{ t('pos.receipt.subtotal') }}</span>
-      <span>{{ formatCurrencyThermal(prefacturaPrintData.cartSubtotal) }}</span>
+    <div v-if="prefacturaPrintData.promoSavings > 0 || prefacturaPrintData.manualDiscountAmount > 0 || prefacturaPrintData.waroDiscountCop > 0" class="receipt-plain-line">
+      {{ prefacturaMoneyLine(t('pos.receipt.subtotal'), prefacturaPrintData.cartSubtotal) }}
     </div>
     <div
       v-for="promo in prefacturaPrintData.promoBreakdown"
       :key="promo.promotion_id ?? promo.promotion_name"
-      class="receipt-item"
+      class="receipt-plain-line"
     >
-      <span>{{ promo.promotion_name }}</span>
-      <span>-{{ formatCurrencyThermal(promo.savings) }}</span>
+      {{ prefacturaMoneyLine(promo.promotion_name, promo.savings, true) }}
     </div>
-    <div v-if="prefacturaPrintData.manualDiscountAmount > 0" class="receipt-item">
-      <span>{{ t('pos.receipt.manualDiscount') }}</span>
-      <span>-{{ formatCurrencyThermal(prefacturaPrintData.manualDiscountAmount) }}</span>
+    <div v-if="prefacturaPrintData.manualDiscountAmount > 0" class="receipt-plain-line">
+      {{ prefacturaMoneyLine(t('pos.receipt.manualDiscount'), prefacturaPrintData.manualDiscountAmount, true) }}
     </div>
-    <div v-if="prefacturaPrintData.waroDiscountCop > 0" class="receipt-item">
-      <span>{{ prefacturaPrintData.waroRewardName ? `WaRo: ${prefacturaPrintData.waroRewardName}` : t('pos.receipt.waroRedeem') }}</span>
-      <span>-{{ formatCurrencyThermal(prefacturaPrintData.waroDiscountCop) }}</span>
+    <div v-if="prefacturaPrintData.waroDiscountCop > 0" class="receipt-plain-line">
+      {{ prefacturaMoneyLine(prefacturaPrintData.waroRewardName ? `WaRo: ${prefacturaPrintData.waroRewardName}` : t('pos.receipt.waroRedeem'), prefacturaPrintData.waroDiscountCop, true) }}
     </div>
-    <div v-if="taxPreview && taxPreview.standard_tax > 0" class="receipt-item">
-      <span>{{ localizedInternalTaxLabel(taxPreview.standard_tax_label) }}</span>
-      <span>{{ formatCurrencyThermal(taxPreview.standard_tax) }}</span>
+    <div v-if="taxPreview && taxPreview.standard_tax > 0" class="receipt-plain-line">
+      {{ prefacturaMoneyLine(localizedInternalTaxLabel(taxPreview.standard_tax_label), taxPreview.standard_tax) }}
     </div>
-    <div v-if="taxPreview && taxPreview.liquor_tax > 0" class="receipt-item">
-      <span>{{ taxPreview.liquor_tax_label || t('pos.receipt.liquorVat') }}</span>
-      <span>{{ formatCurrencyThermal(taxPreview.liquor_tax) }}</span>
+    <div v-if="taxPreview && taxPreview.liquor_tax > 0" class="receipt-plain-line">
+      {{ prefacturaMoneyLine(taxPreview.liquor_tax_label || t('pos.receipt.liquorVat'), taxPreview.liquor_tax) }}
     </div>
     <!-- warocol.com#739 + #939 — pre-bill totals include tip, advance, and split settlement when applicable -->
     <template v-if="prefacturaPrintData.tipAmount > 0 || prefacturaPrintData.advanceApplied > 0">
-      <div class="receipt-item">
-        <span>{{ t('pos.receipt.orderTotal') }}</span>
-        <span>{{ formatCurrencyThermal(prefacturaPrintData.orderTotal) }}</span>
+      <div class="receipt-plain-line">
+        {{ prefacturaMoneyLine(t('pos.receipt.orderTotal'), prefacturaPrintData.orderTotal) }}
       </div>
-      <div class="receipt-item">
-        <span>{{ receiptTipLabel }}</span>
-        <span>{{ formatCurrencyThermal(prefacturaPrintData.tipAmount) }}</span>
+      <div class="receipt-plain-line">
+        {{ prefacturaMoneyLine(receiptTipLabel, prefacturaPrintData.tipAmount) }}
       </div>
-      <div v-if="prefacturaPrintData.tipTaxAmount > 0" class="receipt-item">
-        <span>{{ prefacturaPrintData.tipTaxLabel }}</span>
-        <span>{{ formatCurrencyThermal(prefacturaPrintData.tipTaxAmount) }}</span>
+      <div v-if="prefacturaPrintData.tipTaxAmount > 0" class="receipt-plain-line">
+        {{ prefacturaMoneyLine(prefacturaPrintData.tipTaxLabel, prefacturaPrintData.tipTaxAmount) }}
       </div>
-      <div v-if="prefacturaPrintData.advanceApplied > 0" class="receipt-item">
-        <span>{{ t('pos.receipt.tableAdvance') }}</span>
-        <span>-{{ formatCurrencyThermal(prefacturaPrintData.advanceApplied) }}</span>
+      <div v-if="prefacturaPrintData.advanceApplied > 0" class="receipt-plain-line">
+        {{ prefacturaMoneyLine(t('pos.receipt.tableAdvance'), prefacturaPrintData.advanceApplied, true) }}
       </div>
-      <div class="receipt-total">
-        <span>{{ t('pos.receipt.totalDue') }}</span>
-        <span>{{ formatCurrencyThermal(prefacturaPrintData.amountDue) }}</span>
+      <div class="receipt-plain-line receipt-plain-total">
+        {{ prefacturaMoneyLine(t('pos.receipt.totalDue'), prefacturaPrintData.amountDue) }}
       </div>
     </template>
-    <div v-else class="receipt-total">
-      <span>{{ t('pos.receipt.totalUpper') }}</span>
-      <span>{{ formatCurrencyThermal(prefacturaPrintData.orderTotal) }}</span>
+    <div v-else class="receipt-plain-line receipt-plain-total">
+      {{ prefacturaMoneyLine(t('pos.receipt.totalUpper'), prefacturaPrintData.orderTotal) }}
     </div>
     <template v-if="prefacturaPrintData.splitPayments.length > 0">
-      <div class="receipt-divider">--------------------------------</div>
+      <div class="receipt-plain-line">{{ prefacturaDash }}</div>
       <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.paymentsRegistered') }}</div>
       <div
         v-for="(p, idx) in prefacturaPrintData.splitPayments"
         :key="p.id"
-        class="receipt-item receipt-small"
+        class="receipt-plain-line receipt-small"
       >
-        <span>#{{ idx + 1 }} · {{ p.payment_method_name }}</span>
-        <span>{{ formatCurrencyThermal(p.amount) }}</span>
+        {{ prefacturaMoneyLine(`#${idx + 1} - ${p.payment_method_name}`, p.amount) }}
       </div>
-      <div class="receipt-item">
-        <span>{{ prefacturaPrintData.splitIsComplete ? t('pos.receipt.paymentComplete') : t('pos.receipt.balancePending') }}</span>
-        <span>{{ formatCurrencyThermal(prefacturaPrintData.splitRemaining) }}</span>
+      <div class="receipt-plain-line">
+        {{ prefacturaMoneyLine(prefacturaPrintData.splitIsComplete ? t('pos.receipt.paymentComplete') : t('pos.receipt.balancePending'), prefacturaPrintData.splitRemaining) }}
       </div>
     </template>
 
@@ -5448,7 +5466,7 @@ onUnmounted(() => {
       {{ t('pos.receipt.pendingKitchen') }}
     </div>
 
-    <div class="receipt-divider">================================</div>
+    <div class="receipt-plain-line">{{ prefacturaStrong }}</div>
     <!-- Issue #535 — Legal disclaimer: do NOT remove. -->
     <div class="receipt-footer receipt-small" style="font-weight:bold;">{{ t('pos.receipt.prefacturaBanner') }}</div>
     <div class="receipt-footer receipt-small">
@@ -5708,6 +5726,25 @@ onUnmounted(() => {
 
 /* Prefactura product-line layout — mirrors ReceiptPrintTicket so numbers
    (qty × price = total) never overlap on narrow thermal paper. */
+#pos-prefactura .receipt-plain-line,
+#pos-prefactura .receipt-plain-pre,
+#pos-receipt .receipt-plain-line,
+#pos-receipt .receipt-plain-pre {
+  display: block;
+  margin: 2px 0;
+  padding: 0;
+  white-space: pre;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.9em;
+  line-height: 1.25;
+  text-align: left;
+  overflow: hidden;
+}
+#pos-prefactura .receipt-plain-total,
+#pos-receipt .receipt-plain-total {
+  font-weight: 700;
+  margin-top: 4px;
+}
 #pos-prefactura .receipt-product-header {
   display: grid;
   grid-template-columns: 1fr auto;

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -830,9 +830,10 @@ const printReceipt = async () => {
     browserPrint: () => {},
     getElementHtml: () => {
       if (typeof document === 'undefined') return null
-      const el = document.querySelector('.receipt-print-ticket')
-      const html = el?.outerHTML?.trim()
-      return html || null
+      const el = document.querySelector('.receipt-print-ticket') as HTMLElement | null
+      const text = el?.innerText?.trim()
+      if (text) return text
+      return el?.outerHTML?.trim() || null
     },
   })
   if (mode === 'bridge') {

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -12,6 +12,7 @@ import {
   formatFiscalIdentityLabel,
 } from '~/utils/customerIdentityPresentation'
 import { useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
+import { collectThermalTicketText } from '~/utils/receiptTicketPlainText'
 
 definePageMeta({ layout: 'dashboard', module: 'ventas' })
 
@@ -830,10 +831,7 @@ const printReceipt = async () => {
     browserPrint: () => {},
     getElementHtml: () => {
       if (typeof document === 'undefined') return null
-      const el = document.querySelector('.receipt-print-ticket') as HTMLElement | null
-      const text = el?.innerText?.trim()
-      if (text) return text
-      return el?.outerHTML?.trim() || null
+      return collectThermalTicketText(document.querySelector('.receipt-print-ticket')) || null
     },
   })
   if (mode === 'bridge') {

--- a/utils/receiptTicketPlainText.test.ts
+++ b/utils/receiptTicketPlainText.test.ts
@@ -4,6 +4,7 @@ import {
   formatReceiptProductBlock,
   padReceiptLine,
   receiptDivider,
+  collectThermalTicketText,
 } from './receiptTicketPlainText'
 
 describe('padReceiptLine', () => {
@@ -53,5 +54,43 @@ describe('formatReceiptModifierBlock', () => {
 describe('receiptDivider', () => {
   it('emits fixed-width dashes', () => {
     expect(receiptDivider(10)).toBe('----------')
+  })
+})
+
+describe('collectThermalTicketText', () => {
+  it('preserves padReceiptLine spaces from hidden plain lines', () => {
+    const padded = padReceiptLine('Subtotal', '$ COP 100', 32)
+    const product = formatReceiptProductBlock({
+      name: 'poker',
+      quantity: 2,
+      unitPriceLabel: '$10',
+      lineTotalLabel: '$20',
+    })
+    const root = {
+      classList: { contains: () => false },
+      children: [
+        {
+          classList: { contains: (c: string) => c === 'receipt-plain-line' },
+          textContent: padded,
+          children: [],
+        },
+        {
+          classList: { contains: (c: string) => c === 'receipt-row' },
+          textContent: 'Mesa 15',
+          children: [],
+        },
+        {
+          classList: { contains: (c: string) => c === 'receipt-plain-pre' },
+          textContent: product,
+          children: [],
+        },
+      ],
+    } as unknown as Element
+
+    const text = collectThermalTicketText(root)
+    expect(text).not.toMatch(/Subtotal\$/)
+    expect(text.split('\n')[0]).toMatch(/Subtotal\s{2,}\$ COP 100/)
+    expect(text).toContain('Mesa 15')
+    expect(text).toContain('poker')
   })
 })

--- a/utils/receiptTicketPlainText.test.ts
+++ b/utils/receiptTicketPlainText.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  formatReceiptModifierBlock,
+  formatReceiptProductBlock,
+  padReceiptLine,
+  receiptDivider,
+} from './receiptTicketPlainText'
+
+describe('padReceiptLine', () => {
+  it('keeps a space gap so label and amount do not mash', () => {
+    const line = padReceiptLine('Subtotal', '$ COP 1.763.000,00', 32)
+    expect(line).not.toMatch(/Subtotal\$/)
+    expect(line).toContain('Subtotal')
+    expect(line).toContain('$ COP 1.763.000,00')
+    expect(line.length).toBe(32)
+  })
+
+  it('pads Descripcion / Total header', () => {
+    const line = padReceiptLine('Descripcion', 'Total', 32)
+    expect(line).not.toBe('DescripcionTotal')
+    expect(line.startsWith('Descripcion')).toBe(true)
+    expect(line.endsWith('Total')).toBe(true)
+  })
+})
+
+describe('formatReceiptProductBlock', () => {
+  it('puts name and values on separate lines', () => {
+    const block = formatReceiptProductBlock({
+      name: 'poker 330 und',
+      quantity: 13,
+      unitPriceLabel: '$ COP 45.000,00',
+      lineTotalLabel: '$ COP 585.000,00',
+    })
+    expect(block.split('\n')).toHaveLength(2)
+    expect(block).toContain('poker 330 und')
+    expect(block).not.toMatch(/und13/)
+    expect(block).toContain('13 x')
+  })
+})
+
+describe('formatReceiptModifierBlock', () => {
+  it('keeps modifier description above amounts', () => {
+    const block = formatReceiptModifierBlock({
+      description: '+ TOMATE DE PRUEBA',
+      quantity: 1,
+      unitPriceLabel: '$ COP 9.000,00',
+      lineTotalLabel: '$ COP 9.000,00',
+    })
+    expect(block.startsWith('+ TOMATE DE PRUEBA\n')).toBe(true)
+  })
+})
+
+describe('receiptDivider', () => {
+  it('emits fixed-width dashes', () => {
+    expect(receiptDivider(10)).toBe('----------')
+  })
+})

--- a/utils/receiptTicketPlainText.ts
+++ b/utils/receiptTicketPlainText.ts
@@ -1,0 +1,63 @@
+/**
+ * Fixed-width receipt lines for 58mm thermal (#1979).
+ * Avoids flex/span mash (DescripcionTotal, Subtotal$COP) on PrintBridge/Windows.
+ */
+
+export const RECEIPT_THERMAL_COLS = 32
+
+/** One label/amount row padded to `cols` (spaces between). */
+export function padReceiptLine(
+  left: string,
+  right: string,
+  cols: number = RECEIPT_THERMAL_COLS,
+): string {
+  const l = String(left ?? '').trim()
+  const r = String(right ?? '').trim()
+  if (!r) return l.length <= cols ? l : l.slice(0, cols)
+  if (!l) {
+    return r.length <= cols ? r.padStart(cols) : r.slice(-cols)
+  }
+  const gap = 1
+  const maxLeft = cols - r.length - gap
+  if (maxLeft < 4) {
+    // Amount needs the row; put label above
+    return `${l.length <= cols ? l : l.slice(0, cols)}\n${r.length <= cols ? r.padStart(cols) : r.slice(-cols)}`
+  }
+  const leftPart = l.length > maxLeft ? `${l.slice(0, Math.max(1, maxLeft - 3))}...` : l
+  const spaces = cols - leftPart.length - r.length
+  return leftPart + ' '.repeat(Math.max(gap, spaces)) + r
+}
+
+export function receiptDivider(cols: number = RECEIPT_THERMAL_COLS, char = '-'): string {
+  return char.repeat(cols)
+}
+
+/** Product name on its own line; qty x unit … total padded. */
+export function formatReceiptProductBlock(opts: {
+  name: string
+  quantity: number | string
+  unitPriceLabel: string
+  lineTotalLabel: string
+  cols?: number
+}): string {
+  const cols = opts.cols ?? RECEIPT_THERMAL_COLS
+  const name = String(opts.name ?? '').trim() || 'Item'
+  const qty = opts.quantity
+  const left = `${qty} x ${opts.unitPriceLabel}`
+  return `${name}\n${padReceiptLine(left, opts.lineTotalLabel, cols)}`
+}
+
+/** Modifier indented; qty x unit … total. */
+export function formatReceiptModifierBlock(opts: {
+  description: string
+  quantity: number | string
+  unitPriceLabel: string
+  lineTotalLabel: string
+  cols?: number
+}): string {
+  const cols = opts.cols ?? RECEIPT_THERMAL_COLS
+  const desc = String(opts.description ?? '').trim()
+  const qty = Number(opts.quantity) || 1
+  const left = qty > 1 ? `${qty} x ${opts.unitPriceLabel}` : opts.unitPriceLabel
+  return `${desc}\n${padReceiptLine(`  ${left}`, opts.lineTotalLabel, cols)}`
+}

--- a/utils/receiptTicketPlainText.ts
+++ b/utils/receiptTicketPlainText.ts
@@ -61,6 +61,7 @@ export function collectThermalTicketText(root: Element | null | undefined): stri
       cls.contains('receipt-plain-pre')
       || cls.contains('receipt-plain-line')
       || cls.contains('comanda-ticket-pre')
+      || cls.contains('receipt-divider')
     ) {
       push(el.textContent || '', true)
       return

--- a/utils/receiptTicketPlainText.ts
+++ b/utils/receiptTicketPlainText.ts
@@ -32,6 +32,56 @@ export function receiptDivider(cols: number = RECEIPT_THERMAL_COLS, char = '-'):
   return char.repeat(cols)
 }
 
+/**
+ * Read printable text from a hidden ticket root (`display:none`).
+ * Prefer this over `innerText` (empty when hidden) or `outerHTML`→plain
+ * (collapses padReceiptLine spaces via ticketHtmlToPlainText).
+ */
+export function collectThermalTicketText(root: Element | null | undefined): string {
+  if (!root) return ''
+  const lines: string[] = []
+
+  const push = (raw: string, preserveInternalNewlines: boolean) => {
+    if (preserveInternalNewlines) {
+      const trimmed = raw.replace(/\s+$/g, '').replace(/^\s+/g, '')
+      if (trimmed) lines.push(trimmed)
+      return
+    }
+    const t = raw.replace(/\s+/g, ' ').trim()
+    if (t) lines.push(t)
+  }
+
+  const walk = (el: Element) => {
+    // Skip logos (raster handled separately by ESC/POS). Guard for non-DOM test envs.
+    const tag = (el as { tagName?: string }).tagName
+    if (tag && tag.toLowerCase() === 'img') return
+    if (typeof HTMLImageElement !== 'undefined' && el instanceof HTMLImageElement) return
+    const cls = el.classList
+    if (
+      cls.contains('receipt-plain-pre')
+      || cls.contains('receipt-plain-line')
+      || cls.contains('comanda-ticket-pre')
+    ) {
+      push(el.textContent || '', true)
+      return
+    }
+    if (
+      cls.contains('receipt-row')
+      || cls.contains('receipt-footer')
+      || cls.contains('receipt-header')
+      || cls.contains('receipt-document-title')
+      || cls.contains('receipt-cufe')
+    ) {
+      push(el.textContent || '', false)
+      return
+    }
+    for (const child of Array.from(el.children)) walk(child)
+  }
+
+  walk(root)
+  return lines.join('\n').replace(/\n{3,}/g, '\n\n').trim()
+}
+
 /** Product name on its own line; qty x unit … total padded. */
 export function formatReceiptProductBlock(opts: {
   name: string


### PR DESCRIPTION
## Summary
- Shared 32-col `padReceiptLine` / product blocks so thermal drivers no longer mash `DescripcionTotal` / `Subtotal$`
- `ReceiptPrintTicket` + checkout prefactura use plain monospace lines (ventas/[id] + checkout factura)
- Bridge print prefers `innerText` from the plain layout

Closes #1979

## Test plan
- [ ] Prefactura to thermal (Windows or PrintBridge): header, items, mods, totals on separate readable lines
- [ ] Post-payment factura / ventas reprint same
- [ ] Amounts still correct (subtotal, tip, total a cobrar, legal footer)

## Validation evidence
```
bun test utils/receiptTicketPlainText.test.ts
5 pass, 0 fail
```

## wr-context
See `.wr/1979.yaml` on this branch.

Made with [Cursor](https://cursor.com)