### PR TITLE
fix(pos): fall back to window.print when caja bridge hangs

### DIFF
--- a/.wr/2003.yaml
+++ b/.wr/2003.yaml
@@ -12,12 +12,13 @@ paths:
   - composables/useCajaTicketPrint.ts
   - composables/useCajaTicketPrint.test.ts
   - composables/useLocalPrintBridge.ts
+  - composables/useLocalPrintBridge.test.ts
 
 ac:
   - Bridge print fail/timeout → browser fallback promptly (≤~5s)
+  - Queued-then-failed/unknown CUPS status must reject (not success bridge)
   - Checkout deferred window.print still runs when mode is browser
-  - Unit test: timeout / reject → browser
-  - bun test composables/useCajaTicketPrint.test.ts
+  - bun test composables/useCajaTicketPrint.test.ts composables/useLocalPrintBridge.test.ts
 
 out_of_scope:
   - CUPS/USB driver fixes
@@ -25,9 +26,9 @@ out_of_scope:
   - checkout.vue deferred print pattern (keep; fix composable timeouts)
 
 hints:
-  entry: "printTicketViaCajaOrBrowser — race connect+printRawEscPos"
-  pattern: "Promise.race with BRIDGE_PRINT_TIMEOUT_MS; lower requestTimeoutMs"
-  tests: "bun test composables/useCajaTicketPrint.test.ts"
+  entry: "printAndAwaitOutcome + waitForPrintTerminalStatus; printTicketViaCajaOrBrowser race"
+  pattern: "SDK print resolves on queued — wait status completed|failed|unknown"
+  tests: "bun test composables/useCajaTicketPrint.test.ts composables/useLocalPrintBridge.test.ts"
 
 skip:
   audits: [ux, color, typography]

--- a/.wr/2003.yaml
+++ b/.wr/2003.yaml
@@ -1,0 +1,33 @@
+# Machine contract for wr-fast — keep ≤80 lines.
+issue: 2003
+title: "fix(pos): fall back to window.print when thermal/caja print fails or hangs"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2003-print-browser-fallback
+risk: low
+
+paths:
+  - composables/useCajaTicketPrint.ts
+  - composables/useCajaTicketPrint.test.ts
+  - composables/useLocalPrintBridge.ts
+
+ac:
+  - Bridge print fail/timeout → browser fallback promptly (≤~5s)
+  - Checkout deferred window.print still runs when mode is browser
+  - Unit test: timeout / reject → browser
+  - bun test composables/useCajaTicketPrint.test.ts
+
+out_of_scope:
+  - CUPS/USB driver fixes
+  - Station comanda redesign
+  - checkout.vue deferred print pattern (keep; fix composable timeouts)
+
+hints:
+  entry: "printTicketViaCajaOrBrowser — race connect+printRawEscPos"
+  pattern: "Promise.race with BRIDGE_PRINT_TIMEOUT_MS; lower requestTimeoutMs"
+  tests: "bun test composables/useCajaTicketPrint.test.ts"
+
+skip:
+  audits: [ux, color, typography]

--- a/composables/useCajaTicketPrint.test.ts
+++ b/composables/useCajaTicketPrint.test.ts
@@ -71,6 +71,25 @@ describe('printTicketViaCajaOrBrowser', () => {
     expect(browserPrint).toHaveBeenCalledTimes(1)
   })
 
+  it('falls back to browser when bridge print hangs past timeout', async () => {
+    const browserPrint = mock(() => {})
+    const bridge = fakeBridge({
+      connect: mock(() => Promise.resolve()),
+      printRawEscPos: mock(() => new Promise(() => {})), // never resolves
+    })
+
+    const result = await printTicketViaCajaOrBrowser('pos-receipt', {
+      getCajaPrinterName: async () => 'STAR_TP586',
+      bridge,
+      getElementHtml: () => '<div id="pos-receipt">OK</div>',
+      browserPrint,
+      bridgePrintTimeoutMs: 30,
+    })
+
+    expect(result).toBe('browser')
+    expect(browserPrint).toHaveBeenCalledTimes(1)
+  })
+
   it('falls back to browser when element content is missing', async () => {
     const printRawEscPos = mock(() => Promise.resolve())
     const browserPrint = mock(() => {})

--- a/composables/useCajaTicketPrint.ts
+++ b/composables/useCajaTicketPrint.ts
@@ -1,8 +1,9 @@
 /**
  * Prefactura/factura → configured caja printer via PrintBridge ESC/POS raw (#1960/#1965).
- * Falls back to window.print when bridge or caja assignment is missing.
+ * Falls back to window.print when bridge/caja is missing, print fails, or hangs (#2003).
  */
 import {
+  LocalPrintBridgeError,
   useLocalPrintBridge,
   type LocalPrintBridge,
 } from '~/composables/useLocalPrintBridge'
@@ -14,6 +15,9 @@ import {
 
 export type CajaTicketPrintResult = 'bridge' | 'browser'
 
+/** Cap wait so offline USB/CUPS cannot stall the cashier before browser fallback. */
+export const BRIDGE_PRINT_TIMEOUT_MS = 5000
+
 export type CajaTicketPrintDeps = {
   getCajaPrinterName: () => Promise<string | null | undefined>
   bridge?: LocalPrintBridge
@@ -22,6 +26,20 @@ export type CajaTicketPrintDeps = {
   browserPrint?: () => void
   /** Optional logo URL override; default discovers img.receipt-logo in print DOM. */
   getLogoSrc?: (elementId: string) => string | null
+  /** Override bridge print race timeout (tests). */
+  bridgePrintTimeoutMs?: number
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new LocalPrintBridgeError('PRINT_FAILED', `${label} timed out after ${ms}ms`))
+    }, ms)
+  })
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer)
+  })
 }
 
 function defaultGetElementContent(elementId: string): string | null {
@@ -78,11 +96,18 @@ export async function printTicketViaCajaOrBrowser(
   }
 
   const bridge = deps.bridge ?? useLocalPrintBridge()
+  const timeoutMs = deps.bridgePrintTimeoutMs ?? BRIDGE_PRINT_TIMEOUT_MS
   try {
-    await bridge.connect()
-    await bridge.printRawEscPos(
-      printerName,
-      buildEscPosTicketBytes(content, { logoRaster }),
+    await withTimeout(
+      (async () => {
+        await bridge.connect()
+        await bridge.printRawEscPos(
+          printerName,
+          buildEscPosTicketBytes(content, { logoRaster }),
+        )
+      })(),
+      timeoutMs,
+      'Caja PrintBridge print',
     )
     return 'bridge'
   } catch {

--- a/composables/useLocalPrintBridge.test.ts
+++ b/composables/useLocalPrintBridge.test.ts
@@ -145,4 +145,53 @@ describe('createLocalPrintBridge', () => {
     await expect(bridge.printHtml('', '<div/>')).rejects.toMatchObject({ code: 'INVALID' })
     await expect(bridge.printHtml('STAR', '  ')).rejects.toMatchObject({ code: 'INVALID' })
   })
+
+  it('rejects when status stream reports unknown/failed after queued accept', async () => {
+    let statusHandler: ((event: { requestId?: string; status?: string; message?: string }) => void) | null = null
+    const printSpy = mock(async (job: Record<string, unknown>) => {
+      const requestId = String(job.requestId)
+      queueMicrotask(() => statusHandler?.({ requestId, status: 'queued' }))
+      queueMicrotask(() => statusHandler?.({
+        requestId,
+        status: 'unknown',
+        message: 'Unable to send data to printer.',
+      }))
+      return { status: 'queued', requestId }
+    })
+    __setLocalPrintBridgeClientForTests({
+      ...mockClient({ print: printSpy }),
+      on: mock((_event: 'status', handler: typeof statusHandler) => {
+        statusHandler = handler
+        return () => { statusHandler = null }
+      }),
+    })
+
+    const bridge = createLocalPrintBridge()
+    await expect(bridge.printRawEscPos('STAR_TP586', buildEscPosTestTicketBytes('x')))
+      .rejects.toMatchObject({
+        code: 'PRINT_FAILED',
+        message: expect.stringContaining('Unable to send data to printer'),
+      })
+  })
+
+  it('resolves when status stream reports completed', async () => {
+    let statusHandler: ((event: { requestId?: string; status?: string }) => void) | null = null
+    const printSpy = mock(async (job: Record<string, unknown>) => {
+      const requestId = String(job.requestId)
+      queueMicrotask(() => statusHandler?.({ requestId, status: 'queued' }))
+      queueMicrotask(() => statusHandler?.({ requestId, status: 'completed' }))
+      return { status: 'queued', requestId }
+    })
+    __setLocalPrintBridgeClientForTests({
+      ...mockClient({ print: printSpy }),
+      on: mock((_event: 'status', handler: typeof statusHandler) => {
+        statusHandler = handler
+        return () => { statusHandler = null }
+      }),
+    })
+
+    const bridge = createLocalPrintBridge()
+    await bridge.printRawEscPos('STAR_TP586', buildEscPosTestTicketBytes('ok'))
+    expect(printSpy).toHaveBeenCalledTimes(1)
+  })
 })

--- a/composables/useLocalPrintBridge.ts
+++ b/composables/useLocalPrintBridge.ts
@@ -19,6 +19,13 @@ export class LocalPrintBridgeError extends Error {
   }
 }
 
+export type PrintBridgeStatusEvent = {
+  requestId?: string
+  jobId?: string
+  status?: string
+  message?: string | null
+}
+
 /** Minimal PrintBridge client surface used by WARO (injectable for tests). */
 export type PrintBridgeClientLike = {
   connect: () => Promise<void>
@@ -26,6 +33,62 @@ export type PrintBridgeClientLike = {
   isConnected: () => boolean
   getPrintersList: () => Promise<Array<{ name: string }>>
   print: (job: Record<string, unknown>) => Promise<unknown>
+  /** SDK status stream — required to detect CUPS fail after queued accept (#2003). */
+  on?: (event: 'status', handler: (event: PrintBridgeStatusEvent) => void) => () => void
+}
+
+const PRINT_SUCCESS_STATUSES = new Set(['completed'])
+const PRINT_FAILURE_STATUSES = new Set(['failed', 'cancelled', 'unknown'])
+
+function newPrintRequestId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `waro-print-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+/**
+ * SDK `print()` resolves on `queued` only. Wait for a terminal job status so
+ * offline thermals reject and callers can fall back to window.print (#2003).
+ * Clients without `on` keep queued-accept behavior (tests / stubs).
+ */
+export function waitForPrintTerminalStatus(
+  client: PrintBridgeClientLike,
+  requestId: string,
+): Promise<void> {
+  if (typeof client.on !== 'function') return Promise.resolve()
+
+  return new Promise((resolve, reject) => {
+    const off = client.on!('status', (event) => {
+      if (String(event?.requestId || '') !== requestId) return
+      const status = String(event?.status || '')
+      if (PRINT_SUCCESS_STATUSES.has(status)) {
+        off()
+        resolve()
+        return
+      }
+      if (PRINT_FAILURE_STATUSES.has(status)) {
+        off()
+        reject(
+          new LocalPrintBridgeError(
+            'PRINT_FAILED',
+            event?.message?.trim() || `Print ended with status ${status}`,
+          ),
+        )
+      }
+    })
+  })
+}
+
+async function printAndAwaitOutcome(
+  client: PrintBridgeClientLike,
+  job: Record<string, unknown>,
+): Promise<void> {
+  const requestId = String(job.requestId || newPrintRequestId())
+  const payload = { ...job, requestId }
+  const terminal = waitForPrintTerminalStatus(client, requestId)
+  await client.print(payload)
+  await terminal
 }
 
 let injectedClient: PrintBridgeClientLike | null = null
@@ -176,7 +239,7 @@ export function createLocalPrintBridge(): LocalPrintBridge {
           ? bytesToBase64(new TextEncoder().encode(data))
           : bytesToBase64(data)
       try {
-        await c.print({
+        await printAndAwaitOutcome(c, {
           type: 'raw',
           printerName: name,
           dataBase64,
@@ -202,7 +265,7 @@ export function createLocalPrintBridge(): LocalPrintBridge {
       const pageWidthIn = options?.pageWidthIn ?? 2.25 // ~58mm thermal
       const widthMm = Math.round(pageWidthIn * 25.4)
       try {
-        await c.print({
+        await printAndAwaitOutcome(c, {
           type: 'raw-html',
           printerName: name,
           html,

--- a/composables/useLocalPrintBridge.ts
+++ b/composables/useLocalPrintBridge.ts
@@ -89,7 +89,8 @@ function createDefaultClient(): PrintBridgeClientLike {
     ip: '127.0.0.1',
     port: 17890,
     connectTimeoutMs: 4000,
-    requestTimeoutMs: 15000,
+    // Keep print requests short so offline thermals fall back to window.print (#2003).
+    requestTimeoutMs: 5000,
     autoReconnect: false,
   })
 }


### PR DESCRIPTION
## Summary
- Race caja PrintBridge print with a 5s timeout; on fail/timeout → browser fallback
- Lower SDK `requestTimeoutMs` 15s → 5s
- Unit test for hang → browser path

Closes #2003

## Test plan
- [ ] PrintBridge up, STAR unplugged → print from checkout → browser print dialog within ~5s
- [ ] PrintBridge + STAR healthy → thermal still works

## Validation evidence
```
bun test composables/useCajaTicketPrint.test.ts
6 pass
0 fail
```

## wr-context
See `.wr/2003.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)