### PR TITLE
feat(arqueo): allow opening cash shift with zero float

### DIFF
--- a/.wr/2048.yaml
+++ b/.wr/2048.yaml
@@ -1,0 +1,37 @@
+issue: 2048
+title: "feat(arqueo): allow opening cash shift with zero float"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2048-zero-opening-float
+
+paths:
+  - pages/finanzas/arqueo/apertura.vue
+  - i18n/locales/es/finanzas.json
+  - i18n/locales/en/finanzas.json
+  - .wr/2048.yaml
+
+ac:
+  - Allow openingCash 0 for today/past
+  - Reject negatives only
+  - API unchanged
+
+out_of_scope:
+  - Z/X close logic
+  - API
+
+hints:
+  entry: "canSubmitOpening + submitOpening"
+  pattern: "OpenShiftCreate openingCash ge=0"
+  tests: "none — validation wiring"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "merge main + stop local servers"

--- a/i18n/locales/en/finanzas.json
+++ b/i18n/locales/en/finanzas.json
@@ -115,7 +115,7 @@
       "goToDayClose": "Go to day close",
       "shiftAlreadyOpen": "This shift is already open",
       "openingMustBePositive": "Float must be greater than zero",
-      "openingNotNegative": "Float cannot be negative",
+      "openingNotNegative": "Float cannot be negative. You can open the shift with a zero float.",
       "openFailed": "Could not open the shift",
       "cashCount": "Cash count",
       "cashDetail": "Cash detail",

--- a/i18n/locales/es/finanzas.json
+++ b/i18n/locales/es/finanzas.json
@@ -115,7 +115,7 @@
       "goToDayClose": "Ir al cierre del día",
       "shiftAlreadyOpen": "Este turno ya está abierto",
       "openingMustBePositive": "El fondo debe ser mayor a cero",
-      "openingNotNegative": "El fondo no puede ser negativo",
+      "openingNotNegative": "El fondo no puede ser negativo. Puedes abrir el turno con fondo en 0.",
       "openFailed": "No se pudo abrir el turno",
       "cashCount": "Conteo de caja",
       "cashDetail": "Detalle de caja",

--- a/pages/finanzas/arqueo/apertura.vue
+++ b/pages/finanzas/arqueo/apertura.vue
@@ -424,9 +424,7 @@ const shiftTemplates = computed(() => rawShiftTemplates.value?.data ?? [])
 
 const isPastAnchorDate = computed(() => periodStart.value < today)
 
-const canSubmitOpening = computed(() =>
-  isPastAnchorDate.value ? totalCounted.value >= 0 : totalCounted.value > 0,
-)
+const canSubmitOpening = computed(() => totalCounted.value >= 0)
 
 const { data: rawTemplateWindow } = useQuery({
   key: () => ['cierre', 'shift-window', currentTenant.value?.id, effectiveTemplateId.value, periodStart.value],
@@ -570,11 +568,7 @@ const goToCount = () => {
 
 const submitOpening = async () => {
   submitError.value = null
-  if (!isPastAnchorDate.value && totalCounted.value <= 0) {
-    submitError.value = t('finanzas.arqueo.openingMustBePositive')
-    return
-  }
-  if (isPastAnchorDate.value && totalCounted.value < 0) {
+  if (totalCounted.value < 0) {
     submitError.value = t('finanzas.arqueo.openingNotNegative')
     return
   }


### PR DESCRIPTION
## Summary
- Allow apertura with `openingCash === 0` (API already `ge=0`).
- Still reject negative float.

Closes #2048

## Test plan
- [ ] Open shift today with all counts 0 → success
- [ ] Negative path still blocked if somehow set
- [ ] Past-date apertura with 0 still works

## Validation evidence
```
Front validation-only change aligned with API OpenShiftCreate.ge=0.
No new unit suite.
```

## wr-context
See `.wr/2048.yaml` on this branch.

Made with [Cursor](https://cursor.com)