### PR TITLE
fix(ventas): per-line tax cues on sale reprint and items table

### DIFF
--- a/.wr/2044.yaml
+++ b/.wr/2044.yaml
@@ -1,0 +1,38 @@
+# Compact plan for wr-fast #2044 (front PR)
+issue: 2044
+title: "fix(ventas): per-line tax cues on sale reprint and items table like POS checkout"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2044-ventas-tax-cues
+based_on: wr-2042-product-tax-cue (#2043)
+api_pr: https://github.com/uno0uno/api-warolabs/pull/772
+
+paths:
+  - pages/ventas/[id].vue
+  - .wr/2044.yaml
+
+ac:
+  - saleReceiptItems maps taxAmount/taxLabel/taxCategory/includedInPrice for ReceiptPrintTicket
+  - Items table shows + LABEL · $amount under product (no Incluye)
+  - Exempt shows + Exento when applicable
+
+out_of_scope:
+  - API (PR 772)
+  - Checkout #2042 changes (already on base branch)
+
+hints:
+  entry: "saleReceiptItems + formatItemTaxDisplay"
+  pattern: "pages/pos/checkout.vue formatLineTaxDisplay"
+  tests: "manual — depends on API fields; bun test utils/receiptTicketPlainText.test.ts already on base"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "merge API 772 then front; wr-review"

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -635,9 +635,12 @@ const itemReceiptTotal = (item: any) => {
 /** Per-line tax cue for items table — same style as POS checkout (#2044). */
 const formatItemTaxDisplay = (item: any): string | null => {
   const category = String(item?.tax_category ?? '').toLowerCase()
+  const resolution = String(item?.tax_resolution ?? '').toLowerCase()
   const amount = Number(item?.tax_amount) || 0
   let label = String(item?.tax_label ?? '').trim()
-  if (!label && category === 'exempt') label = t('pos.cartItem.taxExempt')
+  if (!label && (category === 'exempt' || resolution === 'exempt')) {
+    label = t('pos.cartItem.taxExempt')
+  }
   if (!label) return null
   if (amount > 0) {
     return `+ ${t('pos.cartItem.taxLine', { label, amount: formatCurrency(amount) })}`
@@ -649,6 +652,11 @@ const saleReceiptItems = computed(() =>
   items.value.map((item: any) => {
     const quantity = Number(item.quantity) || 1
     const total = itemReceiptTotal(item)
+    const taxResolution = String(item.tax_resolution ?? '').toLowerCase()
+    const taxCategoryRaw = String(item.tax_category ?? '').toLowerCase()
+    const taxCategory = taxResolution === 'exempt' || taxCategoryRaw === 'exempt'
+      ? 'exempt'
+      : (item.tax_category ?? null)
     return {
       id: item.id,
       productId: item.product?.id ?? item.product_id ?? null,
@@ -663,7 +671,7 @@ const saleReceiptItems = computed(() =>
       promoOptOut: item.promo_opt_out ?? item.promoOptOut ?? null,
       discountAllocated: item.discount_allocated ?? null,
       netTotal: item.net_total ?? null,
-      taxCategory: item.tax_category ?? null,
+      taxCategory,
       taxLabel: item.tax_label ?? null,
       taxAmount: item.tax_amount != null ? Number(item.tax_amount) : null,
       includedInPrice: item.included_in_price ?? null,

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -632,6 +632,19 @@ const itemReceiptTotal = (item: any) => {
   return (Number(item.price_at_purchase) + modifiersTotal) * (Number(item.quantity) || 1)
 }
 
+/** Per-line tax cue for items table — same style as POS checkout (#2044). */
+const formatItemTaxDisplay = (item: any): string | null => {
+  const category = String(item?.tax_category ?? '').toLowerCase()
+  const amount = Number(item?.tax_amount) || 0
+  let label = String(item?.tax_label ?? '').trim()
+  if (!label && category === 'exempt') label = t('pos.cartItem.taxExempt')
+  if (!label) return null
+  if (amount > 0) {
+    return `+ ${t('pos.cartItem.taxLine', { label, amount: formatCurrency(amount) })}`
+  }
+  return `+ ${label}`
+}
+
 const saleReceiptItems = computed(() =>
   items.value.map((item: any) => {
     const quantity = Number(item.quantity) || 1
@@ -651,6 +664,9 @@ const saleReceiptItems = computed(() =>
       discountAllocated: item.discount_allocated ?? null,
       netTotal: item.net_total ?? null,
       taxCategory: item.tax_category ?? null,
+      taxLabel: item.tax_label ?? null,
+      taxAmount: item.tax_amount != null ? Number(item.tax_amount) : null,
+      includedInPrice: item.included_in_price ?? null,
       modifiers: (item.modifiers ?? []).map((modifier: any) => ({
         id: modifier.id,
         name: modifier.name || t('ventas.detail.additionFallback'),
@@ -1864,6 +1880,12 @@ onUnmounted(() => {
                       </div>
                       <div>
                         <p class="text-sm font-semibold text-text-primary">{{ item.product.name }}</p>
+                        <p
+                          v-if="formatItemTaxDisplay(item)"
+                          class="text-xs text-text-tertiary mt-0.5"
+                        >
+                          {{ formatItemTaxDisplay(item) }}
+                        </p>
                         <p v-if="item.notes" class="text-xs text-text-tertiary italic mt-0.5">{{ item.notes }}</p>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- Map API per-line tax fields into `saleReceiptItems` for reprint via `ReceiptPrintTicket`.
- Items table on `/ventas/[id]` shows `+ LABEL · $amount` under each product (no Incluye).

Depends on:
- API: https://github.com/uno0uno/api-warolabs/pull/772
- Front base: #2043 (indent + drop Incluye on product tax cues)

Closes #2044

## Test plan
- [ ] With API #772 deployed: open `/ventas/{id}` — table rows show tax under product
- [ ] Reprint prefatura/factura — product lines have `  + tax` cues like checkout completed sale
- [ ] Exempt line shows `+ Exento` when applicable

## Validation evidence
```
$ bun test utils/receiptTicketPlainText.test.ts
15 pass
0 fail
```

## wr-context
See `.wr/2044.yaml` on this branch.

Made with [Cursor](https://cursor.com)