### PR TITLE
fix(pos): hide zero-amount IVA cues on MX commercial-off (#2081)

### DIFF
--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -144,8 +144,9 @@ const productTaxCue = (item: ReceiptItem) => {
   const amount = Number(item.taxAmount)
   const hasAmount = Number.isFinite(amount) && amount > 0
   const isExempt = String(item.taxCategory ?? '').toLowerCase() === 'exempt'
+  const exemptLabel = t('pos.cartItem.taxExempt')
   const label = String(item.taxLabel ?? '').trim()
-    || (isExempt ? t('pos.cartItem.taxExempt') : '')
+    || (isExempt ? exemptLabel : '')
   if (!label) return null
   if (hasAmount) {
     const amountLabel = compactThermalMoneyLabel(money(amount))
@@ -153,8 +154,8 @@ const productTaxCue = (item: ReceiptItem) => {
       text: t('pos.cartItem.taxLine', { label, amount: amountLabel }),
     })
   }
-  // Bare cue only for exempt — never zero-amount IVA (#2081).
-  if (isExempt) return formatReceiptTaxCue({ label })
+  // Bare cue for exempt — also accept snapshot label when category already normalized (#2081).
+  if (isExempt || label === exemptLabel) return formatReceiptTaxCue({ label })
   return null
 }
 

--- a/components/pos/ReceiptPrintTicket.vue
+++ b/components/pos/ReceiptPrintTicket.vue
@@ -143,8 +143,9 @@ const modifierDescription = (modifier: ReceiptItemModifier) => {
 const productTaxCue = (item: ReceiptItem) => {
   const amount = Number(item.taxAmount)
   const hasAmount = Number.isFinite(amount) && amount > 0
+  const isExempt = String(item.taxCategory ?? '').toLowerCase() === 'exempt'
   const label = String(item.taxLabel ?? '').trim()
-    || (String(item.taxCategory ?? '').toLowerCase() === 'exempt' ? t('pos.cartItem.taxExempt') : '')
+    || (isExempt ? t('pos.cartItem.taxExempt') : '')
   if (!label) return null
   if (hasAmount) {
     const amountLabel = compactThermalMoneyLabel(money(amount))
@@ -152,7 +153,9 @@ const productTaxCue = (item: ReceiptItem) => {
       text: t('pos.cartItem.taxLine', { label, amount: amountLabel }),
     })
   }
-  return formatReceiptTaxCue({ label })
+  // Bare cue only for exempt — never zero-amount IVA (#2081).
+  if (isExempt) return formatReceiptTaxCue({ label })
+  return null
 }
 
 const productBlock = (item: ReceiptItem) =>

--- a/pages/facturacion/index.vue
+++ b/pages/facturacion/index.vue
@@ -2164,9 +2164,12 @@ const matiasRegimeLabel = computed(() => {
       </h3>
       <!-- Commercial / non-DIAN: enable toggle + tax lines matrix + category map -->
       <div v-if="showCommercialTaxUi" class="space-y-5">
-        <div class="flex items-center justify-between py-1">
-          <p class="text-sm font-medium text-text-primary">{{ t('facturacion.tax.commercialEnableTitle') }}</p>
-          <label class="relative inline-flex items-center cursor-pointer flex-shrink-0 ms-4">
+        <div class="flex items-start justify-between gap-3 py-1">
+          <div class="min-w-0 flex-1 space-y-1">
+            <p class="text-sm font-medium text-text-primary">{{ t('facturacion.tax.commercialEnableTitle') }}</p>
+            <p class="text-xs text-text-secondary leading-snug">{{ t('facturacion.tax.commercialEnableBody') }}</p>
+          </div>
+          <label class="relative inline-flex items-center cursor-pointer flex-shrink-0 ms-2 mt-0.5">
             <input v-model="commercialTaxApplicable" type="checkbox" class="sr-only peer" />
             <div class="w-10 h-6 bg-border rounded-full peer peer-checked:bg-primary peer-focus:ring-2 peer-focus:ring-primary/30 after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
           </label>

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1778,10 +1778,7 @@ const getLineTaxInfo = (item: any): { amount: number; label: string; includedInP
           : String(taxPreview.value?.standard_tax_label || t('pos.checkout.taxFallback'))))
     return { amount, label: amountLabel, includedInPrice }
   }
-  // Never surface bare "Impuesto" without amount — that was the mesa/prefactura bug.
-  if (label && !isGenericTaxLabel(label)) {
-    return { amount: 0, label, includedInPrice }
-  }
+  // Zero-amount non-exempt labels (e.g. IVA 16% with commercial tax off) must not surface (#2081).
   return null
 }
 
@@ -1793,11 +1790,12 @@ const formatLineTaxDisplay = (info: { amount: number; label: string; includedInP
 
 const lineTaxCueForPrint = (item: any): string | null => {
   const info = getLineTaxInfo(item)
+  const category = String(item.tax_category ?? item.taxCategory ?? '').toLowerCase()
+  const resolution = String(item.tax_resolution ?? item.taxResolution ?? '').toLowerCase()
+  const isExempt = category === 'exempt' || resolution === 'exempt'
   const label = info?.label
     ?? localizedInternalTaxLabel(item.tax_label ?? item.taxLabel)
-    ?? (String(item.tax_category ?? item.taxCategory ?? '').toLowerCase() === 'exempt'
-      ? t('pos.cartItem.taxExempt')
-      : '')
+    ?? (isExempt ? t('pos.cartItem.taxExempt') : '')
   if (!label && !info) return null
   const mergedAmount = Number(item.tax_amount ?? item.taxAmount)
   const amount = Number.isFinite(mergedAmount) && mergedAmount > 0
@@ -1810,7 +1808,9 @@ const lineTaxCueForPrint = (item: any): string | null => {
       text: t('pos.cartItem.taxLine', { label: labelFinal, amount: amountLabel }),
     })
   }
-  return formatReceiptTaxCue({ label: labelFinal })
+  // Bare cue only for exempt lines — never "IVA 16%" with $0 (#2081).
+  if (isExempt && labelFinal) return formatReceiptTaxCue({ label: labelFinal })
+  return null
 }
 
 /** Freeze per-line tax fields onto the receipt snapshot before cart clear. */

--- a/pages/pos/checkout.vue
+++ b/pages/pos/checkout.vue
@@ -1790,7 +1790,12 @@ const formatLineTaxDisplay = (info: { amount: number; label: string; includedInP
 
 const lineTaxCueForPrint = (item: any): string | null => {
   const info = getLineTaxInfo(item)
-  const category = String(item.tax_category ?? item.taxCategory ?? '').toLowerCase()
+  const category = String(
+    item.tax_category
+    ?? item.taxCategory
+    ?? item.product?.tax_category
+    ?? '',
+  ).toLowerCase()
   const resolution = String(item.tax_resolution ?? item.taxResolution ?? '').toLowerCase()
   const isExempt = category === 'exempt' || resolution === 'exempt'
   const label = info?.label
@@ -1808,8 +1813,10 @@ const lineTaxCueForPrint = (item: any): string | null => {
       text: t('pos.cartItem.taxLine', { label: labelFinal, amount: amountLabel }),
     })
   }
-  // Bare cue only for exempt lines — never "IVA 16%" with $0 (#2081).
-  if (isExempt && labelFinal) return formatReceiptTaxCue({ label: labelFinal })
+  // Bare cue for exempt only — getLineTaxInfo returns $0 info solely for exempt (#2081).
+  if ((isExempt || (info != null && info.amount <= 0)) && labelFinal) {
+    return formatReceiptTaxCue({ label: labelFinal })
+  }
   return null
 }
 
@@ -1818,13 +1825,28 @@ const snapshotCartItemsForReceipt = () =>
   cartItems.value.map((item: any) => {
     const preview = getLinePromoPreview(item)
     const info = getLineTaxInfo(item)
+    const resolution = String(
+      preview?.tax_resolution ?? item.tax_resolution ?? item.taxResolution ?? '',
+    ).toLowerCase()
+    const rawCategory = String(
+      preview?.tax_category
+      ?? item.tax_category
+      ?? item.taxCategory
+      ?? item.product?.tax_category
+      ?? '',
+    ).toLowerCase()
+    const isExempt = resolution === 'exempt'
+      || rawCategory === 'exempt'
+      || (info != null && info.amount <= 0 && Boolean(info.label))
     return {
       ...item,
-      tax_category: preview?.tax_category
-        ?? item.tax_category
-        ?? item.taxCategory
-        ?? item.product?.tax_category
-        ?? null,
+      tax_category: isExempt
+        ? 'exempt'
+        : (preview?.tax_category
+          ?? item.tax_category
+          ?? item.taxCategory
+          ?? item.product?.tax_category
+          ?? null),
       tax_label: info?.label ?? preview?.tax_label ?? null,
       tax_amount: info && info.amount > 0
         ? info.amount

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -632,20 +632,23 @@ const itemReceiptTotal = (item: any) => {
   return (Number(item.price_at_purchase) + modifiersTotal) * (Number(item.quantity) || 1)
 }
 
-/** Per-line tax cue for items table — same style as POS checkout (#2044). */
+/** Per-line tax cue for items table — same style as POS checkout (#2044 / #2081). */
 const formatItemTaxDisplay = (item: any): string | null => {
   const category = String(item?.tax_category ?? '').toLowerCase()
   const resolution = String(item?.tax_resolution ?? '').toLowerCase()
+  const isExempt = category === 'exempt' || resolution === 'exempt'
   const amount = Number(item?.tax_amount) || 0
   let label = String(item?.tax_label ?? '').trim()
-  if (!label && (category === 'exempt' || resolution === 'exempt')) {
+  if (!label && isExempt) {
     label = t('pos.cartItem.taxExempt')
   }
   if (!label) return null
   if (amount > 0) {
     return `+ ${t('pos.cartItem.taxLine', { label, amount: formatCurrency(amount) })}`
   }
-  return `+ ${label}`
+  // Bare cue only for exempt — suppress zero-amount IVA labels (#2081).
+  if (isExempt) return `+ ${label}`
+  return null
 }
 
 const saleReceiptItems = computed(() =>

--- a/utils/receiptTicketPlainText.test.ts
+++ b/utils/receiptTicketPlainText.test.ts
@@ -84,7 +84,8 @@ describe('formatReceiptTaxCue', () => {
     })).toBe('IVA 16% · $160')
   })
 
-  it('returns bare label for exempt / zero-amount cues', () => {
+  it('returns bare label for exempt cues (callers gate zero-amount IVA)', () => {
+    // Utility still formats bare labels; checkout/ticket suppress non-exempt $0 (#2081).
     expect(formatReceiptTaxCue({ label: 'Exento' })).toBe('Exento')
     expect(formatReceiptTaxCue({ label: '', amountLabel: '$1' })).toBeNull()
   })

--- a/utils/receiptTicketPlainText.ts
+++ b/utils/receiptTicketPlainText.ts
@@ -158,6 +158,8 @@ export function formatReceiptTaxCue(opts: {
   const label = String(opts.label ?? '').trim()
   if (!label) return null
   const amount = compactThermalMoneyLabel(String(opts.amountLabel ?? '').trim())
+  // Bare label is for exempt (or explicit caller-gated cues). Callers must not
+  // pass zero-amount IVA labels — see #2081 productTaxCue / lineTaxCueForPrint.
   if (!amount) return label
 
   let template = opts.template || opts.exclusiveTemplate || '{label} · {amount}'


### PR DESCRIPTION
## Summary
- Suppress line-item tax cues when amount is 0 on checkout, thermal/`window.print` ticket, and `ventas/[id]` (keep explicit Exento cue).
- Totals already gated on `standard_tax > 0`; no rewrite.
- Render `facturacion.tax.commercialEnableBody` under the commercial tax toggle.

Closes #2081
Parent epic: #2080 (API batch api-warolabs#773 / PR #774 already merged)

## Validation evidence
```text
$ bun test utils/receiptTicketPlainText.test.ts
bun test v1.2.21
19 pass
0 fail
51 expect() calls
Ran 19 tests across 1 file.
```

## Manual validation (owner)
- [ ] TEST MX: Facturación → turn off “Aplicar impuesto a ventas” → save
- [ ] Complete a sale → success / prefactura / thermal / browser print / `ventas/[id]` show no IVA
- [ ] Turn tax back on → IVA 16% still appears when `standard_tax > 0`

## Test plan
- [ ] Taxed MX line still shows `IVA 16% · amount` cue
- [ ] Exempt product still shows Exento without amount

Made with [Cursor](https://cursor.com)