### PR TITLE
fix(pos): indent receipt modifiers and keep full thermal amounts

### DIFF
--- a/.wr/1981.yaml
+++ b/.wr/1981.yaml
@@ -1,0 +1,41 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1981
+title: "Indent receipt modifiers and stop truncating thermal money amounts"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-1981-receipt-indent-money
+
+paths:
+  - utils/receiptTicketPlainText.ts
+  - utils/receiptTicketPlainText.test.ts
+  - components/pos/ReceiptPrintTicket.vue
+  - pages/pos/checkout.vue
+
+ac:
+  - Modifiers indented under parent
+  - No ... truncation of money on 58mm
+  - Compact thermal money + stack when needed
+  - Prefactura/factura/ventas via shared helper
+  - Unit tests
+
+out_of_scope:
+  - DIAN content
+  - Comanda tickets
+  - Screen currency formatting
+
+hints:
+  entry: "padReceiptLine preserve indent; compactThermalMoneyLabel; stack not truncate"
+  pattern: "formatReceiptModifierBlock indent; moneyLine compact"
+  tests: "bun test utils/receiptTicketPlainText.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "thermal smoke prefactura with modifiers"

--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -6,6 +6,7 @@ import {
   formatReceiptProductBlock,
   padReceiptLine,
   receiptDivider,
+  compactThermalMoneyLabel,
 } from '~/utils/receiptTicketPlainText'
 
 interface ReceiptItemModifier {
@@ -148,7 +149,7 @@ const modifierBlock = (modifier: ReceiptItemModifier) =>
   })
 
 const moneyLine = (label: string, amount: number | string | null | undefined, negative = false) => {
-  const amt = money(amount)
+  const amt = compactThermalMoneyLabel(money(amount))
   return padReceiptLine(label, negative ? `-${amt}` : amt)
 }
 

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -25,6 +25,7 @@ import {
   padReceiptLine,
   receiptDivider,
   collectThermalTicketText,
+  compactThermalMoneyLabel,
 } from '~/utils/receiptTicketPlainText'
 import { useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
 import { modifierLineTotal } from '~/utils/saleModifierOption'
@@ -1826,7 +1827,7 @@ const prefacturaDash = receiptDivider()
 const prefacturaStrong = receiptDivider(32, '=')
 
 const prefacturaMoneyLine = (label: string, amount: number | string, negative = false) => {
-  const amt = formatCurrencyThermal(amount)
+  const amt = compactThermalMoneyLabel(formatCurrencyThermal(amount))
   return padReceiptLine(label, negative ? `-${amt}` : amt)
 }
 

--- a/utils/receiptTicketPlainText.test.ts
+++ b/utils/receiptTicketPlainText.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import {
+  compactThermalMoneyLabel,
   formatReceiptModifierBlock,
   formatReceiptProductBlock,
   padReceiptLine,
@@ -7,12 +8,19 @@ import {
   collectThermalTicketText,
 } from './receiptTicketPlainText'
 
+describe('compactThermalMoneyLabel', () => {
+  it('strips COP prefix for narrower thermal columns', () => {
+    expect(compactThermalMoneyLabel('$ COP 45.000,00')).toBe('$45.000,00')
+    expect(compactThermalMoneyLabel('$ 1.000')).toBe('$1.000')
+  })
+})
+
 describe('padReceiptLine', () => {
   it('keeps a space gap so label and amount do not mash', () => {
-    const line = padReceiptLine('Subtotal', '$ COP 1.763.000,00', 32)
+    const line = padReceiptLine('Subtotal', '$1.763.000,00', 32)
     expect(line).not.toMatch(/Subtotal\$/)
     expect(line).toContain('Subtotal')
-    expect(line).toContain('$ COP 1.763.000,00')
+    expect(line).toContain('$1.763.000,00')
     expect(line.length).toBe(32)
   })
 
@@ -22,32 +30,57 @@ describe('padReceiptLine', () => {
     expect(line.startsWith('Descripcion')).toBe(true)
     expect(line.endsWith('Total')).toBe(true)
   })
+
+  it('preserves leading indent and never truncates with ellipsis', () => {
+    const line = padReceiptLine('  13 x $45.000,00', '$585.000,00', 32)
+    expect(line).not.toContain('...')
+    expect(line.startsWith('  ') || line.includes('\n')).toBe(true)
+  })
+
+  it('stacks when both sides cannot fit instead of cutting digits', () => {
+    const line = padReceiptLine(
+      'TOTAL A COBRAR CON SERVICIO INCLUIDO',
+      '$1.845.600,00',
+      32,
+    )
+    expect(line).not.toContain('...')
+    expect(line).toContain('TOTAL A COBRAR')
+    expect(line).toContain('$1.845.600,00')
+    expect(line.includes('\n')).toBe(true)
+  })
 })
 
 describe('formatReceiptProductBlock', () => {
-  it('puts name and values on separate lines', () => {
+  it('puts name and values on separate lines without truncating money', () => {
     const block = formatReceiptProductBlock({
       name: 'poker 330 und',
       quantity: 13,
       unitPriceLabel: '$ COP 45.000,00',
       lineTotalLabel: '$ COP 585.000,00',
     })
-    expect(block.split('\n')).toHaveLength(2)
     expect(block).toContain('poker 330 und')
     expect(block).not.toMatch(/und13/)
     expect(block).toContain('13 x')
+    expect(block).not.toContain('...')
+    expect(block).toContain('$45.000,00')
+    expect(block).toContain('$585.000,00')
   })
 })
 
 describe('formatReceiptModifierBlock', () => {
-  it('keeps modifier description above amounts', () => {
+  it('indents modifier name and amount under the parent item', () => {
     const block = formatReceiptModifierBlock({
       description: '+ TOMATE DE PRUEBA',
-      quantity: 1,
+      quantity: 3,
       unitPriceLabel: '$ COP 9.000,00',
-      lineTotalLabel: '$ COP 9.000,00',
+      lineTotalLabel: '$ COP 27.000,00',
     })
-    expect(block.startsWith('+ TOMATE DE PRUEBA\n')).toBe(true)
+    const lines = block.split('\n')
+    expect(lines[0]).toMatch(/^\s{2}\+ TOMATE DE PRUEBA$/)
+    expect(block).not.toContain('...')
+    expect(block).toContain('$9.000,00')
+    expect(block).toContain('$27.000,00')
+    expect(lines[1]?.startsWith('  ')).toBe(true)
   })
 })
 
@@ -58,13 +91,13 @@ describe('receiptDivider', () => {
 })
 
 describe('collectThermalTicketText', () => {
-  it('preserves padReceiptLine spaces from hidden plain lines', () => {
-    const padded = padReceiptLine('Subtotal', '$ COP 100', 32)
-    const product = formatReceiptProductBlock({
-      name: 'poker',
-      quantity: 2,
-      unitPriceLabel: '$10',
-      lineTotalLabel: '$20',
+  it('preserves pad spaces and modifier indent from hidden plain lines', () => {
+    const padded = padReceiptLine('Subtotal', '$100', 32)
+    const mod = formatReceiptModifierBlock({
+      description: '+ Papas',
+      quantity: 1,
+      unitPriceLabel: '$ COP 5.000,00',
+      lineTotalLabel: '$ COP 5.000,00',
     })
     const root = {
       classList: { contains: () => false },
@@ -75,22 +108,15 @@ describe('collectThermalTicketText', () => {
           children: [],
         },
         {
-          classList: { contains: (c: string) => c === 'receipt-row' },
-          textContent: 'Mesa 15',
-          children: [],
-        },
-        {
           classList: { contains: (c: string) => c === 'receipt-plain-pre' },
-          textContent: product,
+          textContent: mod,
           children: [],
         },
       ],
     } as unknown as Element
 
     const text = collectThermalTicketText(root)
-    expect(text).not.toMatch(/Subtotal\$/)
-    expect(text.split('\n')[0]).toMatch(/Subtotal\s{2,}\$ COP 100/)
-    expect(text).toContain('Mesa 15')
-    expect(text).toContain('poker')
+    expect(text.split('\n')[0]).toMatch(/Subtotal\s{2,}\$100/)
+    expect(text).toMatch(/\n {2}\+ Papas/)
   })
 })

--- a/utils/receiptTicketPlainText.ts
+++ b/utils/receiptTicketPlainText.ts
@@ -1,31 +1,55 @@
 /**
- * Fixed-width receipt lines for 58mm thermal (#1979).
- * Avoids flex/span mash (DescripcionTotal, Subtotal$COP) on PrintBridge/Windows.
+ * Fixed-width receipt lines for 58mm thermal (#1979 / #1981).
+ * Avoids flex/span mash; preserves modifier indent; never truncates money with "...".
  */
 
 export const RECEIPT_THERMAL_COLS = 32
+export const RECEIPT_MODIFIER_INDENT = '  '
 
-/** One label/amount row padded to `cols` (spaces between). */
+/**
+ * Compact `$ COP 45.000,00` → `$45.000,00` so qty×unit + total fit 32 cols.
+ */
+export function compactThermalMoneyLabel(label: string): string {
+  return String(label ?? '')
+    .replace(/^\$\s*COP\s+/i, '$')
+    .replace(/^\$\s+/, '$')
+    .trim()
+}
+
+/**
+ * One label/amount row padded to `cols`.
+ * Preserves leading indent on `left`. If both sides do not fit, stacks
+ * (label line + right-aligned amount) — never truncates with "...".
+ */
 export function padReceiptLine(
   left: string,
   right: string,
   cols: number = RECEIPT_THERMAL_COLS,
 ): string {
-  const l = String(left ?? '').trim()
+  const rawLeft = String(left ?? '')
+  const indentMatch = rawLeft.match(/^(\s*)([\s\S]*)$/)
+  const indent = indentMatch?.[1] ?? ''
+  const l = (indentMatch?.[2] ?? '').replace(/\s+$/g, '')
   const r = String(right ?? '').trim()
-  if (!r) return l.length <= cols ? l : l.slice(0, cols)
+
+  if (!r) {
+    const full = indent + l
+    return full.length <= cols ? full : full.slice(0, cols)
+  }
   if (!l) {
     return r.length <= cols ? r.padStart(cols) : r.slice(-cols)
   }
+
   const gap = 1
-  const maxLeft = cols - r.length - gap
-  if (maxLeft < 4) {
-    // Amount needs the row; put label above
-    return `${l.length <= cols ? l : l.slice(0, cols)}\n${r.length <= cols ? r.padStart(cols) : r.slice(-cols)}`
+  const availableForLeft = cols - r.length - gap - indent.length
+  if (availableForLeft < 1 || indent.length + l.length + gap + r.length > cols) {
+    const nameLine = indent + l
+    const amountLine = r.length <= cols ? r.padStart(cols) : r.slice(-cols)
+    return `${nameLine}\n${amountLine}`
   }
-  const leftPart = l.length > maxLeft ? `${l.slice(0, Math.max(1, maxLeft - 3))}...` : l
-  const spaces = cols - leftPart.length - r.length
-  return leftPart + ' '.repeat(Math.max(gap, spaces)) + r
+
+  const spaces = cols - indent.length - l.length - r.length
+  return indent + l + ' '.repeat(Math.max(gap, spaces)) + r
 }
 
 export function receiptDivider(cols: number = RECEIPT_THERMAL_COLS, char = '-'): string {
@@ -43,7 +67,8 @@ export function collectThermalTicketText(root: Element | null | undefined): stri
 
   const push = (raw: string, preserveInternalNewlines: boolean) => {
     if (preserveInternalNewlines) {
-      const trimmed = raw.replace(/\s+$/g, '').replace(/^\s+/g, '')
+      // Keep leading spaces (modifier indent); only trim trailing on the block.
+      const trimmed = raw.replace(/\s+$/g, '')
       if (trimmed) lines.push(trimmed)
       return
     }
@@ -52,7 +77,6 @@ export function collectThermalTicketText(root: Element | null | undefined): stri
   }
 
   const walk = (el: Element) => {
-    // Skip logos (raster handled separately by ESC/POS). Guard for non-DOM test envs.
     const tag = (el as { tagName?: string }).tagName
     if (tag && tag.toLowerCase() === 'img') return
     if (typeof HTMLImageElement !== 'undefined' && el instanceof HTMLImageElement) return
@@ -80,10 +104,10 @@ export function collectThermalTicketText(root: Element | null | undefined): stri
   }
 
   walk(root)
-  return lines.join('\n').replace(/\n{3,}/g, '\n\n').trim()
+  return lines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd()
 }
 
-/** Product name on its own line; qty x unit … total padded. */
+/** Product name on its own line; qty x unit … total padded (compact money). */
 export function formatReceiptProductBlock(opts: {
   name: string
   quantity: number | string
@@ -93,22 +117,29 @@ export function formatReceiptProductBlock(opts: {
 }): string {
   const cols = opts.cols ?? RECEIPT_THERMAL_COLS
   const name = String(opts.name ?? '').trim() || 'Item'
-  const qty = opts.quantity
-  const left = `${qty} x ${opts.unitPriceLabel}`
-  return `${name}\n${padReceiptLine(left, opts.lineTotalLabel, cols)}`
+  const unit = compactThermalMoneyLabel(opts.unitPriceLabel)
+  const total = compactThermalMoneyLabel(opts.lineTotalLabel)
+  const left = `${opts.quantity} x ${unit}`
+  return `${name}\n${padReceiptLine(left, total, cols)}`
 }
 
-/** Modifier indented; qty x unit … total. */
+/** Modifier indented under parent; compact money; no truncation. */
 export function formatReceiptModifierBlock(opts: {
   description: string
   quantity: number | string
   unitPriceLabel: string
   lineTotalLabel: string
   cols?: number
+  indent?: string
 }): string {
   const cols = opts.cols ?? RECEIPT_THERMAL_COLS
-  const desc = String(opts.description ?? '').trim()
+  const indent = opts.indent ?? RECEIPT_MODIFIER_INDENT
+  let desc = String(opts.description ?? '').trim()
+  if (desc.startsWith('+')) desc = `+ ${desc.slice(1).trim()}`
+  else if (desc) desc = `+ ${desc}`
+  const unit = compactThermalMoneyLabel(opts.unitPriceLabel)
+  const total = compactThermalMoneyLabel(opts.lineTotalLabel)
   const qty = Number(opts.quantity) || 1
-  const left = qty > 1 ? `${qty} x ${opts.unitPriceLabel}` : opts.unitPriceLabel
-  return `${desc}\n${padReceiptLine(`  ${left}`, opts.lineTotalLabel, cols)}`
+  const left = qty > 1 ? `${qty} x ${unit}` : unit
+  return `${indent}${desc}\n${padReceiptLine(`${indent}${left}`, total, cols)}`
 }


### PR DESCRIPTION
## Summary
- Indent modifiers under parent items (preserve leading spaces in pad/collect)
- Compact thermal money (`$45.000` vs `$ COP 45.000,00`) and stack lines instead of `...` truncation
- Applies to prefactura + ReceiptPrintTicket (factura/ventas)

Closes #1981

## Test plan
- [ ] Prefactura with add-ons: modifiers indented; unit/line totals complete (no `13 x $ COP 4...`)
- [ ] Factura / ventas reprint same

## Validation evidence
```
bun test utils/receiptTicketPlainText.test.ts
9 pass, 0 fail
```

## wr-context
See `.wr/1981.yaml` on this branch.

Made with [Cursor](https://cursor.com)