### PR TITLE
fix(pos): bodega-style customer & success slideovers; editable receipt email

### DIFF
--- a/.wr/2008.yaml
+++ b/.wr/2008.yaml
@@ -1,0 +1,34 @@
+# Machine contract for wr-fast — keep ≤80 lines.
+issue: 2008
+title: "fix(pos): bodega-style customer & success slideovers; editable receipt email"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2008-bodega-slideovers-email
+risk: low
+
+paths:
+  - components/pos/CustomerIdentificationModal.vue
+  - components/pos/CustomerIdentificationModal.test.ts
+  - pages/pos/checkout.vue
+
+ac:
+  - Customer search slideover matches bodega StockAdjustmentPanel chrome
+  - Success slideover matches same aesthetic family
+  - Success backdrop click does not dismiss; Nueva Venta / panel X do
+  - Receipt email always editable before send; confirm uses edited address
+  - bunx vitest run components/pos/CustomerIdentificationModal.test.ts
+
+out_of_scope:
+  - Per-line tax (#2007)
+  - CRM redesign
+  - Void-payment modal
+
+hints:
+  entry: "StockAdjustmentPanel.vue chrome; success Teleport @click remove"
+  pattern: "Separate backdrop Transition + panel Transition; profile email was span-only"
+  tests: "bunx vitest run components/pos/CustomerIdentificationModal.test.ts"
+
+skip:
+  audits: [ux, color, typography]

--- a/components/pos/CustomerIdentificationModal.test.ts
+++ b/components/pos/CustomerIdentificationModal.test.ts
@@ -97,6 +97,29 @@ describe('CustomerIdentificationModal shell', () => {
     expect(wrapper.element.contains(overlay!)).toBe(false)
     wrapper.unmount()
   })
+
+  it('uses bodega-style header chrome (surface-secondary band)', () => {
+    const wrapper = mountModal()
+    const panel = dialogEl()
+    expect(panel).toBeTruthy()
+    expect(panel!.className).toContain('md:end-0')
+    const header = Array.from(panel!.querySelectorAll('div')).find(el =>
+      el.className.includes('bg-surface-secondary'),
+    )
+    expect(header).toBeTruthy()
+    wrapper.unmount()
+  })
+
+  it('closes when backdrop is clicked (search UX)', async () => {
+    const wrapper = mountModal()
+    const overlay = Array.from(document.body.querySelectorAll('.fixed.inset-0'))
+      .find(el => el.className.includes('z-[80]')) as HTMLElement
+    expect(overlay).toBeTruthy()
+    overlay.click()
+    await flushPromises()
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([false])
+    wrapper.unmount()
+  })
 })
 
 describe('CustomerIdentificationModal customer identities', () => {

--- a/components/pos/CustomerIdentificationModal.vue
+++ b/components/pos/CustomerIdentificationModal.vue
@@ -1,15 +1,30 @@
 <template>
   <!-- Teleport to body so fixed overlay covers full viewport (not dashboard content pane) #2004 -->
+  <!-- Chrome matches bodega StockAdjustmentPanel (#2008) -->
   <Teleport to="body">
-  <Transition name="sheet">
-    <div
-      v-if="modelValue"
-      class="fixed inset-0 z-[80] flex items-end md:items-stretch md:justify-end bg-overlay-backdrop/50"
-      @click.self="handleClose"
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-200"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
     >
       <div
-        class="bottom-sheet-panel bg-surface w-full max-h-[92dvh] md:max-h-none md:h-full md:max-w-md
-               flex flex-col rounded-t-2xl md:rounded-none shadow-2xl
+        v-if="modelValue"
+        class="fixed inset-0 z-[80] bg-overlay-backdrop/40"
+        aria-hidden="true"
+        @click="handleClose"
+      />
+    </Transition>
+
+    <Transition name="panel">
+      <div
+        v-if="modelValue"
+        class="fixed z-[81] flex flex-col bg-surface shadow-2xl
+               inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh]
+               md:inset-y-0 md:end-0 md:bottom-auto md:start-auto md:inset-x-auto
+               md:rounded-none md:w-full md:max-w-md md:max-h-none md:h-full
                md:border-s md:border-border"
         role="dialog"
         aria-modal="true"
@@ -18,28 +33,41 @@
 
         <!-- Mobile drag handle — bottom sheet; desktop docks as right slideover (#1999) -->
         <div class="flex justify-center pt-3 pb-1 md:hidden flex-shrink-0" aria-hidden="true">
-          <div class="w-10 h-1 rounded-full bg-border"></div>
+          <div class="w-10 h-1 rounded-full bg-sheet-border"></div>
         </div>
 
-        <!-- Header -->
-        <div class="p-5 border-b border-border flex items-center justify-between flex-shrink-0">
-          <div>
-            <h2 class="text-xl font-bold text-text-primary">
-              {{ headerTitle }}
-            </h2>
-            <p class="text-sm text-text-secondary mt-0.5">
-              {{ headerSubtitle }}
-            </p>
+        <!-- Header (bodega articles panel aesthetic) -->
+        <div class="flex-shrink-0 bg-surface-secondary/40 border-b border-border px-6 py-4">
+          <div class="flex items-start justify-between gap-3">
+            <div class="flex items-center gap-3 min-w-0 flex-1">
+              <div
+                class="flex-shrink-0 w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center text-primary"
+                aria-hidden="true"
+              >
+                <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+                </svg>
+              </div>
+              <div class="min-w-0">
+                <h2 class="text-base font-bold text-text-primary leading-tight">
+                  {{ headerTitle }}
+                </h2>
+                <p class="text-xs text-text-secondary leading-snug mt-0.5">
+                  {{ headerSubtitle }}
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              @click="handleClose"
+              :aria-label="t('pos.customer.closeModalAria')"
+              class="flex-shrink-0 min-h-[44px] min-w-[44px] inline-flex items-center justify-center rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 transition-colors"
+            >
+              <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
           </div>
-          <button
-            @click="handleClose"
-            :aria-label="t('pos.customer.closeModalAria')"
-            class="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-xl text-text-secondary hover:bg-surface-secondary hover:text-text-primary transition-colors"
-          >
-            <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
         </div>
 
         <!-- STATE: Search -->
@@ -467,8 +495,7 @@
         </template>
 
       </div>
-    </div>
-  </Transition>
+    </Transition>
   </Teleport>
 </template>
 
@@ -834,28 +861,20 @@ const handleClose = () => {
 </script>
 
 <style scoped>
-/* Backdrop fade */
-.sheet-enter-active,
-.sheet-leave-active {
-  transition: opacity 0.25s ease;
-}
-.sheet-enter-from,
-.sheet-leave-to {
-  opacity: 0;
+/* Match StockAdjustmentPanel / bodega articles slideover (#2008) */
+.panel-enter-active,
+.panel-leave-active {
+  transition: transform 250ms ease;
 }
 
-/* Panel — mobile: bottom sheet; desktop: right slideover (#1999 / #1985) */
-.sheet-enter-active .bottom-sheet-panel,
-.sheet-leave-active .bottom-sheet-panel {
-  transition: transform 0.3s cubic-bezier(0.32, 0.72, 0, 1);
-}
-.sheet-enter-from .bottom-sheet-panel,
-.sheet-leave-to .bottom-sheet-panel {
+.panel-enter-from,
+.panel-leave-to {
   transform: translateY(100%);
 }
+
 @media (min-width: 768px) {
-  .sheet-enter-from .bottom-sheet-panel,
-  .sheet-leave-to .bottom-sheet-panel {
+  .panel-enter-from,
+  .panel-leave-to {
     transform: translateX(100%);
   }
 }

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -5018,7 +5018,6 @@ onUnmounted(() => {
           v-if="showSuccessModal"
           class="fixed inset-0 z-50 bg-overlay-backdrop/40"
           aria-hidden="true"
-          @click="closeSuccessModal"
         />
       </Transition>
 
@@ -5041,54 +5040,54 @@ onUnmounted(() => {
         >
           <!-- Mobile drag handle -->
           <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0" aria-hidden="true">
-            <div class="w-10 h-1 rounded-full bg-border" />
+            <div class="w-10 h-1 rounded-full bg-sheet-border" />
           </div>
 
-          <!-- Header -->
-          <div class="flex-shrink-0 flex items-start justify-between gap-3 px-5 pt-2 pb-3 border-b border-border">
-            <div class="flex items-center gap-3 min-w-0 flex-1">
-              <div class="w-11 h-11 rounded-full flex items-center justify-center bg-state-success-bg flex-shrink-0">
-                <svg
-                  class="w-6 h-6 text-state-success-text"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
+          <!-- Header (bodega StockAdjustmentPanel aesthetic #2008) -->
+          <div class="flex-shrink-0 bg-surface-secondary/40 border-b border-border px-6 py-4">
+            <div class="flex items-start justify-between gap-3">
+              <div class="flex items-center gap-3 min-w-0 flex-1">
+                <div
+                  class="flex-shrink-0 w-10 h-10 rounded-xl bg-state-success-bg flex items-center justify-center text-state-success-text"
                   aria-hidden="true"
                 >
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                  <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                  </svg>
+                </div>
+                <div class="min-w-0">
+                  <h3 class="text-base font-bold leading-tight text-text-primary">
+                    {{
+                      orderResult?.status === 'pending'
+                        ? t('pos.checkout.success.pendingTitle')
+                        : orderResult?.payment_method === 'credit'
+                          ? t('pos.checkout.success.creditTitle')
+                          : t('pos.checkout.success.completedTitle')
+                    }}
+                  </h3>
+                  <p class="text-xs leading-snug text-text-secondary mt-0.5">
+                    {{
+                      orderResult?.status === 'pending'
+                        ? t('pos.checkout.success.pendingBody')
+                        : orderResult?.payment_method === 'credit'
+                          ? t('pos.checkout.success.creditBody')
+                          : t('pos.checkout.success.completedBody')
+                    }}
+                  </p>
+                </div>
+              </div>
+              <!-- Close is an explicit panel action (backdrop does not dismiss #2008) -->
+              <button
+                type="button"
+                class="flex-shrink-0 min-h-[44px] min-w-[44px] inline-flex items-center justify-center rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30 transition-colors"
+                :aria-label="t('pos.comandasPanel.closePanelAria')"
+                @click="closeSuccessModal"
+              >
+                <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
                 </svg>
-              </div>
-              <div class="min-w-0">
-                <h3 class="text-lg font-bold leading-tight text-text-primary">
-                  {{
-                    orderResult?.status === 'pending'
-                      ? t('pos.checkout.success.pendingTitle')
-                      : orderResult?.payment_method === 'credit'
-                        ? t('pos.checkout.success.creditTitle')
-                        : t('pos.checkout.success.completedTitle')
-                  }}
-                </h3>
-                <p class="text-sm leading-snug text-text-secondary mt-0.5">
-                  {{
-                    orderResult?.status === 'pending'
-                      ? t('pos.checkout.success.pendingBody')
-                      : orderResult?.payment_method === 'credit'
-                        ? t('pos.checkout.success.creditBody')
-                        : t('pos.checkout.success.completedBody')
-                  }}
-                </p>
-              </div>
+              </button>
             </div>
-            <button
-              type="button"
-              class="flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center text-text-tertiary hover:bg-surface-secondary hover:text-text-secondary transition-colors focus:outline-none focus:ring-2 focus:ring-action-primary-focus-ring/30"
-              :aria-label="t('pos.comandasPanel.closePanelAria')"
-              @click="closeSuccessModal"
-            >
-              <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
-              </svg>
-            </button>
           </div>
 
           <div class="flex-1 min-h-0 overflow-y-auto overscroll-contain px-5 py-4">
@@ -5337,44 +5336,31 @@ onUnmounted(() => {
 
           <!-- Receipt actions -->
           <div class="mb-4 space-y-3">
-            <!-- Email receipt -->
+            <!-- Email receipt — always editable before send (#2008) -->
             <div class="flex flex-col gap-1.5">
-              <!-- When email comes from profile: confirmation mode -->
-              <template v-if="emailFromProfile && !emailSent">
-	                <p class="text-sm font-medium text-text-primary">
-                    {{ hasGeneratedInvoice ? t('pos.checkout.invoice.sendByEmail') : t('pos.checkout.receiptEmail.askSend') }}
-                  </p>
-                <div class="flex items-center gap-2 rounded-lg border border-border bg-surface px-3 py-2">
-                  <svg class="h-[1em] w-[1em] shrink-0 text-text-secondary" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" /></svg>
-                  <span class="flex-1 truncate text-sm text-text-primary">{{ receiptEmail }}</span>
-                  <button
-                    @click="sendReceiptEmail"
-                    :disabled="!receiptEmail || isSendingEmail"
-                    class="shrink-0 min-h-[36px] px-4 py-1.5 rounded-lg text-sm font-semibold transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed bg-action-primary-bg text-action-primary-text hover:bg-action-primary-hover-bg"
-                  >
-	                    <span v-if="isSendingEmail">{{ t('pos.checkout.receiptEmail.sending') }}</span>
-	                    <span v-else>{{ t('pos.checkout.receiptEmail.confirmSend') }}</span>
-                  </button>
-                </div>
-              </template>
-
-              <!-- When email was sent (from profile or manual) -->
-              <template v-else-if="emailSent">
+              <template v-if="emailSent">
                 <div class="flex items-center gap-2 rounded-lg border border-state-success-border bg-state-success-bg px-3 py-2 text-state-success-text">
                   <svg class="h-[1em] w-[1em] shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
-	                  <span class="text-sm font-medium">
-                      {{ hasGeneratedInvoice
-                        ? t('pos.checkout.invoiceSent', { email: receiptEmail })
-                        : t('pos.checkout.receiptEmail.sentTo', { email: receiptEmail }) }}
-                    </span>
+                  <span class="text-sm font-medium">
+                    {{ hasGeneratedInvoice
+                      ? t('pos.checkout.invoiceSent', { email: receiptEmail })
+                      : t('pos.checkout.receiptEmail.sentTo', { email: receiptEmail }) }}
+                  </span>
                 </div>
               </template>
-
-              <!-- When no profile email: manual input -->
               <template v-else>
-                <label for="receipt-email" class="text-xs font-semibold text-text-secondary">
-	                  {{ hasGeneratedInvoice ? t('pos.checkout.invoice.sendByEmail') : t('pos.checkout.receiptEmail.label') }}
-                    <span class="font-normal text-text-tertiary">{{ t('pos.checkout.optional') }}</span>
+                <label for="receipt-email" class="text-sm font-medium text-text-primary">
+                  {{
+                    hasGeneratedInvoice
+                      ? t('pos.checkout.invoice.sendByEmail')
+                      : (emailFromProfile
+                        ? t('pos.checkout.receiptEmail.askSend')
+                        : t('pos.checkout.receiptEmail.label'))
+                  }}
+                  <span
+                    v-if="!emailFromProfile"
+                    class="font-normal text-text-tertiary"
+                  >{{ t('pos.checkout.optional') }}</span>
                 </label>
                 <div class="flex gap-2">
                   <input
@@ -5382,15 +5368,18 @@ onUnmounted(() => {
                     v-model="receiptEmail"
                     type="email"
                     placeholder="cliente@email.com"
-                    class="flex-1 px-3 py-2 border border-border rounded-lg text-sm text-text-primary bg-background focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
+                    autocomplete="email"
+                    class="flex-1 min-h-[44px] px-3 py-2 border border-border rounded-lg text-sm text-text-primary bg-background focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
                   />
                   <button
+                    type="button"
                     @click="sendReceiptEmail"
                     :disabled="!receiptEmail || isSendingEmail"
-                    class="min-h-[44px] px-4 py-2 rounded-lg text-sm font-medium transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed bg-surface border border-border text-text-primary hover:bg-surface-secondary"
+                    class="shrink-0 min-h-[44px] px-4 py-2 rounded-lg text-sm font-semibold transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed bg-action-primary-bg text-action-primary-text hover:bg-action-primary-hover-bg"
                   >
-	                    <span v-if="isSendingEmail">{{ t('pos.checkout.receiptEmail.sending') }}</span>
-	                    <span v-else>{{ t('pos.checkout.receiptEmail.send') }}</span>
+                    <span v-if="isSendingEmail">{{ t('pos.checkout.receiptEmail.sending') }}</span>
+                    <span v-else-if="emailFromProfile">{{ t('pos.checkout.receiptEmail.confirmSend') }}</span>
+                    <span v-else>{{ t('pos.checkout.receiptEmail.send') }}</span>
                   </button>
                 </div>
               </template>


### PR DESCRIPTION
## Summary
- Align Buscar cliente + Venta Completada with bodega StockAdjustmentPanel chrome
- Success backdrop no longer dismisses (Nueva Venta / panel X still close)
- Receipt email is always editable before send; confirm uses the edited address

Closes #2008

## Test plan
- [ ] Open Buscar cliente — right slideover matches bodega header/backdrop
- [ ] Complete sale — gray backdrop does not close success panel
- [ ] Edit prefilled receipt email and send — uses edited address

## Validation evidence
```
$ bunx vitest run components/pos/CustomerIdentificationModal.test.ts
✓ 7 tests passed
```

## wr-context
See `.wr/2008.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)