### PR TITLE
fix(ventas): Impuesto column on sale detail (#2083)

### DIFF
--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -1870,6 +1870,13 @@ onUnmounted(() => {
                     align="left"
                   />
                 </th>
+                <th class="px-6 py-3 text-start">
+                  <UiTableHeaderFilter
+                    :title="t('ventas.common.impuesto')"
+                    filter-type="none"
+                    align="left"
+                  />
+                </th>
                 <th class="px-6 py-3 text-center">
                   <UiTableHeaderFilter
                     :title="t('ventas.detail.quantityShort')"
@@ -1915,15 +1922,14 @@ onUnmounted(() => {
                       </div>
                       <div>
                         <p class="text-sm font-semibold text-text-primary">{{ item.product.name }}</p>
-                        <p
-                          v-if="formatItemTaxDisplay(item)"
-                          class="text-xs text-text-tertiary mt-0.5"
-                        >
-                          {{ formatItemTaxDisplay(item) }}
-                        </p>
                         <p v-if="item.notes" class="text-xs text-text-tertiary italic mt-0.5">{{ item.notes }}</p>
                       </div>
                     </div>
+                  </td>
+                  <td class="px-6 py-4 text-start">
+                    <span class="text-xs text-text-secondary tabular-nums">
+                      {{ formatItemTaxDisplay(item) || '—' }}
+                    </span>
                   </td>
                   <td class="px-6 py-4 text-center">
                     <span
@@ -1959,6 +1965,9 @@ onUnmounted(() => {
                         <span class="text-xs text-text-secondary">{{ modifier.name }}</span>
                       </div>
                     </td>
+                    <td class="px-6 py-2 text-start">
+                      <span class="text-xs text-text-tertiary">—</span>
+                    </td>
                     <td class="px-6 py-2 text-center">
                       <span class="text-xs text-text-tertiary">x{{ modifier.quantity ?? 1 }}</span>
                     </td>
@@ -1973,7 +1982,7 @@ onUnmounted(() => {
               </template>
               <tr v-if="visibleItems.length === 0">
                 <td
-                  :colspan="isEditMode ? 5 : 4"
+                  :colspan="isEditMode ? 6 : 5"
                   class="px-6 py-12 text-center text-sm text-text-secondary"
                 >
                   {{ t('ventas.detail.noProductsForFilter') }}
@@ -1983,7 +1992,7 @@ onUnmounted(() => {
             <tfoot class="bg-surface-secondary border-t-2 border-border">
               <tr>
                 <td v-if="isEditMode"></td>
-                <td colspan="3" class="px-6 py-4 text-end text-sm font-semibold text-text-primary">
+                <td colspan="4" class="px-6 py-4 text-end text-sm font-semibold text-text-primary">
                   {{ t('ventas.detail.orderTotalLabel') }}
                 </td>
                 <td class="px-6 py-4 text-end">


### PR DESCRIPTION
## Summary
- Move per-line tax cue out of the product cell into a dedicated **Impuesto** column on `/ventas/[id]`.
- Product column keeps name + notes only; modifiers show `—` in the tax column.
- Update empty-state and footer colspans for the extra column.

Closes #2083

## Test plan
- [ ] Open a sale with line tax — Impuesto column shows cue; product name has no tax under it
- [ ] Sale without line tax — Impuesto shows `—`
- [ ] Exempt line still shows Exento (not bare IVA at $0)
- [ ] Edit mode + modifiers: columns still align; footer total spans correctly

## Validation evidence
```text
No targeted unit tests for pages/ventas/[id].vue (plan: manual AC only).
Did not run build/lint (forbidden without approval).
```

## wr-context
Local contract: `.wr/2083.yaml` (gitignored on front — LLM session contract).

Made with [Cursor](https://cursor.com)