### PR TITLE
fix(pos): confirm unconfirmed thermal prints with browser CTA

### DIFF
--- a/components/Commons/ToastContainer.vue
+++ b/components/Commons/ToastContainer.vue
@@ -8,6 +8,7 @@
         :title="toast.title"
         :message="toast.message"
         :duration="toast.duration"
+        :actions="toast.actions"
         :stack-offset="getStackOffset(index)"
         :removing="toast.removing"
         @close="remove(toast.id)"

--- a/components/ui/toast/Toast.vue
+++ b/components/ui/toast/Toast.vue
@@ -24,6 +24,17 @@
       <div class="flex-1 min-w-0">
         <p :class="titleClasses" v-if="title">{{ title }}</p>
         <p :class="messageClasses">{{ message }}</p>
+        <div v-if="actions?.length" class="mt-2 flex flex-wrap gap-2">
+          <button
+            v-for="(action, idx) in actions"
+            :key="`${action.label}-${idx}`"
+            type="button"
+            class="px-2.5 py-1 rounded-md text-xs font-medium border border-border bg-surface hover:bg-control-action-hover-bg transition-colors"
+            @click="runAction(action)"
+          >
+            {{ action.label }}
+          </button>
+        </div>
       </div>
       <button
         @click="close"
@@ -68,6 +79,10 @@ const props = defineProps({
   removing: {
     type: Boolean,
     default: false
+  },
+  actions: {
+    type: Array,
+    default: () => []
   }
 })
 
@@ -139,10 +154,19 @@ const close = () => {
   emit('close')
 }
 
+const runAction = (action) => {
+  try {
+    action?.onClick?.()
+  } finally {
+    close()
+  }
+}
+
 onMounted(() => {
   visible.value = true
-  
-  if (props.duration > 0) {
+
+  // Parent toast store also schedules removal; skip local timer when actions need time.
+  if (props.duration > 0 && !(props.actions?.length)) {
     setTimeout(() => {
       close()
     }, props.duration)

--- a/composables/useCajaTicketPrint.test.ts
+++ b/composables/useCajaTicketPrint.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, mock } from 'bun:test'
-import { printTicketViaCajaOrBrowser } from './useCajaTicketPrint'
+import {
+  notifyUnconfirmedCajaPrint,
+  printTicketViaCajaOrBrowser,
+} from './useCajaTicketPrint'
 import type { LocalPrintBridge } from './useLocalPrintBridge'
 
 function fakeBridge(overrides: Partial<LocalPrintBridge> = {}): LocalPrintBridge {
@@ -7,16 +10,16 @@ function fakeBridge(overrides: Partial<LocalPrintBridge> = {}): LocalPrintBridge
     isAvailable: () => true,
     connect: mock(() => Promise.resolve()),
     listPrinters: mock(() => Promise.resolve(['STAR_TP586'])),
-    printRawEscPos: mock(() => Promise.resolve()),
-    printEscPosTestTicket: mock(() => Promise.resolve()),
-    printHtml: mock(() => Promise.resolve()),
+    printRawEscPos: mock(() => Promise.resolve('completed' as const)),
+    printEscPosTestTicket: mock(() => Promise.resolve('completed' as const)),
+    printHtml: mock(() => Promise.resolve('completed' as const)),
     ...overrides,
   }
 }
 
 describe('printTicketViaCajaOrBrowser', () => {
   it('prints ESC/POS raw via bridge when caja is assigned', async () => {
-    const printRawEscPos = mock(() => Promise.resolve())
+    const printRawEscPos = mock(() => Promise.resolve('completed' as const))
     const browserPrint = mock(() => {})
     const bridge = fakeBridge({ printRawEscPos })
 
@@ -27,7 +30,7 @@ describe('printTicketViaCajaOrBrowser', () => {
       browserPrint,
     })
 
-    expect(result).toBe('bridge')
+    expect(result).toEqual({ mode: 'bridge', confirmed: true, printerName: 'STAR_TP586' })
     expect(printRawEscPos).toHaveBeenCalledTimes(1)
     const [printer, payload] = printRawEscPos.mock.calls[0]!
     expect(printer).toBe('STAR_TP586')
@@ -36,8 +39,23 @@ describe('printTicketViaCajaOrBrowser', () => {
     expect(browserPrint).toHaveBeenCalledTimes(0)
   })
 
+  it('returns unconfirmed when CUPS soft-success outcome is reported', async () => {
+    const browserPrint = mock(() => {})
+    const result = await printTicketViaCajaOrBrowser('pos-receipt', {
+      getCajaPrinterName: async () => 'STAR_TP586',
+      bridge: fakeBridge({
+        printRawEscPos: mock(() => Promise.resolve('unconfirmed' as const)),
+      }),
+      getElementHtml: () => '<div id="pos-receipt">OK</div>',
+      browserPrint,
+    })
+
+    expect(result).toEqual({ mode: 'bridge', confirmed: false, printerName: 'STAR_TP586' })
+    expect(browserPrint).toHaveBeenCalledTimes(0)
+  })
+
   it('falls back to browser when caja assignment is missing', async () => {
-    const printRawEscPos = mock(() => Promise.resolve())
+    const printRawEscPos = mock(() => Promise.resolve('completed' as const))
     const browserPrint = mock(() => {})
     const bridge = fakeBridge({ printRawEscPos })
 
@@ -48,7 +66,7 @@ describe('printTicketViaCajaOrBrowser', () => {
       browserPrint,
     })
 
-    expect(result).toBe('browser')
+    expect(result).toEqual({ mode: 'browser' })
     expect(printRawEscPos).toHaveBeenCalledTimes(0)
     expect(browserPrint).toHaveBeenCalledTimes(1)
   })
@@ -67,7 +85,7 @@ describe('printTicketViaCajaOrBrowser', () => {
       browserPrint,
     })
 
-    expect(result).toBe('browser')
+    expect(result).toEqual({ mode: 'browser' })
     expect(browserPrint).toHaveBeenCalledTimes(1)
   })
 
@@ -86,12 +104,12 @@ describe('printTicketViaCajaOrBrowser', () => {
       bridgePrintTimeoutMs: 30,
     })
 
-    expect(result).toBe('browser')
+    expect(result).toEqual({ mode: 'browser' })
     expect(browserPrint).toHaveBeenCalledTimes(1)
   })
 
   it('falls back to browser when element content is missing', async () => {
-    const printRawEscPos = mock(() => Promise.resolve())
+    const printRawEscPos = mock(() => Promise.resolve('completed' as const))
     const browserPrint = mock(() => {})
 
     const result = await printTicketViaCajaOrBrowser('missing', {
@@ -101,7 +119,7 @@ describe('printTicketViaCajaOrBrowser', () => {
       browserPrint,
     })
 
-    expect(result).toBe('browser')
+    expect(result).toEqual({ mode: 'browser' })
     expect(printRawEscPos).toHaveBeenCalledTimes(0)
     expect(browserPrint).toHaveBeenCalledTimes(1)
   })
@@ -114,8 +132,39 @@ describe('printTicketViaCajaOrBrowser', () => {
       getElementHtml: () => '<div/>',
       browserPrint: () => {},
     })
-    expect(result).toBe('browser')
+    expect(result).toEqual({ mode: 'browser' })
     deferred()
     expect(deferred).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('notifyUnconfirmedCajaPrint', () => {
+  it('shows retry and browser actions only for unconfirmed bridge results', () => {
+    const warning = mock(() => 1)
+    const onRetry = mock(() => {})
+    const onBrowserPrint = mock(() => {})
+    const t = (key: string, params?: Record<string, unknown>) =>
+      params?.name ? `${key}:${params.name}` : key
+
+    notifyUnconfirmedCajaPrint(
+      { mode: 'bridge', confirmed: false, printerName: 'STAR_TP586' },
+      { t, toast: { warning }, onRetry, onBrowserPrint },
+    )
+
+    expect(warning).toHaveBeenCalledTimes(1)
+    const [, options] = warning.mock.calls[0]!
+    expect(options.title).toBe('pos.receipt.printUnconfirmedTitle')
+    expect(options.actions).toHaveLength(2)
+    options.actions[0].onClick()
+    options.actions[1].onClick()
+    expect(onRetry).toHaveBeenCalledTimes(1)
+    expect(onBrowserPrint).toHaveBeenCalledTimes(1)
+
+    warning.mockClear()
+    notifyUnconfirmedCajaPrint(
+      { mode: 'bridge', confirmed: true, printerName: 'STAR_TP586' },
+      { t, toast: { warning }, onRetry, onBrowserPrint },
+    )
+    expect(warning).toHaveBeenCalledTimes(0)
   })
 })

--- a/composables/useCajaTicketPrint.ts
+++ b/composables/useCajaTicketPrint.ts
@@ -1,10 +1,12 @@
 /**
  * Prefactura/factura → configured caja printer via PrintBridge ESC/POS raw (#1960/#1965).
  * Falls back to window.print when bridge/caja is missing, print fails, or hangs (#2003).
+ * Soft CUPS “status gone” stays non-fatal but surfaces as unconfirmed (#2058).
  */
 import {
   LocalPrintBridgeError,
   useLocalPrintBridge,
+  type BridgePrintOutcome,
   type LocalPrintBridge,
 } from '~/composables/useLocalPrintBridge'
 import {
@@ -13,7 +15,10 @@ import {
   loadEscPosLogoRasterFromUrl,
 } from '~/utils/escPosTicket'
 
-export type CajaTicketPrintResult = 'bridge' | 'browser'
+export type CajaTicketPrintResult =
+  | { mode: 'bridge'; confirmed: true; printerName: string }
+  | { mode: 'bridge'; confirmed: false; printerName: string }
+  | { mode: 'browser' }
 
 /** Cap wait so offline USB/CUPS cannot stall the cashier before browser fallback. */
 export const BRIDGE_PRINT_TIMEOUT_MS = 5000
@@ -52,6 +57,17 @@ function defaultGetElementContent(elementId: string): string | null {
   return html || null
 }
 
+function bridgeResult(
+  printerName: string,
+  outcome: BridgePrintOutcome,
+): CajaTicketPrintResult {
+  return {
+    mode: 'bridge',
+    confirmed: outcome === 'completed',
+    printerName,
+  }
+}
+
 /**
  * Try PrintBridge raw ESC/POS to the tenant caja printer; otherwise call browserPrint().
  * Never throws — browser fallback absorbs bridge errors.
@@ -70,19 +86,19 @@ export async function printTicketViaCajaOrBrowser(
     caja = await deps.getCajaPrinterName()
   } catch {
     browserPrint()
-    return 'browser'
+    return { mode: 'browser' }
   }
 
   const printerName = (caja || '').trim()
   if (!printerName) {
     browserPrint()
-    return 'browser'
+    return { mode: 'browser' }
   }
 
   const content = getContent(elementId)
   if (!content?.trim()) {
     browserPrint()
-    return 'browser'
+    return { mode: 'browser' }
   }
 
   let logoRaster: Uint8Array | null = null
@@ -98,10 +114,10 @@ export async function printTicketViaCajaOrBrowser(
   const bridge = deps.bridge ?? useLocalPrintBridge()
   const timeoutMs = deps.bridgePrintTimeoutMs ?? BRIDGE_PRINT_TIMEOUT_MS
   try {
-    await withTimeout(
+    const outcome = await withTimeout(
       (async () => {
         await bridge.connect()
-        await bridge.printRawEscPos(
+        return bridge.printRawEscPos(
           printerName,
           buildEscPosTicketBytes(content, { logoRaster }),
         )
@@ -109,11 +125,52 @@ export async function printTicketViaCajaOrBrowser(
       timeoutMs,
       'Caja PrintBridge print',
     )
-    return 'bridge'
+    return bridgeResult(printerName, outcome)
   } catch {
     browserPrint()
-    return 'browser'
+    return { mode: 'browser' }
   }
+}
+
+export type CajaPrintFeedbackToast = {
+  warning: (
+    message: string,
+    options?: {
+      title?: string
+      duration?: number
+      actions?: Array<{ label: string; onClick: () => void }>
+    },
+  ) => unknown
+}
+
+/** Warn cashier when CUPS could not confirm paper out; offer retry / browser (#2058). */
+export function notifyUnconfirmedCajaPrint(
+  result: CajaTicketPrintResult,
+  opts: {
+    t: (key: string, params?: Record<string, unknown>) => string
+    toast: CajaPrintFeedbackToast
+    onRetry: () => void
+    onBrowserPrint: () => void
+  },
+): void {
+  if (result.mode !== 'bridge' || result.confirmed) return
+  opts.toast.warning(
+    opts.t('pos.receipt.printUnconfirmedBody', { name: result.printerName }),
+    {
+      title: opts.t('pos.receipt.printUnconfirmedTitle'),
+      duration: 15000,
+      actions: [
+        {
+          label: opts.t('pos.receipt.printRetry'),
+          onClick: opts.onRetry,
+        },
+        {
+          label: opts.t('pos.receipt.printWithBrowser'),
+          onClick: opts.onBrowserPrint,
+        },
+      ],
+    },
+  )
 }
 
 export function useCajaTicketPrint() {

--- a/composables/useLocalPrintBridge.test.ts
+++ b/composables/useLocalPrintBridge.test.ts
@@ -190,7 +190,7 @@ describe('createLocalPrintBridge', () => {
       })
   })
 
-  it('resolves when CUPS purges job status after submit (no window.print fallback)', async () => {
+  it('resolves unconfirmed when CUPS purges job status after submit (no auto browser fallback)', async () => {
     let statusHandler: ((event: { requestId?: string; status?: string; message?: string }) => void) | null = null
     const printSpy = mock(async (job: Record<string, unknown>) => {
       const requestId = String(job.requestId)
@@ -212,11 +212,12 @@ describe('createLocalPrintBridge', () => {
     })
 
     const bridge = createLocalPrintBridge()
-    await bridge.printRawEscPos('STAR_TP586', buildEscPosTestTicketBytes('ok'))
+    await expect(bridge.printRawEscPos('STAR_TP586', buildEscPosTestTicketBytes('ok')))
+      .resolves.toBe('unconfirmed')
     expect(printSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('resolves when status stream reports completed', async () => {
+  it('resolves completed when status stream reports completed', async () => {
     let statusHandler: ((event: { requestId?: string; status?: string }) => void) | null = null
     const printSpy = mock(async (job: Record<string, unknown>) => {
       const requestId = String(job.requestId)
@@ -233,7 +234,8 @@ describe('createLocalPrintBridge', () => {
     })
 
     const bridge = createLocalPrintBridge()
-    await bridge.printRawEscPos('STAR_TP586', buildEscPosTestTicketBytes('ok'))
+    await expect(bridge.printRawEscPos('STAR_TP586', buildEscPosTestTicketBytes('ok')))
+      .resolves.toBe('completed')
     expect(printSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/composables/useLocalPrintBridge.ts
+++ b/composables/useLocalPrintBridge.ts
@@ -40,6 +40,9 @@ export type PrintBridgeClientLike = {
 const PRINT_SUCCESS_STATUSES = new Set(['completed'])
 const PRINT_FAILURE_STATUSES = new Set(['failed', 'cancelled', 'unknown'])
 
+/** Bridge accepted the job; CUPS may not confirm paper out (#2058). */
+export type BridgePrintOutcome = 'completed' | 'unconfirmed'
+
 function newPrintRequestId(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID()
@@ -51,6 +54,7 @@ function newPrintRequestId(): string {
  * Star/CUPS often purges the job right after accept. PrintBridge then emits
  * `unknown` + "CUPS job status was no longer available". That is not a print
  * failure — treating it as one caused thermal + window.print double tickets.
+ * Callers should treat it as unconfirmed and offer a manual browser CTA (#2058).
  * Real offline failures use other messages (e.g. "Unable to send data…").
  */
 export function isCupsJobStatusGoneSoftSuccess(
@@ -71,8 +75,8 @@ export function isCupsJobStatusGoneSoftSuccess(
 export function waitForPrintTerminalStatus(
   client: PrintBridgeClientLike,
   requestId: string,
-): Promise<void> {
-  if (typeof client.on !== 'function') return Promise.resolve()
+): Promise<BridgePrintOutcome> {
+  if (typeof client.on !== 'function') return Promise.resolve('completed')
 
   return new Promise((resolve, reject) => {
     const off = client.on!('status', (event) => {
@@ -81,13 +85,13 @@ export function waitForPrintTerminalStatus(
       const message = event?.message
       if (PRINT_SUCCESS_STATUSES.has(status)) {
         off()
-        resolve()
+        resolve('completed')
         return
       }
-      // CUPS purged job after submit (Star thermal) — accept as success.
+      // CUPS purged job after submit — not hard fail; not confirmed either (#2058).
       if (isCupsJobStatusGoneSoftSuccess(status, message)) {
         off()
-        resolve()
+        resolve('unconfirmed')
         return
       }
       if (PRINT_FAILURE_STATUSES.has(status)) {
@@ -106,12 +110,12 @@ export function waitForPrintTerminalStatus(
 async function printAndAwaitOutcome(
   client: PrintBridgeClientLike,
   job: Record<string, unknown>,
-): Promise<void> {
+): Promise<BridgePrintOutcome> {
   const requestId = String(job.requestId || newPrintRequestId())
   const payload = { ...job, requestId }
   const terminal = waitForPrintTerminalStatus(client, requestId)
   await client.print(payload)
-  await terminal
+  return terminal
 }
 
 let injectedClient: PrintBridgeClientLike | null = null
@@ -201,9 +205,9 @@ export type LocalPrintBridge = {
   isAvailable: () => boolean
   connect: () => Promise<void>
   listPrinters: () => Promise<string[]>
-  printRawEscPos: (printerName: string, data: Uint8Array | string) => Promise<void>
-  printEscPosTestTicket: (printerName: string, message?: string) => Promise<void>
-  printHtml: (printerName: string, html: string, options?: { pageWidthIn?: number }) => Promise<void>
+  printRawEscPos: (printerName: string, data: Uint8Array | string) => Promise<BridgePrintOutcome>
+  printEscPosTestTicket: (printerName: string, message?: string) => Promise<BridgePrintOutcome>
+  printHtml: (printerName: string, html: string, options?: { pageWidthIn?: number }) => Promise<BridgePrintOutcome>
 }
 
 export function createLocalPrintBridge(): LocalPrintBridge {
@@ -262,7 +266,7 @@ export function createLocalPrintBridge(): LocalPrintBridge {
           ? bytesToBase64(new TextEncoder().encode(data))
           : bytesToBase64(data)
       try {
-        await printAndAwaitOutcome(c, {
+        return await printAndAwaitOutcome(c, {
           type: 'raw',
           printerName: name,
           dataBase64,
@@ -273,7 +277,7 @@ export function createLocalPrintBridge(): LocalPrintBridge {
     },
 
     async printEscPosTestTicket(printerName: string, message?: string) {
-      await this.printRawEscPos(printerName, buildEscPosTestTicketBytes(message))
+      return this.printRawEscPos(printerName, buildEscPosTestTicketBytes(message))
     },
 
     async printHtml(printerName: string, html: string, options?: { pageWidthIn?: number }) {
@@ -288,7 +292,7 @@ export function createLocalPrintBridge(): LocalPrintBridge {
       const pageWidthIn = options?.pageWidthIn ?? 2.25 // ~58mm thermal
       const widthMm = Math.round(pageWidthIn * 25.4)
       try {
-        await printAndAwaitOutcome(c, {
+        return await printAndAwaitOutcome(c, {
           type: 'raw-html',
           printerName: name,
           html,

--- a/composables/useToast.js
+++ b/composables/useToast.js
@@ -10,7 +10,8 @@ export const useToast = () => {
     const defaultDuration = type === 'error' ? 7000 : type === 'success' ? 4000 : 5000
     const duration = options.duration ?? defaultDuration
     const title = options.title
-    
+    const actions = Array.isArray(options.actions) ? options.actions : []
+
     const id = ++toastIdCounter
     const toast = {
       id,
@@ -18,39 +19,40 @@ export const useToast = () => {
       type, // 'success', 'error', 'warning', 'info'
       title,
       duration,
+      actions,
       visible: true,
       removing: false,
       createdAt: Date.now()
     }
-    
+
     toasts.value.push(toast)
-    
+
     // Auto remove after duration
     if (duration > 0) {
       setTimeout(() => {
         remove(id)
       }, duration)
     }
-    
+
     return id
   }
-  
+
   const remove = (id) => {
-    const toast = toasts.value.find(t => t.id === id)
+    const toast = toasts.value.find(toastItem => toastItem.id === id)
     if (toast && !toast.removing) {
       toast.removing = true
       toast.visible = false
-      
+
       // Remove from array after animation completes
       setTimeout(() => {
-        const index = toasts.value.findIndex(t => t.id === id)
+        const index = toasts.value.findIndex(toastItem => toastItem.id === id)
         if (index > -1) {
           toasts.value.splice(index, 1)
         }
       }, 350) // Match exit animation duration
     }
   }
-  
+
   const clear = () => {
     toasts.value.forEach(toast => {
       if (!toast.removing) {
@@ -58,17 +60,17 @@ export const useToast = () => {
         toast.visible = false
       }
     })
-    
+
     setTimeout(() => {
       toasts.value.splice(0)
     }, 350)
   }
-  
+
   const success = (message, options) => show(message, 'success', options)
   const error = (message, options) => show(message, 'error', options)
   const warning = (message, options) => show(message, 'warning', options)
   const info = (message, options) => show(message, 'info', options)
-  
+
   return {
     toasts: readonly(toasts),
     show,

--- a/i18n/locales/ar/operaciones.json
+++ b/i18n/locales/ar/operaciones.json
@@ -560,7 +560,8 @@
         "linuxAppImage": "Linux AppImage (amd64)",
         "recommended": "Recommended",
         "allReleases": "View all releases on GitHub"
-      }
+      },
+      "testPrintUnconfirmed": "Sent to {name}, but we could not confirm. Check that it is powered on and has paper."
     }
   }
 }

--- a/i18n/locales/ar/pos.json
+++ b/i18n/locales/ar/pos.json
@@ -694,7 +694,11 @@
       "qrDianAlt": "رمز QR للتحقق من DIAN",
       "promoFallback": "عرض",
       "tipTax": "ضريبة الإكرامية",
-      "totalChargedUpper": "الإجمالي المحصّل"
+      "totalChargedUpper": "الإجمالي المحصّل",
+      "printUnconfirmedTitle": "Check the printer",
+      "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
+      "printRetry": "Retry",
+      "printWithBrowser": "Print with browser"
     }
   }
 }

--- a/i18n/locales/de/operaciones.json
+++ b/i18n/locales/de/operaciones.json
@@ -560,7 +560,8 @@
         "linuxAppImage": "Linux AppImage (amd64)",
         "recommended": "Recommended",
         "allReleases": "View all releases on GitHub"
-      }
+      },
+      "testPrintUnconfirmed": "Sent to {name}, but we could not confirm. Check that it is powered on and has paper."
     }
   }
 }

--- a/i18n/locales/de/pos.json
+++ b/i18n/locales/de/pos.json
@@ -694,7 +694,11 @@
       "qrDianAlt": "DIAN Verifizierungs-QR",
       "promoFallback": "Aktion",
       "tipTax": "Trinkgeldsteuer",
-      "totalChargedUpper": "GESAMT ABGERECHNET"
+      "totalChargedUpper": "GESAMT ABGERECHNET",
+      "printUnconfirmedTitle": "Check the printer",
+      "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
+      "printRetry": "Retry",
+      "printWithBrowser": "Print with browser"
     }
   }
 }

--- a/i18n/locales/en/operaciones.json
+++ b/i18n/locales/en/operaciones.json
@@ -45,6 +45,7 @@
       "testPrintAria": "Print test on {name}",
       "testPrintTitle": "Test print",
       "testPrintOk": "Test sent to {name}",
+      "testPrintUnconfirmed": "Sent to {name}, but we could not confirm. Check that it is powered on and has paper.",
       "testPrintNeedPrinter": "Assign a printer first",
       "testPrintError": "Could not print test",
       "stationsTitle": "Kitchen printers",

--- a/i18n/locales/en/pos.json
+++ b/i18n/locales/en/pos.json
@@ -706,7 +706,11 @@
       "qrDianAlt": "DIAN verification QR",
       "promoFallback": "Promotion",
       "tipTax": "Tip tax",
-      "totalChargedUpper": "TOTAL CHARGED"
+      "totalChargedUpper": "TOTAL CHARGED",
+      "printUnconfirmedTitle": "Check the printer",
+      "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
+      "printRetry": "Retry",
+      "printWithBrowser": "Print with browser"
     }
   }
 }

--- a/i18n/locales/es/operaciones.json
+++ b/i18n/locales/es/operaciones.json
@@ -45,6 +45,7 @@
       "testPrintAria": "Imprimir prueba en {name}",
       "testPrintTitle": "Probar",
       "testPrintOk": "Prueba enviada a {name}",
+      "testPrintUnconfirmed": "Enviado a {name}, pero no se pudo confirmar. Verifica que esté encendida y con papel.",
       "testPrintNeedPrinter": "Asigna una impresora primero",
       "testPrintError": "No se pudo imprimir la prueba",
       "stationsTitle": "Impresoras por cocina",

--- a/i18n/locales/es/pos.json
+++ b/i18n/locales/es/pos.json
@@ -706,7 +706,11 @@
       "qrDianAlt": "QR verificación DIAN",
       "promoFallback": "Promoción",
       "tipTax": "Impuesto propina",
-      "totalChargedUpper": "TOTAL COBRADO"
+      "totalChargedUpper": "TOTAL COBRADO",
+      "printUnconfirmedTitle": "Revisa la impresora",
+      "printUnconfirmedBody": "Enviado a {name}, pero no se pudo confirmar que salió el ticket. ¿Está encendida?",
+      "printRetry": "Reintentar",
+      "printWithBrowser": "Imprimir con el navegador"
     }
   }
 }

--- a/i18n/locales/fr/operaciones.json
+++ b/i18n/locales/fr/operaciones.json
@@ -560,7 +560,8 @@
         "linuxAppImage": "Linux AppImage (amd64)",
         "recommended": "Recommended",
         "allReleases": "View all releases on GitHub"
-      }
+      },
+      "testPrintUnconfirmed": "Sent to {name}, but we could not confirm. Check that it is powered on and has paper."
     }
   }
 }

--- a/i18n/locales/fr/pos.json
+++ b/i18n/locales/fr/pos.json
@@ -694,7 +694,11 @@
       "qrDianAlt": "QR de vérification DIAN",
       "promoFallback": "Promotion",
       "tipTax": "Taxe sur le pourboire",
-      "totalChargedUpper": "TOTAL FACTURÉ"
+      "totalChargedUpper": "TOTAL FACTURÉ",
+      "printUnconfirmedTitle": "Check the printer",
+      "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
+      "printRetry": "Retry",
+      "printWithBrowser": "Print with browser"
     }
   }
 }

--- a/i18n/locales/hi/operaciones.json
+++ b/i18n/locales/hi/operaciones.json
@@ -560,7 +560,8 @@
         "linuxAppImage": "Linux AppImage (amd64)",
         "recommended": "Recommended",
         "allReleases": "View all releases on GitHub"
-      }
+      },
+      "testPrintUnconfirmed": "Sent to {name}, but we could not confirm. Check that it is powered on and has paper."
     }
   }
 }

--- a/i18n/locales/hi/pos.json
+++ b/i18n/locales/hi/pos.json
@@ -694,7 +694,11 @@
       "qrDianAlt": "DIAN सत्यापन QR",
       "promoFallback": "प्रमोशन",
       "tipTax": "टिप कर",
-      "totalChargedUpper": "कुल वसूला गया"
+      "totalChargedUpper": "कुल वसूला गया",
+      "printUnconfirmedTitle": "Check the printer",
+      "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
+      "printRetry": "Retry",
+      "printWithBrowser": "Print with browser"
     }
   }
 }

--- a/i18n/locales/pt/operaciones.json
+++ b/i18n/locales/pt/operaciones.json
@@ -560,7 +560,8 @@
         "linuxAppImage": "Linux AppImage (amd64)",
         "recommended": "Recommended",
         "allReleases": "View all releases on GitHub"
-      }
+      },
+      "testPrintUnconfirmed": "Sent to {name}, but we could not confirm. Check that it is powered on and has paper."
     }
   }
 }

--- a/i18n/locales/pt/pos.json
+++ b/i18n/locales/pt/pos.json
@@ -694,7 +694,11 @@
       "qrDianAlt": "QR de verificação DIAN",
       "promoFallback": "Promoção",
       "tipTax": "Imposto sobre gorjeta",
-      "totalChargedUpper": "TOTAL COBRADO"
+      "totalChargedUpper": "TOTAL COBRADO",
+      "printUnconfirmedTitle": "Check the printer",
+      "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
+      "printRetry": "Retry",
+      "printWithBrowser": "Print with browser"
     }
   }
 }

--- a/i18n/locales/zh/operaciones.json
+++ b/i18n/locales/zh/operaciones.json
@@ -560,7 +560,8 @@
         "linuxAppImage": "Linux AppImage (amd64)",
         "recommended": "Recommended",
         "allReleases": "View all releases on GitHub"
-      }
+      },
+      "testPrintUnconfirmed": "Sent to {name}, but we could not confirm. Check that it is powered on and has paper."
     }
   }
 }

--- a/i18n/locales/zh/pos.json
+++ b/i18n/locales/zh/pos.json
@@ -694,7 +694,11 @@
       "qrDianAlt": "DIAN验证二维码",
       "promoFallback": "促销",
       "tipTax": "小费税",
-      "totalChargedUpper": "已收总额"
+      "totalChargedUpper": "已收总额",
+      "printUnconfirmedTitle": "Check the printer",
+      "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
+      "printRetry": "Retry",
+      "printWithBrowser": "Print with browser"
     }
   }
 }

--- a/pages/operaciones/impresoras.vue
+++ b/pages/operaciones/impresoras.vue
@@ -186,10 +186,17 @@ async function printTest(rowId: string, printerName: string) {
   testingRowId.value = rowId
   try {
     await bridge.connect()
-    await bridge.printEscPosTestTicket(name, `WARO · ${name}`)
-    toast.success(t('operaciones.impresoras.testPrintOk', { name }), {
-      title: t('operaciones.impresoras.testPrintTitle'),
-    })
+    const outcome = await bridge.printEscPosTestTicket(name, `WARO · ${name}`)
+    if (outcome === 'unconfirmed') {
+      toast.warning(t('operaciones.impresoras.testPrintUnconfirmed', { name }), {
+        title: t('operaciones.impresoras.testPrintTitle'),
+        duration: 12000,
+      })
+    } else {
+      toast.success(t('operaciones.impresoras.testPrintOk', { name }), {
+        title: t('operaciones.impresoras.testPrintTitle'),
+      })
+    }
   } catch (err) {
     const msg = err instanceof Error ? err.message : t('operaciones.impresoras.testPrintError')
     toast.error(msg, { title: t('operaciones.impresoras.testPrintTitle') })

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -33,7 +33,7 @@ import {
   compactThermalMoneyLabel,
 } from '~/utils/receiptTicketPlainText'
 import { resolveReceiptLogoUrl } from '~/utils/receiptPrintConfig'
-import { useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
+import { notifyUnconfirmedCajaPrint, useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
 import { modifierLineTotal } from '~/utils/saleModifierOption'
 import {
   buildCustomerIdentityPresentation,
@@ -2724,7 +2724,7 @@ const printReceipt = async () => {
   }
   // Defer window.print until after await so body print classes stay until fallback.
   // Prefer teleported ReceiptPrintTicket (plain-text layout #1979), not flex #pos-receipt.
-  const mode = await printTicketElement('pos-receipt', {
+  const printResult = await printTicketElement('pos-receipt', {
     browserPrint: () => {},
     getElementHtml: () => {
       if (typeof document === 'undefined') return null
@@ -2732,8 +2732,19 @@ const printReceipt = async () => {
       return collectThermalTicketText(el) || null
     },
   })
-  if (mode === 'bridge') {
+  if (printResult.mode === 'bridge') {
     cleanup()
+    notifyUnconfirmedCajaPrint(printResult, {
+      t,
+      toast,
+      onRetry: () => { void printReceipt() },
+      onBrowserPrint: () => {
+        document.body.classList.add('printing-receipt-ticket')
+        window.addEventListener('afterprint', cleanup)
+        setTimeout(cleanup, 1500)
+        window.print()
+      },
+    })
     return
   }
   window.addEventListener('afterprint', cleanup)
@@ -3152,15 +3163,26 @@ const printPrefactura = async () => {
 
   await nextTick()
   // Defer window.print until after await so body print classes stay until fallback.
-  const mode = await printTicketElement('pos-prefactura', {
+  const printResult = await printTicketElement('pos-prefactura', {
     browserPrint: () => {},
     getElementHtml: () => {
       if (typeof document === 'undefined') return null
       return collectThermalTicketText(document.getElementById('pos-prefactura')) || null
     },
   })
-  if (mode === 'bridge') {
+  if (printResult.mode === 'bridge') {
     cleanup()
+    notifyUnconfirmedCajaPrint(printResult, {
+      t,
+      toast,
+      onRetry: () => { void printPrefactura() },
+      onBrowserPrint: () => {
+        document.body.classList.add('printing-prefactura')
+        window.addEventListener('afterprint', cleanup)
+        setTimeout(cleanup, 2000)
+        window.print()
+      },
+    })
     return
   }
   window.addEventListener('afterprint', cleanup)

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -11,7 +11,7 @@ import {
   buildCustomerIdentityPresentation,
   formatFiscalIdentityLabel,
 } from '~/utils/customerIdentityPresentation'
-import { useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
+import { notifyUnconfirmedCajaPrint, useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
 import { collectThermalTicketText } from '~/utils/receiptTicketPlainText'
 
 definePageMeta({ layout: 'dashboard', module: 'ventas' })
@@ -860,15 +860,26 @@ const printReceipt = async () => {
     document.body.classList.remove('printing-receipt-ticket')
     window.removeEventListener('afterprint', cleanup)
   }
-  const mode = await printTicketElement('pos-receipt', {
+  const printResult = await printTicketElement('pos-receipt', {
     browserPrint: () => {},
     getElementHtml: () => {
       if (typeof document === 'undefined') return null
       return collectThermalTicketText(document.querySelector('.receipt-print-ticket')) || null
     },
   })
-  if (mode === 'bridge') {
+  if (printResult.mode === 'bridge') {
     cleanup()
+    notifyUnconfirmedCajaPrint(printResult, {
+      t,
+      toast: useToast(),
+      onRetry: () => { void printReceipt() },
+      onBrowserPrint: () => {
+        document.body.classList.add('printing-receipt-ticket')
+        window.addEventListener('afterprint', cleanup)
+        window.setTimeout(cleanup, 1500)
+        window.print()
+      },
+    })
     return
   }
   window.addEventListener('afterprint', cleanup)


### PR DESCRIPTION
## Summary
- Soft CUPS “status no longer available” returns `unconfirmed` (still not a hard fail / no auto double print)
- Checkout, prefactura, and ventas show warning toast with **Retry** and **Print with browser**
- Impresoras test print uses a distinct unconfirmed message

Closes #2058

## Test plan
- [ ] Printer off but listed → print receipt → toast appears; browser CTA opens `window.print`
- [ ] Printer on and working → no warning toast (confirmed/completed path)
- [ ] Hard bridge failure still falls back to browser
- [ ] `bun test composables/useCajaTicketPrint.test.ts composables/useLocalPrintBridge.test.ts`

Made with [Cursor](https://cursor.com)