### PR TITLE
fix(ventas): show correct tip percent after whole-currency rounding

### DIFF
--- a/pages/equipo/miembros/[id].vue
+++ b/pages/equipo/miembros/[id].vue
@@ -3,6 +3,7 @@ import { computed, onMounted, onUnmounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { format as fnsFormat } from 'date-fns'
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
+import { formatDisplayedTipPercent } from '~/utils/tipPercentDisplay'
 
 definePageMeta({
   layout: 'dashboard',
@@ -187,7 +188,19 @@ const formatCurrency = (v: number) =>
     style: 'currency', currency: 'COP', minimumFractionDigits: 0,
   }).format(v || 0)
 
-const formatPercent = (v: number) => `${(v || 0).toFixed(2)}%`
+const formatPercent = (v: number) => `${Math.round(Number(v) || 0)}%`
+
+const formatTipPercentLabel = (item: {
+  tip_amount?: number
+  total_amount?: number
+  tip_source?: string | null
+  tip_percent?: number
+}) => formatDisplayedTipPercent({
+  tipAmount: Number(item.tip_amount) || 0,
+  totalAmount: Number(item.total_amount) || 0,
+  tipSource: item.tip_source,
+  fallbackPercent: item.tip_percent,
+})
 
 const formatDate = (iso: string | null | undefined) => {
   if (!iso) return ''
@@ -315,7 +328,7 @@ onUnmounted(() => clearRefreshHandler(handleRefresh))
                     <p class="text-xs text-text-secondary">{{ t('equipo.miembros.subtotal') }}: {{ formatCurrency(item.total_amount) }}</p>
                     <div class="text-right">
                       <p class="text-lg font-bold text-primary tabular-nums">{{ formatCurrency(item.tip_amount) }}</p>
-                      <p class="text-xs text-text-secondary tabular-nums">{{ formatPercent(item.tip_percent) }}</p>
+                      <p class="text-xs text-text-secondary tabular-nums">{{ formatTipPercentLabel(item) }}</p>
                     </div>
                   </div>
                 </div>
@@ -336,8 +349,8 @@ onUnmounted(() => clearRefreshHandler(handleRefresh))
               <template #cell-tip_amount="{ value }">
                 <span class="text-sm font-bold text-primary tabular-nums">{{ formatCurrency(value) }}</span>
               </template>
-              <template #cell-tip_percent="{ value }">
-                <span class="text-sm tabular-nums text-text-secondary">{{ formatPercent(value) }}</span>
+              <template #cell-tip_percent="{ row }">
+                <span class="text-sm tabular-nums text-text-secondary">{{ formatTipPercentLabel(row) }}</span>
               </template>
             </UiResponsiveDataView>
           </div>

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -13,6 +13,7 @@ import {
 } from '~/utils/customerIdentityPresentation'
 import { notifyCajaPrintResult, useCajaTicketPrint } from '~/composables/useCajaTicketPrint'
 import { collectThermalTicketText } from '~/utils/receiptTicketPlainText'
+import { displayedTipPercent } from '~/utils/tipPercentDisplay'
 
 definePageMeta({ layout: 'dashboard', module: 'ventas' })
 
@@ -467,9 +468,14 @@ const onSaleCustomerIdentified = async (customer: SelectedCustomer) => {
 const orderTipPercent = computed(() => {
   const o = order.value
   if (!o?.tip_amount || o.tip_amount <= 0) return null
-  const total = Number(o.total_amount) || 0
-  if (total <= 0) return null
-  return Math.round((Number(o.tip_amount) / total) * 10000) / 100
+  const presets = (businessProfile.value as { tip_default_percentages?: Array<number | string> } | null)
+    ?.tip_default_percentages
+  return displayedTipPercent({
+    tipAmount: Number(o.tip_amount),
+    totalAmount: Number(o.total_amount) || 0,
+    tipSource: (o as { tip_source?: string | null }).tip_source,
+    presets,
+  })
 })
 
 const orderAdvanceApplied = computed(() => Number(order.value?.advance_applied) || 0)

--- a/pages/ventas/propinas/index.vue
+++ b/pages/ventas/propinas/index.vue
@@ -3,6 +3,7 @@ const { t, locale } = useI18n({ useScope: 'global' })
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import MetricCard from '~/components/shared/MetricCard.vue'
 import type { Column } from '~/components/ui/ResponsiveDataView.vue'
+import { formatDisplayedTipPercent } from '~/utils/tipPercentDisplay'
 
 definePageMeta({
   layout: 'dashboard',
@@ -15,6 +16,7 @@ useHead({ title: () => t('ventas.head.propinas') })
 const { currentTenant } = useTenantReactive()
 const toast = useToast()
 const { formatDateTime: formatDate, formatCurrency } = useFormatters()
+
 
 // Payment groups (same query as /ventas/ordenes — shared cache)
 const { data: paymentGroupsData } = useQuery({
@@ -222,7 +224,29 @@ const exportToEmail = async () => {
 }
 
 // ── Formatting helpers ──────────────────────────────────────────────────────
-const formatPercent = (value: number) => `${(value || 0).toFixed(2)}%`
+const formatPercent = (
+  tipAmount: number,
+  totalAmount: number,
+  tipSource?: string | null,
+  fallbackPercent?: number | null,
+) => formatDisplayedTipPercent({
+  tipAmount,
+  totalAmount,
+  tipSource,
+  fallbackPercent,
+})
+
+const formatPercentLabel = (item: {
+  tip_amount?: number
+  total_amount?: number
+  tip_source?: string | null
+  tip_percent?: number
+}) => formatPercent(
+  Number(item.tip_amount) || 0,
+  Number(item.total_amount) || 0,
+  item.tip_source,
+  item.tip_percent,
+)
 
 const channelLabel = (ch: string | null | undefined) => {
   if (ch === 'online') return t('ventas.propinas.online')
@@ -350,9 +374,9 @@ onUnmounted(() => clearRefreshHandler(refetch))
         />
         <MetricCard
           :title="t('ventas.propinas.avgOverSale')"
-          :value="aggregates.avg_pct"
+          :value="Math.round(Number(aggregates.avg_pct) || 0)"
           format="percentage"
-          :precision="2"
+          :precision="0"
           variant="primary"
         />
         <MetricCard
@@ -549,7 +573,7 @@ onUnmounted(() => clearRefreshHandler(refetch))
               </div>
               <div class="text-end">
                 <p class="text-xl font-bold text-primary tabular-nums">{{ formatCurrency(item.tip_amount) }}</p>
-                <p class="text-xs text-text-secondary tabular-nums">{{ formatPercent(item.tip_percent) }}</p>
+                <p class="text-xs text-text-secondary tabular-nums">{{ formatPercentLabel(item) }}</p>
               </div>
             </div>
           </div>
@@ -577,8 +601,8 @@ onUnmounted(() => clearRefreshHandler(refetch))
         <template #cell-tip_amount="{ value }">
           <span class="text-sm font-bold text-primary tabular-nums">{{ formatCurrency(value) }}</span>
         </template>
-        <template #cell-tip_percent="{ value }">
-          <span class="text-sm tabular-nums text-text-secondary">{{ formatPercent(value) }}</span>
+        <template #cell-tip_percent="{ row }">
+          <span class="text-sm tabular-nums text-text-secondary">{{ formatPercentLabel(row) }}</span>
         </template>
         <template #cell-member_name="{ row }">
           <button

--- a/utils/tipPercentDisplay.test.ts
+++ b/utils/tipPercentDisplay.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  displayedTipPercent,
+  formatDisplayedTipPercent,
+  tipAmountFromPercent,
+} from './tipPercentDisplay'
+
+describe('tipAmountFromPercent', () => {
+  it('matches TipSelector whole-currency rounding', () => {
+    expect(tipAmountFromPercent(225, 30)).toBe(68)
+    expect(tipAmountFromPercent(225, 20)).toBe(45)
+    expect(tipAmountFromPercent(225, 10)).toBe(23)
+  })
+})
+
+describe('displayedTipPercent', () => {
+  it('returns the preset that produced the tip amount (not reverse 30.22)', () => {
+    expect(displayedTipPercent({
+      tipAmount: 68,
+      totalAmount: 225,
+      tipSource: 'preset',
+      presets: [10, 20, 30],
+    })).toBe(30)
+  })
+
+  it('uses default candidates when presets omitted', () => {
+    expect(displayedTipPercent({
+      tipAmount: 68,
+      totalAmount: 225,
+      tipSource: 'preset',
+    })).toBe(30)
+  })
+
+  it('rounds custom tips to a whole percent', () => {
+    expect(displayedTipPercent({
+      tipAmount: 50,
+      totalAmount: 225,
+      tipSource: 'custom',
+    })).toBe(22)
+  })
+
+  it('returns null for empty tip or total', () => {
+    expect(displayedTipPercent({ tipAmount: 0, totalAmount: 225 })).toBeNull()
+    expect(displayedTipPercent({ tipAmount: 68, totalAmount: 0 })).toBeNull()
+  })
+})
+
+describe('formatDisplayedTipPercent', () => {
+  it('formats matched preset as integer percent label', () => {
+    expect(formatDisplayedTipPercent({
+      tipAmount: 68,
+      totalAmount: 225,
+      tipSource: 'preset',
+      presets: [10, 20, 30],
+    })).toBe('30%')
+  })
+
+  it('rounds API fallback percent when amounts missing', () => {
+    expect(formatDisplayedTipPercent({
+      tipAmount: 0,
+      totalAmount: 0,
+      fallbackPercent: 30.22,
+    })).toBe('30%')
+  })
+})

--- a/utils/tipPercentDisplay.ts
+++ b/utils/tipPercentDisplay.ts
@@ -1,0 +1,64 @@
+/**
+ * Display tip % after whole-currency tip rounding (warocol.com#2085).
+ * Checkout stores tip = round(total × preset/100); reverse tip/total shows noise like 30.22%.
+ */
+
+export function tipAmountFromPercent(totalAmount: number, percent: number): number {
+  const total = Number(totalAmount) || 0
+  const p = Number(percent) || 0
+  if (total <= 0 || p <= 0) return 0
+  return Math.round(total * (p / 100))
+}
+
+/** Common POS presets used when tenant list is unavailable. */
+export const DEFAULT_TIP_PERCENT_CANDIDATES = [5, 10, 12, 15, 18, 20, 25, 30] as const
+
+export function displayedTipPercent(opts: {
+  tipAmount: number
+  totalAmount: number
+  tipSource?: string | null
+  presets?: Array<number | string> | null
+}): number | null {
+  const tip = Math.round(Number(opts.tipAmount) || 0)
+  const total = Number(opts.totalAmount) || 0
+  if (tip <= 0 || total <= 0) return null
+
+  const fromOpts = (opts.presets ?? [])
+    .map(p => Number(p))
+    .filter(p => Number.isFinite(p) && p > 0)
+  const candidates = fromOpts.length > 0
+    ? fromOpts
+    : [...DEFAULT_TIP_PERCENT_CANDIDATES]
+
+  const matches = candidates.filter(p => tipAmountFromPercent(total, p) === tip)
+  if (matches.length === 1) return matches[0]
+  if (matches.length > 1) {
+    const reverse = (tip / total) * 100
+    return matches.reduce((best, p) =>
+      Math.abs(p - reverse) < Math.abs(best - reverse) ? p : best,
+    )
+  }
+
+  // Custom / unmatched: whole percent only (never two-decimal reverse noise).
+  return Math.round((tip / total) * 100)
+}
+
+export function formatDisplayedTipPercent(opts: {
+  tipAmount: number
+  totalAmount: number
+  tipSource?: string | null
+  presets?: Array<number | string> | null
+  /** When only API reverse % is available (no amounts). */
+  fallbackPercent?: number | null
+}): string {
+  if (
+    (Number(opts.tipAmount) || 0) > 0
+    && (Number(opts.totalAmount) || 0) > 0
+  ) {
+    const p = displayedTipPercent(opts)
+    return p == null ? '' : `${p}%`
+  }
+  const fb = Number(opts.fallbackPercent)
+  if (!Number.isFinite(fb) || fb <= 0) return ''
+  return `${Math.round(fb)}%`
+}


### PR DESCRIPTION
## Summary
- Add `displayedTipPercent` / `formatDisplayedTipPercent` to reverse whole-currency tip rounding back to the preset (or a whole custom %).
- Use the helper on order detail, tips list, and member tip cells; round aggregate avg % labels.
- Cover the 225/68 → 30% case with bun unit tests.

Closes #2085

## Test plan
- [ ] Order with preset tip (e.g. total 225, tip 68 / 30%) shows **30%** on `/ventas/[id]`, not 30.22%
- [ ] Custom tip shows a whole percent (`Math.round`)
- [ ] `/ventas/propinas` and `/equipo/miembros/[id]` tip % cells match
- [ ] Tip amounts and totals unchanged
- [ ] `bun test utils/tipPercentDisplay.test.ts`

## wr-context
See `.wr/2085.yaml` on this branch (LLM contract; local/gitignored).

Made with [Cursor](https://cursor.com)