### PR TITLE
feat(pos): per-product tax declaration on CO checkout lines and prefactura

### DIFF
--- a/.wr/2007.yaml
+++ b/.wr/2007.yaml
@@ -1,0 +1,37 @@
+# Machine contract for wr-fast — keep ≤80 lines.
+issue: 2007
+title: "feat(pos): per-product tax declaration on CO checkout lines and prefactura"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2007-pos-line-tax-cue
+risk: low
+
+paths:
+  - utils/receiptTicketPlainText.ts
+  - utils/receiptTicketPlainText.test.ts
+  - utils/receiptPrintLines.ts
+  - components/pos/ReceiptPrintTicket.vue
+  - pages/pos/checkout.vue
+  - i18n/locales/*/pos.json
+
+ac:
+  - Checkout order list shows per-line tax cue (IVA/INC/liquor/exempt)
+  - Prefactura product block includes same cue
+  - Thermal + window.print ReceiptPrintTicket shows same cue
+  - Footer tax totals unchanged; no double-counting
+  - bun test utils/receiptTicketPlainText.test.ts
+
+out_of_scope:
+  - Tax calculation / DIAN payloads
+  - Kitchen comandas
+  - Success slideover UX (#2008)
+
+hints:
+  entry: "getLineTaxInfo + formatReceiptProductBlock taxCue"
+  pattern: "annotate_line_tax_amounts on tax-preview lines; taxCategory was unused on print"
+  tests: "bun test utils/receiptTicketPlainText.test.ts"
+
+skip:
+  audits: [ux, color, typography]

--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -279,6 +279,7 @@ const printableItems = computed(() =>
     quantity: item => item.quantity,
     unitPrice: item => item.unitPrice,
     total: item => item.total,
+    taxAmount: item => item.taxAmount,
     modifiers: item => item.modifiers,
     notes: item => item.notes,
     guards: item => [
@@ -296,6 +297,7 @@ const printableItems = computed(() =>
       ...item,
       quantity: aggregate.quantity,
       total: aggregate.total,
+      taxAmount: aggregate.taxAmount > 0 ? aggregate.taxAmount : item.taxAmount,
     }),
   })
 )

--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -4,6 +4,7 @@ import { consolidateReceiptPrintLines } from '~/utils/receiptPrintLines'
 import {
   formatReceiptModifierBlock,
   formatReceiptProductBlock,
+  formatReceiptTaxCue,
   padReceiptLine,
   receiptDivider,
   compactThermalMoneyLabel,
@@ -33,6 +34,9 @@ interface ReceiptItem {
   discountAllocated?: number | string | null
   netTotal?: number | string | null
   taxCategory?: string | null
+  taxLabel?: string | null
+  taxAmount?: number | string | null
+  includedInPrice?: boolean | null
 }
 
 interface ReceiptPaymentLine {
@@ -132,12 +136,27 @@ const modifierDescription = (modifier: ReceiptItemModifier) => {
   return qty > 1 ? `+ ${modifier.name} x${qty}` : `+ ${modifier.name}`
 }
 
-const productBlock = (item: { name: string; quantity: number | string; unitPrice: number; total: number }) =>
+const productTaxCue = (item: ReceiptItem) => {
+  const amount = Number(item.taxAmount)
+  const hasAmount = Number.isFinite(amount) && amount > 0
+  const label = String(item.taxLabel ?? '').trim()
+    || (String(item.taxCategory ?? '').toLowerCase() === 'exempt' ? t('pos.cartItem.taxExempt') : '')
+  return formatReceiptTaxCue({
+    label,
+    amountLabel: hasAmount ? money(amount) : null,
+    includedInPrice: item.includedInPrice === true,
+    includedTemplate: t('pos.cartItem.taxIncluded'),
+    exclusiveTemplate: t('pos.cartItem.taxLine'),
+  })
+}
+
+const productBlock = (item: ReceiptItem) =>
   formatReceiptProductBlock({
     name: item.name,
     quantity: item.quantity,
     unitPriceLabel: money(item.unitPrice),
     lineTotalLabel: money(item.total),
+    taxCue: productTaxCue(item),
   })
 
 const modifierBlock = (modifier: ReceiptItemModifier) =>
@@ -270,6 +289,8 @@ const printableItems = computed(() =>
       item.discountAllocated,
       item.netTotal,
       item.taxCategory,
+      item.taxLabel,
+      item.includedInPrice,
     ],
     merge: (item, aggregate) => ({
       ...item,

--- a/i18n/locales/ar/pos.json
+++ b/i18n/locales/ar/pos.json
@@ -45,6 +45,7 @@
       "perUnit": "لكل وحدة",
       "taxLine": "{label} · {amount}",
       "taxIncluded": "يشمل {label} · {amount}",
+      "taxExempt": "معفى",
       "note": "ملاحظة:",
       "decreaseQtyAria": "تقليل الكمية",
       "increaseQtyAria": "زيادة الكمية",

--- a/i18n/locales/de/pos.json
+++ b/i18n/locales/de/pos.json
@@ -45,6 +45,7 @@
       "perUnit": "Stk.",
       "taxLine": "{label} · {amount}",
       "taxIncluded": "Inkl. {label} · {amount}",
+      "taxExempt": "Steuerfrei",
       "note": "Hinweis:",
       "decreaseQtyAria": "Menge reduzieren",
       "increaseQtyAria": "Menge erhöhen",

--- a/i18n/locales/en/pos.json
+++ b/i18n/locales/en/pos.json
@@ -45,6 +45,7 @@
       "perUnit": "ea",
       "taxLine": "{label} · {amount}",
       "taxIncluded": "Includes {label} · {amount}",
+      "taxExempt": "Exempt",
       "note": "Note:",
       "decreaseQtyAria": "Decrease quantity",
       "increaseQtyAria": "Increase quantity",

--- a/i18n/locales/es/pos.json
+++ b/i18n/locales/es/pos.json
@@ -45,6 +45,7 @@
       "perUnit": "c/u",
       "taxLine": "{label} · {amount}",
       "taxIncluded": "Incluye {label} · {amount}",
+      "taxExempt": "Exento",
       "note": "Nota:",
       "decreaseQtyAria": "Reducir cantidad",
       "increaseQtyAria": "Aumentar cantidad",

--- a/i18n/locales/fr/pos.json
+++ b/i18n/locales/fr/pos.json
@@ -45,6 +45,7 @@
       "perUnit": "l'unité",
       "taxLine": "{label} · {amount}",
       "taxIncluded": "Inclut {label} · {amount}",
+      "taxExempt": "Exonéré",
       "note": "Note :",
       "decreaseQtyAria": "Diminuer la quantité",
       "increaseQtyAria": "Augmenter la quantité",

--- a/i18n/locales/hi/pos.json
+++ b/i18n/locales/hi/pos.json
@@ -45,6 +45,7 @@
       "perUnit": "प्रत्येक",
       "taxLine": "{label} · {amount}",
       "taxIncluded": "शामिल {label} · {amount}",
+      "taxExempt": "कर मुक्त",
       "note": "नोट:",
       "decreaseQtyAria": "मात्रा घटाएँ",
       "increaseQtyAria": "मात्रा बढ़ाएँ",

--- a/i18n/locales/pt/pos.json
+++ b/i18n/locales/pt/pos.json
@@ -45,6 +45,7 @@
       "perUnit": "cada",
       "taxLine": "{label} · {amount}",
       "taxIncluded": "Inclui {label} · {amount}",
+      "taxExempt": "Isento",
       "note": "Nota:",
       "decreaseQtyAria": "Diminuir quantidade",
       "increaseQtyAria": "Aumentar quantidade",

--- a/i18n/locales/zh/pos.json
+++ b/i18n/locales/zh/pos.json
@@ -45,6 +45,7 @@
       "perUnit": "每件",
       "taxLine": "{label} · {amount}",
       "taxIncluded": "含 {label} · {amount}",
+      "taxExempt": "免税",
       "note": "备注:",
       "decreaseQtyAria": "减少数量",
       "increaseQtyAria": "增加数量",

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -22,6 +22,7 @@ import { buildReceiptTicketItems, consolidateReceiptPrintLines } from '~/utils/r
 import {
   formatReceiptModifierBlock,
   formatReceiptProductBlock,
+  formatReceiptTaxCue,
   padReceiptLine,
   receiptDivider,
   collectThermalTicketText,
@@ -331,6 +332,8 @@ type PromoPreviewLine = {
   tax_amount?: number
   tax_label?: string | null
   tax_rate?: number | null
+  tax_category?: string | null
+  tax_resolution?: string | null
   included_in_price?: boolean | null
 }
 
@@ -1062,7 +1065,7 @@ function openSplitSuccessModal(completeData: Record<string, any>) {
       : {}),
     ...waroOrderResultFields(completeData.waro_redemption_summary, cartTotal.value),
   }
-  cartItemsSnapshot.value = [...cartItems.value]
+  cartItemsSnapshot.value = snapshotCartItemsForReceipt()
   receiptEmail.value = ''
   emailSent.value = false
   emailFromProfile.value = false
@@ -1705,21 +1708,69 @@ const getLinePromoPreview = (item: any): PromoPreviewLine | undefined => {
 const getLineTaxInfo = (item: any): { amount: number; label: string; includedInPrice: boolean } | null => {
   const preview = getLinePromoPreview(item)
   const amount = Number(preview?.tax_amount) || 0
-  if (amount <= 0) return null
-  return {
-    amount,
-    label: localizedInternalTaxLabel(preview?.tax_label),
-    includedInPrice: preview?.included_in_price === true,
+  const category = String(
+    preview?.tax_category
+    ?? item.tax_category
+    ?? item.taxCategory
+    ?? item.product?.tax_category
+    ?? '',
+  ).toLowerCase()
+  const resolution = String(preview?.tax_resolution ?? item.tax_resolution ?? '').toLowerCase()
+  const label = localizedInternalTaxLabel(preview?.tax_label)
+  const includedInPrice = preview?.included_in_price === true
+
+  if (amount > 0 && label) {
+    return { amount, label, includedInPrice }
   }
+  if (category === 'exempt' || resolution === 'exempt') {
+    return { amount: 0, label: t('pos.cartItem.taxExempt'), includedInPrice: false }
+  }
+  if (label) {
+    return { amount: 0, label, includedInPrice }
+  }
+  return null
 }
 
 const formatLineTaxDisplay = (info: { amount: number; label: string; includedInPrice: boolean }): string => {
+  if (info.amount <= 0) return info.label
   const amount = formatCurrency(info.amount)
   if (info.includedInPrice) {
     return t('pos.cartItem.taxIncluded', { label: info.label, amount })
   }
   return t('pos.cartItem.taxLine', { label: info.label, amount })
 }
+
+const lineTaxCueForPrint = (item: any): string | null => {
+  const info = getLineTaxInfo(item)
+  if (!info) return null
+  return formatReceiptTaxCue({
+    label: info.label,
+    amountLabel: info.amount > 0 ? formatCurrencyThermal(info.amount) : null,
+    includedInPrice: info.includedInPrice,
+    includedTemplate: t('pos.cartItem.taxIncluded'),
+    exclusiveTemplate: t('pos.cartItem.taxLine'),
+  })
+}
+
+/** Freeze per-line tax fields onto the receipt snapshot before cart clear. */
+const snapshotCartItemsForReceipt = () =>
+  cartItems.value.map((item: any) => {
+    const preview = getLinePromoPreview(item)
+    const info = getLineTaxInfo(item)
+    return {
+      ...item,
+      tax_category: preview?.tax_category
+        ?? item.tax_category
+        ?? item.taxCategory
+        ?? item.product?.tax_category
+        ?? null,
+      tax_label: info?.label ?? preview?.tax_label ?? null,
+      tax_amount: info && info.amount > 0
+        ? info.amount
+        : (Number(preview?.tax_amount) || null),
+      included_in_price: info?.includedInPrice ?? preview?.included_in_price ?? null,
+    }
+  })
 
 const getLinePromoSavings = (item: any): number => {
   if (isLinePromoOptedOut(item)) return 0
@@ -1837,6 +1888,7 @@ const prefacturaProductBlock = (item: any) =>
     quantity: item.quantity,
     unitPriceLabel: formatCurrencyThermal(getItemUnitPrice(item)),
     lineTotalLabel: formatCurrencyThermal(getItemTotal(item)),
+    taxCue: lineTaxCueForPrint(item),
   })
 
 const prefacturaModifierBlock = (mod: PrintModifier) =>
@@ -1856,6 +1908,8 @@ const receiptPrintLineGuards = (item: any) => [
   item.promoType,
   item.applied_promotion_id,
   item.tax_category,
+  item.tax_label,
+  item.included_in_price,
 ]
 
 const checkoutProductKey = (item: any) =>
@@ -1966,7 +2020,7 @@ const processOrder = async () => {
           liquor_tax_label: localizedInternalTaxLabel(taxPreview.value?.liquor_tax_label),
         }
         wasMesaMode.value = false
-        cartItemsSnapshot.value = [...cartItems.value]
+        cartItemsSnapshot.value = snapshotCartItemsForReceipt()
         captureReceiptPrintContext()
         receiptEmail.value = ''
         emailSent.value = false
@@ -2069,7 +2123,7 @@ const processOrder = async () => {
         ...waroOrderResultFields(closeData.waro_redemption_summary, _subtotal),
       }
       wasMesaMode.value = true
-      cartItemsSnapshot.value = [...cartItems.value]
+      cartItemsSnapshot.value = snapshotCartItemsForReceipt()
       captureReceiptPrintContext({
         singleCashReceived: isCashMethod.value && cashReceivedInput.value > 0
           ? Number(cashReceivedInput.value)
@@ -2207,7 +2261,7 @@ const processOrder = async () => {
           Number(response.data.subtotal) || _subtotalPos,
         ),
       }
-      cartItemsSnapshot.value = [...cartItems.value]
+      cartItemsSnapshot.value = snapshotCartItemsForReceipt()
       captureReceiptPrintContext({
         singleCashReceived: isCashMethod.value && cashReceivedInput.value > 0
           ? Number(cashReceivedInput.value)

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1742,11 +1742,24 @@ const formatLineTaxDisplay = (info: { amount: number; label: string; includedInP
 
 const lineTaxCueForPrint = (item: any): string | null => {
   const info = getLineTaxInfo(item)
-  if (!info) return null
+  const label = info?.label
+    ?? localizedInternalTaxLabel(item.tax_label ?? item.taxLabel)
+    ?? (String(item.tax_category ?? item.taxCategory ?? '').toLowerCase() === 'exempt'
+      ? t('pos.cartItem.taxExempt')
+      : '')
+  if (!label && !info) return null
+  const mergedAmount = Number(item.tax_amount ?? item.taxAmount)
+  const amount = Number.isFinite(mergedAmount) && mergedAmount > 0
+    ? mergedAmount
+    : (info?.amount ?? 0)
+  const includedInPrice = info?.includedInPrice
+    ?? item.included_in_price
+    ?? item.includedInPrice
+    ?? false
   return formatReceiptTaxCue({
-    label: info.label,
-    amountLabel: info.amount > 0 ? formatCurrencyThermal(info.amount) : null,
-    includedInPrice: info.includedInPrice,
+    label: label || info!.label,
+    amountLabel: amount > 0 ? formatCurrencyThermal(amount) : null,
+    includedInPrice: includedInPrice === true,
     includedTemplate: t('pos.cartItem.taxIncluded'),
     exclusiveTemplate: t('pos.cartItem.taxLine'),
   })
@@ -1928,12 +1941,18 @@ const consolidateCheckoutPrintItems = (items: any[]) =>
     quantity: item => item.quantity,
     unitPrice: item => getItemUnitPrice(item),
     total: item => getItemTotal(item),
+    taxAmount: item => {
+      const fromItem = Number(item.tax_amount ?? item.taxAmount)
+      if (Number.isFinite(fromItem) && fromItem > 0) return fromItem
+      return getLineTaxInfo(item)?.amount ?? 0
+    },
     modifiers: item => item.modifiers ?? [],
     notes: item => item.notes,
     guards: receiptPrintLineGuards,
     merge: (item, aggregate) => ({
       ...item,
       quantity: aggregate.quantity,
+      tax_amount: aggregate.taxAmount > 0 ? aggregate.taxAmount : item.tax_amount,
     }),
   })
 

--- a/utils/receiptPrintLines.test.ts
+++ b/utils/receiptPrintLines.test.ts
@@ -46,6 +46,33 @@ const groupWithPromoGuard = (items: Array<TestLine & { promo?: string | null }>)
   })
 
 describe('consolidateReceiptPrintLines', () => {
+  it('sums taxAmount when consolidating duplicate taxed lines', () => {
+    const lines = consolidateReceiptPrintLines(
+      [
+        { productId: 'a', name: 'Agua', quantity: 1, unitPrice: 3500, total: 3500, taxAmount: 280 },
+        { productId: 'a', name: 'Agua', quantity: 1, unitPrice: 3500, total: 3500, taxAmount: 280 },
+      ],
+      {
+        productKey: item => item.productId,
+        displayName: item => item.name,
+        quantity: item => item.quantity,
+        unitPrice: item => item.unitPrice,
+        total: item => item.total,
+        taxAmount: item => item.taxAmount,
+        merge: (item, aggregate) => ({
+          ...item,
+          quantity: aggregate.quantity,
+          total: aggregate.total,
+          taxAmount: aggregate.taxAmount,
+        }),
+      },
+    )
+    assert.equal(lines.length, 1)
+    assert.equal(lines[0].quantity, 2)
+    assert.equal(lines[0].total, 7000)
+    assert.equal(lines[0].taxAmount, 560)
+  })
+
   it('groups plain duplicate products for receipt printing', () => {
     const lines = group([
       { productId: 'burger', name: 'Burger', quantity: 1, unitPrice: 12000, total: 12000 },

--- a/utils/receiptPrintLines.ts
+++ b/utils/receiptPrintLines.ts
@@ -88,10 +88,11 @@ type ConsolidateOptions<T> = {
   quantity: (item: T) => number | string | null | undefined
   unitPrice: (item: T) => number | string | null | undefined
   total: (item: T) => number | string | null | undefined
+  taxAmount?: (item: T) => number | string | null | undefined
   modifiers?: (item: T) => ReceiptPrintLineModifier[] | null | undefined
   notes?: (item: T) => string | null | undefined
   guards?: (item: T) => Array<string | number | boolean | null | undefined>
-  merge: (base: T, aggregate: { quantity: number; total: number }) => T
+  merge: (base: T, aggregate: { quantity: number; total: number; taxAmount: number }) => T
 }
 
 const numericKey = (value: number | string | null | undefined) => {
@@ -197,7 +198,7 @@ export function consolidateReceiptPrintLines<T>(
   items: readonly T[],
   options: ConsolidateOptions<T>,
 ): T[] {
-  const grouped = new Map<string, { item: T; quantity: number; total: number }>()
+  const grouped = new Map<string, { item: T; quantity: number; total: number; taxAmount: number }>()
 
   for (const item of items) {
     const key = JSON.stringify({
@@ -211,13 +212,15 @@ export function consolidateReceiptPrintLines<T>(
 
     const quantity = Number(options.quantity(item)) || 0
     const total = Number(options.total(item)) || 0
+    const taxAmount = Number(options.taxAmount?.(item)) || 0
     const existing = grouped.get(key)
 
     if (existing) {
       existing.quantity += quantity
       existing.total += total
+      existing.taxAmount += taxAmount
     } else {
-      grouped.set(key, { item, quantity, total })
+      grouped.set(key, { item, quantity, total, taxAmount })
     }
   }
 
@@ -225,6 +228,7 @@ export function consolidateReceiptPrintLines<T>(
     options.merge(group.item, {
       quantity: group.quantity,
       total: group.total,
+      taxAmount: group.taxAmount,
     })
   )
 }

--- a/utils/receiptPrintLines.ts
+++ b/utils/receiptPrintLines.ts
@@ -35,6 +35,9 @@ export type ReceiptTicketItem = {
   discountAllocated?: number | string | null
   netTotal?: number | string | null
   taxCategory?: string | null
+  taxLabel?: string | null
+  taxAmount?: number | string | null
+  includedInPrice?: boolean | null
 }
 
 type ReceiptTicketSourceItem = {
@@ -71,6 +74,12 @@ type ReceiptTicketSourceItem = {
   net_total?: number | string | null
   taxCategory?: string | null
   tax_category?: string | null
+  taxLabel?: string | null
+  tax_label?: string | null
+  taxAmount?: number | string | null
+  tax_amount?: number | string | null
+  includedInPrice?: boolean | null
+  included_in_price?: boolean | null
 }
 
 type ConsolidateOptions<T> = {
@@ -156,6 +165,9 @@ export function buildReceiptTicketItems(
       discountAllocated: item.discountAllocated ?? item.discount_allocated ?? null,
       netTotal: item.netTotal ?? item.net_total ?? null,
       taxCategory: item.taxCategory ?? item.tax_category ?? null,
+      taxLabel: item.taxLabel ?? item.tax_label ?? null,
+      taxAmount: item.taxAmount ?? item.tax_amount ?? null,
+      includedInPrice: item.includedInPrice ?? item.included_in_price ?? null,
     }
   })
 }

--- a/utils/receiptTicketPlainText.test.ts
+++ b/utils/receiptTicketPlainText.test.ts
@@ -3,6 +3,7 @@ import {
   compactThermalMoneyLabel,
   formatReceiptModifierBlock,
   formatReceiptProductBlock,
+  formatReceiptTaxCue,
   padReceiptLine,
   receiptDivider,
   collectThermalTicketText,
@@ -50,6 +51,27 @@ describe('padReceiptLine', () => {
   })
 })
 
+describe('formatReceiptTaxCue', () => {
+  it('formats included and exclusive tax with amount', () => {
+    expect(formatReceiptTaxCue({
+      label: 'IVA 19%',
+      amountLabel: '$ COP 1.900,00',
+      includedInPrice: true,
+      includedTemplate: 'Incluye {label} · {amount}',
+    })).toBe('Incluye IVA 19% · $1.900,00')
+    expect(formatReceiptTaxCue({
+      label: 'IVA 16%',
+      amountLabel: '$160',
+      includedInPrice: false,
+    })).toBe('IVA 16% · $160')
+  })
+
+  it('returns bare label for exempt / zero-amount cues', () => {
+    expect(formatReceiptTaxCue({ label: 'Exento' })).toBe('Exento')
+    expect(formatReceiptTaxCue({ label: '', amountLabel: '$1' })).toBeNull()
+  })
+})
+
 describe('formatReceiptProductBlock', () => {
   it('puts name and values on separate lines without truncating money', () => {
     const block = formatReceiptProductBlock({
@@ -64,6 +86,20 @@ describe('formatReceiptProductBlock', () => {
     expect(block).not.toContain('...')
     expect(block).toContain('$45.000,00')
     expect(block).toContain('$585.000,00')
+  })
+
+  it('appends per-line tax declaration under the qty/total row', () => {
+    const block = formatReceiptProductBlock({
+      name: 'Agua',
+      quantity: 1,
+      unitPriceLabel: '$3.500',
+      lineTotalLabel: '$3.500',
+      taxCue: 'Incluye INC · $280',
+    })
+    const lines = block.split('\n')
+    expect(lines[0]).toBe('Agua')
+    expect(lines[1]).toContain('1 x')
+    expect(lines[2]).toBe('Incluye INC · $280')
   })
 })
 

--- a/utils/receiptTicketPlainText.ts
+++ b/utils/receiptTicketPlainText.ts
@@ -107,12 +107,34 @@ export function collectThermalTicketText(root: Element | null | undefined): stri
   return lines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd()
 }
 
+/**
+ * Compact per-line tax declaration for thermal / window.print.
+ * Amount line when taxed; bare label for exempt / label-only.
+ */
+export function formatReceiptTaxCue(opts: {
+  label?: string | null
+  amountLabel?: string | null
+  includedInPrice?: boolean | null
+  includedTemplate?: string
+  exclusiveTemplate?: string
+}): string | null {
+  const label = String(opts.label ?? '').trim()
+  if (!label) return null
+  const amount = compactThermalMoneyLabel(String(opts.amountLabel ?? '').trim())
+  if (!amount) return label
+  const template = opts.includedInPrice
+    ? (opts.includedTemplate || 'Incluye {label} · {amount}')
+    : (opts.exclusiveTemplate || '{label} · {amount}')
+  return template.replace('{label}', label).replace('{amount}', amount)
+}
+
 /** Product name on its own line; qty x unit … total padded (compact money). */
 export function formatReceiptProductBlock(opts: {
   name: string
   quantity: number | string
   unitPriceLabel: string
   lineTotalLabel: string
+  taxCue?: string | null
   cols?: number
 }): string {
   const cols = opts.cols ?? RECEIPT_THERMAL_COLS
@@ -120,7 +142,9 @@ export function formatReceiptProductBlock(opts: {
   const unit = compactThermalMoneyLabel(opts.unitPriceLabel)
   const total = compactThermalMoneyLabel(opts.lineTotalLabel)
   const left = `${opts.quantity} x ${unit}`
-  return `${name}\n${padReceiptLine(left, total, cols)}`
+  const body = `${name}\n${padReceiptLine(left, total, cols)}`
+  const cue = String(opts.taxCue ?? '').trim()
+  return cue ? `${body}\n${cue}` : body
 }
 
 /** Modifier indented under parent; compact money; no truncation. */


### PR DESCRIPTION
## Summary
- Show per-line tax cue on checkout Orden (IVA/INC/liquor + Exento)
- Prefactura and thermal/`window.print` product blocks include the same declaration
- Snapshot tax fields before cart clear so post-sale receipts keep the cue

Closes #2007

## Test plan
- [ ] Mixed cart (taxed + liquor + exempt): checkout lines show cues
- [ ] Prefactura print includes per-line tax text
- [ ] Thermal / window.print receipt includes same cues; footer totals unchanged

## Validation evidence
```
$ bun test utils/receiptTicketPlainText.test.ts
bun test v1.2.21
12 pass
0 fail
```

## wr-context
See `.wr/2007.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)