### PR TITLE
fix(pos): auto-email after FE on split + usable customer email

### DIFF
--- a/.wr/2025.yaml
+++ b/.wr/2025.yaml
@@ -1,0 +1,35 @@
+issue: 2025
+title: "fix(pos): auto-email after FE on split + usable customer email"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2025-auto-email-split-usable
+
+paths:
+  - pages/pos/checkout.vue
+
+ac:
+  - Split success calls applyReceiptEmailAfterSale (not blank email)
+  - Usable non-temp email autofills even when phone is 0000000000
+  - FE accepted + Matias auto-send when receiptEmail set
+  - Without FE autofill only; send-another kept
+
+out_of_scope:
+  - Non-Matias auto-send policy
+  - API receipt-email endpoint
+
+hints:
+  entry: "openSplitSuccessModal + applyReceiptEmailAfterSale"
+  pattern: "mesa/normal paths already call applyReceiptEmailAfterSale before clearAll"
+  tests: "manual: split + customer email → emit FE → auto-send"
+
+risk:
+  sensitive: false
+  areas: [pos-checkout]
+
+skip:
+  audits: [color, typography, ux]
+
+next:
+  after_pr: "merge when approved"

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1085,10 +1085,8 @@ function openSplitSuccessModal(completeData: Record<string, any>) {
     ...waroOrderResultFields(completeData.waro_redemption_summary, cartTotal.value),
   }
   cartItemsSnapshot.value = snapshotCartItemsForReceipt()
-  receiptEmail.value = ''
-  emailSent.value = false
-  lastSentEmail.value = ''
-  emailFromProfile.value = false
+  // Same email prep as normal/mesa success — required for FE auto-send (#2025)
+  applyReceiptEmailAfterSale(selectedCustomer.value)
   splitMode.value = false
   posStore.clearAll()
   showSuccessModal.value = true
@@ -1336,24 +1334,22 @@ const selectedWaroReward = ref<WaroReward | null>(null)
 const warosBalance = computed(() => warosSummary.value?.current_balance ?? 0)
 const isAnonymousCustomer = computed(() => selectedCustomer.value?.phone_number === '0000000000')
 
-/** Same rule as InvoiceEmailModal (#603 / #1763): Genérico walk-in must not lock receipt email. */
-function isGenericReceiptCustomer(customer: { phone_number?: string | null; email?: string | null } | null | undefined): boolean {
-  if (!customer) return true
-  const phone = customer.phone_number ?? ''
-  const email = (customer.email ?? '').toLowerCase()
-  return phone === '0000000000' || email.endsWith('@customer.temp')
+/** Usable receipt email: real address only (ignore walk-in @customer.temp). */
+function usableReceiptEmail(customer: { email?: string | null } | null | undefined): string {
+  const email = (customer?.email ?? '').trim()
+  if (!email || email.toLowerCase().endsWith('@customer.temp')) return ''
+  return email
 }
 
+/**
+ * Prefill Venta Completada email from the selected customer (#1893 / #2025).
+ * Prefer a usable email even when phone is the Genérico placeholder `0000000000`
+ * (cashier selected Genérico but filled a real email, or profile was updated).
+ */
 function applyReceiptEmailAfterSale(customer: { phone_number?: string | null; email?: string | null } | null | undefined) {
   emailSent.value = false
   lastSentEmail.value = ''
-  if (isGenericReceiptCustomer(customer)) {
-    receiptEmail.value = ''
-    emailFromProfile.value = false
-    return
-  }
-  const email = customer?.email ?? ''
-  const usable = email && !email.toLowerCase().endsWith('@customer.temp') ? email : ''
+  const usable = usableReceiptEmail(customer)
   receiptEmail.value = usable
   emailFromProfile.value = !!usable
 }


### PR DESCRIPTION
## Summary
- Split Venta Completada now prefills receipt email like normal/mesa sales
- Usable (non-`@customer.temp`) email is kept even when phone is `0000000000`
- Unblocks CO FE auto-send (`maybeAutoSendInvoiceEmailAfterFe`) after emit

Closes #2025

## Test plan
- [ ] Split sale + customer with real email → emit FE → email auto-sends
- [ ] Genérico phone `0000000000` but real email on profile → field autofilled / auto-send
- [ ] Temp `@customer.temp` only → no autofill; toast if FE accepted without email
- [ ] After send, can still send to another recipient

## Validation evidence
```
Manual UI path on /pos/checkout (no unit test for this panel)
Diff: openSplitSuccessModal → applyReceiptEmailAfterSale; usableReceiptEmail ignores phone gate
```

## wr-context
See `.wr/2025.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)