### PR TITLE
fix(pos): Star CUPS soft-success as OK + print success toast

### DIFF
--- a/composables/useCajaTicketPrint.test.ts
+++ b/composables/useCajaTicketPrint.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
 import {
-  notifyUnconfirmedCajaPrint,
+  notifyCajaPrintResult,
   printTicketViaCajaOrBrowser,
 } from './useCajaTicketPrint'
 import type { LocalPrintBridge } from './useLocalPrintBridge'
@@ -64,19 +64,19 @@ describe('printTicketViaCajaOrBrowser', () => {
     expect(browserPrint).toHaveBeenCalledTimes(0)
   })
 
-  it('returns unconfirmed when CUPS soft-success outcome is reported', async () => {
+  it('returns confirmed when CUPS soft-success outcome is reported as completed', async () => {
     const browserPrint = mock(() => {})
     const result = await printTicketViaCajaOrBrowser('pos-receipt', {
       getCajaPrinterName: async () => 'STAR_TP586',
       bridge: fakeBridge({
-        printRawEscPos: mock(() => Promise.resolve('unconfirmed' as const)),
+        printRawEscPos: mock(() => Promise.resolve('completed' as const)),
       }),
       getElementHtml: () => '<div id="pos-receipt">OK</div>',
       browserPrint,
       isForceBrowser: () => false,
     })
 
-    expect(result).toEqual({ mode: 'bridge', confirmed: false, printerName: 'STAR_TP586' })
+    expect(result).toEqual({ mode: 'bridge', confirmed: true, printerName: 'STAR_TP586' })
     expect(browserPrint).toHaveBeenCalledTimes(0)
   })
 
@@ -180,20 +180,43 @@ describe('printTicketViaCajaOrBrowser', () => {
   })
 })
 
-describe('notifyUnconfirmedCajaPrint', () => {
+describe('notifyCajaPrintResult', () => {
+  it('shows success toast for confirmed bridge results', () => {
+    const success = mock(() => 1)
+    const warning = mock(() => 1)
+    const t = (key: string, params?: Record<string, unknown>) =>
+      params?.name ? `${key}:${params.name}` : key
+
+    notifyCajaPrintResult(
+      { mode: 'bridge', confirmed: true, printerName: 'STAR_TP586' },
+      {
+        t,
+        toast: { success, warning },
+        onRetry: () => {},
+        onBrowserPrint: () => {},
+      },
+    )
+
+    expect(success).toHaveBeenCalledTimes(1)
+    expect(warning).toHaveBeenCalledTimes(0)
+    expect(success.mock.calls[0]![1].title).toBe('pos.receipt.printOkTitle')
+  })
+
   it('shows retry and browser actions only for unconfirmed bridge results', () => {
+    const success = mock(() => 1)
     const warning = mock(() => 1)
     const onRetry = mock(() => {})
     const onBrowserPrint = mock(() => {})
     const t = (key: string, params?: Record<string, unknown>) =>
       params?.name ? `${key}:${params.name}` : key
 
-    notifyUnconfirmedCajaPrint(
+    notifyCajaPrintResult(
       { mode: 'bridge', confirmed: false, printerName: 'STAR_TP586' },
-      { t, toast: { warning }, onRetry, onBrowserPrint },
+      { t, toast: { success, warning }, onRetry, onBrowserPrint },
     )
 
     expect(warning).toHaveBeenCalledTimes(1)
+    expect(success).toHaveBeenCalledTimes(0)
     const [, options] = warning.mock.calls[0]!
     expect(options.title).toBe('pos.receipt.printUnconfirmedTitle')
     expect(options.actions).toHaveLength(2)
@@ -201,26 +224,20 @@ describe('notifyUnconfirmedCajaPrint', () => {
     options.actions[1].onClick()
     expect(onRetry).toHaveBeenCalledTimes(1)
     expect(onBrowserPrint).toHaveBeenCalledTimes(1)
-
-    warning.mockClear()
-    notifyUnconfirmedCajaPrint(
-      { mode: 'bridge', confirmed: true, printerName: 'STAR_TP586' },
-      { t, toast: { warning }, onRetry, onBrowserPrint },
-    )
-    expect(warning).toHaveBeenCalledTimes(0)
   })
 
   it('enables sticky force-browser when cashier chooses browser CTA', () => {
     localStorage.removeItem('waro.cajaPrint.forceBrowser')
+    const success = mock(() => 1)
     const warning = mock(() => 1)
     const onBrowserPrint = mock(() => {})
     const t = (key: string) => key
 
-    notifyUnconfirmedCajaPrint(
+    notifyCajaPrintResult(
       { mode: 'bridge', confirmed: false, printerName: 'STAR_TP586' },
       {
         t,
-        toast: { warning },
+        toast: { success, warning },
         onRetry: () => {},
         onBrowserPrint,
       },

--- a/composables/useCajaTicketPrint.ts
+++ b/composables/useCajaTicketPrint.ts
@@ -1,7 +1,7 @@
 /**
  * Prefactura/factura → configured caja printer via PrintBridge ESC/POS raw (#1960/#1965).
  * Falls back to window.print when bridge/caja is missing, print fails, or hangs (#2003).
- * Soft CUPS “status gone” stays non-fatal but surfaces as unconfirmed (#2058).
+ * Soft CUPS “status gone” counts as completed (Star always purges; #2070).
  * Sticky browser mode skips bridge until cashier returns to thermal (#2060).
  */
 import {
@@ -146,6 +146,13 @@ export async function printTicketViaCajaOrBrowser(
 }
 
 export type CajaPrintFeedbackToast = {
+  success: (
+    message: string,
+    options?: {
+      title?: string
+      duration?: number
+    },
+  ) => unknown
   warning: (
     message: string,
     options?: {
@@ -156,8 +163,11 @@ export type CajaPrintFeedbackToast = {
   ) => unknown
 }
 
-/** Warn cashier when CUPS could not confirm paper out; offer retry / browser (#2058). */
-export function notifyUnconfirmedCajaPrint(
+/**
+ * Bridge feedback: success when accepted/completed; warning + retry/browser
+ * only for rare unconfirmed outcomes (#2058/#2070).
+ */
+export function notifyCajaPrintResult(
   result: CajaTicketPrintResult,
   opts: {
     t: (key: string, params?: Record<string, unknown>) => string
@@ -166,7 +176,17 @@ export function notifyUnconfirmedCajaPrint(
     onBrowserPrint: () => void
   },
 ): void {
-  if (result.mode !== 'bridge' || result.confirmed) return
+  if (result.mode !== 'bridge') return
+  if (result.confirmed) {
+    opts.toast.success(
+      opts.t('pos.receipt.printOkBody', { name: result.printerName }),
+      {
+        title: opts.t('pos.receipt.printOkTitle'),
+        duration: 3500,
+      },
+    )
+    return
+  }
   opts.toast.warning(
     opts.t('pos.receipt.printUnconfirmedBody', { name: result.printerName }),
     {
@@ -187,6 +207,19 @@ export function notifyUnconfirmedCajaPrint(
       ],
     },
   )
+}
+
+/** @deprecated Prefer notifyCajaPrintResult (also shows success toast). */
+export function notifyUnconfirmedCajaPrint(
+  result: CajaTicketPrintResult,
+  opts: {
+    t: (key: string, params?: Record<string, unknown>) => string
+    toast: CajaPrintFeedbackToast
+    onRetry: () => void
+    onBrowserPrint: () => void
+  },
+): void {
+  notifyCajaPrintResult(result, opts)
 }
 
 export function useCajaTicketPrint() {

--- a/composables/useLocalPrintBridge.test.ts
+++ b/composables/useLocalPrintBridge.test.ts
@@ -190,7 +190,7 @@ describe('createLocalPrintBridge', () => {
       })
   })
 
-  it('resolves unconfirmed when CUPS purges job status after submit (no auto browser fallback)', async () => {
+  it('resolves completed when CUPS purges job status after submit (Star soft-success)', async () => {
     let statusHandler: ((event: { requestId?: string; status?: string; message?: string }) => void) | null = null
     const printSpy = mock(async (job: Record<string, unknown>) => {
       const requestId = String(job.requestId)
@@ -213,7 +213,7 @@ describe('createLocalPrintBridge', () => {
 
     const bridge = createLocalPrintBridge()
     await expect(bridge.printRawEscPos('STAR_TP586', buildEscPosTestTicketBytes('ok')))
-      .resolves.toBe('unconfirmed')
+      .resolves.toBe('completed')
     expect(printSpy).toHaveBeenCalledTimes(1)
   })
 

--- a/composables/useLocalPrintBridge.ts
+++ b/composables/useLocalPrintBridge.ts
@@ -54,7 +54,7 @@ function newPrintRequestId(): string {
  * Star/CUPS often purges the job right after accept. PrintBridge then emits
  * `unknown` + "CUPS job status was no longer available". That is not a print
  * failure — treating it as one caused thermal + window.print double tickets.
- * Callers should treat it as unconfirmed and offer a manual browser CTA (#2058).
+ * Treat as completed: Star reports this even when the ticket prints (#2070).
  * Real offline failures use other messages (e.g. "Unable to send data…").
  */
 export function isCupsJobStatusGoneSoftSuccess(
@@ -88,10 +88,10 @@ export function waitForPrintTerminalStatus(
         resolve('completed')
         return
       }
-      // CUPS purged job after submit — not hard fail; not confirmed either (#2058).
+      // CUPS purged job after submit — normal for Star; treat as success (#2070).
       if (isCupsJobStatusGoneSoftSuccess(status, message)) {
         off()
-        resolve('unconfirmed')
+        resolve('completed')
         return
       }
       if (PRINT_FAILURE_STATUSES.has(status)) {

--- a/i18n/locales/ar/pos.json
+++ b/i18n/locales/ar/pos.json
@@ -695,6 +695,8 @@
       "promoFallback": "عرض",
       "tipTax": "ضريبة الإكرامية",
       "totalChargedUpper": "الإجمالي المحصّل",
+      "printOkTitle": "Ticket sent",
+      "printOkBody": "Printed on {name}",
       "printUnconfirmedTitle": "Check the printer",
       "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
       "printRetry": "Retry",

--- a/i18n/locales/de/pos.json
+++ b/i18n/locales/de/pos.json
@@ -695,6 +695,8 @@
       "promoFallback": "Aktion",
       "tipTax": "Trinkgeldsteuer",
       "totalChargedUpper": "GESAMT ABGERECHNET",
+      "printOkTitle": "Ticket sent",
+      "printOkBody": "Printed on {name}",
       "printUnconfirmedTitle": "Check the printer",
       "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
       "printRetry": "Retry",

--- a/i18n/locales/en/pos.json
+++ b/i18n/locales/en/pos.json
@@ -707,6 +707,8 @@
       "promoFallback": "Promotion",
       "tipTax": "Tip tax",
       "totalChargedUpper": "TOTAL CHARGED",
+      "printOkTitle": "Ticket sent",
+      "printOkBody": "Printed on {name}",
       "printUnconfirmedTitle": "Check the printer",
       "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
       "printRetry": "Retry",

--- a/i18n/locales/es/pos.json
+++ b/i18n/locales/es/pos.json
@@ -707,6 +707,8 @@
       "promoFallback": "Promoción",
       "tipTax": "Impuesto propina",
       "totalChargedUpper": "TOTAL COBRADO",
+      "printOkTitle": "Ticket enviado",
+      "printOkBody": "Impreso en {name}",
       "printUnconfirmedTitle": "Revisa la impresora",
       "printUnconfirmedBody": "Enviado a {name}, pero no se pudo confirmar que salió el ticket. ¿Está encendida?",
       "printRetry": "Reintentar",

--- a/i18n/locales/fr/pos.json
+++ b/i18n/locales/fr/pos.json
@@ -695,6 +695,8 @@
       "promoFallback": "Promotion",
       "tipTax": "Taxe sur le pourboire",
       "totalChargedUpper": "TOTAL FACTURÉ",
+      "printOkTitle": "Ticket sent",
+      "printOkBody": "Printed on {name}",
       "printUnconfirmedTitle": "Check the printer",
       "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
       "printRetry": "Retry",

--- a/i18n/locales/hi/pos.json
+++ b/i18n/locales/hi/pos.json
@@ -695,6 +695,8 @@
       "promoFallback": "प्रमोशन",
       "tipTax": "टिप कर",
       "totalChargedUpper": "कुल वसूला गया",
+      "printOkTitle": "Ticket sent",
+      "printOkBody": "Printed on {name}",
       "printUnconfirmedTitle": "Check the printer",
       "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
       "printRetry": "Retry",

--- a/i18n/locales/pt/pos.json
+++ b/i18n/locales/pt/pos.json
@@ -695,6 +695,8 @@
       "promoFallback": "Promoção",
       "tipTax": "Imposto sobre gorjeta",
       "totalChargedUpper": "TOTAL COBRADO",
+      "printOkTitle": "Ticket sent",
+      "printOkBody": "Printed on {name}",
       "printUnconfirmedTitle": "Check the printer",
       "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
       "printRetry": "Retry",

--- a/i18n/locales/zh/pos.json
+++ b/i18n/locales/zh/pos.json
@@ -695,6 +695,8 @@
       "promoFallback": "促销",
       "tipTax": "小费税",
       "totalChargedUpper": "已收总额",
+      "printOkTitle": "Ticket sent",
+      "printOkBody": "Printed on {name}",
       "printUnconfirmedTitle": "Check the printer",
       "printUnconfirmedBody": "Sent to {name}, but we could not confirm the ticket printed. Is it powered on?",
       "printRetry": "Retry",

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -33,7 +33,7 @@ import {
   compactThermalMoneyLabel,
 } from '~/utils/receiptTicketPlainText'
 import { resolveReceiptLogoUrl } from '~/utils/receiptPrintConfig'
-import { notifyUnconfirmedCajaPrint, useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
+import { notifyCajaPrintResult, useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
 import { modifierLineTotal } from '~/utils/saleModifierOption'
 import {
   buildCustomerIdentityPresentation,
@@ -2734,7 +2734,7 @@ const printReceipt = async () => {
   })
   if (printResult.mode === 'bridge') {
     cleanup()
-    notifyUnconfirmedCajaPrint(printResult, {
+    notifyCajaPrintResult(printResult, {
       t,
       toast,
       onRetry: () => { void printReceipt() },
@@ -3172,7 +3172,7 @@ const printPrefactura = async () => {
   })
   if (printResult.mode === 'bridge') {
     cleanup()
-    notifyUnconfirmedCajaPrint(printResult, {
+    notifyCajaPrintResult(printResult, {
       t,
       toast,
       onRetry: () => { void printPrefactura() },

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -11,7 +11,7 @@ import {
   buildCustomerIdentityPresentation,
   formatFiscalIdentityLabel,
 } from '~/utils/customerIdentityPresentation'
-import { notifyUnconfirmedCajaPrint, useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
+import { notifyCajaPrintResult, useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
 import { collectThermalTicketText } from '~/utils/receiptTicketPlainText'
 
 definePageMeta({ layout: 'dashboard', module: 'ventas' })
@@ -869,7 +869,7 @@ const printReceipt = async () => {
   })
   if (printResult.mode === 'bridge') {
     cleanup()
-    notifyUnconfirmedCajaPrint(printResult, {
+    notifyCajaPrintResult(printResult, {
       t,
       toast: useToast(),
       onRetry: () => { void printReceipt() },


### PR DESCRIPTION
## Summary
- Map CUPS “status gone” soft-success → `completed` (normal for Star)
- Success toast on confirmed thermal print
- Keep hard failures → browser fallback; unconfirmed warning only for rare cases

Closes #2070

## Test plan
- [ ] Print receipt with STAR on → success toast, no “Revisa la impresora”
- [ ] Prefactura same
- [ ] Operaciones test print shows OK (not unconfirmed)
- [ ] Printer off / hard fail still falls back or errors

Made with [Cursor](https://cursor.com)