### PR TITLE
chore(ventas): remove period totals row on productos list

### DIFF
--- a/.wr/2017.yaml
+++ b/.wr/2017.yaml
@@ -1,0 +1,26 @@
+issue: 2017
+title: "chore(ventas): remove period totals row on productos list"
+repo: warocol.com
+branch: wr-2017-remove-productos-totals-row
+date: 2026-08-01
+status: implemented
+
+intent: >
+  Remove the bottom period totals strip on /ventas/productos that duplicated
+  MetricCards (units + revenue). Keep filters, table, pagination, and header cards.
+
+changes:
+  - path: pages/ventas/productos.vue
+    note: Removed bottom Totals row block; totals computed kept for MetricCards.
+
+out_of_scope:
+  - API / schema changes
+  - Removing MetricCards
+  - i18n key cleanup (totalProducts unused in UI is optional)
+
+validation:
+  - UI-only removal; no automated test required
+  - Manual: page still shows MetricCards + table + pagination without bottom strip
+
+pr_notes: |
+  Closes #2017

--- a/pages/ventas/productos.vue
+++ b/pages/ventas/productos.vue
@@ -384,18 +384,6 @@ onUnmounted(() => {
         </template>
       </UiResponsiveDataView>
 
-      <!-- Totals row (period totals — not page-only) -->
-      <div
-        v-if="productsTotal > 0 && !isRefreshing"
-        class="flex items-center justify-between px-4 py-3 bg-surface border border-border rounded-xl text-sm font-semibold"
-      >
-        <span class="text-text-secondary">{{ productsTotal === 1 ? t('ventas.productos.totalProducts', { count: productsTotal }) : t('ventas.productos.totalProducts_plural', { count: productsTotal }) }}</span>
-        <div class="flex items-center gap-6">
-          <span class="text-text-primary">{{ totals.quantity_sold }} {{ t('ventas.productos.unitsAbbr') }}</span>
-          <span class="text-primary">{{ formatCurrency(totals.total_revenue) }}</span>
-        </div>
-      </div>
-
       <!-- Pagination (match ventas/ordenes) -->
       <div v-if="productsTotal > 0" class="flex items-center justify-end px-1 py-2">
         <div class="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- Remove the bottom period totals strip on `/ventas/productos` that duplicated the header MetricCards (units + revenue).
- Keep filters, product table, pagination, and MetricCards unchanged.

## Test plan
- [ ] Open `/ventas/productos` with sales data for the selected period
- [ ] Confirm MetricCards still show units sold and revenue
- [ ] Confirm the bottom “Total (N productos) / uds / $…” row is gone
- [ ] Confirm pagination still works

Closes #2017

Made with [Cursor](https://cursor.com)