### PR TITLE
fix(pos): compact receipt chrome for thermal space

### DIFF
--- a/components/pos/ReceiptPlatformFooter.vue
+++ b/components/pos/ReceiptPlatformFooter.vue
@@ -2,13 +2,13 @@
 const { t, locale } = useI18n({ useScope: 'global' })
 /**
  * Pie de documento: software WARO + (si FE) facturador Matias.
- * Datos desde backend platform_legal (env). Nunca hardcode de NIT/PII.
- * Emisor de la venta = tenant (cabecera), no este pie.
+ * Compact thermal chrome (#2054) — legal fields kept, fewer blank lines.
  */
 import {
   EMPTY_PLATFORM_LEGAL,
   type PlatformLegalPrint,
 } from '~/constants/waroLegalEntity'
+import { joinReceiptParts } from '~/utils/receiptTicketPlainText'
 
 const props = withDefaults(defineProps<{
   documentKind?: 'prefactura' | 'sale' | 'fe'
@@ -39,7 +39,6 @@ const showFacturador = computed(() =>
 
 const softwareRoleLabel = computed(() => {
   void locale.value
-  // Prefer API-provided legal Spanish only for the source locale.
   if (locale.value !== 'es') return t('pos.receipt.softwareRole')
   return software.value.role_label || t('pos.receipt.softwareRole')
 })
@@ -65,52 +64,38 @@ const facturadorNotIssuer = computed(() => {
   if (locale.value !== 'es') return t('pos.receipt.notIssuer')
   return facturador.value.not_issuer_disclaimer || t('pos.receipt.notIssuer')
 })
+
+const softwareLine = computed(() => joinReceiptParts([
+  softwareRoleLabel.value,
+  software.value.commercial_name,
+  software.value.nit ? t('pos.receipt.nitBare', { nit: software.value.nit }) : null,
+  software.value.website,
+  softwareIvaLabel.value,
+  softwareNotIssuer.value,
+]))
+
+const facturadorLine = computed(() => joinReceiptParts([
+  facturadorRoleLabel.value,
+  facturador.value.brand_name,
+  facturador.value.nit ? t('pos.receipt.nitBare', { nit: facturador.value.nit }) : null,
+  facturador.value.legal_name,
+  facturadorNotIssuer.value,
+  t('pos.receipt.dianIssuerTenant'),
+]))
 </script>
 
 <template>
   <div v-if="hasSoftware || showFacturador" class="receipt-platform-footer">
     <div class="receipt-divider" aria-hidden="true" />
 
-    <template v-if="hasSoftware">
-      <div class="receipt-row receipt-small" style="font-weight:bold;">
-        {{ softwareRoleLabel }}
-      </div>
-      <div v-if="software.commercial_name" class="receipt-row receipt-small">
-        {{ software.commercial_name }}
-      </div>
-      <div v-if="software.nit" class="receipt-row receipt-small">
-        {{ t('pos.receipt.nitBare', { nit: software.nit }) }}
-      </div>
-      <div v-if="software.website" class="receipt-row receipt-small">
-        {{ software.website }}
-      </div>
-      <div v-if="softwareIvaLabel" class="receipt-row receipt-small">
-        {{ softwareIvaLabel }}
-      </div>
-      <div class="receipt-row receipt-small" style="font-weight:bold;">
-        {{ softwareNotIssuer }}
-      </div>
-    </template>
+    <div v-if="hasSoftware && softwareLine" class="receipt-row receipt-small">
+      {{ softwareLine }}
+    </div>
 
-    <template v-if="showFacturador">
+    <template v-if="showFacturador && facturadorLine">
       <div class="receipt-divider" aria-hidden="true" />
-      <div class="receipt-row receipt-small" style="font-weight:bold;">
-        {{ facturadorRoleLabel }}
-      </div>
-      <div v-if="facturador.brand_name" class="receipt-row receipt-small">
-        {{ facturador.brand_name }}
-      </div>
-      <div v-if="facturador.nit" class="receipt-row receipt-small">
-        {{ t('pos.receipt.nitBare', { nit: facturador.nit }) }}
-      </div>
-      <div v-if="facturador.legal_name" class="receipt-row receipt-small">
-        {{ facturador.legal_name }}
-      </div>
-      <div class="receipt-row receipt-small" style="font-weight:bold;">
-        {{ facturadorNotIssuer }}
-      </div>
       <div class="receipt-row receipt-small">
-        {{ t('pos.receipt.dianIssuerTenant') }}
+        {{ facturadorLine }}
       </div>
     </template>
 

--- a/components/pos/ReceiptPrintHeader.vue
+++ b/components/pos/ReceiptPrintHeader.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 const { t } = useI18n({ useScope: 'global' })
 import { buildReceiptLogoStyle } from '~/utils/receiptPrintConfig'
+import { joinReceiptParts } from '~/utils/receiptTicketPlainText'
 
 const props = defineProps<{
   fiscalData?: {
@@ -20,8 +21,7 @@ const props = defineProps<{
 
 /**
  * Cabecera del establecimiento (tenant) — emisor comercial / vendedor.
- * Según práctica Colombia: nombre o razón social + NIT del establecimiento.
- * WARO no va aquí (ver ReceiptPlatformFooter).
+ * Compact thermal chrome: fewer blank lines (#2054).
  */
 const headerName = computed(() =>
   props.fiscalData?.business_name?.trim()
@@ -43,6 +43,21 @@ const displayPhone = computed(() =>
 
 const sellerNit = computed(() => props.fiscalData?.nit?.trim() || null)
 
+const addressLine = computed(() => {
+  const address = String(displayAddress.value ?? '').trim()
+  const city = String(displayCity.value ?? '').trim()
+  if (address && city) return `${address}, ${city}`
+  return address || city || null
+})
+
+/** Role + NIT + tel + email on one dense line. */
+const metaLine = computed(() => joinReceiptParts([
+  t('pos.receipt.establishmentSeller'),
+  sellerNit.value ? t('pos.receipt.nit', { nit: sellerNit.value }) : null,
+  displayPhone.value ? t('pos.receipt.tel', { phone: displayPhone.value }) : null,
+  props.fiscalData?.email?.trim() || null,
+]))
+
 const logoStyle = computed(() => buildReceiptLogoStyle())
 </script>
 
@@ -56,21 +71,8 @@ const logoStyle = computed(() => buildReceiptLogoStyle())
       :style="logoStyle"
     >
     <div class="receipt-header">{{ headerName }}</div>
-    <div class="receipt-row receipt-small" style="font-weight:bold;">
-      {{ t('pos.receipt.establishmentSeller') }}
-    </div>
-    <div v-if="sellerNit" class="receipt-row receipt-small">
-      {{ t('pos.receipt.nit', { nit: sellerNit }) }}
-    </div>
-    <div v-if="displayAddress" class="receipt-row receipt-small">
-      {{ displayAddress }}<span v-if="displayCity">, {{ displayCity }}</span>
-    </div>
-    <div v-if="displayPhone" class="receipt-row receipt-small">
-      {{ t('pos.receipt.tel', { phone: displayPhone }) }}
-    </div>
-    <div v-if="fiscalData?.email" class="receipt-row receipt-small">
-      {{ fiscalData.email }}
-    </div>
+    <div v-if="metaLine" class="receipt-row receipt-small">{{ metaLine }}</div>
+    <div v-if="addressLine" class="receipt-row receipt-small">{{ addressLine }}</div>
   </div>
 </template>
 
@@ -84,5 +86,8 @@ const logoStyle = computed(() => buildReceiptLogoStyle())
   object-position: center top;
   filter: grayscale(100%);
   -webkit-filter: grayscale(100%);
+}
+.receipt-print-header .receipt-header {
+  margin-bottom: 1px;
 }
 </style>

--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -6,6 +6,7 @@ import {
   formatReceiptProductBlock,
   formatReceiptTaxBulletLine,
   formatReceiptTaxCue,
+  joinReceiptParts,
   padReceiptLine,
   receiptDivider,
   receiptItemSeparator,
@@ -265,6 +266,40 @@ const invoicePaymentLabel = computed(() => {
   return props.singlePaymentLabel || null
 })
 
+/** Dense chrome lines — keep products/totals verbose (#2054). */
+const saleMetaLine = computed(() => joinReceiptParts([
+  props.soldAt,
+  props.locationLabel,
+  props.waiterName ? t('pos.receipt.waiter', { name: props.waiterName }) : null,
+]))
+
+const saleContactLine = computed(() => joinReceiptParts([
+  props.customerName,
+  props.customerPhone ? t('pos.receipt.phone', { phone: props.customerPhone }) : null,
+  props.customerEmail ? t('pos.receipt.email', { email: props.customerEmail }) : null,
+  !props.invoice && props.customerFiscalLabel ? props.customerFiscalLabel : null,
+]))
+
+const feChromeLine = computed(() => {
+  if (!props.invoice) return null
+  return joinReceiptParts([
+    t('pos.receipt.printedElectronicInvoice'),
+    props.invoice.issuedAt
+      ? t('pos.receipt.dianIssueDate', { date: props.invoice.issuedAt })
+      : null,
+    !hasCompleteHeaderIssuer.value && (props.invoice.issuerLabel || fallbackIssuerLabel.value)
+      ? t('pos.receipt.issuer', { label: props.invoice.issuerLabel || fallbackIssuerLabel.value })
+      : null,
+    props.invoice.acquirerLabel
+      ? t('pos.receipt.acquirer', { label: props.invoice.acquirerLabel })
+      : null,
+    props.invoice.resolutionText,
+    invoicePaymentLabel.value
+      ? t('pos.receipt.paymentForm', { label: invoicePaymentLabel.value })
+      : null,
+  ])
+})
+
 const invoiceTaxLines = computed(() => {
   const explicit = (props.invoice?.taxLines ?? []).filter(line =>
     line?.label || Number(line?.base) > 0 || Number(line?.amount) > 0,
@@ -339,17 +374,14 @@ const printableItems = computed(() =>
         {{ documentLabel }}<template v-if="orderNumber"> #{{ orderNumber }}</template>
       </template>
     </div>
-    <div v-if="soldAt" class="receipt-row receipt-small">{{ soldAt }}</div>
-    <div v-if="locationLabel" class="receipt-row receipt-small">{{ locationLabel }}</div>
-    <div v-if="waiterName" class="receipt-row receipt-small">{{ t('pos.receipt.waiter', { name: waiterName }) }}</div>
+    <div v-if="saleMetaLine" class="receipt-row receipt-small">{{ saleMetaLine }}</div>
 
-    <template v-if="customerName || customerPhone || customerEmail">
+    <template v-if="saleContactLine">
       <div class="receipt-plain-line">{{ dashDivider }}</div>
-      <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.saleContact') }}</div>
-      <div v-if="customerName" class="receipt-row receipt-small">{{ customerName }}</div>
-      <div v-if="customerPhone" class="receipt-row receipt-small">{{ t('pos.receipt.phone', { phone: customerPhone }) }}</div>
-      <div v-if="customerEmail" class="receipt-row receipt-small">{{ t('pos.receipt.email', { email: customerEmail }) }}</div>
-      <div v-if="!invoice && customerFiscalLabel" class="receipt-row receipt-small">{{ customerFiscalLabel }}</div>
+      <div class="receipt-row receipt-small">
+        <span style="font-weight:bold;">{{ t('pos.receipt.saleContact') }}</span>
+        · {{ saleContactLine }}
+      </div>
     </template>
 
     <div class="receipt-plain-line">{{ dashDivider }}</div>
@@ -461,24 +493,7 @@ const printableItems = computed(() =>
 
     <template v-else>
       <div class="receipt-plain-line">{{ strongDivider }}</div>
-      <div class="receipt-fe-details">
-        <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.printedElectronicInvoice') }}</div>
-        <div v-if="invoice.issuedAt" class="receipt-row receipt-row--start receipt-small">{{ t('pos.receipt.dianIssueDate', { date: invoice.issuedAt }) }}</div>
-        <div
-          v-if="!hasCompleteHeaderIssuer && (invoice.issuerLabel || fallbackIssuerLabel)"
-          class="receipt-row receipt-row--start receipt-small"
-        >
-          {{ t('pos.receipt.issuer', { label: invoice.issuerLabel || fallbackIssuerLabel }) }}
-        </div>
-        <div
-          v-if="invoice.acquirerLabel"
-          class="receipt-row receipt-row--start receipt-small"
-        >
-          {{ t('pos.receipt.acquirer', { label: invoice.acquirerLabel }) }}
-        </div>
-        <div v-if="invoice.resolutionText" class="receipt-row receipt-row--start receipt-small">{{ invoice.resolutionText }}</div>
-        <div v-if="invoicePaymentLabel" class="receipt-row receipt-row--start receipt-small">{{ t('pos.receipt.paymentForm', { label: invoicePaymentLabel }) }}</div>
-      </div>
+      <div v-if="feChromeLine" class="receipt-row receipt-row--start receipt-small">{{ feChromeLine }}</div>
       <template v-if="invoiceTaxLines.length > 0">
         <div class="receipt-plain-line">{{ dashDivider }}</div>
         <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.taxTributaryDetail') }}</div>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -24,6 +24,7 @@ import {
   formatReceiptProductBlock,
   formatReceiptTaxBulletLine,
   formatReceiptTaxCue,
+  joinReceiptParts,
   padReceiptLine,
   receiptDivider,
   receiptItemSeparator,
@@ -3058,6 +3059,81 @@ function captureReceiptPrintContext(opts?: { singleCashReceived?: number | null;
 const prefacturaDateTime = computed(() =>
   formatTenantDateTime()
 )
+
+const prefacturaSaleMetaLine = computed(() => {
+  const session = posStore.activeTableSession
+  const mesaLabel = isKitchenServiceMode.value && session?.tableName
+    ? `${tableSingular.value} ${prefacturaTableCode.value} — ${session.tableName}`
+    : null
+  return joinReceiptParts([
+    prefacturaDateTime.value,
+    mesaLabel,
+    !mesaLabel && session?.isBar ? t('pos.receipt.bar') : null,
+    !mesaLabel && !session?.isBar ? t('pos.receipt.counter') : null,
+    prefacturaWaiterName.value
+      ? t('pos.receipt.waiter', { name: prefacturaWaiterName.value })
+      : null,
+  ])
+})
+
+const prefacturaSaleContactLine = computed(() => {
+  const customer = selectedCustomer.value
+  if (!customer || isAnonymousCustomer.value) return ''
+  return joinReceiptParts([
+    customer.name || null,
+    customer.phone_number
+      ? t('pos.receipt.phone', { phone: customer.phone_number })
+      : null,
+    customer.email
+      ? t('pos.receipt.email', { email: customer.email })
+      : null,
+    customer.fiscal_id && !selectedCustomerIdentity.value.showSeparateAcquirer
+      ? `${customer.fiscal_id_type}: ${customer.fiscal_id}`
+      : null,
+  ])
+})
+
+const prefacturaAcquirerLine = computed(() => {
+  if (!selectedCustomerIdentity.value.showSeparateAcquirer) return ''
+  const acquirer = selectedCustomerIdentity.value.acquirer
+  return joinReceiptParts([
+    acquirer.name || null,
+    acquirer.fiscalId
+      ? `${acquirer.fiscalIdType}: ${acquirer.fiscalId}`
+      : null,
+    acquirer.email
+      ? t('pos.receipt.email', { email: acquirer.email })
+      : null,
+  ])
+})
+
+const checkoutSaleMetaLine = computed(() => {
+  const ctx = receiptPrintContext.value
+  if (!ctx) return ''
+  return joinReceiptParts([
+    ctx.soldAt || null,
+    ctx.wasMesa && ctx.tableName
+      ? `${tableSingular.value} ${ctx.tableCode} — ${ctx.tableName}`
+      : null,
+    !ctx.wasMesa && ctx.isBar ? t('pos.receipt.bar') : null,
+    !ctx.wasMesa && !ctx.isBar ? t('pos.receipt.counter') : null,
+    ctx.waiterName ? t('pos.receipt.waiter', { name: ctx.waiterName }) : null,
+  ])
+})
+
+const checkoutSaleContactLine = computed(() => {
+  const ctx = receiptPrintContext.value
+  if (!ctx?.customerName && !ctx?.customerPhone && !ctx?.customerEmail) return ''
+  return joinReceiptParts([
+    ctx?.customerName || null,
+    ctx?.customerPhone ? t('pos.receipt.phone', { phone: ctx.customerPhone }) : null,
+    ctx?.customerEmail ? t('pos.receipt.email', { email: ctx.customerEmail }) : null,
+    !invoiceResult.value && ctx?.customerFiscalId
+      ? `${ctx.customerFiscalIdType}: ${ctx.customerFiscalId}`
+      : null,
+  ])
+})
+
 // Prefactura is purely visual — never block on tax preview state. If taxes
 // haven't loaded (or the tenant has no taxes configured), the prefactura
 // just omits those lines. The prefactura footer disclaimer makes the document
@@ -5579,40 +5655,17 @@ onUnmounted(() => {
     <div class="receipt-row receipt-small" style="font-weight:bold;">
       {{ prefacturaDocumentLabel }}<span v-if="prefacturaDocNumber"> #{{ prefacturaDocNumber }}</span>
     </div>
-    <div class="receipt-row receipt-small">{{ prefacturaDateTime }}</div>
-    <div v-if="isKitchenServiceMode && posStore.activeTableSession?.tableName" class="receipt-row receipt-small">
-      {{ tableSingular }} {{ prefacturaTableCode }} — {{ posStore.activeTableSession.tableName }}
-    </div>
-    <div v-else-if="posStore.activeTableSession?.isBar" class="receipt-row receipt-small">{{ t('pos.receipt.bar') }}</div>
-    <div v-else class="receipt-row receipt-small">{{ t('pos.receipt.counter') }}</div>
-    <div v-if="prefacturaWaiterName" class="receipt-row receipt-small">
-      {{ t('pos.receipt.waiter', { name: prefacturaWaiterName }) }}
-    </div>
-    <template v-if="selectedCustomer && !isAnonymousCustomer">
+    <div v-if="prefacturaSaleMetaLine" class="receipt-row receipt-small">{{ prefacturaSaleMetaLine }}</div>
+    <template v-if="prefacturaSaleContactLine || prefacturaAcquirerLine">
       <div class="receipt-divider receipt-small">--------------------------------</div>
-      <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.saleContact') }}</div>
-      <div v-if="selectedCustomer.name" class="receipt-row receipt-small">{{ selectedCustomer.name }}</div>
-      <div v-if="selectedCustomer.phone_number" class="receipt-row receipt-small">
-        {{ t('pos.receipt.phone', { phone: selectedCustomer.phone_number }) }}
+      <div v-if="prefacturaSaleContactLine" class="receipt-row receipt-small">
+        <span style="font-weight:bold;">{{ t('pos.receipt.saleContact') }}</span>
+        · {{ prefacturaSaleContactLine }}
       </div>
-      <div v-if="selectedCustomer.email" class="receipt-row receipt-small">
-        {{ t('pos.receipt.email', { email: selectedCustomer.email }) }}
+      <div v-if="prefacturaAcquirerLine" class="receipt-row receipt-small">
+        <span style="font-weight:bold;">{{ t('pos.receipt.fiscalAcquirer') }}</span>
+        · {{ prefacturaAcquirerLine }}
       </div>
-      <div v-if="selectedCustomer.fiscal_id && !selectedCustomerIdentity.showSeparateAcquirer" class="receipt-row receipt-small">
-        {{ selectedCustomer.fiscal_id_type }}: {{ selectedCustomer.fiscal_id }}
-      </div>
-      <template v-if="selectedCustomerIdentity.showSeparateAcquirer">
-        <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.fiscalAcquirer') }}</div>
-        <div v-if="selectedCustomerIdentity.acquirer.name" class="receipt-row receipt-small">
-          {{ selectedCustomerIdentity.acquirer.name }}
-        </div>
-        <div v-if="selectedCustomerIdentity.acquirer.fiscalId" class="receipt-row receipt-small">
-          {{ selectedCustomerIdentity.acquirer.fiscalIdType }}: {{ selectedCustomerIdentity.acquirer.fiscalId }}
-        </div>
-        <div v-if="selectedCustomerIdentity.acquirer.email" class="receipt-row receipt-small">
-          {{ t('pos.receipt.email', { email: selectedCustomerIdentity.acquirer.email }) }}
-        </div>
-      </template>
     </template>
     <div class="receipt-plain-line">{{ prefacturaDash }}</div>
 
@@ -5720,27 +5773,12 @@ onUnmounted(() => {
     <div class="receipt-row receipt-small" style="font-weight:bold;">
       {{ receiptDocumentLabel }}<span v-if="(orderResult?.order_number ?? 0) > 0"> #{{ orderResult?.order_number }}</span>
     </div>
-    <div v-if="receiptPrintContext?.soldAt" class="receipt-row receipt-small">{{ receiptPrintContext.soldAt }}</div>
-    <div v-if="receiptPrintContext?.wasMesa && receiptPrintContext.tableName" class="receipt-row receipt-small">
-      {{ tableSingular }} {{ receiptPrintContext.tableCode }} — {{ receiptPrintContext.tableName }}
-    </div>
-    <div v-else-if="receiptPrintContext?.isBar" class="receipt-row receipt-small">{{ t('pos.receipt.bar') }}</div>
-    <div v-else-if="receiptPrintContext" class="receipt-row receipt-small">{{ t('pos.receipt.counter') }}</div>
-    <div v-if="receiptPrintContext?.waiterName" class="receipt-row receipt-small">
-      {{ t('pos.receipt.waiter', { name: receiptPrintContext.waiterName }) }}
-    </div>
-    <template v-if="receiptPrintContext?.customerName || receiptPrintContext?.customerPhone || receiptPrintContext?.customerEmail">
+    <div v-if="checkoutSaleMetaLine" class="receipt-row receipt-small">{{ checkoutSaleMetaLine }}</div>
+    <template v-if="checkoutSaleContactLine">
       <div class="receipt-divider receipt-small">--------------------------------</div>
-      <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.saleContact') }}</div>
-      <div v-if="receiptPrintContext.customerName" class="receipt-row receipt-small">{{ receiptPrintContext.customerName }}</div>
-      <div v-if="receiptPrintContext.customerPhone" class="receipt-row receipt-small">
-        {{ t('pos.receipt.phone', { phone: receiptPrintContext.customerPhone }) }}
-      </div>
-      <div v-if="receiptPrintContext.customerEmail" class="receipt-row receipt-small">
-        {{ t('pos.receipt.email', { email: receiptPrintContext.customerEmail }) }}
-      </div>
-      <div v-if="!invoiceResult && receiptPrintContext.customerFiscalId" class="receipt-row receipt-small">
-        {{ receiptPrintContext.customerFiscalIdType }}: {{ receiptPrintContext.customerFiscalId }}
+      <div class="receipt-row receipt-small">
+        <span style="font-weight:bold;">{{ t('pos.receipt.saleContact') }}:</span>
+        {{ ' ' }}{{ checkoutSaleContactLine }}
       </div>
     </template>
     <div class="receipt-divider">--------------------------------</div>

--- a/utils/receiptTicketPlainText.test.ts
+++ b/utils/receiptTicketPlainText.test.ts
@@ -5,11 +5,19 @@ import {
   formatReceiptProductBlock,
   formatReceiptTaxBulletLine,
   formatReceiptTaxCue,
+  joinReceiptParts,
   padReceiptLine,
   receiptDivider,
   receiptItemSeparator,
   collectThermalTicketText,
 } from './receiptTicketPlainText'
+
+describe('joinReceiptParts', () => {
+  it('joins non-empty parts with a middle-dot separator', () => {
+    expect(joinReceiptParts(['NIT 1', '', 'Tel: 2', null, 'a@b.com'])).toBe('NIT 1 · Tel: 2 · a@b.com')
+    expect(joinReceiptParts([])).toBe('')
+  })
+})
 
 describe('compactThermalMoneyLabel', () => {
   it('strips COP prefix for narrower thermal columns', () => {

--- a/utils/receiptTicketPlainText.ts
+++ b/utils/receiptTicketPlainText.ts
@@ -6,6 +6,17 @@
 export const RECEIPT_THERMAL_COLS = 32
 export const RECEIPT_MODIFIER_INDENT = '  '
 
+/** Join non-empty receipt fragments with a compact separator (thermal chrome). */
+export function joinReceiptParts(
+  parts: Array<string | null | undefined>,
+  sep = ' · ',
+): string {
+  return parts
+    .map(part => String(part ?? '').trim())
+    .filter(Boolean)
+    .join(sep)
+}
+
 /** Light separator between product blocks (not the section dash). */
 export function receiptItemSeparator(cols: number = RECEIPT_THERMAL_COLS): string {
   return '·'.repeat(Math.max(8, Math.min(cols, 32)))


### PR DESCRIPTION
## Summary
- Dense receipt header/meta/customer/FE/platform footer lines joined with ` · `
- Prefactura + shared print ticket/header/footer components updated
- Product rows and sale totals/tax/payment detail left unchanged

Closes #2054

## Test plan
- [ ] Print FE / sale receipt — fewer blank chrome lines; products/totals look the same
- [ ] Print prefactura — meta + customer denser; disclaimer + products intact
- [ ] `bun test utils/receiptTicketPlainText.test.ts`

## wr-context
See local `.wr/2054.yaml` (gitignored).

Made with [Cursor](https://cursor.com)