### PR TITLE
fix(print): treat CUPS status-gone as bridge success

### DIFF
--- a/composables/useLocalPrintBridge.test.ts
+++ b/composables/useLocalPrintBridge.test.ts
@@ -6,6 +6,7 @@ import {
   buildEscPosTestTicketBytes,
   bytesToBase64,
   createLocalPrintBridge,
+  isCupsJobStatusGoneSoftSuccess,
   normalizePrinterList,
 } from './useLocalPrintBridge'
 
@@ -146,6 +147,21 @@ describe('createLocalPrintBridge', () => {
     await expect(bridge.printHtml('STAR', '  ')).rejects.toMatchObject({ code: 'INVALID' })
   })
 
+  it('isCupsJobStatusGoneSoftSuccess detects Star/CUPS purge message', () => {
+    expect(isCupsJobStatusGoneSoftSuccess(
+      'unknown',
+      'CUPS job status was no longer available',
+    )).toBe(true)
+    expect(isCupsJobStatusGoneSoftSuccess(
+      'Unable to confirm next status',
+      'CUPS job status was no longer available',
+    )).toBe(true)
+    expect(isCupsJobStatusGoneSoftSuccess(
+      'unknown',
+      'Unable to send data to printer.',
+    )).toBe(false)
+  })
+
   it('rejects when status stream reports unknown/failed after queued accept', async () => {
     let statusHandler: ((event: { requestId?: string; status?: string; message?: string }) => void) | null = null
     const printSpy = mock(async (job: Record<string, unknown>) => {
@@ -172,6 +188,32 @@ describe('createLocalPrintBridge', () => {
         code: 'PRINT_FAILED',
         message: expect.stringContaining('Unable to send data to printer'),
       })
+  })
+
+  it('resolves when CUPS purges job status after submit (no window.print fallback)', async () => {
+    let statusHandler: ((event: { requestId?: string; status?: string; message?: string }) => void) | null = null
+    const printSpy = mock(async (job: Record<string, unknown>) => {
+      const requestId = String(job.requestId)
+      queueMicrotask(() => statusHandler?.({ requestId, status: 'queued' }))
+      queueMicrotask(() => statusHandler?.({ requestId, status: 'submitted' }))
+      queueMicrotask(() => statusHandler?.({
+        requestId,
+        status: 'unknown',
+        message: 'CUPS job status was no longer available',
+      }))
+      return { status: 'queued', requestId }
+    })
+    __setLocalPrintBridgeClientForTests({
+      ...mockClient({ print: printSpy }),
+      on: mock((_event: 'status', handler: typeof statusHandler) => {
+        statusHandler = handler
+        return () => { statusHandler = null }
+      }),
+    })
+
+    const bridge = createLocalPrintBridge()
+    await bridge.printRawEscPos('STAR_TP586', buildEscPosTestTicketBytes('ok'))
+    expect(printSpy).toHaveBeenCalledTimes(1)
   })
 
   it('resolves when status stream reports completed', async () => {

--- a/composables/useLocalPrintBridge.ts
+++ b/composables/useLocalPrintBridge.ts
@@ -48,6 +48,22 @@ function newPrintRequestId(): string {
 }
 
 /**
+ * Star/CUPS often purges the job right after accept. PrintBridge then emits
+ * `unknown` + "CUPS job status was no longer available". That is not a print
+ * failure — treating it as one caused thermal + window.print double tickets.
+ * Real offline failures use other messages (e.g. "Unable to send data…").
+ */
+export function isCupsJobStatusGoneSoftSuccess(
+  status: string,
+  message?: string | null,
+): boolean {
+  const msg = String(message || '').toLowerCase()
+  if (!msg.includes('cups job status was no longer available')) return false
+  const s = String(status || '').toLowerCase()
+  return s === 'unknown' || s.includes('unable to confirm') || s === ''
+}
+
+/**
  * SDK `print()` resolves on `queued` only. Wait for a terminal job status so
  * offline thermals reject and callers can fall back to window.print (#2003).
  * Clients without `on` keep queued-accept behavior (tests / stubs).
@@ -62,7 +78,14 @@ export function waitForPrintTerminalStatus(
     const off = client.on!('status', (event) => {
       if (String(event?.requestId || '') !== requestId) return
       const status = String(event?.status || '')
+      const message = event?.message
       if (PRINT_SUCCESS_STATUSES.has(status)) {
+        off()
+        resolve()
+        return
+      }
+      // CUPS purged job after submit (Star thermal) — accept as success.
+      if (isCupsJobStatusGoneSoftSuccess(status, message)) {
         off()
         resolve()
         return
@@ -72,7 +95,7 @@ export function waitForPrintTerminalStatus(
         reject(
           new LocalPrintBridgeError(
             'PRINT_FAILED',
-            event?.message?.trim() || `Print ended with status ${status}`,
+            message?.trim() || `Print ended with status ${status}`,
           ),
         )
       }


### PR DESCRIPTION
## Summary
- PrintBridge often reports `unknown` + `CUPS job status was no longer available` after Star thermals print successfully (CUPS purges the job).
- WARO treated that as `PRINT_FAILED` → caja/station fallback called `window.print` **after** the thermal already printed (double ticket).
- Soft-succeed on that specific CUPS purge message; keep real failures (e.g. Unable to send data) as fail → browser fallback.

## Test plan
- [ ] Probar on Impresoras: ticket prints, green success toast (no red CUPS error)
- [ ] POS receipt: thermal only — no browser print dialog after success
- [ ] Unplug / disabled printer with hard fail message still falls back to window.print

## Validation evidence
```
bun test composables/useLocalPrintBridge.test.ts composables/useCajaTicketPrint.test.ts
17 pass 0 fail
```

Made with [Cursor](https://cursor.com)