### PR TITLE
fix(finanzas): compact arqueo MetricCards without global shrink

### DIFF
--- a/.wr/2076.yaml
+++ b/.wr/2076.yaml
@@ -1,0 +1,36 @@
+issue: 2076
+title: "fix(finanzas): compact arqueo summary MetricCards so currency fits"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2076-arqueo-metriccard-compact
+
+paths:
+  - components/shared/MetricCard.vue
+  - pages/finanzas/arqueo/index.vue
+
+ac:
+  - Arqueo summary amounts fully visible for compact currency ($6,67 M / -$333,78 k)
+  - Use MetricCard size=compact on arqueo grid only (no blind global shrink)
+  - Other MetricCard call sites keep default/sm/lg visuals
+  - grid-cols-2 / md:3 / xl:5 still layout correctly
+
+out_of_scope:
+  - API/totals math
+  - arqueo create/detail pages
+
+hints:
+  entry: "pages/finanzas/arqueo/index.vue MetricCard grid"
+  pattern: "MetricCard.vue already has size sm|default|lg CVA — add compact denser than sm"
+  tests: "bun test components/shared/metricCardValue.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "merge + pull + stop local servers"

--- a/components/shared/MetricCard.vue
+++ b/components/shared/MetricCard.vue
@@ -38,7 +38,10 @@
     </div>
 
     <!-- Mobile Layout (below md) -->
-    <div class="md:hidden flex flex-col flex-1 justify-between min-h-[52px]">
+    <div
+      class="md:hidden flex flex-col flex-1 justify-between"
+      :class="size === 'compact' ? 'min-h-[44px]' : 'min-h-[52px]'"
+    >
       <!-- Title -->
       <div :class="cn(titleVariants({ size }), 'text-text-primary opacity-85')">
         {{ title }}
@@ -83,6 +86,8 @@ const metricCardVariants = cva(
         info: 'border-info'
       },
       size: {
+        // Dense KPI strip (e.g. arqueo summary) — smaller than sm, opt-in only (#2076).
+        compact: 'px-3 py-2.5 md:px-3 md:py-2.5',
         sm: 'px-4 py-4 md:px-6 md:py-3',
         default: 'px-5 py-4 md:px-8 md:py-4',
         lg: 'px-6 py-5 md:px-10 md:py-6'
@@ -108,6 +113,7 @@ const valueVariants = cva(
         info: 'text-info'
       },
       size: {
+        compact: 'text-lg md:text-xl tabular-nums tracking-tight',
         sm: 'text-2xl md:text-2xl',
         default: 'text-3xl md:text-4xl',
         lg: 'text-3xl md:text-5xl'
@@ -125,6 +131,7 @@ const titleVariants = cva(
   {
     variants: {
       size: {
+        compact: 'text-xs leading-tight md:text-xs md:font-semibold md:tracking-wide',
         sm: 'text-sm leading-tight md:text-sm md:font-semibold md:tracking-wide',
         default: 'text-sm leading-tight md:text-base md:font-semibold md:tracking-wide',
         lg: 'text-base leading-tight md:text-lg md:font-semibold md:tracking-wide'
@@ -141,6 +148,7 @@ const subtitleVariants = cva(
   {
     variants: {
       size: {
+        compact: 'text-xs md:text-xs',
         sm: 'text-sm md:text-xs',
         default: 'text-sm md:text-xs',
         lg: 'text-base md:text-sm'
@@ -165,6 +173,7 @@ const unitVariants = cva(
         info: 'text-info'
       },
       size: {
+        compact: 'text-xs',
         sm: 'text-sm',
         default: 'text-base',
         lg: 'text-lg'

--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -13,16 +13,17 @@
         v-if="closedRows.length > 0"
         class="grid grid-cols-2 gap-3 md:gap-4 md:grid-cols-3 xl:grid-cols-5"
       >
-        <MetricCard :title="t('finanzas.arqueo.totalSales')" :value="summaryStats.totalSales" format="currency" variant="primary" />
+        <MetricCard size="compact" :title="t('finanzas.arqueo.totalSales')" :value="summaryStats.totalSales" format="currency" variant="primary" />
         <MetricCard
+          size="compact"
           :title="t('finanzas.arqueo.cashDiff')"
           :value="summaryStats.cashDifference"
           format="currency"
           :variant="summaryStats.cashDifference >= 0 ? 'primary' : 'destructive'"
         />
-        <MetricCard :title="t('finanzas.common.cash')" :value="summaryStats.totalCash" format="currency" variant="primary" />
-        <MetricCard :title="t('finanzas.common.card')" :value="summaryStats.totalCard" format="currency" variant="primary" />
-        <MetricCard :title="t('finanzas.arqueo.cashExpenses')" :value="summaryStats.gastosEfectivo" format="currency" variant="primary" class="col-span-2 md:col-span-1 xl:col-span-1" />
+        <MetricCard size="compact" :title="t('finanzas.common.cash')" :value="summaryStats.totalCash" format="currency" variant="primary" />
+        <MetricCard size="compact" :title="t('finanzas.common.card')" :value="summaryStats.totalCard" format="currency" variant="primary" />
+        <MetricCard size="compact" :title="t('finanzas.arqueo.cashExpenses')" :value="summaryStats.gastosEfectivo" format="currency" variant="primary" class="col-span-2 md:col-span-1 xl:col-span-1" />
       </div>
 
       <!-- ── Filter bar ────────────────────────────────────────────────────── -->


### PR DESCRIPTION
## Summary
- Add opt-in `MetricCard` size `compact` (smaller value font + padding)
- Use it only on `/finanzas/arqueo` summary KPI strip
- Leave default/sm/lg unchanged for other screens

Closes #2076

## Test plan
- [ ] `/finanzas/arqueo` summary cards show full values like `$6,67 M` / `-$333,78 k`
- [ ] Cards look denser but readable on 2 / 3 / 5 column grids
- [ ] Other MetricCard pages (analitica, cartera, propinas) look unchanged

## Validation evidence
```text
$ bun test components/shared/metricCardValue.test.ts
bun test v1.2.21
(pass) MetricCard value formatting > delegates currency values and empty states to the tenant formatter
(pass) MetricCard value formatting > delegates number punctuation while preserving suffixes
2 pass
0 fail
```

## wr-context
See `.wr/2076.yaml` on this branch (LLM contract).