### PR TITLE
feat(pos): show DIAN resolution on FE thermal/HTML receipts

### DIFF
--- a/.wr/2046.yaml
+++ b/.wr/2046.yaml
@@ -1,0 +1,42 @@
+# Compact plan for wr-fast #2046
+issue: 2046
+title: "feat(pos): show DIAN resolution number on thermal/HTML receipts when configured"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2046-dian-resolution-receipt
+
+paths:
+  - pages/pos/checkout.vue
+  - pages/ventas/[id].vue
+  - i18n/locales/es/pos.json
+  - i18n/locales/en/pos.json
+  - .wr/2046.yaml
+
+ac:
+  - Populate invoice.resolutionText from presentation.resolution when available
+  - FE footer slot in ReceiptPrintTicket shows line (thermal + HTML)
+  - Checkout + ventas/[id] wired
+  - Omit when no resolution
+  - Prefactura out of scope
+
+out_of_scope:
+  - Prefactura sale footer
+  - Email template
+  - API changes
+
+hints:
+  entry: "receiptInvoice / saleReceiptInvoice resolutionText"
+  pattern: "ReceiptPrintTicket.vue:475 invoice.resolutionText"
+  tests: "none — i18n + wiring; manual print check"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "merge to main"

--- a/i18n/locales/en/pos.json
+++ b/i18n/locales/en/pos.json
@@ -697,6 +697,7 @@
       "dianIssueDate": "DIAN issue date: {date}",
       "issuer": "Issuer: {label}",
       "acquirer": "Buyer: {label}",
+      "dianResolution": "DIAN resolution: {number}",
       "paymentForm": "Payment form/method: {label}",
       "taxTributaryDetail": "Tax detail",
       "taxBase": "Base {amount}",

--- a/i18n/locales/es/pos.json
+++ b/i18n/locales/es/pos.json
@@ -697,6 +697,7 @@
       "dianIssueDate": "Fecha emisión DIAN: {date}",
       "issuer": "Emisor: {label}",
       "acquirer": "Adquirente: {label}",
+      "dianResolution": "Resolución DIAN: {number}",
       "paymentForm": "Forma/medio de pago: {label}",
       "taxTributaryDetail": "Detalle tributario",
       "taxBase": "Base {amount}",

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -2937,6 +2937,11 @@ const receiptInvoice = computed(() => {
     selectedCustomer.value,
     invoice.presentation?.acquirer,
   )
+  const resolutionNumber = String(
+    invoice.presentation?.resolution?.number
+    ?? invoice.presentation?.resolution?.resolution_number
+    ?? '',
+  ).trim()
   return {
     prefix: invoice.prefix,
     invoice_number: invoice.invoice_number,
@@ -2951,6 +2956,9 @@ const receiptInvoice = computed(() => {
     // Adquirente FE = snapshot fiscal returned by the invoice presentation.
     acquirerLabel: invoice.presentation?.acquirer
       ? formatFiscalIdentityLabel(invoiceIdentity.acquirer)
+      : null,
+    resolutionText: resolutionNumber
+      ? t('pos.receipt.dianResolution', { number: resolutionNumber })
       : null,
   }
 })

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -775,6 +775,12 @@ const saleReceiptIssuerLabel = computed(() => {
 
 const saleReceiptInvoice = computed(() => {
   if (!invoiceData.value) return null
+  const presentation = (invoiceData.value as any)?.presentation
+  const resolutionNumber = String(
+    presentation?.resolution?.number
+    ?? presentation?.resolution?.resolution_number
+    ?? '',
+  ).trim()
   return {
     prefix: invoiceData.value.prefix,
     invoice_number: invoiceData.value.invoice_number,
@@ -786,6 +792,9 @@ const saleReceiptInvoice = computed(() => {
     taxLines: saleReceiptInvoiceTaxLines.value,
     issuerLabel: saleReceiptIssuerLabel.value,
     acquirerLabel: invoiceAcquirerLabel.value,
+    resolutionText: resolutionNumber
+      ? t('pos.receipt.dianResolution', { number: resolutionNumber })
+      : null,
   }
 })
 


### PR DESCRIPTION
## Summary
- Wire `invoice.resolutionText` from `presentation.resolution` on checkout and `/ventas/[id]`.
- Uses existing FE footer slot in `ReceiptPrintTicket` (thermal + HTML).
- Copy: `Resolución DIAN: {number}` (omit when not configured).

Closes #2046

## Test plan
- [ ] Complete sale with FE + configured resolution → print shows Resolución DIAN
- [ ] Reprint from `/ventas/[id]` same
- [ ] No resolution configured → line absent
- [ ] Prefactura unchanged (no FE block)

## Validation evidence
```
Wiring-only change; ReceiptPrintTicket slot already renders invoice.resolutionText.
No new unit test file (i18n + computed mapping).
```

## wr-context
See `.wr/2046.yaml` on this branch.

Made with [Cursor](https://cursor.com)