### PR TITLE
fix(pos): subtle section separators on dense receipts

### DIFF
--- a/components/pos/ReceiptPlatformFooter.vue
+++ b/components/pos/ReceiptPlatformFooter.vue
@@ -8,7 +8,7 @@ import {
   EMPTY_PLATFORM_LEGAL,
   type PlatformLegalPrint,
 } from '~/constants/waroLegalEntity'
-import { joinReceiptParts } from '~/utils/receiptTicketPlainText'
+import { joinReceiptParts, receiptSectionSeparator } from '~/utils/receiptTicketPlainText'
 
 const props = withDefaults(defineProps<{
   documentKind?: 'prefactura' | 'sale' | 'fe'
@@ -20,6 +20,8 @@ const props = withDefaults(defineProps<{
   platformLegal: null,
   matiasDian: false,
 })
+
+const sectionSeparator = receiptSectionSeparator()
 
 const legal = computed(() => props.platformLegal ?? EMPTY_PLATFORM_LEGAL)
 const software = computed(() => legal.value.software)
@@ -86,14 +88,14 @@ const facturadorLine = computed(() => joinReceiptParts([
 
 <template>
   <div v-if="hasSoftware || showFacturador" class="receipt-platform-footer">
-    <div class="receipt-divider" aria-hidden="true" />
+    <div class="receipt-plain-line receipt-small">{{ sectionSeparator }}</div>
 
     <div v-if="hasSoftware && softwareLine" class="receipt-row receipt-small">
       {{ softwareLine }}
     </div>
 
     <template v-if="showFacturador && facturadorLine">
-      <div class="receipt-divider" aria-hidden="true" />
+      <div class="receipt-plain-line receipt-small">{{ sectionSeparator }}</div>
       <div class="receipt-row receipt-small">
         {{ facturadorLine }}
       </div>

--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -10,6 +10,7 @@ import {
   padReceiptLine,
   receiptDivider,
   receiptItemSeparator,
+  receiptSectionSeparator,
   compactThermalMoneyLabel,
 } from '~/utils/receiptTicketPlainText'
 
@@ -184,9 +185,9 @@ const taxBulletLine = (label: string, amount: number | string | null | undefined
   })
 
 
-const dashDivider = receiptDivider()
 const strongDivider = receiptDivider(32, '=')
 const itemSeparator = receiptItemSeparator()
+const sectionSeparator = receiptSectionSeparator()
 
 const hasBreakdownSubtotal = computed(() =>
   (props.promoBreakdown?.length ?? 0) > 0
@@ -377,14 +378,14 @@ const printableItems = computed(() =>
     <div v-if="saleMetaLine" class="receipt-row receipt-small">{{ saleMetaLine }}</div>
 
     <template v-if="saleContactLine">
-      <div class="receipt-plain-line">{{ dashDivider }}</div>
+      <div class="receipt-plain-line receipt-small">{{ sectionSeparator }}</div>
       <div class="receipt-row receipt-small">
         <span style="font-weight:bold;">{{ t('pos.receipt.saleContact') }}</span>
         · {{ saleContactLine }}
       </div>
     </template>
 
-    <div class="receipt-plain-line">{{ dashDivider }}</div>
+    <div class="receipt-plain-line receipt-small">{{ sectionSeparator }}</div>
     <div class="receipt-plain-line receipt-small">{{ padReceiptLine(t('pos.receipt.description'), t('pos.receipt.total')) }}</div>
 
     <template v-for="(item, idx) in printableItems" :key="item.id ?? item.name">
@@ -397,7 +398,7 @@ const printableItems = computed(() =>
       >{{ modifierBlock(modifier) }}</pre>
     </template>
 
-    <div class="receipt-plain-line">{{ dashDivider }}</div>
+    <div class="receipt-plain-line receipt-small">{{ sectionSeparator }}</div>
 
     <div v-if="hasBreakdownSubtotal && subtotal != null" class="receipt-plain-line">
       {{ moneyLine(t('pos.receipt.subtotal'), subtotal) }}
@@ -447,7 +448,7 @@ const printableItems = computed(() =>
       {{ moneyLine(t('pos.receipt.totalUpper'), orderTotal) }}
     </div>
 
-    <div class="receipt-plain-line">{{ dashDivider }}</div>
+    <div class="receipt-plain-line receipt-small">{{ sectionSeparator }}</div>
     <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.paymentDetail') }}</div>
     <template v-if="(payments?.length ?? 0) > 0">
       <template v-for="(payment, idx) in payments" :key="payment.id ?? idx">
@@ -469,7 +470,7 @@ const printableItems = computed(() =>
     <template v-if="!invoice">
       <div class="receipt-plain-line">{{ strongDivider }}</div>
       <div class="receipt-footer">{{ t('pos.receipt.thanks') }}</div>
-      <div class="receipt-plain-line">{{ dashDivider }}</div>
+      <div class="receipt-plain-line receipt-small">{{ sectionSeparator }}</div>
       <div class="receipt-row receipt-small" style="font-weight:bold;">
         {{ t('pos.receipt.saleReceipt') }}
       </div>
@@ -495,7 +496,7 @@ const printableItems = computed(() =>
       <div class="receipt-plain-line">{{ strongDivider }}</div>
       <div v-if="feChromeLine" class="receipt-row receipt-row--start receipt-small">{{ feChromeLine }}</div>
       <template v-if="invoiceTaxLines.length > 0">
-        <div class="receipt-plain-line">{{ dashDivider }}</div>
+        <div class="receipt-plain-line receipt-small">{{ sectionSeparator }}</div>
         <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.taxTributaryDetail') }}</div>
         <div
           v-for="(line, idx) in invoiceTaxLines"

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -28,6 +28,7 @@ import {
   padReceiptLine,
   receiptDivider,
   receiptItemSeparator,
+  receiptSectionSeparator,
   collectThermalTicketText,
   compactThermalMoneyLabel,
 } from '~/utils/receiptTicketPlainText'
@@ -1937,6 +1938,7 @@ const formatModifierPrintDesc = (mod: PrintModifier) => {
 const prefacturaDash = receiptDivider()
 const prefacturaStrong = receiptDivider(32, '=')
 const prefacturaItemSep = receiptItemSeparator()
+const prefacturaSectionSep = receiptSectionSeparator()
 
 const prefacturaMoneyLine = (label: string, amount: number | string, negative = false) => {
   const amt = compactThermalMoneyLabel(formatCurrencyThermal(amount))
@@ -5657,7 +5659,7 @@ onUnmounted(() => {
     </div>
     <div v-if="prefacturaSaleMetaLine" class="receipt-row receipt-small">{{ prefacturaSaleMetaLine }}</div>
     <template v-if="prefacturaSaleContactLine || prefacturaAcquirerLine">
-      <div class="receipt-divider receipt-small">--------------------------------</div>
+      <div class="receipt-plain-line receipt-small">{{ prefacturaSectionSep }}</div>
       <div v-if="prefacturaSaleContactLine" class="receipt-row receipt-small">
         <span style="font-weight:bold;">{{ t('pos.receipt.saleContact') }}</span>
         · {{ prefacturaSaleContactLine }}
@@ -5667,7 +5669,7 @@ onUnmounted(() => {
         · {{ prefacturaAcquirerLine }}
       </div>
     </template>
-    <div class="receipt-plain-line">{{ prefacturaDash }}</div>
+    <div class="receipt-plain-line receipt-small">{{ prefacturaSectionSep }}</div>
 
     <div class="receipt-plain-line receipt-small">{{ padReceiptLine(t('pos.receipt.description'), t('pos.receipt.total')) }}</div>
     <template v-for="(item, idx) in printablePrefacturaItems" :key="item.id ?? item.orderItemId">
@@ -5679,7 +5681,7 @@ onUnmounted(() => {
         class="receipt-plain-pre"
       >{{ prefacturaModifierBlock(mod) }}</pre>
     </template>
-    <div class="receipt-plain-line">{{ prefacturaDash }}</div>
+    <div class="receipt-plain-line receipt-small">{{ prefacturaSectionSep }}</div>
 
     <div v-if="prefacturaPrintData.promoSavings > 0 || prefacturaPrintData.manualDiscountAmount > 0 || prefacturaPrintData.waroDiscountCop > 0" class="receipt-plain-line">
       {{ prefacturaMoneyLine(t('pos.receipt.subtotal'), prefacturaPrintData.cartSubtotal) }}
@@ -5725,7 +5727,7 @@ onUnmounted(() => {
       {{ prefacturaMoneyLine(t('pos.receipt.totalUpper'), prefacturaPrintData.orderTotal) }}
     </div>
     <template v-if="prefacturaPrintData.splitPayments.length > 0">
-      <div class="receipt-plain-line">{{ prefacturaDash }}</div>
+      <div class="receipt-plain-line receipt-small">{{ prefacturaSectionSep }}</div>
       <div class="receipt-row receipt-small" style="font-weight:bold;">{{ t('pos.receipt.paymentsRegistered') }}</div>
       <div
         v-for="(p, idx) in prefacturaPrintData.splitPayments"
@@ -5775,13 +5777,13 @@ onUnmounted(() => {
     </div>
     <div v-if="checkoutSaleMetaLine" class="receipt-row receipt-small">{{ checkoutSaleMetaLine }}</div>
     <template v-if="checkoutSaleContactLine">
-      <div class="receipt-divider receipt-small">--------------------------------</div>
+      <div class="receipt-plain-line receipt-small">{{ prefacturaSectionSep }}</div>
       <div class="receipt-row receipt-small">
         <span style="font-weight:bold;">{{ t('pos.receipt.saleContact') }}:</span>
         {{ ' ' }}{{ checkoutSaleContactLine }}
       </div>
     </template>
-    <div class="receipt-divider">--------------------------------</div>
+    <div class="receipt-plain-line receipt-small">{{ prefacturaSectionSep }}</div>
 
     <div class="receipt-grid-header receipt-small">
       <span class="receipt-col-desc">{{ t('pos.receipt.description') }}</span>

--- a/utils/receiptTicketPlainText.test.ts
+++ b/utils/receiptTicketPlainText.test.ts
@@ -9,6 +9,7 @@ import {
   padReceiptLine,
   receiptDivider,
   receiptItemSeparator,
+  receiptSectionSeparator,
   collectThermalTicketText,
 } from './receiptTicketPlainText'
 
@@ -16,6 +17,13 @@ describe('joinReceiptParts', () => {
   it('joins non-empty parts with a middle-dot separator', () => {
     expect(joinReceiptParts(['NIT 1', '', 'Tel: 2', null, 'a@b.com'])).toBe('NIT 1 · Tel: 2 · a@b.com')
     expect(joinReceiptParts([])).toBe('')
+  })
+})
+
+describe('receiptSectionSeparator', () => {
+  it('emits spaced dots quieter than a solid item separator', () => {
+    expect(receiptSectionSeparator(32)).toBe('· · · · · · · · · · · · · · · ·')
+    expect(receiptSectionSeparator(32)).not.toBe(receiptItemSeparator(32))
   })
 })
 

--- a/utils/receiptTicketPlainText.ts
+++ b/utils/receiptTicketPlainText.ts
@@ -23,6 +23,15 @@ export function receiptItemSeparator(cols: number = RECEIPT_THERMAL_COLS): strin
 }
 
 /**
+ * Subtle separator between major receipt sections (header / meta / products / totals).
+ * Spaced dots — quieter than full dashes, visible in thermal text (#2056).
+ */
+export function receiptSectionSeparator(cols: number = RECEIPT_THERMAL_COLS): string {
+  const n = Math.max(4, Math.floor(Math.min(cols, 32) / 2))
+  return Array.from({ length: n }, () => '·').join(' ')
+}
+
+/**
  * Compact `$ COP 45.000,00` → `$45.000,00` so qty×unit + total fit 32 cols.
  */
 export function compactThermalMoneyLabel(label: string): string {


### PR DESCRIPTION
## Summary
- Add `receiptSectionSeparator` (spaced `·`) between major receipt sections
- Prefactura + `PosReceiptPrintTicket` (ventas/órdenes reprint) + platform footer use thermal-visible seps
- Dense field joins from #2054 kept; product/totals content unchanged

Closes #2056

## Test plan
- [ ] Prefactura — subtle breaks between meta/contact/products/totals/footer
- [ ] Sale + FE print — same hierarchy; products unchanged
- [ ] Ventas order reprint — matches ticket
- [ ] `bun test utils/receiptTicketPlainText.test.ts`

Made with [Cursor](https://cursor.com)