### PR TITLE
fix(facturacion): sync Impuestos tax_lines on fiscal save

### DIFF
--- a/.wr/2031.yaml
+++ b/.wr/2031.yaml
@@ -1,0 +1,31 @@
+# Machine contract for wr-fast — keep ≤80 lines.
+issue: 2031
+title: "Facturación: sync sales tax profile and Impuestos tax_lines in one save"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2031-tax-profile-tax-lines-sync
+risk: low
+
+paths:
+  - pages/facturacion/index.vue
+  - composables/useTenantTaxProfile.ts
+  - composables/useTenantTaxProfile.test.ts
+
+ac:
+  - saveFiscalData (CO) also PUTs tax-config with rebuilt tax_lines in one flow
+  - buildCoTaxSavePayload remaps stale iva↔inc menu keys to active primary
+  - Liquor/custom lines preserved; fiscal save does not require liquor category mapping
+
+out_of_scope:
+  - Commercial tax UI
+  - Impuestos copy / layout changes
+
+hints:
+  entry: "saveFiscalData after fiscal PUT → buildCoTaxLinesDraft + buildCoTaxSavePayload"
+  pattern: "mirror Impuestos CO save without liquor-category toast gate"
+  tests: "bunx vitest run composables/useTenantTaxProfile.test.ts"
+
+skip:
+  audits: [ux, color, typography]

--- a/composables/useTenantTaxProfile.test.ts
+++ b/composables/useTenantTaxProfile.test.ts
@@ -382,7 +382,7 @@ describe('useTenantTaxProfile', () => {
       menu_category_line_map: {
         [catA]: 'liquor',
         [catB]: 'iva',
-        [catC]: 'inc', // dropped — INC not active
+        [catC]: 'inc', // remapped to active primary (#2031)
         '': 'iva',
       },
       exempt_menu_category_ids: [catB],
@@ -390,8 +390,61 @@ describe('useTenantTaxProfile', () => {
     expect(body.menu_category_line_map).toEqual({
       [catA]: 'liquor',
       [catB]: 'iva',
+      [catC]: 'iva',
     })
     expect(body.exempt_menu_category_ids).toEqual([catB])
+  })
+
+  it('syncs IVA→INC tax_lines and remaps menu primary (#2031)', () => {
+    const catA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    const catB = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+    const lines = buildCoTaxLinesDraft({
+      inc_applicable: true,
+      iva_applicable: false,
+      liquor_tax_applicable: true,
+      iva_rate: 0.19,
+      inc_rate: 0.08,
+      liquor_tax_rate: 0.05,
+      iva_included_in_price: true,
+      inc_included_in_price: true,
+      liquor_tax_included_in_price: true,
+      custom_lines: [{
+        key: 'bebidas',
+        label: 'Bebidas 5%',
+        rate: 0.05,
+        included_in_price: true,
+        gl_role: 'iva',
+        mode: 'alternate',
+        exclusive_group: 'vat',
+      }],
+    })
+    expect(lines.map(l => l.key)).toEqual(['inc', 'liquor', 'bebidas'])
+    const body = buildCoTaxSavePayload({
+      inc_applicable: true,
+      inc_included_in_price: true,
+      iva_applicable: false,
+      iva_included_in_price: true,
+      liquor_tax_applicable: true,
+      liquor_tax_included_in_price: true,
+      iva_rate: 0.19,
+      inc_rate: 0.08,
+      liquor_tax_rate: 0.05,
+      tax_lines: lines,
+      menu_category_line_map: {
+        [catA]: 'iva',
+        [catB]: 'liquor',
+      },
+    })
+    expect((body.tax_lines as { key: string }[]).map(l => l.key)).toEqual(['inc', 'liquor', 'bebidas'])
+    expect(body.category_map).toEqual({
+      standard: 'inc',
+      liquor: 'liquor',
+      exempt: null,
+    })
+    expect(body.menu_category_line_map).toEqual({
+      [catA]: 'inc',
+      [catB]: 'liquor',
+    })
   })
 
   it('uses menu-category tax UI for commercial tax_lines and CO columns (#1885 / #1994)', () => {

--- a/composables/useTenantTaxProfile.ts
+++ b/composables/useTenantTaxProfile.ts
@@ -513,6 +513,12 @@ export function buildCoTaxSavePayload(options: {
     for (const line of tax_lines) allowedKeys.add(line.key)
   }
 
+  const primaryKey = options.inc_applicable
+    ? 'inc'
+    : (options.iva_applicable ? 'iva' : null)
+  const legacyPrimary = primaryKey === 'inc' ? 'iva' : (primaryKey === 'iva' ? 'inc' : null)
+
+  // Remap stale iva↔inc menu keys when Perfil de ventas flips (#2031).
   const menu_category_line_map: Record<string, string | null> = {}
   for (const [catId, lineKey] of Object.entries(options.menu_category_line_map || {})) {
     const id = String(catId || '').trim()
@@ -521,14 +527,15 @@ export function buildCoTaxSavePayload(options: {
       menu_category_line_map[id] = null
       continue
     }
-    const key = String(lineKey)
+    let key = String(lineKey)
+    if (legacyPrimary && key === legacyPrimary && primaryKey) {
+      key = primaryKey
+    } else if ((key === 'iva' || key === 'inc') && primaryKey && key !== primaryKey) {
+      key = primaryKey
+    }
     if (!allowedKeys.has(key)) continue
     menu_category_line_map[id] = key
   }
-
-  const primaryKey = options.inc_applicable
-    ? 'inc'
-    : (options.iva_applicable ? 'iva' : null)
   const category_map = options.category_map
     ? {
         standard: resolveCategoryMapValue(options.category_map.standard, primaryKey),

--- a/pages/facturacion/index.vue
+++ b/pages/facturacion/index.vue
@@ -1104,6 +1104,39 @@ const saveFiscalData = async () => {
         matias_company_id: fiscalForm.matias_company_id.trim(),
       },
     })
+    // #2031 — same as commercial: one save keeps Impuestos tax_lines aligned.
+    // Do not require liquor category mapping here (Impuestos owns that UX).
+    if (!isWaroCommercial.value) {
+      const tax_lines = buildCoTaxLinesDraft({
+        inc_applicable: taxForm.inc_applicable,
+        iva_applicable: taxForm.iva_applicable,
+        liquor_tax_applicable: taxForm.liquor_tax_applicable,
+        iva_rate: Math.max(0, Number(taxForm.iva_rate_pct) || 0) / 100,
+        inc_rate: Math.max(0, Number(taxForm.inc_rate_pct) || 0) / 100,
+        liquor_tax_rate: Math.max(0, Number(taxForm.liquor_tax_rate_pct) || 0) / 100,
+        iva_included_in_price: taxForm.iva_included_in_price,
+        inc_included_in_price: taxForm.inc_included_in_price,
+        liquor_tax_included_in_price: taxForm.liquor_tax_included_in_price,
+        custom_lines: coCustomLinesToDraft(),
+      })
+      await $fetch('/api/api/tenant/tax-config', {
+        method: 'PUT',
+        body: buildCoTaxSavePayload({
+          inc_applicable: taxForm.inc_applicable,
+          inc_included_in_price: taxForm.inc_included_in_price,
+          iva_applicable: taxForm.iva_applicable,
+          iva_included_in_price: taxForm.iva_included_in_price,
+          liquor_tax_applicable: taxForm.liquor_tax_applicable,
+          liquor_tax_included_in_price: taxForm.liquor_tax_included_in_price,
+          iva_rate: Math.max(0, Number(taxForm.iva_rate_pct) || 0) / 100,
+          inc_rate: Math.max(0, Number(taxForm.inc_rate_pct) || 0) / 100,
+          liquor_tax_rate: Math.max(0, Number(taxForm.liquor_tax_rate_pct) || 0) / 100,
+          menu_category_line_map: { ...menuCategoryLineMap.value },
+          exempt_menu_category_ids: [...exemptMenuCategoryIds.value],
+          tax_lines,
+        }),
+      })
+    }
     await refreshFiscal()
     await refreshTaxConfig()
     invalidateReadiness()


### PR DESCRIPTION
## Summary
- `saveFiscalData` (CO) also PUTs tax-config with rebuilt `tax_lines` (liquor/custom preserved; no liquor-category gate)
- `buildCoTaxSavePayload` remaps stale `iva`↔`inc` menu keys to the active primary
- Vitest coverage for IVA→INC sync payload

Closes #2031

Companion API: https://github.com/uno0uno/api-warolabs/pull/768

## Test plan
- [x] `bunx vitest run composables/useTenantTaxProfile.test.ts` (41 passed)
- [ ] Manual: Datos fiscales flip IVA→INC → Guardar once → Impuestos/POS show INC without second Impuestos save

## wr-context
See `.wr/2031.yaml` on this branch.

Made with [Cursor](https://cursor.com)