### PR TITLE
fix(pos): use bullets for receipt product lines

### DIFF
--- a/.wr/2052.yaml
+++ b/.wr/2052.yaml
@@ -1,0 +1,40 @@
+issue: 2052
+title: "fix(pos): use bullets instead of numbers for receipt product lines"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2052-receipt-product-bullets
+
+paths:
+  - utils/receiptTicketPlainText.ts
+  - utils/receiptTicketPlainText.test.ts
+  - components/pos/ReceiptPrintTicket.vue
+  - pages/pos/checkout.vue
+  - .wr/2052.yaml
+
+ac:
+  - Product lines use • prefix not N.
+  - Separators between items remain
+  - Prefatura/factura + #pos-receipt
+  - Payment #N unchanged
+  - Tests updated
+
+out_of_scope:
+  - Payment numbering
+  - Tax math
+
+hints:
+  entry: "formatReceiptProductBlock bullet"
+  pattern: "replace index with bullet:true"
+  tests: "bun test utils/receiptTicketPlainText.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "merge main + stop local"

--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -153,14 +153,14 @@ const productTaxCue = (item: ReceiptItem) => {
   return formatReceiptTaxCue({ label })
 }
 
-const productBlock = (item: ReceiptItem, index: number) =>
+const productBlock = (item: ReceiptItem) =>
   formatReceiptProductBlock({
     name: item.name,
     quantity: item.quantity,
     unitPriceLabel: money(item.unitPrice),
     lineTotalLabel: money(item.total),
     taxCue: productTaxCue(item),
-    index,
+    bullet: true,
   })
 
 const modifierBlock = (modifier: ReceiptItemModifier) =>
@@ -357,7 +357,7 @@ const printableItems = computed(() =>
 
     <template v-for="(item, idx) in printableItems" :key="item.id ?? item.name">
       <div v-if="idx > 0" class="receipt-plain-line receipt-small">{{ itemSeparator }}</div>
-      <pre class="receipt-plain-pre">{{ productBlock(item, idx + 1) }}</pre>
+      <pre class="receipt-plain-pre">{{ productBlock(item) }}</pre>
       <pre
         v-for="modifier in (item.modifiers ?? [])"
         :key="`${item.id ?? item.name}-${modifier.id ?? modifier.name}`"

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1949,14 +1949,14 @@ const prefacturaTaxBulletLine = (label: string, amount: number | string) =>
   })
 
 
-const prefacturaProductBlock = (item: any, index: number) =>
+const prefacturaProductBlock = (item: any) =>
   formatReceiptProductBlock({
     name: `${item.product?.name || item.name || 'Item'}${isKitchenServiceMode.value && item.fired === false ? ' *' : ''}`,
     quantity: item.quantity,
     unitPriceLabel: formatCurrencyThermal(getItemUnitPrice(item)),
     lineTotalLabel: formatCurrencyThermal(getItemTotal(item)),
     taxCue: lineTaxCueForPrint(item),
-    index,
+    bullet: true,
   })
 
 const prefacturaModifierBlock = (mod: PrintModifier) =>
@@ -5619,7 +5619,7 @@ onUnmounted(() => {
     <div class="receipt-plain-line receipt-small">{{ padReceiptLine(t('pos.receipt.description'), t('pos.receipt.total')) }}</div>
     <template v-for="(item, idx) in printablePrefacturaItems" :key="item.id ?? item.orderItemId">
       <div v-if="idx > 0" class="receipt-plain-line receipt-small">{{ prefacturaItemSep }}</div>
-      <pre class="receipt-plain-pre">{{ prefacturaProductBlock(item, idx + 1) }}</pre>
+      <pre class="receipt-plain-pre">{{ prefacturaProductBlock(item) }}</pre>
       <pre
         v-for="mod in (item.modifiers ?? [])"
         :key="`${item.id ?? item.orderItemId}-${mod.id}`"
@@ -5754,7 +5754,7 @@ onUnmounted(() => {
     <template v-for="(item, idx) in printableReceiptItems" :key="item.id ?? item.orderItemId">
       <div v-if="idx > 0" class="receipt-divider receipt-small">{{ prefacturaItemSep }}</div>
       <div class="receipt-grid-row receipt-small">
-        <span class="receipt-col-desc">{{ idx + 1 }}. {{ item.product?.name || item.name }}</span>
+        <span class="receipt-col-desc">• {{ item.product?.name || item.name }}</span>
         <span class="receipt-col-qty">{{ item.quantity }}</span>
         <span class="receipt-col-price">{{ formatCurrencyThermal(getItemUnitPrice(item)) }}</span>
         <span class="receipt-col-total">{{ formatCurrencyThermal(getItemTotal(item)) }}</span>

--- a/utils/receiptTicketPlainText.test.ts
+++ b/utils/receiptTicketPlainText.test.ts
@@ -124,15 +124,16 @@ describe('formatReceiptProductBlock', () => {
     expect(block).not.toMatch(/Incluye/i)
   })
 
-  it('prefixes a 1-based index on the product name', () => {
+  it('prefixes a bullet on the product name when requested', () => {
     const block = formatReceiptProductBlock({
       name: 'Agua',
       quantity: 1,
       unitPriceLabel: '$3.500',
       lineTotalLabel: '$3.500',
-      index: 2,
+      bullet: true,
     })
-    expect(block.split('\n')[0]).toBe('2. Agua')
+    expect(block.split('\n')[0]).toBe('• Agua')
+    expect(block.split('\n')[0]).not.toMatch(/^\d+\./)
   })
 })
 

--- a/utils/receiptTicketPlainText.ts
+++ b/utils/receiptTicketPlainText.ts
@@ -166,13 +166,12 @@ export function formatReceiptProductBlock(opts: {
   lineTotalLabel: string
   taxCue?: string | null
   cols?: number
-  /** 1-based line number shown before the product name. */
-  index?: number | null
+  /** Prefix product name with a bullet (not a number). */
+  bullet?: boolean | null
 }): string {
   const cols = opts.cols ?? RECEIPT_THERMAL_COLS
   const nameRaw = String(opts.name ?? '').trim() || 'Item'
-  const index = Number(opts.index)
-  const name = Number.isFinite(index) && index > 0 ? `${index}. ${nameRaw}` : nameRaw
+  const name = opts.bullet ? `• ${nameRaw}` : nameRaw
   const unit = compactThermalMoneyLabel(opts.unitPriceLabel)
   const total = compactThermalMoneyLabel(opts.lineTotalLabel)
   const left = `${opts.quantity} x ${unit}`


### PR DESCRIPTION
## Summary
- Replace `1.` / `2.` product prefixes with `•` on prefatura/factura prints.
- Keep between-item separators; payment `#N` numbering unchanged.

Closes #2052

## Test plan
- [ ] Prefatura/factura multi-item — bullets + separators
- [ ] Payment lines still `#1 · …`

## Validation evidence
```
$ bun test utils/receiptTicketPlainText.test.ts
17 pass
0 fail
```

## wr-context
See `.wr/2052.yaml` on this branch.

Made with [Cursor](https://cursor.com)