### PR TITLE
Add CO exempt category chips on Facturación

### DIFF
--- a/composables/useTenantTaxProfile.test.ts
+++ b/composables/useTenantTaxProfile.test.ts
@@ -336,6 +336,25 @@ describe('useTenantTaxProfile', () => {
     expect(body.iva_rate).toBe(0.19)
     expect(body.liquor_tax_rate).toBe(0.05)
     expect(body.iva_applicable).toBe(true)
+    expect(body.exempt_menu_category_ids).toEqual([])
+  })
+
+  it('includes exempt menu category ids in CO tax save payload (#1989)', () => {
+    const catA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    const catB = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+    const body = buildCoTaxSavePayload({
+      inc_applicable: true,
+      inc_included_in_price: true,
+      iva_applicable: false,
+      iva_included_in_price: false,
+      liquor_tax_applicable: false,
+      iva_rate: 0.19,
+      inc_rate: 0.08,
+      liquor_tax_rate: 0.05,
+      exempt_menu_category_ids: [catB, catA, catB, ''],
+    })
+    expect(body.exempt_menu_category_ids).toEqual([catB, catA])
+    expect(body.inc_applicable).toBe(true)
   })
 
   it('uses menu-category tax UI only for commercial tax_lines (#1885)', () => {

--- a/composables/useTenantTaxProfile.ts
+++ b/composables/useTenantTaxProfile.ts
@@ -333,7 +333,9 @@ export function buildCoTaxSavePayload(options: {
   iva_rate: number
   inc_rate: number
   liquor_tax_rate: number
-}): Record<string, boolean | number> {
+  /** Menu category UUIDs treated as tax-exempt (#1989). */
+  exempt_menu_category_ids?: unknown
+}): Record<string, boolean | number | string[]> {
   return {
     inc_applicable: Boolean(options.inc_applicable),
     inc_included_in_price: Boolean(options.inc_included_in_price),
@@ -343,6 +345,9 @@ export function buildCoTaxSavePayload(options: {
     iva_rate: Math.max(0, Number(options.iva_rate) || 0),
     inc_rate: Math.max(0, Number(options.inc_rate) || 0),
     liquor_tax_rate: Math.max(0, Number(options.liquor_tax_rate) || 0),
+    exempt_menu_category_ids: normalizeExemptMenuCategoryIds(
+      options.exempt_menu_category_ids ?? [],
+    ),
   }
 }
 

--- a/pages/facturacion/index.vue
+++ b/pages/facturacion/index.vue
@@ -343,7 +343,8 @@ const { data: menuCategoriesData } = useQuery({
   query: () => $fetch<{ data?: MenuCategoryOption[] }>('/api/menu/categories', {
     query: { limit: 50 },
   }),
-  enabled: () => !!currentTenant.value && showCommercialTaxUi.value,
+  // Commercial matrix + CO exempt chips (#1989) both need the category list.
+  enabled: () => !!currentTenant.value && (showCommercialTaxUi.value || isFiscalIntegrated.value),
   staleTime: 60_000,
 })
 
@@ -768,6 +769,7 @@ const saveTaxConfig = async () => {
           iva_rate: Math.max(0, Number(taxForm.iva_rate_pct) || 0) / 100,
           inc_rate: Math.max(0, Number(taxForm.inc_rate_pct) || 0) / 100,
           liquor_tax_rate: Math.max(0, Number(taxForm.liquor_tax_rate_pct) || 0) / 100,
+          exempt_menu_category_ids: [...exemptMenuCategoryIds.value],
         }),
       })
     }
@@ -2114,6 +2116,63 @@ const matiasRegimeLabel = computed(() => {
               class="w-full min-h-[44px] rounded-lg border-2 border-border bg-background px-3 text-sm text-text-primary tabular-nums"
             >
           </div>
+        </div>
+
+        <div class="border-t border-border/40" />
+
+        <!-- CO exempt categories (#1989) — reuse commercial search/chips helpers -->
+        <div class="space-y-2 rounded-xl border border-border bg-surface-secondary/30 p-4">
+          <div>
+            <p class="text-sm font-medium text-text-primary">{{ t('facturacion.tax.exemptTitle') }}</p>
+            <p class="text-xs text-text-tertiary mt-0.5 leading-relaxed">{{ t('facturacion.tax.exemptHint') }}</p>
+          </div>
+          <div class="relative">
+            <input
+              id="co-tax-exempt-cat-search"
+              type="search"
+              autocomplete="off"
+              :value="exemptSearch"
+              :placeholder="t('facturacion.tax.searchExemptCategory')"
+              class="w-full min-h-[44px] rounded-lg border border-border bg-background px-3 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20"
+              @focus="openExemptSearch"
+              @blur="closeExemptSearchSoon"
+              @input="onExemptSearchInput"
+            >
+            <ul
+              v-if="exemptSearchOpen && filteredExemptCategories.length"
+              class="absolute z-20 mt-1 max-h-48 w-full overflow-y-auto rounded-lg border border-border bg-surface shadow-lg p-1"
+              role="listbox"
+            >
+              <li v-for="choice in filteredExemptCategories" :key="`co-exempt-${choice.id}`">
+                <button
+                  type="button"
+                  class="w-full text-start rounded-md px-3 py-2 text-sm text-text-primary hover:bg-surface-secondary focus:bg-surface-secondary focus:outline-none"
+                  @mousedown.prevent="assignExemptCategory(choice.id)"
+                >
+                  {{ choice.name }}
+                </button>
+              </li>
+            </ul>
+          </div>
+          <ul v-if="exemptMenuCategoryIds.length" class="flex flex-wrap gap-2" role="list">
+            <li
+              v-for="catId in exemptMenuCategoryIds"
+              :key="`co-exempt-chip-${catId}`"
+              class="text-xs bg-surface-secondary text-text-secondary px-2.5 py-1 rounded-full flex items-center gap-1 font-medium border border-border"
+            >
+              <span>{{ menuCategoryLabel(catId) }}</span>
+              <button
+                type="button"
+                class="hover:opacity-70 min-h-[24px] min-w-[24px] flex items-center justify-center"
+                :aria-label="t('facturacion.tax.removeCategory', { name: menuCategoryLabel(catId) })"
+                @click="unassignExemptCategory(catId)"
+              >
+                ×
+              </button>
+            </li>
+          </ul>
+          <p v-else class="text-xs text-text-tertiary">{{ t('facturacion.tax.noExemptYet') }}</p>
+          <p class="text-xs text-text-tertiary leading-relaxed">{{ t('facturacion.tax.exemptNote') }}</p>
         </div>
 
       </div>


### PR DESCRIPTION
## Summary
- Enable menu-category query for fiscal-integrated CO tenants
- Surface exempt search + chips under CO Impuestos (reuse commercial helpers)
- Persist `exempt_menu_category_ids` via `buildCoTaxSavePayload` + CO `saveTaxConfig`

## Test plan
- [ ] CO `/facturacion` Impuestos: search category, add/remove exempt chip, save, reload
- [ ] Commercial tax UI still works (query enable widened only)
- [ ] POS smoke: exempt category inherits no INC/IVA (operator-owned)

## Validation evidence
```text
$ bunx vitest run composables/useTenantTaxProfile.test.ts
 ✓ composables/useTenantTaxProfile.test.ts (34 tests) 10ms
 Test Files  1 passed (1)
      Tests  34 passed (34)
```

Closes #1989

Made with [Cursor](https://cursor.com)