### PR TITLE
fix(pos): merge receipt lines; skip comanda auto-print on pay

### DIFF
--- a/.wr/1983.yaml
+++ b/.wr/1983.yaml
@@ -1,0 +1,44 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 1983
+title: "Merge identical receipt lines; do not auto-print comanda on sale finalize"
+repo: both
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: both
+branch: wr-1983-receipt-merge-no-comanda-pay
+
+paths:
+  - utils/receiptPrintLines.test.ts
+  - pages/pos/checkout.vue
+  - composables/useAutoComandaPrint.ts
+  - composables/useAutoComandaPrint.test.ts
+  - app/services/comandas_service.py
+  - app/services/pos_cart_service.py
+  - app/services/tables_service.py
+  - tests/test_comanda_fired_notification.py
+
+ac:
+  - Identical products merge on receipt (qty summed)
+  - Different mods/notes stay separate
+  - Checkout/pay autofire does not SSE auto-print comanda
+  - Explicit fire still notifies/prints
+  - Focused tests
+
+out_of_scope:
+  - Thermal layout
+  - Multi-station printers
+
+hints:
+  entry: "checkout guards + receiptTicketItems consolidate; fire_comandas notify_print=False"
+  pattern: "POS complete + close_session autofire skip notify"
+  tests: "Front: bunx vitest run utils/receiptPrintLines.test.ts composables/useAutoComandaPrint.test.ts | API: ./venv/bin/pytest tests/test_comanda_fired_notification.py -q"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "pay mesa with unfired items — no comanda print; prefactura merges poker lines"

--- a/composables/useAutoComandaPrint.test.ts
+++ b/composables/useAutoComandaPrint.test.ts
@@ -206,6 +206,27 @@ describe('autoPrintComandaFired', () => {
     expect(bridge.printRawEscPos).not.toHaveBeenCalled()
   })
 
+  it('skips when auto_print is false (checkout autofire)', async () => {
+    const bridge = fakeBridge()
+    const result = await autoPrintComandaFired(
+      {
+        type: 'comanda_fired',
+        source_type: 'table',
+        auto_print: false,
+        comandas: [
+          { id: 'c-pay', comanda_number: 1, items: [{ kitchen_name: 'X', quantity: 1 }] },
+        ],
+      },
+      {
+        bridge,
+        getCajaPrinterName: async () => 'CAJA',
+        getUserId: () => 'u1',
+      },
+    )
+    expect(result).toBe('skipped')
+    expect(bridge.printRawEscPos).not.toHaveBeenCalled()
+  })
+
   it('skips pos without user printer', async () => {
     const bridge = fakeBridge()
     const result = await autoPrintComandaFired(

--- a/composables/useAutoComandaPrint.ts
+++ b/composables/useAutoComandaPrint.ts
@@ -23,6 +23,9 @@ export type ComandaFiredSsePayload = {
   table_display_name?: string | null
   /** Explicit target from API: caja (mesa) | user (mostrador/barra) */
   auto_print_target?: 'caja' | 'user' | string
+  /** When false, SSE may exist but client must not auto-print (#1983) */
+  auto_print?: boolean
+  skip_auto_print?: boolean
   comandas?: unknown[]
 }
 
@@ -128,6 +131,7 @@ export async function autoPrintComandaFired(
   deps: AutoPrintDeps,
 ): Promise<'printed' | 'skipped'> {
   if (payload?.type && payload.type !== 'comanda_fired') return 'skipped'
+  if (payload.auto_print === false || payload.skip_auto_print === true) return 'skipped'
 
   const rawList = (payload.comandas || []) as Record<string, unknown>[]
   const mapped: ComandaPrintWithFallback[] = mapComandasForPrint(rawList).map((c) => {

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1848,20 +1848,28 @@ const prefacturaModifierBlock = (mod: PrintModifier) =>
   })
 
 const receiptPrintLineGuards = (item: any) => [
+  // Identity-only — never qty-scaled fields (net_total / promoSavings / discount)
+  // or they block merging identical products (#1983).
   item.promo_opt_out,
   item.promoOptOut,
   item.promotionName,
   item.promoType,
-  item.promoSavings,
   item.applied_promotion_id,
-  item.discount_allocated,
-  item.net_total,
   item.tax_category,
 ]
 
+const checkoutProductKey = (item: any) =>
+  item.product?.id
+  ?? item.productId
+  ?? item.product_id
+  // Never fall back to line item.id — that prevents merging duplicates (#1983).
+  ?? item.product?.name
+  ?? item.productName
+  ?? item.name
+
 const consolidateCheckoutPrintItems = (items: any[]) =>
   consolidateReceiptPrintLines(items, {
-    productKey: item => item.product?.id ?? item.productId ?? item.product_id ?? item.id,
+    productKey: checkoutProductKey,
     displayName: item => item.product?.name ?? item.productName ?? item.name,
     quantity: item => item.quantity,
     unitPrice: item => getItemUnitPrice(item),
@@ -1884,7 +1892,7 @@ const printableReceiptItems = computed(() =>
 )
 
 const receiptTicketItems = computed(() =>
-  buildReceiptTicketItems(cartItemsSnapshot.value)
+  buildReceiptTicketItems(consolidateCheckoutPrintItems(cartItemsSnapshot.value))
 )
 
 function checkoutErrorMessage(error: any, fallback: string) {

--- a/utils/receiptPrintLines.test.ts
+++ b/utils/receiptPrintLines.test.ts
@@ -128,6 +128,16 @@ describe('consolidateReceiptPrintLines', () => {
 
     assert.equal(lines.length, 2)
   })
+
+  it('merges plain duplicates like poker 13 + 19 into one line', () => {
+    const lines = group([
+      { productId: 'poker', name: 'poker 330 und', quantity: 13, unitPrice: 45000, total: 585000 },
+      { productId: 'poker', name: 'poker 330 und', quantity: 19, unitPrice: 45000, total: 855000 },
+    ])
+    assert.equal(lines.length, 1)
+    assert.equal(lines[0]!.quantity, 32)
+    assert.equal(lines[0]!.total, 1440000)
+  })
 })
 
 describe('buildReceiptTicketItems', () => {


### PR DESCRIPTION
## Summary
- Consolidate identical products on factura/prefactura (fix qty-scaled guards + productKey; wire `receiptTicketItems`)
- Honor `auto_print: false` / `skip_auto_print` on SSE auto-print
- Companion API: checkout autofire does not emit comanda_fired

Closes #1983

## Test plan
- [ ] Prefactura/factura: poker 13 + 19 → one line qty 32
- [ ] Pay sale → no comanda print; explicit fire still prints

## Validation evidence
```
bunx vitest run utils/receiptPrintLines.test.ts composables/useAutoComandaPrint.test.ts
22 passed
```

## wr-context
See `.wr/1983.yaml` on this branch.

Made with [Cursor](https://cursor.com)