### PR TITLE
fix(ui): default MetricCard size to compact everywhere

### DIFF
--- a/components/shared/MetricCard.vue
+++ b/components/shared/MetricCard.vue
@@ -95,7 +95,7 @@ const metricCardVariants = cva(
     },
     defaultVariants: {
       variant: 'secondary',
-      size: 'default'
+      size: 'compact'
     }
   }
 )
@@ -121,7 +121,7 @@ const valueVariants = cva(
     },
     defaultVariants: {
       variant: 'secondary',
-      size: 'default'
+      size: 'compact'
     }
   }
 )
@@ -138,7 +138,7 @@ const titleVariants = cva(
       }
     },
     defaultVariants: {
-      size: 'default'
+      size: 'compact'
     }
   }
 )
@@ -155,7 +155,7 @@ const subtitleVariants = cva(
       }
     },
     defaultVariants: {
-      size: 'default'
+      size: 'compact'
     }
   }
 )
@@ -181,7 +181,7 @@ const unitVariants = cva(
     },
     defaultVariants: {
       variant: 'secondary',
-      size: 'default'
+      size: 'compact'
     }
   }
 )
@@ -265,7 +265,7 @@ interface Props extends MetricCardProps { }
 
 const props = withDefaults(defineProps<Props>(), {
   variant: 'secondary',
-  size: 'default',
+  size: 'compact',
   suffix: '',
   unit: '',
   subtitle: '',

--- a/pages/analitica/articulos-de-bodega/[id].vue
+++ b/pages/analitica/articulos-de-bodega/[id].vue
@@ -38,7 +38,7 @@
           :value="formatQuantity(metrics.consumed_quantity)"
           format="text"
           variant="primary"
-          size="sm"
+          size="compact"
           :subtitle="displayIngredientUnit"
           class="min-w-0 overflow-hidden"
         />
@@ -47,7 +47,7 @@
           :value="formatCurrency(metrics.estimated_consumed_cost)"
           format="text"
           variant="primary"
-          size="sm"
+          size="compact"
           :subtitle="costBasisLabel"
           class="min-w-0 overflow-hidden"
         />
@@ -56,7 +56,7 @@
           :value="formatUnitCost(metrics.weighted_avg_cost_per_unit)"
           format="text"
           variant="primary"
-          size="sm"
+          size="compact"
           :subtitle="t('analitica.ingredientes.weightedPurchase')"
           class="min-w-0 overflow-hidden"
         />
@@ -65,7 +65,7 @@
           :value="formatUnitCost(metrics.latest_cost_per_unit)"
           format="text"
           variant="primary"
-          size="sm"
+          size="compact"
           :subtitle="latestCostLabel"
           class="min-w-0 overflow-hidden"
         />
@@ -74,7 +74,7 @@
           :value="formatCostVariation(metrics.cost_variation_pct)"
           format="text"
           variant="primary"
-          size="sm"
+          size="compact"
           :subtitle="t('analitica.ingredientes.firstVsLastPurchase')"
           class="min-w-0 overflow-hidden"
         />
@@ -83,7 +83,7 @@
           :value="metrics.movement_count"
           format="number"
           variant="primary"
-          size="sm"
+          size="compact"
           :subtitle="coverageLabel(metrics.data_coverage)"
           class="min-w-0 overflow-hidden"
         />

--- a/pages/equipo/salarios/index.vue
+++ b/pages/equipo/salarios/index.vue
@@ -130,21 +130,21 @@ onUnmounted(() => {
           :value="stats.totalPayroll"
           format="currency"
           variant="primary"
-          size="sm"
+          size="compact"
         />
         <SharedMetricCard
           :title="t('equipo.salarios.employees')"
           :value="stats.totalEmployees"
           format="number"
           variant="primary"
-          size="sm"
+          size="compact"
         />
         <SharedMetricCard
           :title="t('equipo.salarios.withSalary')"
           :value="stats.employeesWithSalary"
           format="number"
           variant="primary"
-          size="sm"
+          size="compact"
           class="col-span-2 md:col-span-1"
         />
       </div>


### PR DESCRIPTION
## Summary
- Default `MetricCard` size → `compact`
- Update remaining `sm` KPI cards (salarios, articulos-de-bodega detail)

Closes #2078

## Test plan
- [ ] Arqueo / analitica / cartera / propinas MetricCards look compact
- [ ] Explicit size overrides still work if used

## Validation evidence
```text
$ bun test components/shared/metricCardValue.test.ts
2 pass
0 fail
```

Made with [Cursor](https://cursor.com)