### PR TITLE
fix(shell): compact dashboard header for clearer hierarchy

### DIFF
--- a/components/DashboardTenantSelector.vue
+++ b/components/DashboardTenantSelector.vue
@@ -54,29 +54,30 @@
   </Teleport>
 
   <!-- Header: Tenant + User info (desktop only) -->
-  <div class="hidden lg:flex items-center gap-2">
-    <!-- Tenant selector button — same style as refresh button -->
+  <div class="hidden lg:flex items-center gap-1">
+    <!-- Tenant selector — compact -->
     <button
       @click="openTenantModal"
       :disabled="isLoadingTenants"
       aria-label="Cambiar negocio"
-      class="flex items-center gap-2 h-11 px-3 bg-shell-account-bg border-2 border-shell-account-border rounded-lg text-sm font-medium text-shell-account-text hover:bg-shell-account-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      :title="isLoadingTenants ? 'Cargando...' : (selectedTenant?.name || 'Seleccionar')"
+      class="flex items-center gap-1.5 h-9 px-2 bg-shell-account-bg border border-shell-account-border rounded-lg text-xs font-medium text-shell-account-text hover:bg-shell-account-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
     >
-      <span class="w-2 h-2 bg-shell-account-indicator-bg rounded-full flex-shrink-0" />
-      <span class="truncate max-w-[150px]">{{ isLoadingTenants ? 'Cargando...' : (selectedTenant?.name || 'Seleccionar') }}</span>
+      <span class="w-1.5 h-1.5 bg-shell-account-indicator-bg rounded-full flex-shrink-0" />
+      <span class="truncate max-w-[7.5rem] xl:max-w-[9rem]">{{ isLoadingTenants ? 'Cargando...' : (selectedTenant?.name || 'Seleccionar') }}</span>
       <ChevronDownIcon class="w-3.5 h-3.5 text-shell-account-chevron-text flex-shrink-0" />
     </button>
 
-    <!-- User profile -->
+    <!-- User profile — avatar only (name in aria/title) -->
     <NuxtLink
       to="/perfil"
       :aria-label="t('perfil.navigation.open')"
-      class="flex items-center gap-2 h-11 px-3 bg-shell-account-bg border-2 border-shell-account-border rounded-lg hover:bg-shell-account-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring transition-colors"
+      :title="userName"
+      class="flex items-center justify-center h-9 w-9 bg-shell-account-bg border border-shell-account-border rounded-lg hover:bg-shell-account-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring transition-colors"
     >
-      <span class="text-sm font-medium text-shell-account-text truncate max-w-[120px]">{{ userName }}</span>
-      <div class="w-8 h-8 bg-shell-account-avatar-bg border border-shell-account-avatar-border rounded-full overflow-hidden flex items-center justify-center flex-shrink-0">
+      <div class="w-7 h-7 bg-shell-account-avatar-bg border border-shell-account-avatar-border rounded-full overflow-hidden flex items-center justify-center flex-shrink-0">
         <img v-if="userAvatar" :src="userAvatar" :alt="t('perfil.avatar.alt', { name: userName })" class="h-full w-full object-cover" />
-        <span v-else class="text-xs font-bold text-shell-account-icon-text" aria-hidden="true">{{ userInitials }}</span>
+        <span v-else class="text-[10px] font-bold text-shell-account-icon-text" aria-hidden="true">{{ userInitials }}</span>
       </div>
     </NuxtLink>
   </div>

--- a/components/dashboard/BusinessStatusToggle.vue
+++ b/components/dashboard/BusinessStatusToggle.vue
@@ -5,18 +5,18 @@
       @click="openModal"
       :disabled="isUpdating"
       :aria-label="businessProfile.is_currently_open ? t('shell.businessOpenAria') : t('shell.businessClosedAria')"
-      class="flex items-center gap-1.5 min-h-[44px] px-3 rounded-lg border transition-all focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring disabled:opacity-50 disabled:cursor-not-allowed"
+      class="flex items-center gap-1.5 h-9 px-2 rounded-lg border border-transparent transition-all focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring disabled:opacity-50 disabled:cursor-not-allowed hover:bg-surface-secondary/70"
       :class="businessProfile.is_currently_open
-        ? 'bg-status-success-bg border-status-success-text text-status-success-text hover:opacity-80'
-        : 'bg-status-critical-bg border-status-critical-text text-status-critical-text hover:opacity-80'"
+        ? 'text-status-success-text'
+        : 'text-status-critical-text'"
     >
       <!-- Status dot -->
       <span
-        class="w-2 h-2 rounded-full flex-shrink-0"
-        :class="businessProfile.is_currently_open ? 'bg-status-success-text animate-pulse' : 'bg-status-critical-text'"
+        class="w-1.5 h-1.5 rounded-full flex-shrink-0"
+        :class="businessProfile.is_currently_open ? 'bg-status-success-text' : 'bg-status-critical-text'"
         aria-hidden="true"
       />
-      <span class="text-sm font-medium hidden sm:inline">
+      <span class="text-xs font-medium hidden sm:inline">
         {{ businessProfile.is_currently_open ? t('shell.businessOpen') : t('shell.businessClosed') }}
       </span>
       <!-- Spinner when updating -->

--- a/components/dashboard/DashboardShellHeader.vue
+++ b/components/dashboard/DashboardShellHeader.vue
@@ -1,111 +1,124 @@
 <template>
-  <header class="bg-shell-header-bg border-b border-shell-header-border px-4 py-3 md:px-6 xl:px-8 md:py-4 flex-shrink-0">
-    <div class="flex min-w-0 items-center justify-between gap-3">
-      <div class="flex min-w-0 items-center gap-2 sm:gap-4">
+  <header class="bg-shell-header-bg border-b border-shell-header-border px-3 py-2 md:px-5 xl:px-6 flex-shrink-0">
+    <div class="flex min-w-0 items-center justify-between gap-2">
+      <div class="flex min-w-0 items-center gap-2">
         <NuxtLink
           v-if="!hideLogo"
           :to="dashboardHome"
-          class="dashboard-header-logo hidden xl:flex h-12 w-fit max-w-[220px] flex-shrink-0 items-center justify-start overflow-visible"
+          class="dashboard-header-logo hidden xl:flex h-9 w-fit max-w-[160px] flex-shrink-0 items-center justify-start overflow-visible"
           :aria-label="t('shell.goToDashboardHome')"
         >
           <img
             :src="headerLogoSrc"
             alt="WARO"
-            class="h-8 w-auto max-h-9 object-contain object-left"
+            class="h-7 w-auto max-h-8 object-contain object-left"
           />
         </NuxtLink>
-
       </div>
 
       <TransitionGroup
         name="header-actions"
         tag="div"
-          class="dashboard-header-actions relative flex w-fit min-w-0 max-w-full flex-shrink-0 items-center justify-end gap-1.5 overflow-x-auto md:gap-2 lg:overflow-visible"
+        class="dashboard-header-actions relative flex w-fit min-w-0 max-w-full flex-shrink-0 items-center justify-end gap-1.5 overflow-x-auto lg:overflow-visible"
       >
-        <PosCajaPrintThermalChip
-          v-if="forceBrowserPrint"
-          key="caja-print-thermal-chip"
-        />
-
-        <NotificationsNotificationBell key="notifications-bell" class="hidden lg:flex" />
-
-        <NuxtLink
-          key="upload-invoice"
-          to="/abastecimiento/compras-directas/crear"
-          class="flex flex-shrink-0 items-center gap-1 md:gap-2 h-11 bg-shell-cta-bg text-shell-cta-text px-2 lg:px-4 rounded-xl font-medium hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring transition-all"
-          :title="t('shell.uploadInvoiceAi')"
+        <!-- Actions: print mode, alerts, quick entry -->
+        <div
+          key="group-actions"
+          class="flex items-center gap-1"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z" /><path d="M20 2v4" /><path d="M22 4h-4" /><circle cx="4" cy="20" r="2" /></svg>
-          <span class="hidden lg:inline text-base">{{ t('shell.uploadInvoiceAi') }}</span>
-        </NuxtLink>
+          <PosCajaPrintThermalChip v-if="forceBrowserPrint" />
 
-        <button
-          key="pos-link"
-          type="button"
-          class="flex flex-shrink-0 items-center gap-1 md:gap-2 h-11 bg-shell-action-bg border-2 border-shell-action-border text-shell-action-text px-2 lg:px-4 rounded-lg text-base font-medium hover:bg-shell-action-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring transition-colors"
-          :title="t('nav.pos')"
-          @click="$emit('navigate-pos')"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14" /><path d="M12 5v14" /></svg>
-          <span class="hidden lg:inline text-base">{{ t('nav.pos') }}</span>
-        </button>
+          <NotificationsNotificationBell class="hidden lg:flex shrink-0 [&_button]:!w-9 [&_button]:!h-9 [&_svg]:!w-5 [&_svg]:!h-5" />
 
-        <div key="portal-actions" id="dashboard-header-actions" class="flex items-center" />
-
-        <button
-          v-if="headerAction"
-          key="dynamic-header-action"
-          :class="[
-            'h-11 flex-shrink-0 rounded-lg font-medium focus:outline-none focus:ring-2 transition-colors flex items-center justify-center gap-2',
-            headerAction.iconOnly
-              ? 'bg-shell-icon-bg text-shell-icon-text hover:bg-shell-icon-hover-bg focus:ring-shell-action-focus-ring'
-              : 'bg-shell-cta-bg text-shell-cta-text hover:bg-shell-cta-hover-bg focus:ring-shell-cta-focus-ring',
-            headerAction.iconOnly ? 'w-11 px-0' : 'max-w-48 px-3 lg:px-4',
-          ]"
-          :aria-label="headerAction.ariaLabel || headerAction.label"
-          :title="headerAction.ariaLabel || headerAction.label"
-          @click="headerAction.handler"
-        >
-          <svg v-if="headerAction.icon === 'printer' || headerAction.icon === true" class="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 9V3h12v6" />
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" />
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 14h12v7H6z" />
-          </svg>
-          <span v-if="!headerAction.iconOnly" class="truncate">{{ headerAction.label }}</span>
-        </button>
-
-        <span
-          v-if="status"
-          key="dynamic-status"
-          :class="['h-11 max-w-36 flex flex-shrink-0 items-center px-3 rounded-lg text-sm font-medium', status.color]"
-        >
-          <span class="truncate">{{ status.label }}</span>
-        </span>
-
-        <DashboardBusinessStatusToggle key="business-status-toggle" />
-
-        <button
-          key="refresh-button"
-          :disabled="isRefreshing || isProgressiveLoading"
-          :aria-label="t('shell.refreshData')"
-          :aria-busy="isRefreshing || isProgressiveLoading"
-          class="hidden md:flex w-11 h-11 items-center justify-center bg-shell-icon-bg border-0 rounded-lg text-shell-icon-text hover:bg-shell-icon-hover-bg transition-all focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring disabled:opacity-50 disabled:cursor-not-allowed"
-          :title="t('shell.refresh')"
-          @click="$emit('refresh')"
-        >
-          <UiLoadingMatrix v-if="isRefreshing || isProgressiveLoading" size="5.5px" />
-          <svg
-            v-else
-            class="w-5 h-5 transition-transform duration-300 hover:rotate-180"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
+          <NuxtLink
+            to="/abastecimiento/compras-directas/crear"
+            class="flex flex-shrink-0 items-center justify-center gap-1.5 h-9 bg-shell-cta-bg text-shell-cta-text px-2 xl:px-2.5 rounded-lg text-sm font-medium hover:bg-shell-cta-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-cta-focus-ring transition-all"
+            :title="t('shell.uploadInvoiceAi')"
+            :aria-label="t('shell.uploadInvoiceAi')"
           >
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 0 0 4.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 0 1-15.357-2m15.357 2H15" />
-          </svg>
-        </button>
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z" /><path d="M20 2v4" /><path d="M22 4h-4" /><circle cx="4" cy="20" r="2" /></svg>
+            <span class="hidden xl:inline">{{ t('shell.uploadInvoiceAi') }}</span>
+          </NuxtLink>
 
-        <DashboardTenantSelector key="tenant-selector" />
+          <button
+            type="button"
+            class="flex flex-shrink-0 items-center justify-center gap-1.5 h-9 bg-shell-action-bg border border-shell-action-border text-shell-action-text px-2 xl:px-2.5 rounded-lg text-sm font-medium hover:bg-shell-action-hover-bg focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring transition-colors"
+            :title="t('nav.pos')"
+            :aria-label="t('nav.pos')"
+            @click="$emit('navigate-pos')"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14" /><path d="M12 5v14" /></svg>
+            <span class="hidden xl:inline">{{ t('nav.pos') }}</span>
+          </button>
+
+          <div id="dashboard-header-actions" class="flex items-center" />
+        </div>
+
+        <!-- Status -->
+        <div
+          key="group-status"
+          class="flex items-center gap-1 ps-2 ms-0.5 border-s border-border/70"
+        >
+          <button
+            v-if="headerAction"
+            type="button"
+            :class="[
+              'h-9 flex-shrink-0 rounded-lg text-sm font-medium focus:outline-none focus:ring-2 transition-colors flex items-center justify-center gap-1.5',
+              headerAction.iconOnly
+                ? 'bg-shell-icon-bg text-shell-icon-text hover:bg-shell-icon-hover-bg focus:ring-shell-action-focus-ring w-9 px-0'
+                : 'bg-shell-action-bg border border-shell-action-border text-shell-action-text hover:bg-shell-action-hover-bg focus:ring-shell-action-focus-ring max-w-40 px-2 xl:px-2.5',
+            ]"
+            :aria-label="headerAction.ariaLabel || headerAction.label"
+            :title="headerAction.ariaLabel || headerAction.label"
+            @click="headerAction.handler"
+          >
+            <svg v-if="headerAction.icon === 'printer' || headerAction.icon === true" class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 9V3h12v6" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 14h12v7H6z" />
+            </svg>
+            <span v-if="!headerAction.iconOnly" class="truncate hidden xl:inline">{{ headerAction.label }}</span>
+          </button>
+
+          <span
+            v-if="status"
+            :class="['h-9 max-w-28 flex flex-shrink-0 items-center px-2 rounded-lg text-xs font-medium', status.color]"
+          >
+            <span class="truncate">{{ status.label }}</span>
+          </span>
+
+          <DashboardBusinessStatusToggle />
+
+          <button
+            type="button"
+            :disabled="isRefreshing || isProgressiveLoading"
+            :aria-label="t('shell.refreshData')"
+            :aria-busy="isRefreshing || isProgressiveLoading"
+            class="hidden md:flex w-9 h-9 items-center justify-center bg-shell-icon-bg border-0 rounded-lg text-shell-icon-text hover:bg-shell-icon-hover-bg transition-all focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring disabled:opacity-50 disabled:cursor-not-allowed"
+            :title="t('shell.refresh')"
+            @click="$emit('refresh')"
+          >
+            <UiLoadingMatrix v-if="isRefreshing || isProgressiveLoading" size="5px" />
+            <svg
+              v-else
+              class="w-4 h-4 transition-transform duration-300 hover:rotate-180"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 0 0 4.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 0 1-15.357-2m15.357 2H15" />
+            </svg>
+          </button>
+        </div>
+
+        <!-- Identity -->
+        <div
+          key="group-identity"
+          class="flex items-center ps-2 ms-0.5 border-s border-border/70"
+        >
+          <DashboardTenantSelector />
+        </div>
       </TransitionGroup>
     </div>
   </header>

--- a/components/pos/CajaPrintThermalChip.vue
+++ b/components/pos/CajaPrintThermalChip.vue
@@ -2,7 +2,7 @@
 /**
  * Compact header control when sticky browser-print is active (#2062/#2064).
  * Clears force-browser so the next caja ticket uses the thermal printer again.
- * Copy lives under shell.* so the dashboard header always resolves i18n.
+ * Quiet chip — temporary mode, not a primary CTA.
  */
 const { t, te } = useI18n({ useScope: 'global' })
 const { clearForceBrowser } = useCajaPrintPreference()
@@ -27,7 +27,7 @@ const title = computed(() =>
 <template>
   <button
     type="button"
-    class="h-9 max-w-[9.5rem] flex-shrink-0 inline-flex items-center justify-center rounded-lg border border-border bg-surface px-2.5 text-xs font-semibold text-text-primary hover:bg-surface-secondary focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring transition-colors truncate"
+    class="h-8 max-w-[7.5rem] flex-shrink-0 inline-flex items-center justify-center rounded-md px-2 text-[11px] font-medium text-text-secondary bg-surface-secondary/60 hover:bg-surface-secondary hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring transition-colors truncate"
     :title="title"
     :aria-label="ariaLabel"
     @click="clearForceBrowser"

--- a/pages/pos/index.vue
+++ b/pages/pos/index.vue
@@ -2202,16 +2202,16 @@ onUnmounted(() => {
         type="button"
         :aria-label="readyComandasCount > 0 ? t('pos.banner.comandasStatusReady', { count: readyComandasCount }) : t('pos.banner.comandasStatus')"
         :title="readyComandasCount > 0 ? (readyComandasCount === 1 ? t('pos.banner.comandasReadyTitleOne', { count: readyComandasCount }) : t('pos.banner.comandasReadyTitleMany', { count: readyComandasCount })) : t('pos.banner.comandasStatus')"
-        class="relative inline-flex items-center gap-2 h-11 rounded-lg border-2 border-surface-secondary bg-action-secondary-bg text-action-secondary-text text-sm font-medium hover:bg-action-secondary-hover-bg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-action-secondary-focus-ring me-1.5 md:me-2 px-2.5 sm:px-3 md:px-4"
-        :class="readyComandasCount > 0 ? 'ring-1 ring-state-success-border/60' : ''"
+        class="relative inline-flex items-center gap-1.5 h-9 rounded-lg border border-shell-action-border bg-shell-action-bg text-shell-action-text text-sm font-medium hover:bg-shell-action-hover-bg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-shell-action-focus-ring px-2 xl:px-2.5"
+        :class="readyComandasCount > 0 ? 'ring-1 ring-state-success-border/50' : ''"
         @click="showExpediterPanel = true"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/>
           <rect x="8" y="2" width="8" height="4" rx="1" ry="1"/>
           <path d="m9 14 2 2 4-4"/>
         </svg>
-        <span class="hidden sm:inline text-sm font-medium">{{ t('pos.banner.comandas') }}</span>
+        <span class="hidden xl:inline text-sm font-medium">{{ t('pos.banner.comandas') }}</span>
         <!-- Count badge: numeric on sm+, dot indicator on mobile -->
         <span
           v-if="readyComandasCount > 0"


### PR DESCRIPTION
## Summary
- Compact header controls (`h-9`, `text-sm`/`text-xs`)
- Groups: actions | status | identity with light separators
- Quieter Abierto + Usar térmica; avatar-only profile
- Comandas portal button aligned to compact shell

Closes #2066

## Test plan
- [ ] Header looks less crowded on laptop with térmica + Comandas visible
- [ ] Hover avatar shows full name; tenant still readable
- [ ] IA remains the sole filled CTA; POS/Comandas outline

Made with [Cursor](https://cursor.com)