### PR TITLE
feat(crm): wallet COP movements as data table

### DIFF
--- a/.wr/2021.yaml
+++ b/.wr/2021.yaml
@@ -1,0 +1,39 @@
+issue: 2021
+title: "feat(crm): wallet COP movements as data table"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2021-wallet-cop-data-table
+
+paths:
+  - pages/crm/clientes/[id].vue
+  - i18n/locales/es/analitica.json
+  - i18n/locales/en/analitica.json
+  - i18n/locales/pt/analitica.json
+  - i18n/locales/fr/analitica.json
+  - i18n/locales/de/analitica.json
+  - i18n/locales/ar/analitica.json
+  - i18n/locales/hi/analitica.json
+  - i18n/locales/zh/analitica.json
+
+ac:
+  - Wallet movements use UiResponsiveDataView like Cartera/orders
+  - i18n for receive/apply/void_apply (+ recharge/redeem/refund aliases)
+  - No 5-row hard cap; show API movements payload
+  - Keep balance header + Recargar
+
+out_of_scope:
+  - POS split ledger (#2020)
+  - Recharge business logic changes
+
+hints:
+  entry: "pages/crm/clientes/[id].vue wallet section"
+  tests: "UI-only; no automated front test"
+
+risk:
+  sensitive: false
+  areas: [crm-ui]
+
+next:
+  after_pr: "merge and pull main"

--- a/i18n/locales/ar/analitica.json
+++ b/i18n/locales/ar/analitica.json
@@ -358,7 +358,13 @@
         "error": "خطأ في تسجيل الشحن",
         "movementRecharge": "شحن",
         "movementRedeem": "استخدام في طلب",
-        "movementRefund": "استرداد"
+        "movementRefund": "استرداد",
+        "movementReceive": "شحن",
+        "movementApply": "استخدام في البيع",
+        "movementVoidApply": "إلغاء استخدام",
+        "colType": "النوع",
+        "colBalanceAfter": "الرصيد",
+        "empty": "لا توجد حركات محفظة"
       },
       "credit": {
         "title": "الذمم المدينة",

--- a/i18n/locales/de/analitica.json
+++ b/i18n/locales/de/analitica.json
@@ -358,7 +358,13 @@
         "error": "Fehler beim Registrieren der Aufladung",
         "movementRecharge": "Aufladung",
         "movementRedeem": "Nutzung bei Bestellung",
-        "movementRefund": "Rückerstattung"
+        "movementRefund": "Rückerstattung",
+        "movementReceive": "Aufladung",
+        "movementApply": "Verkaufsnutzung",
+        "movementVoidApply": "Nutzung storniert",
+        "colType": "Typ",
+        "colBalanceAfter": "Saldo",
+        "empty": "Keine Wallet-Bewegungen"
       },
       "credit": {
         "title": "Forderungen",

--- a/i18n/locales/en/analitica.json
+++ b/i18n/locales/en/analitica.json
@@ -364,7 +364,13 @@
         "error": "Error registering recharge",
         "movementRecharge": "Recharge",
         "movementRedeem": "Order use",
-        "movementRefund": "Refund"
+        "movementRefund": "Refund",
+        "movementReceive": "Recharge",
+        "movementApply": "Sale use",
+        "movementVoidApply": "Use voided",
+        "colType": "Type",
+        "colBalanceAfter": "Balance",
+        "empty": "No wallet movements"
       },
       "credit": {
         "title": "Accounts receivable",

--- a/i18n/locales/es/analitica.json
+++ b/i18n/locales/es/analitica.json
@@ -364,7 +364,13 @@
         "error": "Error al registrar la recarga",
         "movementRecharge": "Recarga",
         "movementRedeem": "Uso en pedido",
-        "movementRefund": "Devolución"
+        "movementRefund": "Devolución",
+        "movementReceive": "Recarga",
+        "movementApply": "Uso en venta",
+        "movementVoidApply": "Anulación de uso",
+        "colType": "Tipo",
+        "colBalanceAfter": "Saldo",
+        "empty": "Sin movimientos de billetera"
       },
       "credit": {
         "title": "Cartera",

--- a/i18n/locales/fr/analitica.json
+++ b/i18n/locales/fr/analitica.json
@@ -358,7 +358,13 @@
         "error": "Erreur lors de l'enregistrement de la recharge",
         "movementRecharge": "Recharge",
         "movementRedeem": "Utilisation en commande",
-        "movementRefund": "Remboursement"
+        "movementRefund": "Remboursement",
+        "movementReceive": "Recharge",
+        "movementApply": "Utilisation en vente",
+        "movementVoidApply": "Annulation d'utilisation",
+        "colType": "Type",
+        "colBalanceAfter": "Solde",
+        "empty": "Aucun mouvement de portefeuille"
       },
       "credit": {
         "title": "Comptes clients",

--- a/i18n/locales/hi/analitica.json
+++ b/i18n/locales/hi/analitica.json
@@ -358,7 +358,13 @@
         "error": "रिचार्ज दर्ज करने में त्रुटि",
         "movementRecharge": "रिचार्ज",
         "movementRedeem": "ऑर्डर में उपयोग",
-        "movementRefund": "वापसी"
+        "movementRefund": "वापसी",
+        "movementReceive": "रिचार्ज",
+        "movementApply": "बिक्री में उपयोग",
+        "movementVoidApply": "उपयोग रद्द",
+        "colType": "प्रकार",
+        "colBalanceAfter": "शेष",
+        "empty": "कोई वॉलेट मूवमेंट नहीं"
       },
       "credit": {
         "title": "प्राप्य खाते",

--- a/i18n/locales/pt/analitica.json
+++ b/i18n/locales/pt/analitica.json
@@ -358,7 +358,13 @@
         "error": "Erro ao registrar a recarga",
         "movementRecharge": "Recarga",
         "movementRedeem": "Uso no pedido",
-        "movementRefund": "Reembolso"
+        "movementRefund": "Reembolso",
+        "movementReceive": "Recarga",
+        "movementApply": "Uso na venda",
+        "movementVoidApply": "Anulação de uso",
+        "colType": "Tipo",
+        "colBalanceAfter": "Saldo",
+        "empty": "Sem movimentos da carteira"
       },
       "credit": {
         "title": "Contas a Receber",

--- a/i18n/locales/zh/analitica.json
+++ b/i18n/locales/zh/analitica.json
@@ -358,7 +358,13 @@
         "error": "充值登记失败",
         "movementRecharge": "充值",
         "movementRedeem": "订单使用",
-        "movementRefund": "退款"
+        "movementRefund": "退款",
+        "movementReceive": "充值",
+        "movementApply": "销售使用",
+        "movementVoidApply": "使用撤销",
+        "colType": "类型",
+        "colBalanceAfter": "余额",
+        "empty": "暂无钱包流水"
       },
       "credit": {
         "title": "应收账款",

--- a/pages/crm/clientes/[id].vue
+++ b/pages/crm/clientes/[id].vue
@@ -134,10 +134,16 @@ const paymentStatusLabel = (status: string) =>
     ? t('analitica.customerDetail.paymentStatus.partial')
     : t('analitica.customerDetail.paymentStatus.credit')
 const walletMovementLabel = (type: string) => {
-  if (type === 'recharge') return t('analitica.customerDetail.wallet.movementRecharge')
-  if (type === 'redeem') return t('analitica.customerDetail.wallet.movementRedeem')
-  if (type === 'refund') return t('analitica.customerDetail.wallet.movementRefund')
-  return type
+  const keyByType: Record<string, string> = {
+    receive: 'analitica.customerDetail.wallet.movementReceive',
+    recharge: 'analitica.customerDetail.wallet.movementRecharge',
+    apply: 'analitica.customerDetail.wallet.movementApply',
+    redeem: 'analitica.customerDetail.wallet.movementRedeem',
+    refund: 'analitica.customerDetail.wallet.movementRefund',
+    void_apply: 'analitica.customerDetail.wallet.movementVoidApply',
+  }
+  const key = keyByType[type]
+  return key ? t(key) : type
 }
 const statusColors: Record<string, string> = {
   completed: 'bg-green-100 text-green-800',
@@ -174,6 +180,13 @@ const carteraColumns = computed(() => [
   { key: 'due_date', title: t('analitica.customerDetail.credit.due'), sortable: false },
   { key: 'status_badge', title: t('analitica.customerDetail.status.title'), sortable: false },
   { key: 'cartera_actions', title: '', sortable: false },
+])
+
+const walletColumns = computed(() => [
+  { key: 'movement_type', title: t('analitica.customerDetail.wallet.colType'), sortable: false },
+  { key: 'created_at', title: t('analitica.common.date'), sortable: false },
+  { key: 'amount_cop', title: t('analitica.customerDetail.wallet.amount'), sortable: false },
+  { key: 'balance_after_cop', title: t('analitica.customerDetail.wallet.colBalanceAfter'), sortable: false },
 ])
 
 // Invoice slideover state
@@ -621,51 +634,83 @@ onUnmounted(() => {
           </div>
         </div>
 
-        <!-- Wallet COP section -->
-        <div class="border-t border-border px-5 py-4">
-          <div class="flex items-center justify-between gap-4">
-            <div>
-              <p class="text-xs text-text-secondary uppercase tracking-wider font-medium mb-0.5">{{ t('analitica.customerDetail.wallet.title') }}</p>
-              <p v-if="isLoadingWallet" class="text-sm font-semibold text-text-secondary">{{ t('common.loading') }}</p>
-              <p v-else-if="walletLoadError" class="text-sm font-semibold text-red-600">{{ t('analitica.customerDetail.wallet.loadError') }}</p>
-              <p v-else class="text-sm font-semibold text-primary">{{ formatCurrency(walletBalance) }}</p>
-            </div>
-            <button
-              type="button"
-              :aria-label="t('analitica.customerDetail.wallet.rechargeAria')"
-              @click="showWalletRechargeModal = true"
-              class="min-h-[44px] px-4 text-sm font-semibold rounded-lg border-2 border-primary/30 text-primary bg-primary/5 hover:bg-primary/10 transition-colors"
-            >
-              {{ t('analitica.customerDetail.wallet.recharge') }}
-            </button>
-          </div>
-          <div v-if="walletMovements.length" class="mt-3 space-y-2 max-h-40 overflow-y-auto">
-            <div
-              v-for="mov in walletMovements.slice(0, 5)"
-              :key="mov.id"
-              class="flex items-center justify-between gap-3 text-sm py-1.5 border-b border-border/50 last:border-0"
-            >
-              <div class="min-w-0">
-                <p class="text-text-primary font-medium">{{ walletMovementLabel(mov.movement_type) }}</p>
-                <p class="text-xs text-text-secondary">{{ formatDate(mov.created_at) }}</p>
-              </div>
-              <span
-                :class="[
-                  'font-semibold flex-shrink-0',
-                  mov.amount_cop >= 0 ? 'text-green-700' : 'text-red-600',
-                ]"
-              >
-                {{ mov.amount_cop >= 0 ? '+' : '' }}{{ formatCurrency(Math.abs(mov.amount_cop)) }}
-              </span>
-            </div>
-          </div>
-        </div>
       </div>
 
       <!-- Stats -->
       <div class="grid grid-cols-2 gap-4">
         <MetricCard :title="t('analitica.customerDetail.totalOrders')" :value="customer.total_orders" format="number" variant="primary" />
         <MetricCard :title="t('analitica.clientes.avgTicket')" :value="avgTicket" format="currency" variant="primary" />
+      </div>
+
+      <!-- Wallet COP Section -->
+      <div class="bg-white border border-border rounded-xl overflow-hidden">
+        <div class="px-5 py-4 border-b border-border flex items-center justify-between gap-3">
+          <div class="flex items-center gap-2 min-w-0">
+            <h3 class="text-sm font-bold text-text-primary uppercase tracking-wider">
+              {{ t('analitica.customerDetail.wallet.title') }}
+            </h3>
+            <span v-if="isLoadingWallet" class="text-sm text-text-secondary">{{ t('common.loading') }}</span>
+            <span v-else-if="walletLoadError" class="text-sm font-semibold text-red-600">{{ t('analitica.customerDetail.wallet.loadError') }}</span>
+            <span v-else class="text-lg font-bold text-primary">{{ formatCurrency(walletBalance) }}</span>
+          </div>
+          <button
+            type="button"
+            :aria-label="t('analitica.customerDetail.wallet.rechargeAria')"
+            @click="showWalletRechargeModal = true"
+            class="min-h-[36px] px-3 text-xs font-semibold rounded-lg bg-surface-secondary border-0 text-primary hover:bg-surface-secondary/80 transition-all focus:outline-none focus:ring-2 focus:ring-ring"
+          >
+            {{ t('analitica.customerDetail.wallet.recharge') }}
+          </button>
+        </div>
+        <UiResponsiveDataView
+          row-size="sm"
+          :columns="walletColumns"
+          :data="walletMovements"
+          :empty-message="t('analitica.customerDetail.wallet.empty')"
+          variant="default"
+        >
+          <template #card="{ item }">
+            <div class="p-4 border-b border-border">
+              <div class="flex justify-between items-start gap-3">
+                <div class="min-w-0">
+                  <p class="text-sm font-semibold text-text-primary">{{ walletMovementLabel(item.movement_type) }}</p>
+                  <p class="text-xs text-text-secondary mt-0.5">{{ formatDate(item.created_at) }}</p>
+                </div>
+                <span
+                  :class="[
+                    'text-sm font-semibold flex-shrink-0',
+                    item.amount_cop >= 0 ? 'text-green-700' : 'text-red-600',
+                  ]"
+                >
+                  {{ item.amount_cop >= 0 ? '+' : '−' }}{{ formatCurrency(Math.abs(item.amount_cop)) }}
+                </span>
+              </div>
+              <p class="text-xs text-text-secondary mt-2">
+                {{ t('analitica.customerDetail.wallet.colBalanceAfter') }}:
+                {{ formatCurrency(item.balance_after_cop) }}
+              </p>
+            </div>
+          </template>
+          <template #cell-movement_type="{ value }">
+            <span class="text-sm font-medium text-text-primary">{{ walletMovementLabel(value) }}</span>
+          </template>
+          <template #cell-created_at="{ value }">
+            <span class="text-sm text-text-secondary">{{ formatDate(value) }}</span>
+          </template>
+          <template #cell-amount_cop="{ value }">
+            <span
+              :class="[
+                'text-sm font-semibold',
+                value >= 0 ? 'text-green-700' : 'text-red-600',
+              ]"
+            >
+              {{ value >= 0 ? '+' : '−' }}{{ formatCurrency(Math.abs(value)) }}
+            </span>
+          </template>
+          <template #cell-balance_after_cop="{ value }">
+            <span class="text-sm text-text-primary">{{ formatCurrency(value) }}</span>
+          </template>
+        </UiResponsiveDataView>
       </div>
 
       <!-- Cartera Section -->

--- a/pages/crm/clientes/[id].vue
+++ b/pages/crm/clientes/[id].vue
@@ -663,6 +663,7 @@ onUnmounted(() => {
           </button>
         </div>
         <UiResponsiveDataView
+          v-if="!isLoadingWallet"
           row-size="sm"
           :columns="walletColumns"
           :data="walletMovements"


### PR DESCRIPTION
## Summary
- Rebuild CRM customer **Billetera COP** as a `UiResponsiveDataView` section (same pattern as Cartera / order history).
- Translate API movement types `receive` / `apply` / `void_apply` (keep recharge/redeem/refund aliases).
- Remove the 5-row mini-list cap; show movements returned by the wallet endpoint.

## Test plan
- [ ] Open `/crm/clientes/{id}` with wallet movements
- [ ] Confirm table/cards show type (localized), date, amount, balance after
- [ ] Confirm `receive`/`apply` are not raw English strings
- [ ] Confirm Recargar still works

## Validation evidence
UI-only change; no automated front test in repo for this page.

## wr-context
See `.wr/2021.yaml` on this branch (LLM contract).

Closes #2021

Made with [Cursor](https://cursor.com)