### PR TITLE
feat(shell): Usar térmica header chip for sticky browser print

### DIFF
--- a/components/dashboard/DashboardShellHeader.vue
+++ b/components/dashboard/DashboardShellHeader.vue
@@ -22,6 +22,11 @@
         tag="div"
           class="dashboard-header-actions relative flex w-fit min-w-0 max-w-full flex-shrink-0 items-center justify-end gap-1.5 overflow-x-auto md:gap-2 lg:overflow-visible"
       >
+        <PosCajaPrintThermalChip
+          v-if="forceBrowserPrint"
+          key="caja-print-thermal-chip"
+        />
+
         <NotificationsNotificationBell key="notifications-bell" class="hidden lg:flex" />
 
         <NuxtLink
@@ -111,6 +116,7 @@ import { getDashboardHome } from '~/utils/internalAccess'
 
 const { t } = useI18n()
 const accessStore = useAccessStore()
+const { forceBrowser: forceBrowserPrint } = useCajaPrintPreference()
 
 const dashboardHome = computed(() =>
   getDashboardHome(accessStore.modules, { isLoaded: accessStore.isLoaded }),

--- a/components/pos/CajaPrintThermalChip.vue
+++ b/components/pos/CajaPrintThermalChip.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+/**
+ * Compact header control when sticky browser-print is active (#2062).
+ * Clears force-browser so the next caja ticket uses the thermal printer again.
+ */
+const { t } = useI18n({ useScope: 'global' })
+const { clearForceBrowser } = useCajaPrintPreference()
+</script>
+
+<template>
+  <button
+    type="button"
+    class="h-9 max-w-[9.5rem] flex-shrink-0 inline-flex items-center justify-center rounded-lg border border-border bg-surface px-2.5 text-xs font-semibold text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring transition-colors truncate"
+    :title="t('pos.receipt.printBrowserStickyBody')"
+    :aria-label="t('pos.receipt.printUseThermal')"
+    @click="clearForceBrowser"
+  >
+    {{ t('pos.receipt.printUseThermalShort') }}
+  </button>
+</template>

--- a/i18n/locales/ar/pos.json
+++ b/i18n/locales/ar/pos.json
@@ -700,7 +700,8 @@
       "printRetry": "Retry",
       "printWithBrowser": "Print with browser",
       "printBrowserStickyBody": "Printing with the browser until you switch back to the thermal printer.",
-      "printUseThermal": "Use thermal printer"
+      "printUseThermal": "Use thermal printer",
+      "printUseThermalShort": "Use thermal"
     }
   }
 }

--- a/i18n/locales/de/pos.json
+++ b/i18n/locales/de/pos.json
@@ -700,7 +700,8 @@
       "printRetry": "Retry",
       "printWithBrowser": "Print with browser",
       "printBrowserStickyBody": "Printing with the browser until you switch back to the thermal printer.",
-      "printUseThermal": "Use thermal printer"
+      "printUseThermal": "Use thermal printer",
+      "printUseThermalShort": "Use thermal"
     }
   }
 }

--- a/i18n/locales/en/pos.json
+++ b/i18n/locales/en/pos.json
@@ -712,7 +712,8 @@
       "printRetry": "Retry",
       "printWithBrowser": "Print with browser",
       "printBrowserStickyBody": "Printing with the browser until you switch back to the thermal printer.",
-      "printUseThermal": "Use thermal printer"
+      "printUseThermal": "Use thermal printer",
+      "printUseThermalShort": "Use thermal"
     }
   }
 }

--- a/i18n/locales/es/pos.json
+++ b/i18n/locales/es/pos.json
@@ -712,7 +712,8 @@
       "printRetry": "Reintentar",
       "printWithBrowser": "Imprimir con el navegador",
       "printBrowserStickyBody": "Imprimiendo por el navegador hasta que vuelvas a la térmica.",
-      "printUseThermal": "Usar impresora térmica"
+      "printUseThermal": "Usar impresora térmica",
+      "printUseThermalShort": "Usar térmica"
     }
   }
 }

--- a/i18n/locales/fr/pos.json
+++ b/i18n/locales/fr/pos.json
@@ -700,7 +700,8 @@
       "printRetry": "Retry",
       "printWithBrowser": "Print with browser",
       "printBrowserStickyBody": "Printing with the browser until you switch back to the thermal printer.",
-      "printUseThermal": "Use thermal printer"
+      "printUseThermal": "Use thermal printer",
+      "printUseThermalShort": "Use thermal"
     }
   }
 }

--- a/i18n/locales/hi/pos.json
+++ b/i18n/locales/hi/pos.json
@@ -700,7 +700,8 @@
       "printRetry": "Retry",
       "printWithBrowser": "Print with browser",
       "printBrowserStickyBody": "Printing with the browser until you switch back to the thermal printer.",
-      "printUseThermal": "Use thermal printer"
+      "printUseThermal": "Use thermal printer",
+      "printUseThermalShort": "Use thermal"
     }
   }
 }

--- a/i18n/locales/pt/pos.json
+++ b/i18n/locales/pt/pos.json
@@ -700,7 +700,8 @@
       "printRetry": "Retry",
       "printWithBrowser": "Print with browser",
       "printBrowserStickyBody": "Printing with the browser until you switch back to the thermal printer.",
-      "printUseThermal": "Use thermal printer"
+      "printUseThermal": "Use thermal printer",
+      "printUseThermalShort": "Use thermal"
     }
   }
 }

--- a/i18n/locales/zh/pos.json
+++ b/i18n/locales/zh/pos.json
@@ -700,7 +700,8 @@
       "printRetry": "Retry",
       "printWithBrowser": "Print with browser",
       "printBrowserStickyBody": "Printing with the browser until you switch back to the thermal printer.",
-      "printUseThermal": "Use thermal printer"
+      "printUseThermal": "Use thermal printer",
+      "printUseThermalShort": "Use thermal"
     }
   }
 }

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -33,7 +33,6 @@ import {
   compactThermalMoneyLabel,
 } from '~/utils/receiptTicketPlainText'
 import { resolveReceiptLogoUrl } from '~/utils/receiptPrintConfig'
-import { useCajaPrintPreference } from '~/composables/useCajaPrintPreference'
 import { notifyUnconfirmedCajaPrint, useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
 import { modifierLineTotal } from '~/utils/saleModifierOption'
 import {
@@ -68,10 +67,6 @@ const cache = useQueryCache()
 const toast = useToast()
 const { currentTenant, businessProfile } = useTenantReactive()
 const { printElement: printTicketElement } = useCajaTicketPrint()
-const {
-  forceBrowser: forceBrowserPrint,
-  clearForceBrowser: clearForceBrowserPrint,
-} = useCajaPrintPreference()
 
 /** POS-scoped tenant display/settings — available to cashier via restaurant-context. */
 const posCheckoutContext = computed(() => settingsData.value?.data ?? null)
@@ -3586,24 +3581,6 @@ onUnmounted(() => {
     <!-- Main Grid (cart has items and sync completed) -->
     <div v-else class="grid grid-cols-1 lg:grid-cols-12 gap-6 items-start">
 
-      <!-- Sticky browser print mode (#2060) -->
-      <div
-        v-if="forceBrowserPrint"
-        role="status"
-        class="lg:col-span-12 flex flex-wrap items-center justify-between gap-3 min-h-[44px] px-4 py-3 bg-state-warning-bg border border-state-warning-border rounded-xl"
-      >
-        <p class="text-sm text-state-warning-text font-medium">
-          {{ t('pos.receipt.printBrowserStickyBody') }}
-        </p>
-        <button
-          type="button"
-          class="shrink-0 min-h-[36px] px-3 py-1.5 text-sm font-semibold rounded-lg border border-state-warning-border bg-surface text-text-primary hover:bg-surface-secondary transition-colors"
-          @click="clearForceBrowserPrint"
-        >
-          {{ t('pos.receipt.printUseThermal') }}
-        </button>
-      </div>
-
       <!-- Live promotion hint — checkout header (warocol.com#983) -->
       <div
         v-if="hasActivePromos"
@@ -5616,24 +5593,6 @@ onUnmounted(() => {
                   <span v-else>{{ t('pos.checkout.receiptEmail.send') }}</span>
                 </button>
               </div>
-            </div>
-
-            <!-- Sticky browser print mode (#2060) -->
-            <div
-              v-if="forceBrowserPrint"
-              role="status"
-              class="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-state-warning-border bg-state-warning-bg px-3 py-2"
-            >
-              <p class="text-xs text-state-warning-text font-medium">
-                {{ t('pos.receipt.printBrowserStickyBody') }}
-              </p>
-              <button
-                type="button"
-                class="shrink-0 text-xs font-semibold underline text-text-primary"
-                @click="clearForceBrowserPrint"
-              >
-                {{ t('pos.receipt.printUseThermal') }}
-              </button>
             </div>
 
             <!-- Print -->

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -11,7 +11,6 @@ import {
   buildCustomerIdentityPresentation,
   formatFiscalIdentityLabel,
 } from '~/utils/customerIdentityPresentation'
-import { useCajaPrintPreference } from '~/composables/useCajaPrintPreference'
 import { notifyUnconfirmedCajaPrint, useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
 import { collectThermalTicketText } from '~/utils/receiptTicketPlainText'
 
@@ -22,10 +21,6 @@ useHead({ title: () => t('ventas.head.detail') })
 // Tenant reactivity
 const { currentTenant, businessProfile } = useTenantReactive()
 const { printElement: printTicketElement } = useCajaTicketPrint()
-const {
-  forceBrowser: forceBrowserPrint,
-  clearForceBrowser: clearForceBrowserPrint,
-} = useCajaPrintPreference()
 const { singular: tableSingular } = useTableLabel()
 const {
   receiptPrintSettings,
@@ -1107,23 +1102,6 @@ onUnmounted(() => {
 
     <!-- Order Details -->
     <div v-else class="space-y-6">
-      <div
-        v-if="forceBrowserPrint"
-        role="status"
-        class="flex flex-wrap items-center justify-between gap-3 min-h-[44px] px-4 py-3 bg-state-warning-bg border border-state-warning-border rounded-xl"
-      >
-        <p class="text-sm text-state-warning-text font-medium">
-          {{ t('pos.receipt.printBrowserStickyBody') }}
-        </p>
-        <button
-          type="button"
-          class="shrink-0 min-h-[36px] px-3 py-1.5 text-sm font-semibold rounded-lg border border-state-warning-border bg-surface text-text-primary hover:bg-surface-secondary transition-colors"
-          @click="clearForceBrowserPrint"
-        >
-          {{ t('pos.receipt.printUseThermal') }}
-        </button>
-      </div>
-
       <!-- Order Info Grid -->
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
         <!-- Customer Name -->


### PR DESCRIPTION
## Summary
- Compact **Usar térmica** chip in dashboard header when sticky browser print is on
- Click clears sticky mode (next print uses thermal again)
- Removes checkout / ventas page banners

Closes #2062

## Test plan
- [ ] Unconfirmed → Print with browser → chip appears in header on any dashboard page
- [ ] Click Usar térmica → chip gone; next print uses PrintBridge
- [ ] No large warning banners on checkout or ventas/[id]

Made with [Cursor](https://cursor.com)