### PR TITLE
fix(pos): number and separate product rows on receipt prints

### DIFF
--- a/.wr/2050.yaml
+++ b/.wr/2050.yaml
@@ -1,0 +1,40 @@
+issue: 2050
+title: "fix(pos): number and separate product rows on prefatura/factura prints"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2050-receipt-item-separators
+
+paths:
+  - utils/receiptTicketPlainText.ts
+  - utils/receiptTicketPlainText.test.ts
+  - components/pos/ReceiptPrintTicket.vue
+  - pages/pos/checkout.vue
+  - .wr/2050.yaml
+
+ac:
+  - Numbered product lines 1. 2. 3.
+  - Light separator between products
+  - Prefatura + factura (ReceiptPrintTicket + checkout paths)
+  - Modifiers stay under parent
+  - Unit tests for index + separator
+
+out_of_scope:
+  - Cart UI
+  - Tax math
+
+hints:
+  entry: "formatReceiptProductBlock index + receiptItemSeparator"
+  pattern: "ReceiptPrintTicket printableItems loop"
+  tests: "bun test utils/receiptTicketPlainText.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "merge main + stop local bac/front"

--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -8,6 +8,7 @@ import {
   formatReceiptTaxCue,
   padReceiptLine,
   receiptDivider,
+  receiptItemSeparator,
   compactThermalMoneyLabel,
 } from '~/utils/receiptTicketPlainText'
 
@@ -152,13 +153,14 @@ const productTaxCue = (item: ReceiptItem) => {
   return formatReceiptTaxCue({ label })
 }
 
-const productBlock = (item: ReceiptItem) =>
+const productBlock = (item: ReceiptItem, index: number) =>
   formatReceiptProductBlock({
     name: item.name,
     quantity: item.quantity,
     unitPriceLabel: money(item.unitPrice),
     lineTotalLabel: money(item.total),
     taxCue: productTaxCue(item),
+    index,
   })
 
 const modifierBlock = (modifier: ReceiptItemModifier) =>
@@ -183,6 +185,7 @@ const taxBulletLine = (label: string, amount: number | string | null | undefined
 
 const dashDivider = receiptDivider()
 const strongDivider = receiptDivider(32, '=')
+const itemSeparator = receiptItemSeparator()
 
 const hasBreakdownSubtotal = computed(() =>
   (props.promoBreakdown?.length ?? 0) > 0
@@ -352,8 +355,9 @@ const printableItems = computed(() =>
     <div class="receipt-plain-line">{{ dashDivider }}</div>
     <div class="receipt-plain-line receipt-small">{{ padReceiptLine(t('pos.receipt.description'), t('pos.receipt.total')) }}</div>
 
-    <template v-for="item in printableItems" :key="item.id ?? item.name">
-      <pre class="receipt-plain-pre">{{ productBlock(item) }}</pre>
+    <template v-for="(item, idx) in printableItems" :key="item.id ?? item.name">
+      <div v-if="idx > 0" class="receipt-plain-line receipt-small">{{ itemSeparator }}</div>
+      <pre class="receipt-plain-pre">{{ productBlock(item, idx + 1) }}</pre>
       <pre
         v-for="modifier in (item.modifiers ?? [])"
         :key="`${item.id ?? item.name}-${modifier.id ?? modifier.name}`"

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -26,6 +26,7 @@ import {
   formatReceiptTaxCue,
   padReceiptLine,
   receiptDivider,
+  receiptItemSeparator,
   collectThermalTicketText,
   compactThermalMoneyLabel,
 } from '~/utils/receiptTicketPlainText'
@@ -1934,6 +1935,7 @@ const formatModifierPrintDesc = (mod: PrintModifier) => {
 
 const prefacturaDash = receiptDivider()
 const prefacturaStrong = receiptDivider(32, '=')
+const prefacturaItemSep = receiptItemSeparator()
 
 const prefacturaMoneyLine = (label: string, amount: number | string, negative = false) => {
   const amt = compactThermalMoneyLabel(formatCurrencyThermal(amount))
@@ -1947,13 +1949,14 @@ const prefacturaTaxBulletLine = (label: string, amount: number | string) =>
   })
 
 
-const prefacturaProductBlock = (item: any) =>
+const prefacturaProductBlock = (item: any, index: number) =>
   formatReceiptProductBlock({
     name: `${item.product?.name || item.name || 'Item'}${isKitchenServiceMode.value && item.fired === false ? ' *' : ''}`,
     quantity: item.quantity,
     unitPriceLabel: formatCurrencyThermal(getItemUnitPrice(item)),
     lineTotalLabel: formatCurrencyThermal(getItemTotal(item)),
     taxCue: lineTaxCueForPrint(item),
+    index,
   })
 
 const prefacturaModifierBlock = (mod: PrintModifier) =>
@@ -5614,8 +5617,9 @@ onUnmounted(() => {
     <div class="receipt-plain-line">{{ prefacturaDash }}</div>
 
     <div class="receipt-plain-line receipt-small">{{ padReceiptLine(t('pos.receipt.description'), t('pos.receipt.total')) }}</div>
-    <template v-for="item in printablePrefacturaItems" :key="item.id ?? item.orderItemId">
-      <pre class="receipt-plain-pre">{{ prefacturaProductBlock(item) }}</pre>
+    <template v-for="(item, idx) in printablePrefacturaItems" :key="item.id ?? item.orderItemId">
+      <div v-if="idx > 0" class="receipt-plain-line receipt-small">{{ prefacturaItemSep }}</div>
+      <pre class="receipt-plain-pre">{{ prefacturaProductBlock(item, idx + 1) }}</pre>
       <pre
         v-for="mod in (item.modifiers ?? [])"
         :key="`${item.id ?? item.orderItemId}-${mod.id}`"
@@ -5747,9 +5751,10 @@ onUnmounted(() => {
       <span class="receipt-col-price">{{ t('pos.receipt.price') }}</span>
       <span class="receipt-col-total">{{ t('pos.receipt.total') }}</span>
     </div>
-    <template v-for="item in printableReceiptItems" :key="item.id ?? item.orderItemId">
+    <template v-for="(item, idx) in printableReceiptItems" :key="item.id ?? item.orderItemId">
+      <div v-if="idx > 0" class="receipt-divider receipt-small">{{ prefacturaItemSep }}</div>
       <div class="receipt-grid-row receipt-small">
-        <span class="receipt-col-desc">{{ item.product?.name || item.name }}</span>
+        <span class="receipt-col-desc">{{ idx + 1 }}. {{ item.product?.name || item.name }}</span>
         <span class="receipt-col-qty">{{ item.quantity }}</span>
         <span class="receipt-col-price">{{ formatCurrencyThermal(getItemUnitPrice(item)) }}</span>
         <span class="receipt-col-total">{{ formatCurrencyThermal(getItemTotal(item)) }}</span>

--- a/utils/receiptTicketPlainText.test.ts
+++ b/utils/receiptTicketPlainText.test.ts
@@ -7,6 +7,7 @@ import {
   formatReceiptTaxCue,
   padReceiptLine,
   receiptDivider,
+  receiptItemSeparator,
   collectThermalTicketText,
 } from './receiptTicketPlainText'
 
@@ -121,6 +122,25 @@ describe('formatReceiptProductBlock', () => {
     expect(lines[1]).toContain('1 x')
     expect(lines[2]).toBe('  + INC · $280')
     expect(block).not.toMatch(/Incluye/i)
+  })
+
+  it('prefixes a 1-based index on the product name', () => {
+    const block = formatReceiptProductBlock({
+      name: 'Agua',
+      quantity: 1,
+      unitPriceLabel: '$3.500',
+      lineTotalLabel: '$3.500',
+      index: 2,
+    })
+    expect(block.split('\n')[0]).toBe('2. Agua')
+  })
+})
+
+describe('receiptItemSeparator', () => {
+  it('emits a light middle-dot line for between-item gaps', () => {
+    const sep = receiptItemSeparator(10)
+    expect(sep).toBe('··········')
+    expect(sep).not.toContain('-')
   })
 })
 

--- a/utils/receiptTicketPlainText.ts
+++ b/utils/receiptTicketPlainText.ts
@@ -6,6 +6,11 @@
 export const RECEIPT_THERMAL_COLS = 32
 export const RECEIPT_MODIFIER_INDENT = '  '
 
+/** Light separator between product blocks (not the section dash). */
+export function receiptItemSeparator(cols: number = RECEIPT_THERMAL_COLS): string {
+  return '·'.repeat(Math.max(8, Math.min(cols, 32)))
+}
+
 /**
  * Compact `$ COP 45.000,00` → `$45.000,00` so qty×unit + total fit 32 cols.
  */
@@ -161,9 +166,13 @@ export function formatReceiptProductBlock(opts: {
   lineTotalLabel: string
   taxCue?: string | null
   cols?: number
+  /** 1-based line number shown before the product name. */
+  index?: number | null
 }): string {
   const cols = opts.cols ?? RECEIPT_THERMAL_COLS
-  const name = String(opts.name ?? '').trim() || 'Item'
+  const nameRaw = String(opts.name ?? '').trim() || 'Item'
+  const index = Number(opts.index)
+  const name = Number.isFinite(index) && index > 0 ? `${index}. ${nameRaw}` : nameRaw
   const unit = compactThermalMoneyLabel(opts.unitPriceLabel)
   const total = compactThermalMoneyLabel(opts.lineTotalLabel)
   const left = `${opts.quantity} x ${unit}`


### PR DESCRIPTION
## Summary
- Number product lines `1.`, `2.`, … on prefatura/factura thermal + HTML.
- Light `·` separators between products (modifiers stay under parent).

Closes #2050

## Test plan
- [ ] Prefatura with 2+ items — numbered + separators
- [ ] Factura / ventas reprint — same
- [ ] Single-item ticket — no between-item separator

## Validation evidence
```
$ bun test utils/receiptTicketPlainText.test.ts
17 pass
0 fail
```

## wr-context
See `.wr/2050.yaml` on this branch.

Made with [Cursor](https://cursor.com)