### PR TITLE
fix(receipt): indent tax detail lines like adicionales

### DIFF
--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -4,6 +4,7 @@ import { consolidateReceiptPrintLines } from '~/utils/receiptPrintLines'
 import {
   formatReceiptModifierBlock,
   formatReceiptProductBlock,
+  formatReceiptTaxBulletLine,
   formatReceiptTaxCue,
   padReceiptLine,
   receiptDivider,
@@ -174,6 +175,13 @@ const moneyLine = (label: string, amount: number | string | null | undefined, ne
   const amt = compactThermalMoneyLabel(money(amount))
   return padReceiptLine(label, negative ? `-${amt}` : amt)
 }
+
+const taxBulletLine = (label: string, amount: number | string | null | undefined) =>
+  formatReceiptTaxBulletLine({
+    label,
+    amountLabel: money(amount),
+  })
+
 
 const dashDivider = receiptDivider()
 const strongDivider = receiptDivider(32, '=')
@@ -377,10 +385,10 @@ const printableItems = computed(() =>
     <template v-if="hasTaxBreakdown">
       <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.taxDetail') }}</div>
       <div v-if="Number(standardTax) > 0" class="receipt-plain-line receipt-small">
-        {{ moneyLine(displayStandardTaxLabel, standardTax) }}
+        {{ taxBulletLine(displayStandardTaxLabel, standardTax) }}
       </div>
       <div v-if="Number(liquorTax) > 0" class="receipt-plain-line receipt-small">
-        {{ moneyLine(displayLiquorTaxLabel, liquorTax) }}
+        {{ taxBulletLine(displayLiquorTaxLabel, liquorTax) }}
       </div>
     </template>
 
@@ -477,7 +485,7 @@ const printableItems = computed(() =>
           :key="`${line.label ?? 'tax'}-${idx}`"
           class="receipt-plain-line receipt-small"
         >
-          {{ moneyLine(
+          {{ taxBulletLine(
             [
               line.label || t('pos.checkout.taxFallback'),
               formatRate(line.rate),

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -22,6 +22,7 @@ import { buildReceiptTicketItems, consolidateReceiptPrintLines } from '~/utils/r
 import {
   formatReceiptModifierBlock,
   formatReceiptProductBlock,
+  formatReceiptTaxBulletLine,
   formatReceiptTaxCue,
   padReceiptLine,
   receiptDivider,
@@ -1948,6 +1949,13 @@ const prefacturaMoneyLine = (label: string, amount: number | string, negative = 
   const amt = compactThermalMoneyLabel(formatCurrencyThermal(amount))
   return padReceiptLine(label, negative ? `-${amt}` : amt)
 }
+
+const prefacturaTaxBulletLine = (label: string, amount: number | string) =>
+  formatReceiptTaxBulletLine({
+    label,
+    amountLabel: formatCurrencyThermal(amount),
+  })
+
 
 const prefacturaProductBlock = (item: any) =>
   formatReceiptProductBlock({
@@ -5635,10 +5643,10 @@ onUnmounted(() => {
       {{ prefacturaMoneyLine(prefacturaPrintData.waroRewardName ? `WaRo: ${prefacturaPrintData.waroRewardName}` : t('pos.receipt.waroRedeem'), prefacturaPrintData.waroDiscountCop, true) }}
     </div>
     <div v-if="taxPreview && taxPreview.standard_tax > 0" class="receipt-plain-line">
-      {{ prefacturaMoneyLine(localizedInternalTaxLabel(taxPreview.standard_tax_label), taxPreview.standard_tax) }}
+      {{ prefacturaTaxBulletLine(localizedInternalTaxLabel(taxPreview.standard_tax_label), taxPreview.standard_tax) }}
     </div>
     <div v-if="taxPreview && taxPreview.liquor_tax > 0" class="receipt-plain-line">
-      {{ prefacturaMoneyLine(taxPreview.liquor_tax_label || t('pos.receipt.liquorVat'), taxPreview.liquor_tax) }}
+      {{ prefacturaTaxBulletLine(taxPreview.liquor_tax_label || t('pos.receipt.liquorVat'), taxPreview.liquor_tax) }}
     </div>
     <!-- warocol.com#739 + #939 — pre-bill totals include tip, advance, and split settlement when applicable -->
     <template v-if="prefacturaPrintData.tipAmount > 0 || prefacturaPrintData.advanceApplied > 0">
@@ -5786,13 +5794,11 @@ onUnmounted(() => {
     </div>
     <template v-if="orderResult?.standard_tax && orderResult.standard_tax > 0 || orderResult?.liquor_tax && orderResult.liquor_tax > 0">
 	      <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.taxDetail') }}</div>
-      <div v-if="orderResult?.standard_tax && orderResult.standard_tax > 0" class="receipt-item receipt-small">
-        <span>{{ localizedInternalTaxLabel(orderResult.standard_tax_label) }}</span>
-        <span>{{ formatCurrencyThermal(orderResult.standard_tax) }}</span>
+      <div v-if="orderResult?.standard_tax && orderResult.standard_tax > 0" class="receipt-plain-line receipt-small">
+        {{ prefacturaTaxBulletLine(localizedInternalTaxLabel(orderResult.standard_tax_label), orderResult.standard_tax) }}
       </div>
-      <div v-if="orderResult?.liquor_tax && orderResult.liquor_tax > 0" class="receipt-item receipt-small">
-	        <span>{{ localizedInternalTaxLabel(orderResult.liquor_tax_label) || t('pos.receipt.liquorVat') }}</span>
-        <span>{{ formatCurrencyThermal(orderResult.liquor_tax) }}</span>
+      <div v-if="orderResult?.liquor_tax && orderResult.liquor_tax > 0" class="receipt-plain-line receipt-small">
+	        {{ prefacturaTaxBulletLine(localizedInternalTaxLabel(orderResult.liquor_tax_label) || t('pos.receipt.liquorVat'), orderResult.liquor_tax) }}
       </div>
     </template>
     <!-- warocol.com#739 — printed receipt mirrors success modal + split payments -->

--- a/utils/receiptTicketPlainText.test.ts
+++ b/utils/receiptTicketPlainText.test.ts
@@ -3,6 +3,7 @@ import {
   compactThermalMoneyLabel,
   formatReceiptModifierBlock,
   formatReceiptProductBlock,
+  formatReceiptTaxBulletLine,
   formatReceiptTaxCue,
   padReceiptLine,
   receiptDivider,
@@ -138,6 +139,18 @@ describe('formatReceiptModifierBlock', () => {
     expect(block).toContain('$9.000,00')
     expect(block).toContain('$27.000,00')
     expect(lines[1]?.startsWith('  ')).toBe(true)
+  })
+})
+
+describe('formatReceiptTaxBulletLine', () => {
+  it('indents tax lines with + like adicionales', () => {
+    const line = formatReceiptTaxBulletLine({
+      label: 'INC 8%',
+      amountLabel: '$ COP 800,00',
+    })
+    expect(line).toMatch(/^\s{2}\+ INC 8%/)
+    expect(line).toContain('$800,00')
+    expect(line).not.toContain('...')
   })
 })
 

--- a/utils/receiptTicketPlainText.ts
+++ b/utils/receiptTicketPlainText.ts
@@ -182,3 +182,22 @@ export function formatReceiptModifierBlock(opts: {
   const left = qty > 1 ? `${qty} x ${unit}` : unit
   return `${indent}${desc}\n${padReceiptLine(`${indent}${left}`, total, cols)}`
 }
+
+/**
+ * Tax / tributary breakdown line — same indent + bullet as adicionales
+ * so Detalle de impuestos / Detalle tributario matches prefatura/factura modifiers.
+ */
+export function formatReceiptTaxBulletLine(opts: {
+  label: string
+  amountLabel: string
+  cols?: number
+  indent?: string
+}): string {
+  const cols = opts.cols ?? RECEIPT_THERMAL_COLS
+  const indent = opts.indent ?? RECEIPT_MODIFIER_INDENT
+  let label = String(opts.label ?? '').trim()
+  if (label.startsWith('+')) label = label.slice(1).trim()
+  const left = label ? `${indent}+ ${label}` : indent
+  const right = compactThermalMoneyLabel(opts.amountLabel)
+  return padReceiptLine(left, right, cols)
+}


### PR DESCRIPTION
## Summary
- Tax / tributary breakdown lines on prefatura and factura now use the same indented `+` bullet style as adicionales (modifiers).
- Shared helper `formatReceiptTaxBulletLine` in `receiptTicketPlainText`.

## Test plan
- [ ] Prefactura with INC/IVA: under Detalle de impuestos, lines show `  + INC…` aligned like modifiers
- [ ] Factura / receipt with FE tax lines: Detalle tributario same indent
- [ ] Modifiers still print as before

## Validation evidence
```
bun test utils/receiptTicketPlainText.test.ts
15 pass 0 fail
```

Made with [Cursor](https://cursor.com)