### PR TITLE
fix(pos): customer search right slideover + compact card

### DIFF
--- a/components/pos/CustomerIdentificationModal.test.ts
+++ b/components/pos/CustomerIdentificationModal.test.ts
@@ -70,6 +70,18 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
+describe('CustomerIdentificationModal shell', () => {
+  it('docks as a right slideover on desktop (md:max-w-md)', () => {
+    const wrapper = mountModal()
+    const panel = wrapper.find('[role="dialog"]')
+    const classes = panel.classes()
+    expect(classes).toContain('md:max-w-md')
+    expect(classes).toContain('md:h-full')
+    expect(classes).not.toContain('h-full')
+    wrapper.unmount()
+  })
+})
+
 describe('CustomerIdentificationModal customer identities', () => {
   it('shows contact and a distinct fiscal acquirer in a compact result', async () => {
     const wrapper = mountModal()

--- a/components/pos/CustomerIdentificationModal.vue
+++ b/components/pos/CustomerIdentificationModal.vue
@@ -2,17 +2,19 @@
   <Transition name="sheet">
     <div
       v-if="modelValue"
-      class="fixed inset-0 z-[60] flex bg-overlay-backdrop/50"
+      class="fixed inset-0 z-[60] flex items-end md:items-stretch md:justify-end bg-overlay-backdrop/50"
       @click.self="handleClose"
     >
       <div
-        class="bottom-sheet-panel bg-surface w-full h-full max-h-[100dvh] flex flex-col"
+        class="bottom-sheet-panel bg-surface w-full max-h-[92dvh] md:max-h-none md:h-full md:max-w-md
+               flex flex-col rounded-t-2xl md:rounded-none shadow-2xl
+               md:border-s md:border-border"
         role="dialog"
         aria-modal="true"
         @click.stop
       >
 
-        <!-- Mobile drag handle (kept for familiarity; panel is full-viewport) -->
+        <!-- Mobile drag handle — bottom sheet; desktop docks as right slideover (#1999) -->
         <div class="flex justify-center pt-3 pb-1 md:hidden flex-shrink-0" aria-hidden="true">
           <div class="w-10 h-1 rounded-full bg-border"></div>
         </div>
@@ -839,7 +841,7 @@ const handleClose = () => {
   opacity: 0;
 }
 
-/* Panel — mobile: slide up from bottom */
+/* Panel — mobile: bottom sheet; desktop: right slideover (#1999 / #1985) */
 .sheet-enter-active .bottom-sheet-panel,
 .sheet-leave-active .bottom-sheet-panel {
   transition: transform 0.3s cubic-bezier(0.32, 0.72, 0, 1);
@@ -848,12 +850,10 @@ const handleClose = () => {
 .sheet-leave-to .bottom-sheet-panel {
   transform: translateY(100%);
 }
-
-/* Panel — desktop: no slide, just backdrop fade */
 @media (min-width: 768px) {
   .sheet-enter-from .bottom-sheet-panel,
   .sheet-leave-to .bottom-sheet-panel {
-    transform: translateY(0);
+    transform: translateX(100%);
   }
 }
 </style>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -3497,7 +3497,7 @@ onUnmounted(() => {
                   <svg class="h-[1em] w-[1em] flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
                   {{ t('pos.checkout.invoiceFiscalPrefix', { type: selectedCustomer.fiscal_id_type, id: selectedCustomer.fiscal_id }) }}
                 </span>
-                <template v-if="!isAnonymousCustomer">
+                <span v-if="!isAnonymousCustomer" class="inline-flex" aria-live="polite">
                   <div
                     v-if="isWalletPending"
                     class="h-5 w-[6.5rem] rounded-full bg-surface-secondary animate-pulse"
@@ -3509,7 +3509,7 @@ onUnmounted(() => {
                   >
                     {{ t('pos.checkout.walletBalance', { amount: formatCurrency(walletBalanceCop) }) }}
                   </span>
-                </template>
+                </span>
               </div>
               <div
                 v-if="selectedCustomerIdentity.showSeparateAcquirer"

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -3475,35 +3475,50 @@ onUnmounted(() => {
             {{ t('pos.checkout.customerData') }}
           </h2>
 
-          <!-- Customer selected: compact contact | fiscal layout -->
-          <div v-if="selectedCustomer" class="flex items-start gap-3 p-3 md:p-4 bg-primary/5 border border-primary/20 rounded-xl">
-            <div class="w-9 h-9 md:w-10 md:h-10 rounded-full bg-primary/10 text-primary flex items-center justify-center font-bold text-sm flex-shrink-0">
+          <!-- Customer selected: compact horizontal layout (#1999) -->
+          <div v-if="selectedCustomer" class="flex items-center gap-3 p-3 bg-primary/5 border border-primary/20 rounded-xl">
+            <div class="w-9 h-9 rounded-full bg-primary/10 text-primary flex items-center justify-center font-bold text-sm flex-shrink-0">
               {{ selectedCustomer.name?.charAt(0)?.toUpperCase() || selectedCustomer.phone_number?.charAt(0) || '?' }}
             </div>
-            <div
-              class="flex-1 min-w-0 grid grid-cols-1 gap-3 md:gap-4"
-              :class="selectedCustomerIdentity.showSeparateAcquirer ? 'md:grid-cols-2' : ''"
-            >
+            <div class="flex-1 min-w-0 space-y-1">
               <div class="min-w-0">
                 <p class="text-[10px] font-bold uppercase tracking-wider text-text-tertiary">
                   {{ t('pos.receipt.saleContact') }}
                 </p>
-                <p class="font-semibold text-text-primary truncate">{{ selectedCustomerDisplayName }}</p>
-                <p class="text-sm text-text-secondary truncate">{{ selectedCustomer.phone_number || t('pos.checkout.noPhone') }}</p>
-                <p v-if="selectedCustomer.email" class="text-xs text-text-secondary truncate">{{ selectedCustomer.email }}</p>
-                <p v-if="selectedCustomer.fiscal_id && !selectedCustomerIdentity.showSeparateAcquirer" class="text-xs text-state-success-text truncate mt-0.5 flex items-center gap-1">
-                  <svg class="h-[1em] w-[1em]" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
+                <p class="font-semibold text-text-primary truncate leading-tight">{{ selectedCustomerDisplayName }}</p>
+              </div>
+              <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-text-secondary">
+                <span class="truncate">{{ selectedCustomer.phone_number || t('pos.checkout.noPhone') }}</span>
+                <span v-if="selectedCustomer.email" class="truncate text-xs">{{ selectedCustomer.email }}</span>
+                <span
+                  v-if="selectedCustomer.fiscal_id && !selectedCustomerIdentity.showSeparateAcquirer"
+                  class="inline-flex items-center gap-1 text-xs text-state-success-text truncate"
+                >
+                  <svg class="h-[1em] w-[1em] flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
                   {{ t('pos.checkout.invoiceFiscalPrefix', { type: selectedCustomer.fiscal_id_type, id: selectedCustomer.fiscal_id }) }}
-                </p>
+                </span>
+                <template v-if="!isAnonymousCustomer">
+                  <div
+                    v-if="isWalletPending"
+                    class="h-5 w-[6.5rem] rounded-full bg-surface-secondary animate-pulse"
+                    :aria-label="t('pos.checkout.loadingWalletAria')"
+                  />
+                  <span
+                    v-else
+                    class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-state-success-bg text-state-success-text border border-state-success-border"
+                  >
+                    {{ t('pos.checkout.walletBalance', { amount: formatCurrency(walletBalanceCop) }) }}
+                  </span>
+                </template>
               </div>
               <div
                 v-if="selectedCustomerIdentity.showSeparateAcquirer"
-                class="min-w-0 md:border-s md:border-primary/15 md:ps-4"
+                class="flex flex-wrap items-baseline gap-x-3 gap-y-0.5 pt-0.5 border-t border-primary/15"
               >
                 <p class="text-[10px] font-bold uppercase tracking-wider text-state-warning-text">
                   {{ t('pos.receipt.fiscalAcquirer') }}
                 </p>
-                <p v-if="selectedCustomerIdentity.acquirer.name" class="text-sm font-semibold text-text-primary truncate">
+                <p v-if="selectedCustomerIdentity.acquirer.name" class="text-xs font-semibold text-text-primary truncate">
                   {{ selectedCustomerIdentity.acquirer.name }}
                 </p>
                 <p v-if="selectedCustomerIdentity.acquirer.fiscalId" class="text-xs text-text-secondary truncate">
@@ -3513,27 +3528,10 @@ onUnmounted(() => {
                   {{ selectedCustomerIdentity.acquirer.email }}
                 </p>
               </div>
-              <div
-                v-if="!isAnonymousCustomer"
-                class="flex flex-wrap gap-2 md:col-span-2"
-                aria-live="polite"
-              >
-                <div
-                  v-if="isWalletPending"
-                  class="h-5 w-[6.5rem] rounded-full bg-surface-secondary animate-pulse"
-                  :aria-label="t('pos.checkout.loadingWalletAria')"
-                />
-                <span
-                  v-else
-                  class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 rounded-full bg-state-success-bg text-state-success-text border border-state-success-border"
-                >
-                  {{ t('pos.checkout.walletBalance', { amount: formatCurrency(walletBalanceCop) }) }}
-                </span>
-              </div>
             </div>
             <button
               @click="showCustomerModal = true"
-              class="min-h-[44px] px-3 py-2 text-sm text-primary font-medium hover:bg-primary/10 rounded-lg transition-colors flex-shrink-0 self-center"
+              class="min-h-[44px] min-w-[44px] px-3 py-2 text-sm text-primary font-medium hover:bg-primary/10 rounded-lg transition-colors flex-shrink-0 self-center"
             >
               {{ t('pos.checkout.changeCustomer') }}
             </button>


### PR DESCRIPTION
## Summary
- Dock `CustomerIdentificationModal` as a right slideover on `md+` (bottom sheet on mobile), matching checkout success / `#1985`
- Compact `/pos/checkout` customer card into a horizontal layout (phone · email · fiscal · wallet)
- Keep backdrop dismiss on customer search (success dismiss lock is `#2000`)

Closes #1999

## Test plan
- [ ] `/pos/checkout` → Identificar/Cambiar cliente — right slideover on desktop
- [ ] Search + select still assigns customer
- [ ] Customer card is denser horizontal; Cambiar still tappable
- [ ] Spot-check Ventas “Cambiar cliente” uses same shell

## Validation evidence
```
bunx vitest run components/pos/CustomerIdentificationModal.test.ts
✓ components/pos/CustomerIdentificationModal.test.ts (4 tests) 57ms
Test Files  1 passed (1)
Tests  4 passed (4)
```

Made with [Cursor](https://cursor.com)