### PR TITLE
fix(pos): indent product tax cues and drop Incluye

### DIFF
--- a/.wr/2042.yaml
+++ b/.wr/2042.yaml
@@ -1,0 +1,44 @@
+# Compact plan for wr-fast #2042
+issue: 2042
+title: "fix(pos): indent product-line tax cues and drop Incluye on receipts/checkout"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2042-product-tax-cue
+
+paths:
+  - utils/receiptTicketPlainText.ts
+  - utils/receiptTicketPlainText.test.ts
+  - components/pos/ReceiptPrintTicket.vue
+  - pages/pos/checkout.vue
+  - .wr/2042.yaml
+
+ac:
+  - Prefatura/factura product tax cue indented like adicionales (e.g. "  + IVA 19% · $X")
+  - Checkout order details same indent + no "Incluye"
+  - Always taxLine "{label} · {amount}" whether included-in-price or exclusive
+  - Exempt/label-only still works with indent under product
+  - Detalle de impuestos bullet style unchanged
+  - Unit tests cover no-Incluye + indent
+
+out_of_scope:
+  - Fiscal calc / API
+  - Detalle de impuestos redesign
+  - POS cart outside checkout
+  - Logo / brand assets
+
+hints:
+  entry: "formatReceiptProductBlock taxCue; formatLineTaxDisplay; productTaxCue"
+  pattern: "utils/receiptTicketPlainText.ts:formatReceiptModifierBlock indent+bullet"
+  tests: "bun test utils/receiptTicketPlainText.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "wr-review then human merge"

--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -146,9 +146,7 @@ const productTaxCue = (item: ReceiptItem) => {
   if (hasAmount) {
     const amountLabel = compactThermalMoneyLabel(money(amount))
     return formatReceiptTaxCue({
-      text: item.includedInPrice === true
-        ? t('pos.cartItem.taxIncluded', { label, amount: amountLabel })
-        : t('pos.cartItem.taxLine', { label, amount: amountLabel }),
+      text: t('pos.cartItem.taxLine', { label, amount: amountLabel }),
     })
   }
   return formatReceiptTaxCue({ label })

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1783,12 +1783,9 @@ const getLineTaxInfo = (item: any): { amount: number; label: string; includedInP
 }
 
 const formatLineTaxDisplay = (info: { amount: number; label: string; includedInPrice: boolean }): string => {
-  if (info.amount <= 0) return info.label
+  if (info.amount <= 0) return `+ ${info.label}`
   const amount = formatCurrency(info.amount)
-  if (info.includedInPrice) {
-    return t('pos.cartItem.taxIncluded', { label: info.label, amount })
-  }
-  return t('pos.cartItem.taxLine', { label: info.label, amount })
+  return `+ ${t('pos.cartItem.taxLine', { label: info.label, amount })}`
 }
 
 const lineTaxCueForPrint = (item: any): string | null => {
@@ -1803,18 +1800,11 @@ const lineTaxCueForPrint = (item: any): string | null => {
   const amount = Number.isFinite(mergedAmount) && mergedAmount > 0
     ? mergedAmount
     : (info?.amount ?? 0)
-  const includedInPrice = info?.includedInPrice
-    ?? item.included_in_price
-    ?? item.includedInPrice
-    ?? false
   const labelFinal = label || info!.label
   if (amount > 0) {
     const amountLabel = compactThermalMoneyLabel(formatCurrencyThermal(amount))
-    // Pass interpolated i18n text — never t('taxIncluded') as a .replace template.
     return formatReceiptTaxCue({
-      text: includedInPrice
-        ? t('pos.cartItem.taxIncluded', { label: labelFinal, amount: amountLabel })
-        : t('pos.cartItem.taxLine', { label: labelFinal, amount: amountLabel }),
+      text: t('pos.cartItem.taxLine', { label: labelFinal, amount: amountLabel }),
     })
   }
   return formatReceiptTaxCue({ label: labelFinal })

--- a/utils/receiptTicketPlainText.test.ts
+++ b/utils/receiptTicketPlainText.test.ts
@@ -53,13 +53,13 @@ describe('padReceiptLine', () => {
 })
 
 describe('formatReceiptTaxCue', () => {
-  it('formats included and exclusive tax with amount', () => {
+  it('formats tax with amount using taxLine style (never Incluye)', () => {
     expect(formatReceiptTaxCue({
       label: 'IVA 19%',
       amountLabel: '$ COP 1.900,00',
       includedInPrice: true,
       includedTemplate: 'Incluye {label} · {amount}',
-    })).toBe('Incluye IVA 19% · $1.900,00')
+    })).toBe('IVA 19% · $1.900,00')
     expect(formatReceiptTaxCue({
       label: 'IVA 16%',
       amountLabel: '$160',
@@ -74,21 +74,19 @@ describe('formatReceiptTaxCue', () => {
 
   it('accepts pre-localized text from vue-i18n t(key, params)', () => {
     expect(formatReceiptTaxCue({
-      text: 'Incluye IVA 19% · $2.076,00',
-    })).toBe('Incluye IVA 19% · $2.076,00')
+      text: 'IVA 19% · $2.076,00',
+    })).toBe('IVA 19% · $2.076,00')
   })
 
-  it('recovers when i18n emptied template placeholders (Incluye ·)', () => {
+  it('recovers when i18n emptied template placeholders', () => {
     expect(formatReceiptTaxCue({
       label: 'IVA 19%',
       amountLabel: '$2.076,00',
-      includedInPrice: true,
-      includedTemplate: 'Incluye ·',
-    })).toBe('Incluye IVA 19% · $2.076,00')
+      exclusiveTemplate: '·',
+    })).toBe('IVA 19% · $2.076,00')
     expect(formatReceiptTaxCue({
       label: 'IVA licores 5%',
       amountLabel: '$1.500,00',
-      includedInPrice: false,
       exclusiveTemplate: '·',
     })).toBe('IVA licores 5% · $1.500,00')
   })
@@ -110,18 +108,19 @@ describe('formatReceiptProductBlock', () => {
     expect(block).toContain('$585.000,00')
   })
 
-  it('appends per-line tax declaration under the qty/total row', () => {
+  it('appends indented per-line tax cue under the qty/total row', () => {
     const block = formatReceiptProductBlock({
       name: 'Agua',
       quantity: 1,
       unitPriceLabel: '$3.500',
       lineTotalLabel: '$3.500',
-      taxCue: 'Incluye INC · $280',
+      taxCue: 'INC · $280',
     })
     const lines = block.split('\n')
     expect(lines[0]).toBe('Agua')
     expect(lines[1]).toContain('1 x')
-    expect(lines[2]).toBe('Incluye INC · $280')
+    expect(lines[2]).toBe('  + INC · $280')
+    expect(block).not.toMatch(/Incluye/i)
   })
 })
 

--- a/utils/receiptTicketPlainText.ts
+++ b/utils/receiptTicketPlainText.ts
@@ -110,19 +110,22 @@ export function collectThermalTicketText(root: Element | null | undefined): stri
 /**
  * Compact per-line tax declaration for thermal / window.print.
  * Amount line when taxed; bare label for exempt / label-only.
+ * Always `{label} · {amount}` — never “Incluye …” wording.
  *
- * Prefer passing `text` from `t('…', { label, amount })` — vue-i18n already
- * interpolates placeholders, so do NOT pass `t('taxIncluded')` as a template
- * (that yields "Incluye ·" with empty slots).
+ * Prefer passing `text` from `t('pos.cartItem.taxLine', { label, amount })`.
+ * Do not pass broken i18n templates (empty placeholders).
  */
 export function formatReceiptTaxCue(opts: {
   label?: string | null
   amountLabel?: string | null
+  /** @deprecated Ignored — included-in-price no longer changes copy. */
   includedInPrice?: boolean | null
   /** Pre-localized full cue (preferred). */
   text?: string | null
+  /** @deprecated Ignored — use `template` / taxLine only. */
   includedTemplate?: string
   exclusiveTemplate?: string
+  template?: string
 }): string | null {
   const preformatted = String(opts.text ?? '').trim()
   if (preformatted) return preformatted
@@ -132,15 +135,22 @@ export function formatReceiptTaxCue(opts: {
   const amount = compactThermalMoneyLabel(String(opts.amountLabel ?? '').trim())
   if (!amount) return label
 
-  // Templates must still contain `{label}` / `{amount}`. If vue-i18n already
-  // emptied them ("Incluye ·"), rebuild from safe defaults.
-  let template = opts.includedInPrice
-    ? (opts.includedTemplate || 'Incluye {label} · {amount}')
-    : (opts.exclusiveTemplate || '{label} · {amount}')
+  let template = opts.template || opts.exclusiveTemplate || '{label} · {amount}'
   if (!template.includes('{label}') || !template.includes('{amount}')) {
-    template = opts.includedInPrice ? 'Incluye {label} · {amount}' : '{label} · {amount}'
+    template = '{label} · {amount}'
   }
   return template.replaceAll('{label}', label).replaceAll('{amount}', amount)
+}
+
+/** Indent product tax cue like adicionales (`  + …`). */
+export function formatReceiptProductTaxCueLine(
+  cue: string,
+  indent: string = RECEIPT_MODIFIER_INDENT,
+): string {
+  let text = String(cue ?? '').trim()
+  if (!text) return ''
+  if (text.startsWith('+')) text = text.slice(1).trim()
+  return `${indent}+ ${text}`
 }
 
 /** Product name on its own line; qty x unit … total padded (compact money). */
@@ -159,7 +169,7 @@ export function formatReceiptProductBlock(opts: {
   const left = `${opts.quantity} x ${unit}`
   const body = `${name}\n${padReceiptLine(left, total, cols)}`
   const cue = String(opts.taxCue ?? '').trim()
-  return cue ? `${body}\n${cue}` : body
+  return cue ? `${body}\n${formatReceiptProductTaxCueLine(cue)}` : body
 }
 
 /** Modifier indented under parent; compact money; no truncation. */


### PR DESCRIPTION
## Summary
- Product-line tax cues on prefatura/factura print indent like adicionales (`  + …`).
- Drop “Incluye” / `taxIncluded` — always `{label} · {amount}` (`taxLine`).
- Checkout order details match the same cue style.

Closes #2042

## Test plan
- [ ] Prefatura/factura: tax under product shows `  + LABEL · $amount`, no Incluye
- [ ] Checkout order details: `+ LABEL · $amount` under product rows
- [ ] Exempt lines still show under product with `+`
- [ ] Detalle de impuestos bullet indent unchanged

## Validation evidence
```
$ bun test utils/receiptTicketPlainText.test.ts
bun test v1.2.21
15 pass
0 fail
43 expect() calls
Ran 15 tests across 1 file. [269.00ms]
```

## wr-context
See `.wr/2042.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)