### PR TITLE
batch(menu): CO product inherit/exempt/override tax lines

### DIFF
--- a/composables/useTenantTaxProfile.test.ts
+++ b/composables/useTenantTaxProfile.test.ts
@@ -19,6 +19,7 @@ import {
   taxConfigHasTaxes,
   taxConfigUsesMenuCategoryTaxUi,
   taxLineForCategory,
+  taxLinesForUi,
   validateCommercialMatrix,
   wave1PresetForCountry,
   additiveOrderTaxTotal,
@@ -386,11 +387,32 @@ describe('useTenantTaxProfile', () => {
     expect(body.exempt_menu_category_ids).toEqual([catB])
   })
 
-  it('uses menu-category tax UI only for commercial tax_lines (#1885)', () => {
-    expect(taxConfigUsesMenuCategoryTaxUi({ inc_applicable: true })).toBe(false)
+  it('uses menu-category tax UI for commercial tax_lines and CO columns (#1885 / #1994)', () => {
+    expect(taxConfigUsesMenuCategoryTaxUi({ inc_applicable: true, inc_rate: 0.08 })).toBe(true)
     expect(taxConfigUsesMenuCategoryTaxUi({
       tax_lines: [{ key: 'iva', label: 'IVA', rate: 0.16, included_in_price: false, gl_role: 'iva' }],
     })).toBe(true)
+    expect(taxConfigUsesMenuCategoryTaxUi({})).toBe(false)
+  })
+
+  it('synthesizes CO tax lines for Menú UI (#1994)', () => {
+    const lines = taxLinesForUi({
+      iva_applicable: true,
+      iva_rate: 0.19,
+      iva_included_in_price: false,
+      liquor_tax_applicable: true,
+      liquor_tax_rate: 0.05,
+    })
+    expect(lines.map(l => l.key)).toEqual(['iva', 'liquor'])
+    expect(lines[0]?.label).toBe('IVA 19%')
+    expect(lines[1]?.label).toBe('IVA licores 5%')
+
+    const incOnly = taxLinesForUi({
+      inc_applicable: true,
+      inc_rate: 0.08,
+      inc_included_in_price: true,
+    })
+    expect(incOnly.map(l => l.key)).toEqual(['inc'])
   })
 
   it('inherits tax line from menu category map with override precedence (#1885)', () => {
@@ -424,6 +446,37 @@ describe('useTenantTaxProfile', () => {
     expect(legacyTaxCategoryFromResolution(cfg, {
       tax_resolution: 'exempt',
     })).toBe('exempt')
+  })
+
+  it('CO inherit/preview uses synthesized lines and dual-writes liquor (#1994)', () => {
+    const catA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    const catB = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+    const cfg = {
+      iva_applicable: true,
+      iva_rate: 0.19,
+      iva_included_in_price: false,
+      liquor_tax_applicable: true,
+      liquor_tax_rate: 0.05,
+      menu_category_line_map: { [catA]: 'liquor' },
+      exempt_menu_category_ids: [catB],
+    }
+    expect(inheritedTaxLineForMenuCategory(cfg, catA)?.key).toBe('liquor')
+    expect(inheritedTaxLineForMenuCategory(cfg, catB)).toBeNull()
+    expect(inheritedTaxLineForMenuCategory(cfg, 'unknown')?.key).toBe('iva')
+    expect(resolveProductTaxLinePreview(cfg, {
+      categoryId: catA,
+      tax_resolution: 'line',
+      tax_line_key: 'liquor',
+    })?.key).toBe('liquor')
+    expect(legacyTaxCategoryFromResolution(cfg, {
+      categoryId: catA,
+      tax_resolution: 'line',
+      tax_line_key: 'liquor',
+    })).toBe('liquor')
+    expect(legacyTaxCategoryFromResolution(cfg, {
+      categoryId: 'unknown',
+      tax_resolution: 'inherit',
+    })).toBe('standard')
   })
 
   it('additiveOrderTaxTotal includes exclusive MX IVA and skips included CO INC', () => {

--- a/composables/useTenantTaxProfile.ts
+++ b/composables/useTenantTaxProfile.ts
@@ -391,13 +391,16 @@ export function taxLineForCategory(
   category: TaxCategoryKey,
 ): TaxLineDraft | null {
   if (category === 'exempt') return null
-  const lines = normalizeTaxLines(cfg?.tax_lines)
+  const lines = taxLinesForUi(cfg)
   if (!lines.length) return null
   const map = normalizeCategoryMap(cfg?.category_map)
   const mappedKey = map?.[category]
   if (mappedKey) {
     const match = lines.find(line => line.key === mappedKey)
     if (match) return match
+  }
+  if (category === 'liquor') {
+    return lines.find(line => line.key === 'liquor') ?? null
   }
   if (category === 'standard') return lines[0] ?? null
   return null
@@ -460,14 +463,59 @@ export function taxCategoryOptions(cfg: Record<string, unknown> | null | undefin
   return ['standard', 'liquor', 'exempt']
 }
 
-/** Commercial Menú inherit/override UX when tax_lines exist (#1885). CO keeps fiscal chips. */
+/**
+ * Tax lines for Menú UI: stored commercial tax_lines, else CO column synthesis (#1994).
+ * Mirrors API `_profile_from_co_columns` keys: `iva`|`inc` + optional `liquor`.
+ */
+export function taxLinesForUi(cfg: Record<string, unknown> | null | undefined): TaxLineDraft[] {
+  const stored = normalizeTaxLines(cfg?.tax_lines)
+  if (stored.length) return stored
+  if (!cfg) return []
+
+  const lines: TaxLineDraft[] = []
+  if (cfg.inc_applicable) {
+    const rate = Math.max(0, Number(cfg.inc_rate) || 0)
+    lines.push({
+      key: 'inc',
+      label: `INC ${Math.round(rate * 100)}%`,
+      rate,
+      included_in_price: Boolean(cfg.inc_included_in_price ?? true),
+      gl_role: 'inc',
+    })
+  } else if (cfg.iva_applicable) {
+    const rate = Math.max(0, Number(cfg.iva_rate) || 0)
+    lines.push({
+      key: 'iva',
+      label: `IVA ${Math.round(rate * 100)}%`,
+      rate,
+      included_in_price: Boolean(cfg.iva_included_in_price ?? false),
+      gl_role: 'iva',
+    })
+  }
+
+  if (cfg.liquor_tax_applicable) {
+    const rate = Math.max(0, Number(cfg.liquor_tax_rate) || 0.05)
+    const pct = Math.round(rate * 100)
+    lines.push({
+      key: 'liquor',
+      label: Math.abs(rate - 0.05) < 1e-9 ? 'IVA licores 5%' : `IVA licores ${pct}%`,
+      rate,
+      included_in_price: false,
+      gl_role: 'liquor',
+    })
+  }
+
+  return lines
+}
+
+/** Menú inherit/override UX when commercial tax_lines or CO synthesized lines exist (#1885 / #1994). */
 export type ProductTaxResolution = 'inherit' | 'exempt' | 'line'
 
 export function taxConfigUsesMenuCategoryTaxUi(
   cfg: Record<string, unknown> | null | undefined,
 ): boolean {
   if (!taxConfigHasTaxes(cfg)) return false
-  return normalizeTaxLines(cfg?.tax_lines).length > 0
+  return taxLinesForUi(cfg).length > 0
 }
 
 /**
@@ -478,7 +526,7 @@ export function inheritedTaxLineForMenuCategory(
   cfg: Record<string, unknown> | null | undefined,
   categoryId: string | null | undefined,
 ): TaxLineDraft | null {
-  const lines = normalizeTaxLines(cfg?.tax_lines)
+  const lines = taxLinesForUi(cfg)
   if (!lines.length) return null
   const catId = String(categoryId || '').trim()
   const exemptIds = new Set(normalizeExemptMenuCategoryIds(cfg?.exempt_menu_category_ids))
@@ -504,7 +552,7 @@ export function resolveProductTaxLinePreview(
     tax_line_key?: string | null
   },
 ): TaxLineDraft | null {
-  const lines = normalizeTaxLines(cfg?.tax_lines)
+  const lines = taxLinesForUi(cfg)
   if (!lines.length) return null
   const resolution = String(options.tax_resolution || 'inherit').trim().toLowerCase()
   if (resolution === 'exempt') return null
@@ -528,6 +576,8 @@ export function legacyTaxCategoryFromResolution(
   if (!line) return 'exempt'
   const map = normalizeCategoryMap(cfg?.category_map)
   if (map?.liquor && line.key === map.liquor) return 'liquor'
+  // CO synthesized profile: liquor line key is always `liquor` (#1994).
+  if (line.key === 'liquor') return 'liquor'
   return 'standard'
 }
 
@@ -658,6 +708,7 @@ export function useTenantTaxProfile() {
     normalizeExemptMenuCategoryIds,
     normalizeJurisdictionOptions,
     taxConfigHasTaxes,
+    taxLinesForUi,
     taxLineForCategory,
     primaryTaxLine,
     taxCategoryOptions,

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -1029,12 +1029,12 @@ const {
   taxConfigUsesMenuCategoryTaxUi,
   inheritedTaxLineForMenuCategory,
   legacyTaxCategoryFromResolution,
-  normalizeTaxLines,
+  taxLinesForUi,
 } = useTenantTaxProfile()
 const hasTaxes = computed(() => taxConfigHasTaxes(taxConfig.value))
 const usesMenuCategoryTaxUi = computed(() => taxConfigUsesMenuCategoryTaxUi(taxConfig.value))
 const taxCategories = computed(() => taxCategoryOptions(taxConfig.value))
-const commercialTaxLines = computed(() => normalizeTaxLines(taxConfig.value?.tax_lines))
+const commercialTaxLines = computed(() => taxLinesForUi(taxConfig.value))
 const standardTaxHint = computed(() => {
   const line = taxLineForCategory(taxConfig.value, 'standard')
   if (line?.label) return line.label

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -866,12 +866,12 @@ const {
   taxConfigUsesMenuCategoryTaxUi,
   inheritedTaxLineForMenuCategory,
   legacyTaxCategoryFromResolution,
-  normalizeTaxLines,
+  taxLinesForUi,
 } = useTenantTaxProfile()
 const hasTaxes = computed(() => taxConfigHasTaxes(taxConfig.value))
 const usesMenuCategoryTaxUi = computed(() => taxConfigUsesMenuCategoryTaxUi(taxConfig.value))
 const taxCategories = computed(() => taxCategoryOptions(taxConfig.value))
-const commercialTaxLines = computed(() => normalizeTaxLines(taxConfig.value?.tax_lines))
+const commercialTaxLines = computed(() => taxLinesForUi(taxConfig.value))
 const standardTaxHint = computed(() => {
   const line = taxLineForCategory(taxConfig.value, 'standard')
   if (line?.label) return line.label


### PR DESCRIPTION
## Summary
- Add `taxLinesForUi` (commercial `tax_lines` or CO synthesized `iva`|`inc` + `liquor`)
- Gate + inherit/preview/legacy helpers use synthesized lines; liquor key dual-writes `tax_category`
- Product `[id]` + crear override select uses `taxLinesForUi`

Replaces closed #1996 (auto-closed when #1995 base branch was deleted). Closes #1994

## Test plan
- [ ] CO product edit: inherit / exempt / override (not takeaway chips)
- [ ] Inherit reflects Facturación category map + exempt
- [ ] Override liquor saves `tax_resolution=line` + `tax_line_key=liquor`
- [ ] Commercial product tax UI unchanged
- [ ] `bun test composables/useTenantTaxProfile.test.ts`

## Validation evidence
```text
bun test composables/useTenantTaxProfile.test.ts
37 pass
0 fail
102 expect() calls
```

Made with [Cursor](https://cursor.com)