### PR TITLE
feat(pos): sticky browser print after unconfirmed thermal

### DIFF
--- a/composables/useCajaPrintPreference.test.ts
+++ b/composables/useCajaPrintPreference.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test'
+import {
+  CAJA_PRINT_FORCE_BROWSER_KEY,
+  __resetCajaPrintPreferenceRefsForTests,
+  clearCajaPrintForceBrowser,
+  enableCajaPrintForceBrowser,
+  isCajaPrintForceBrowser,
+  useCajaPrintPreference,
+} from './useCajaPrintPreference'
+
+function installMemoryLocalStorage() {
+  const store = new Map<string, string>()
+  const memoryStorage = {
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    setItem: (key: string, value: string) => { store.set(key, String(value)) },
+    removeItem: (key: string) => { store.delete(key) },
+    clear: () => { store.clear() },
+  }
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: memoryStorage,
+    configurable: true,
+    writable: true,
+  })
+  Object.defineProperty(globalThis, 'window', {
+    value: { localStorage: memoryStorage },
+    configurable: true,
+    writable: true,
+  })
+}
+
+describe('useCajaPrintPreference', () => {
+  beforeEach(() => {
+    installMemoryLocalStorage()
+    __resetCajaPrintPreferenceRefsForTests()
+    localStorage.removeItem(CAJA_PRINT_FORCE_BROWSER_KEY)
+  })
+
+  afterEach(() => {
+    __resetCajaPrintPreferenceRefsForTests()
+    localStorage.removeItem(CAJA_PRINT_FORCE_BROWSER_KEY)
+  })
+
+  it('defaults to not forcing browser', () => {
+    expect(isCajaPrintForceBrowser()).toBe(false)
+  })
+
+  it('persists enable/clear in localStorage', () => {
+    enableCajaPrintForceBrowser()
+    expect(localStorage.getItem(CAJA_PRINT_FORCE_BROWSER_KEY)).toBe('1')
+    expect(isCajaPrintForceBrowser()).toBe(true)
+
+    clearCajaPrintForceBrowser()
+    expect(localStorage.getItem(CAJA_PRINT_FORCE_BROWSER_KEY)).toBe(null)
+    expect(isCajaPrintForceBrowser()).toBe(false)
+  })
+
+  it('keeps reactive banner flag in sync across composable instances', () => {
+    const a = useCajaPrintPreference()
+    const b = useCajaPrintPreference()
+    expect(a.forceBrowser.value).toBe(false)
+
+    a.enableForceBrowser()
+    expect(a.forceBrowser.value).toBe(true)
+    expect(b.forceBrowser.value).toBe(true)
+
+    b.clearForceBrowser()
+    expect(a.forceBrowser.value).toBe(false)
+    expect(b.forceBrowser.value).toBe(false)
+  })
+})

--- a/composables/useCajaPrintPreference.ts
+++ b/composables/useCajaPrintPreference.ts
@@ -1,0 +1,68 @@
+/**
+ * Sticky “print caja tickets via browser” preference (#2060).
+ * Set when cashier chooses browser after an unconfirmed thermal print;
+ * cleared explicitly when they switch back to the thermal printer.
+ */
+import { ref, type Ref } from 'vue'
+
+export const CAJA_PRINT_FORCE_BROWSER_KEY = 'waro.cajaPrint.forceBrowser'
+
+export function isCajaPrintForceBrowser(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    return localStorage.getItem(CAJA_PRINT_FORCE_BROWSER_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+export function enableCajaPrintForceBrowser(): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(CAJA_PRINT_FORCE_BROWSER_KEY, '1')
+  } catch {
+    /* ignore quota / private mode */
+  }
+  syncForceBrowserRefs(true)
+}
+
+export function clearCajaPrintForceBrowser(): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.removeItem(CAJA_PRINT_FORCE_BROWSER_KEY)
+  } catch {
+    /* ignore */
+  }
+  syncForceBrowserRefs(false)
+}
+
+/** Shared reactive flag so POS/ventas banners update when sticky mode toggles. */
+const forceBrowserRefs = new Set<Ref<boolean>>()
+
+function syncForceBrowserRefs(value: boolean): void {
+  for (const r of forceBrowserRefs) r.value = value
+}
+
+export function useCajaPrintPreference() {
+  const forceBrowser = ref(isCajaPrintForceBrowser())
+  forceBrowserRefs.add(forceBrowser)
+
+  function enableForceBrowser(): void {
+    enableCajaPrintForceBrowser()
+  }
+
+  function clearForceBrowser(): void {
+    clearCajaPrintForceBrowser()
+  }
+
+  return {
+    forceBrowser,
+    enableForceBrowser,
+    clearForceBrowser,
+  }
+}
+
+/** Test helper — drop reactive listeners between suites. */
+export function __resetCajaPrintPreferenceRefsForTests(): void {
+  forceBrowserRefs.clear()
+}

--- a/composables/useCajaTicketPrint.test.ts
+++ b/composables/useCajaTicketPrint.test.ts
@@ -1,9 +1,34 @@
-import { describe, expect, it, mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
 import {
   notifyUnconfirmedCajaPrint,
   printTicketViaCajaOrBrowser,
 } from './useCajaTicketPrint'
 import type { LocalPrintBridge } from './useLocalPrintBridge'
+
+function installMemoryLocalStorage() {
+  const store = new Map<string, string>()
+  const memoryStorage = {
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    setItem: (key: string, value: string) => { store.set(key, String(value)) },
+    removeItem: (key: string) => { store.delete(key) },
+    clear: () => { store.clear() },
+  }
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: memoryStorage,
+    configurable: true,
+    writable: true,
+  })
+  Object.defineProperty(globalThis, 'window', {
+    value: { localStorage: memoryStorage },
+    configurable: true,
+    writable: true,
+  })
+}
+
+beforeEach(() => {
+  installMemoryLocalStorage()
+  localStorage.removeItem('waro.cajaPrint.forceBrowser')
+})
 
 function fakeBridge(overrides: Partial<LocalPrintBridge> = {}): LocalPrintBridge {
   return {
@@ -48,10 +73,27 @@ describe('printTicketViaCajaOrBrowser', () => {
       }),
       getElementHtml: () => '<div id="pos-receipt">OK</div>',
       browserPrint,
+      isForceBrowser: () => false,
     })
 
     expect(result).toEqual({ mode: 'bridge', confirmed: false, printerName: 'STAR_TP586' })
     expect(browserPrint).toHaveBeenCalledTimes(0)
+  })
+
+  it('skips bridge when sticky force-browser preference is on', async () => {
+    const printRawEscPos = mock(() => Promise.resolve('completed' as const))
+    const browserPrint = mock(() => {})
+    const result = await printTicketViaCajaOrBrowser('pos-receipt', {
+      getCajaPrinterName: async () => 'STAR_TP586',
+      bridge: fakeBridge({ printRawEscPos }),
+      getElementHtml: () => '<div id="pos-receipt">OK</div>',
+      browserPrint,
+      isForceBrowser: () => true,
+    })
+
+    expect(result).toEqual({ mode: 'browser' })
+    expect(printRawEscPos).toHaveBeenCalledTimes(0)
+    expect(browserPrint).toHaveBeenCalledTimes(1)
   })
 
   it('falls back to browser when caja assignment is missing', async () => {
@@ -166,5 +208,28 @@ describe('notifyUnconfirmedCajaPrint', () => {
       { t, toast: { warning }, onRetry, onBrowserPrint },
     )
     expect(warning).toHaveBeenCalledTimes(0)
+  })
+
+  it('enables sticky force-browser when cashier chooses browser CTA', () => {
+    localStorage.removeItem('waro.cajaPrint.forceBrowser')
+    const warning = mock(() => 1)
+    const onBrowserPrint = mock(() => {})
+    const t = (key: string) => key
+
+    notifyUnconfirmedCajaPrint(
+      { mode: 'bridge', confirmed: false, printerName: 'STAR_TP586' },
+      {
+        t,
+        toast: { warning },
+        onRetry: () => {},
+        onBrowserPrint,
+      },
+    )
+
+    const [, options] = warning.mock.calls[0]!
+    options.actions[1].onClick()
+    expect(localStorage.getItem('waro.cajaPrint.forceBrowser')).toBe('1')
+    expect(onBrowserPrint).toHaveBeenCalledTimes(1)
+    localStorage.removeItem('waro.cajaPrint.forceBrowser')
   })
 })

--- a/composables/useCajaTicketPrint.ts
+++ b/composables/useCajaTicketPrint.ts
@@ -2,7 +2,12 @@
  * Prefactura/factura → configured caja printer via PrintBridge ESC/POS raw (#1960/#1965).
  * Falls back to window.print when bridge/caja is missing, print fails, or hangs (#2003).
  * Soft CUPS “status gone” stays non-fatal but surfaces as unconfirmed (#2058).
+ * Sticky browser mode skips bridge until cashier returns to thermal (#2060).
  */
+import {
+  enableCajaPrintForceBrowser,
+  isCajaPrintForceBrowser,
+} from '~/composables/useCajaPrintPreference'
 import {
   LocalPrintBridgeError,
   useLocalPrintBridge,
@@ -33,6 +38,8 @@ export type CajaTicketPrintDeps = {
   getLogoSrc?: (elementId: string) => string | null
   /** Override bridge print race timeout (tests). */
   bridgePrintTimeoutMs?: number
+  /** Sticky browser preference (#2060); default reads localStorage. */
+  isForceBrowser?: () => boolean
 }
 
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
@@ -80,6 +87,12 @@ export async function printTicketViaCajaOrBrowser(
     if (typeof window !== 'undefined') window.print()
   })
   const getContent = deps.getElementHtml ?? defaultGetElementContent
+  const forceBrowser = deps.isForceBrowser ?? isCajaPrintForceBrowser
+
+  if (forceBrowser()) {
+    browserPrint()
+    return { mode: 'browser' }
+  }
 
   let caja: string | null | undefined
   try {
@@ -166,7 +179,10 @@ export function notifyUnconfirmedCajaPrint(
         },
         {
           label: opts.t('pos.receipt.printWithBrowser'),
-          onClick: opts.onBrowserPrint,
+          onClick: () => {
+            enableCajaPrintForceBrowser()
+            opts.onBrowserPrint()
+          },
         },
       ],
     },

--- a/i18n/locales/ar/pos.json
+++ b/i18n/locales/ar/pos.json
@@ -698,7 +698,9 @@
       "printUnconfirmedTitle": "Check the printer",
       "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
       "printRetry": "Retry",
-      "printWithBrowser": "Print with browser"
+      "printWithBrowser": "Print with browser",
+      "printBrowserStickyBody": "Printing with the browser until you switch back to the thermal printer.",
+      "printUseThermal": "Use thermal printer"
     }
   }
 }

--- a/i18n/locales/de/pos.json
+++ b/i18n/locales/de/pos.json
@@ -698,7 +698,9 @@
       "printUnconfirmedTitle": "Check the printer",
       "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
       "printRetry": "Retry",
-      "printWithBrowser": "Print with browser"
+      "printWithBrowser": "Print with browser",
+      "printBrowserStickyBody": "Printing with the browser until you switch back to the thermal printer.",
+      "printUseThermal": "Use thermal printer"
     }
   }
 }

--- a/i18n/locales/en/pos.json
+++ b/i18n/locales/en/pos.json
@@ -710,7 +710,9 @@
       "printUnconfirmedTitle": "Check the printer",
       "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
       "printRetry": "Retry",
-      "printWithBrowser": "Print with browser"
+      "printWithBrowser": "Print with browser",
+      "printBrowserStickyBody": "Printing with the browser until you switch back to the thermal printer.",
+      "printUseThermal": "Use thermal printer"
     }
   }
 }

--- a/i18n/locales/es/pos.json
+++ b/i18n/locales/es/pos.json
@@ -710,7 +710,9 @@
       "printUnconfirmedTitle": "Revisa la impresora",
       "printUnconfirmedBody": "Enviado a {name}, pero no se pudo confirmar que salió el ticket. ¿Está encendida?",
       "printRetry": "Reintentar",
-      "printWithBrowser": "Imprimir con el navegador"
+      "printWithBrowser": "Imprimir con el navegador",
+      "printBrowserStickyBody": "Imprimiendo por el navegador hasta que vuelvas a la térmica.",
+      "printUseThermal": "Usar impresora térmica"
     }
   }
 }

--- a/i18n/locales/fr/pos.json
+++ b/i18n/locales/fr/pos.json
@@ -698,7 +698,9 @@
       "printUnconfirmedTitle": "Check the printer",
       "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
       "printRetry": "Retry",
-      "printWithBrowser": "Print with browser"
+      "printWithBrowser": "Print with browser",
+      "printBrowserStickyBody": "Printing with the browser until you switch back to the thermal printer.",
+      "printUseThermal": "Use thermal printer"
     }
   }
 }

--- a/i18n/locales/hi/pos.json
+++ b/i18n/locales/hi/pos.json
@@ -698,7 +698,9 @@
       "printUnconfirmedTitle": "Check the printer",
       "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
       "printRetry": "Retry",
-      "printWithBrowser": "Print with browser"
+      "printWithBrowser": "Print with browser",
+      "printBrowserStickyBody": "Printing with the browser until you switch back to the thermal printer.",
+      "printUseThermal": "Use thermal printer"
     }
   }
 }

--- a/i18n/locales/pt/pos.json
+++ b/i18n/locales/pt/pos.json
@@ -698,7 +698,9 @@
       "printUnconfirmedTitle": "Check the printer",
       "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
       "printRetry": "Retry",
-      "printWithBrowser": "Print with browser"
+      "printWithBrowser": "Print with browser",
+      "printBrowserStickyBody": "Printing with the browser until you switch back to the thermal printer.",
+      "printUseThermal": "Use thermal printer"
     }
   }
 }

--- a/i18n/locales/zh/pos.json
+++ b/i18n/locales/zh/pos.json
@@ -698,7 +698,9 @@
       "printUnconfirmedTitle": "Check the printer",
       "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
       "printRetry": "Retry",
-      "printWithBrowser": "Print with browser"
+      "printWithBrowser": "Print with browser",
+      "printBrowserStickyBody": "Printing with the browser until you switch back to the thermal printer.",
+      "printUseThermal": "Use thermal printer"
     }
   }
 }

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -33,6 +33,7 @@ import {
   compactThermalMoneyLabel,
 } from '~/utils/receiptTicketPlainText'
 import { resolveReceiptLogoUrl } from '~/utils/receiptPrintConfig'
+import { useCajaPrintPreference } from '~/composables/useCajaPrintPreference'
 import { notifyUnconfirmedCajaPrint, useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
 import { modifierLineTotal } from '~/utils/saleModifierOption'
 import {
@@ -67,6 +68,10 @@ const cache = useQueryCache()
 const toast = useToast()
 const { currentTenant, businessProfile } = useTenantReactive()
 const { printElement: printTicketElement } = useCajaTicketPrint()
+const {
+  forceBrowser: forceBrowserPrint,
+  clearForceBrowser: clearForceBrowserPrint,
+} = useCajaPrintPreference()
 
 /** POS-scoped tenant display/settings — available to cashier via restaurant-context. */
 const posCheckoutContext = computed(() => settingsData.value?.data ?? null)
@@ -3581,6 +3586,24 @@ onUnmounted(() => {
     <!-- Main Grid (cart has items and sync completed) -->
     <div v-else class="grid grid-cols-1 lg:grid-cols-12 gap-6 items-start">
 
+      <!-- Sticky browser print mode (#2060) -->
+      <div
+        v-if="forceBrowserPrint"
+        role="status"
+        class="lg:col-span-12 flex flex-wrap items-center justify-between gap-3 min-h-[44px] px-4 py-3 bg-state-warning-bg border border-state-warning-border rounded-xl"
+      >
+        <p class="text-sm text-state-warning-text font-medium">
+          {{ t('pos.receipt.printBrowserStickyBody') }}
+        </p>
+        <button
+          type="button"
+          class="shrink-0 min-h-[36px] px-3 py-1.5 text-sm font-semibold rounded-lg border border-state-warning-border bg-surface text-text-primary hover:bg-surface-secondary transition-colors"
+          @click="clearForceBrowserPrint"
+        >
+          {{ t('pos.receipt.printUseThermal') }}
+        </button>
+      </div>
+
       <!-- Live promotion hint — checkout header (warocol.com#983) -->
       <div
         v-if="hasActivePromos"
@@ -5593,6 +5616,24 @@ onUnmounted(() => {
                   <span v-else>{{ t('pos.checkout.receiptEmail.send') }}</span>
                 </button>
               </div>
+            </div>
+
+            <!-- Sticky browser print mode (#2060) -->
+            <div
+              v-if="forceBrowserPrint"
+              role="status"
+              class="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-state-warning-border bg-state-warning-bg px-3 py-2"
+            >
+              <p class="text-xs text-state-warning-text font-medium">
+                {{ t('pos.receipt.printBrowserStickyBody') }}
+              </p>
+              <button
+                type="button"
+                class="shrink-0 text-xs font-semibold underline text-text-primary"
+                @click="clearForceBrowserPrint"
+              >
+                {{ t('pos.receipt.printUseThermal') }}
+              </button>
             </div>
 
             <!-- Print -->

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -11,6 +11,7 @@ import {
   buildCustomerIdentityPresentation,
   formatFiscalIdentityLabel,
 } from '~/utils/customerIdentityPresentation'
+import { useCajaPrintPreference } from '~/composables/useCajaPrintPreference'
 import { notifyUnconfirmedCajaPrint, useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
 import { collectThermalTicketText } from '~/utils/receiptTicketPlainText'
 
@@ -21,6 +22,10 @@ useHead({ title: () => t('ventas.head.detail') })
 // Tenant reactivity
 const { currentTenant, businessProfile } = useTenantReactive()
 const { printElement: printTicketElement } = useCajaTicketPrint()
+const {
+  forceBrowser: forceBrowserPrint,
+  clearForceBrowser: clearForceBrowserPrint,
+} = useCajaPrintPreference()
 const { singular: tableSingular } = useTableLabel()
 const {
   receiptPrintSettings,
@@ -1102,6 +1107,23 @@ onUnmounted(() => {
 
     <!-- Order Details -->
     <div v-else class="space-y-6">
+      <div
+        v-if="forceBrowserPrint"
+        role="status"
+        class="flex flex-wrap items-center justify-between gap-3 min-h-[44px] px-4 py-3 bg-state-warning-bg border border-state-warning-border rounded-xl"
+      >
+        <p class="text-sm text-state-warning-text font-medium">
+          {{ t('pos.receipt.printBrowserStickyBody') }}
+        </p>
+        <button
+          type="button"
+          class="shrink-0 min-h-[36px] px-3 py-1.5 text-sm font-semibold rounded-lg border border-state-warning-border bg-surface text-text-primary hover:bg-surface-secondary transition-colors"
+          @click="clearForceBrowserPrint"
+        >
+          {{ t('pos.receipt.printUseThermal') }}
+        </button>
+      </div>
+
       <!-- Order Info Grid -->
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
         <!-- Customer Name -->


### PR DESCRIPTION
## Summary
- Choosing **Print with browser** enables sticky force-browser mode (localStorage)
- Prefactura / checkout / ventas skip PrintBridge while sticky and use `window.print`
- Banner with **Use thermal printer** clears sticky mode

Closes #2060

## Test plan
- [ ] Unconfirmed thermal → browser CTA → next prints open browser dialog without toast
- [ ] Banner “Use thermal printer” restores bridge path
- [ ] `bun test composables/useCajaPrintPreference.test.ts composables/useCajaTicketPrint.test.ts`

Made with [Cursor](https://cursor.com)