### PR TITLE
fix(pos): restore prefactura tax cues and print logos

### DIFF
--- a/components/pos/ReceiptPrintHeader.vue
+++ b/components/pos/ReceiptPrintHeader.vue
@@ -53,7 +53,6 @@ const logoStyle = computed(() => buildReceiptLogoStyle())
       :src="logoUrl"
       alt=""
       class="receipt-logo"
-      crossorigin="anonymous"
       :style="logoStyle"
     >
     <div class="receipt-header">{{ headerName }}</div>

--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -141,13 +141,16 @@ const productTaxCue = (item: ReceiptItem) => {
   const hasAmount = Number.isFinite(amount) && amount > 0
   const label = String(item.taxLabel ?? '').trim()
     || (String(item.taxCategory ?? '').toLowerCase() === 'exempt' ? t('pos.cartItem.taxExempt') : '')
-  return formatReceiptTaxCue({
-    label,
-    amountLabel: hasAmount ? money(amount) : null,
-    includedInPrice: item.includedInPrice === true,
-    includedTemplate: t('pos.cartItem.taxIncluded'),
-    exclusiveTemplate: t('pos.cartItem.taxLine'),
-  })
+  if (!label) return null
+  if (hasAmount) {
+    const amountLabel = compactThermalMoneyLabel(money(amount))
+    return formatReceiptTaxCue({
+      text: item.includedInPrice === true
+        ? t('pos.cartItem.taxIncluded', { label, amount: amountLabel })
+        : t('pos.cartItem.taxLine', { label, amount: amountLabel }),
+    })
+  }
+  return formatReceiptTaxCue({ label })
 }
 
 const productBlock = (item: ReceiptItem) =>

--- a/composables/useReceiptPrintSettings.ts
+++ b/composables/useReceiptPrintSettings.ts
@@ -2,6 +2,8 @@
  * POS receipt print settings from restaurant-context (warocol.com#930).
  * Used by receipt print components starting batch #931.
  */
+import { resolveReceiptLogoUrl } from '~/utils/receiptPrintConfig'
+
 export function useReceiptPrintSettings() {
   const { currentTenant } = useTenantReactive()
   const { businessProfile } = useTenantReactive()
@@ -20,7 +22,7 @@ export function useReceiptPrintSettings() {
   const receiptLogoUrl = computed(() => {
     if (!receiptPrintSettings.value.show_logo) return null
     const url = settingsData.value?.data?.logo_url ?? businessProfile.value?.logo_url ?? null
-    return url && String(url).startsWith('http') ? url : null
+    return resolveReceiptLogoUrl(url)
   })
 
   return { receiptPrintSettings, receiptLogoUrl, settingsData }

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -28,6 +28,7 @@ import {
   collectThermalTicketText,
   compactThermalMoneyLabel,
 } from '~/utils/receiptTicketPlainText'
+import { resolveReceiptLogoUrl } from '~/utils/receiptPrintConfig'
 import { useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
 import { modifierLineTotal } from '~/utils/saleModifierOption'
 import {
@@ -1805,13 +1806,17 @@ const lineTaxCueForPrint = (item: any): string | null => {
     ?? item.included_in_price
     ?? item.includedInPrice
     ?? false
-  return formatReceiptTaxCue({
-    label: label || info!.label,
-    amountLabel: amount > 0 ? formatCurrencyThermal(amount) : null,
-    includedInPrice: includedInPrice === true,
-    includedTemplate: t('pos.cartItem.taxIncluded'),
-    exclusiveTemplate: t('pos.cartItem.taxLine'),
-  })
+  const labelFinal = label || info!.label
+  if (amount > 0) {
+    const amountLabel = compactThermalMoneyLabel(formatCurrencyThermal(amount))
+    // Pass interpolated i18n text — never t('taxIncluded') as a .replace template.
+    return formatReceiptTaxCue({
+      text: includedInPrice
+        ? t('pos.cartItem.taxIncluded', { label: labelFinal, amount: amountLabel })
+        : t('pos.cartItem.taxLine', { label: labelFinal, amount: amountLabel }),
+    })
+  }
+  return formatReceiptTaxCue({ label: labelFinal })
 }
 
 /** Freeze per-line tax fields onto the receipt snapshot before cart clear. */
@@ -2744,7 +2749,7 @@ const receiptTipLabel = computed(() => {
 const receiptLogoUrl = computed(() => {
   if (!receiptPrintSettings.value.show_logo) return null
   const url = settingsData.value?.data?.logo_url ?? businessProfile.value?.logo_url ?? null
-  return url && String(url).startsWith('http') ? url : null
+  return resolveReceiptLogoUrl(url)
 })
 
 // warocol.com#939 — pre-bill always reads as prefactura; post-payment uses receiptDocumentLabel.

--- a/utils/receiptPrintConfig.ts
+++ b/utils/receiptPrintConfig.ts
@@ -22,3 +22,16 @@ export function buildReceiptLogoStyle() {
     '--receipt-logo-margin': `${cfg.logoTopOffsetMm}mm auto ${cfg.logoBottomMarginMm}mm`,
   }
 }
+
+/** Normalize tenant logo for window.print / thermal HTML (http(s), data:, or absolute path). */
+export function resolveReceiptLogoUrl(url?: string | null): string | null {
+  if (!url) return null
+  const s = String(url).trim()
+  if (!s) return null
+  if (s.startsWith('http://') || s.startsWith('https://') || s.startsWith('data:')) return s
+  if (s.startsWith('/') && typeof window !== 'undefined' && window.location?.origin) {
+    return `${window.location.origin}${s}`
+  }
+  if (s.startsWith('/')) return s
+  return null
+}

--- a/utils/receiptTicketPlainText.test.ts
+++ b/utils/receiptTicketPlainText.test.ts
@@ -70,6 +70,27 @@ describe('formatReceiptTaxCue', () => {
     expect(formatReceiptTaxCue({ label: 'Exento' })).toBe('Exento')
     expect(formatReceiptTaxCue({ label: '', amountLabel: '$1' })).toBeNull()
   })
+
+  it('accepts pre-localized text from vue-i18n t(key, params)', () => {
+    expect(formatReceiptTaxCue({
+      text: 'Incluye IVA 19% · $2.076,00',
+    })).toBe('Incluye IVA 19% · $2.076,00')
+  })
+
+  it('recovers when i18n emptied template placeholders (Incluye ·)', () => {
+    expect(formatReceiptTaxCue({
+      label: 'IVA 19%',
+      amountLabel: '$2.076,00',
+      includedInPrice: true,
+      includedTemplate: 'Incluye ·',
+    })).toBe('Incluye IVA 19% · $2.076,00')
+    expect(formatReceiptTaxCue({
+      label: 'IVA licores 5%',
+      amountLabel: '$1.500,00',
+      includedInPrice: false,
+      exclusiveTemplate: '·',
+    })).toBe('IVA licores 5% · $1.500,00')
+  })
 })
 
 describe('formatReceiptProductBlock', () => {

--- a/utils/receiptTicketPlainText.ts
+++ b/utils/receiptTicketPlainText.ts
@@ -110,22 +110,37 @@ export function collectThermalTicketText(root: Element | null | undefined): stri
 /**
  * Compact per-line tax declaration for thermal / window.print.
  * Amount line when taxed; bare label for exempt / label-only.
+ *
+ * Prefer passing `text` from `t('…', { label, amount })` — vue-i18n already
+ * interpolates placeholders, so do NOT pass `t('taxIncluded')` as a template
+ * (that yields "Incluye ·" with empty slots).
  */
 export function formatReceiptTaxCue(opts: {
   label?: string | null
   amountLabel?: string | null
   includedInPrice?: boolean | null
+  /** Pre-localized full cue (preferred). */
+  text?: string | null
   includedTemplate?: string
   exclusiveTemplate?: string
 }): string | null {
+  const preformatted = String(opts.text ?? '').trim()
+  if (preformatted) return preformatted
+
   const label = String(opts.label ?? '').trim()
   if (!label) return null
   const amount = compactThermalMoneyLabel(String(opts.amountLabel ?? '').trim())
   if (!amount) return label
-  const template = opts.includedInPrice
+
+  // Templates must still contain `{label}` / `{amount}`. If vue-i18n already
+  // emptied them ("Incluye ·"), rebuild from safe defaults.
+  let template = opts.includedInPrice
     ? (opts.includedTemplate || 'Incluye {label} · {amount}')
     : (opts.exclusiveTemplate || '{label} · {amount}')
-  return template.replace('{label}', label).replace('{amount}', amount)
+  if (!template.includes('{label}') || !template.includes('{amount}')) {
+    template = opts.includedInPrice ? 'Incluye {label} · {amount}' : '{label} · {amount}'
+  }
+  return template.replaceAll('{label}', label).replaceAll('{amount}', amount)
 }
 
 /** Product name on its own line; qty x unit … total padded (compact money). */


### PR DESCRIPTION
## Summary
- Prefactura/receipt tax cues use interpolated i18n (`t(key, { label, amount })`) so lines are not `Incluye ·`
- Recover if a broken emptied template is still passed
- Remove `crossorigin` on receipt logo; resolve relative logo URLs for window.print

Closes #2013

## Test plan
- [ ] Mesa prefactura: café/coca → Incluye IVA 19% · $…; coronita → licores cue
- [ ] window.print prefactura + post-sale receipt show logo when enabled
- [ ] Checkout on-screen tax cues unchanged

## Validation evidence
```
$ bun test utils/receiptTicketPlainText.test.ts
14 pass
0 fail
```

Made with [Cursor](https://cursor.com)