### PR TITLE
fix(gastos): show tenant currency on amount inputs

### DIFF
--- a/pages/finanzas/gastos/[id]/editar.vue
+++ b/pages/finanzas/gastos/[id]/editar.vue
@@ -83,14 +83,14 @@
                   Monto *
                 </label>
                 <div class="relative">
-                  <span class="absolute start-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
+                  <span class="absolute start-3 top-1/2 -translate-y-1/2 text-xs font-medium text-text-secondary pointer-events-none">{{ currencyCode }}</span>
                   <input
                     type="number"
                     v-model.number="form.amount"
                     required
                     min="0"
                     step="1"
-                    class="input-base w-full ps-8 pe-4 py-2"
+                    class="input-base w-full ps-12 pe-4 py-2"
                     placeholder="0"
                   />
                 </div>
@@ -158,6 +158,7 @@
 <script setup lang="ts">
 import { useQuery, useQueryCache } from '@pinia/colada'
 import { usePaymentMethods } from '~/composables/usePaymentMethods'
+import { useFormatters } from '~/composables/useFormatters'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
@@ -166,6 +167,7 @@ const expenseId = route.params.id as string
 
 const { currentTenant } = useTenantReactive()
 const cache = useQueryCache()
+const { currencyCode } = useFormatters()
 
 // Payment methods
 const { paymentGroups, fetchPaymentMethods } = usePaymentMethods()

--- a/pages/finanzas/gastos/[id]/index.vue
+++ b/pages/finanzas/gastos/[id]/index.vue
@@ -352,14 +352,14 @@
                   {{ t('finanzas.gastos.amountReq') }}
                 </label>
                 <div class="relative">
-                  <span class="absolute start-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
+                  <span class="absolute start-3 top-1/2 -translate-y-1/2 text-xs font-medium text-text-secondary pointer-events-none">{{ currencyCode }}</span>
                   <input
                     type="number"
                     v-model.number="form.amount"
                     required
                     min="0"
                     step="1"
-                    class="input-base w-full ps-8 pe-4 py-2"
+                    class="input-base w-full ps-12 pe-4 py-2"
                     placeholder="0"
                   />
                 </div>
@@ -925,7 +925,7 @@ const handleSubmit = async () => {
 }
 
 // Format functions
-const { formatDate, formatCalendarDate, formatCurrency } = useFormatters()
+const { formatDate, formatCalendarDate, formatCurrency, currencyCode } = useFormatters()
 
 const formatFileSize = (bytes: number) => {
   if (!bytes) return '0 Bytes'

--- a/pages/finanzas/gastos/[id]/instancia.vue
+++ b/pages/finanzas/gastos/[id]/instancia.vue
@@ -2,6 +2,7 @@
 import { ref, reactive, computed, watch } from 'vue'
 import { useOperationalQuotaGate } from '~/composables/useOperationalQuotaGate'
 import { useQuotaExceeded } from '~/composables/useQuotaExceeded'
+import { useFormatters } from '~/composables/useFormatters'
 
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 
@@ -141,14 +142,7 @@ const onCreateInstanceClick = () => {
   void handleCreateClick(() => { void createInstance() })
 }
 
-// Helper functions
-const formatCurrency = (value: number) => {
-  return new Intl.NumberFormat('es-CO', {
-    style: 'currency',
-    currency: 'COP',
-    minimumFractionDigits: 0
-  }).format(value)
-}
+const { formatCurrency, currencyCode } = useFormatters()
 
 const formatFileSize = (bytes: number) => {
   if (bytes === 0) return '0 Bytes'
@@ -272,13 +266,13 @@ watch(expenseData, (data) => {
                   Monto (Opcional)
                 </label>
                 <div class="relative">
-                  <span class="absolute start-3 top-1/2 -translate-y-1/2 text-text-secondary pointer-events-none">$</span>
+                  <span class="absolute start-3 top-1/2 -translate-y-1/2 text-xs font-medium text-text-secondary pointer-events-none">{{ currencyCode }}</span>
                   <UiDecimalInput
                     v-model="instanceForm.amount"
                     :min="0"
                     :precision="2"
                     :placeholder="`Predeterminado: ${expense ? formatCurrency(expense.amount) : ''}`"
-                    class="input-base w-full ps-8 pe-4 py-2"
+                    class="input-base w-full ps-12 pe-4 py-2"
                   />
                 </div>
                 <p class="text-xs text-text-tertiary mt-1">

--- a/pages/finanzas/gastos/crear.vue
+++ b/pages/finanzas/gastos/crear.vue
@@ -63,14 +63,14 @@
                   {{ t('finanzas.gastos.amountReq') }}
                 </label>
                 <div class="relative">
-                  <span class="absolute start-3 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
+                  <span class="absolute start-3 top-1/2 -translate-y-1/2 text-xs font-medium text-text-secondary pointer-events-none">{{ currencyCode }}</span>
                   <input
                     v-model.number="form.amount"
                     type="number"
                     required
                     min="0"
                     step="1"
-                    class="input-base w-full ps-8 pe-4 py-2"
+                    class="input-base w-full ps-12 pe-4 py-2"
                     placeholder="0"
                   />
                 </div>
@@ -328,7 +328,7 @@ const { handleQuotaError, getQuotaMessage } = useQuotaExceeded()
 
 const { currentTenant } = useTenantReactive()
 const { todayISO } = useTenantTimezone()
-const { formatCalendarDate, formatCurrency } = useFormatters()
+const { formatCalendarDate, formatCurrency, currencyCode } = useFormatters()
 const cache = useQueryCache()
 
 const { paymentGroups, fetchPaymentMethods } = usePaymentMethods()


### PR DESCRIPTION
## Summary
- Replace hardcoded `$` on Gastos amount inputs with tenant `currencyCode` from `useFormatters` (same pattern as compras-directas).
- Cover create, edit, detail edit, and instance forms; widen input padding for ISO codes.
- Instance page now uses tenant `formatCurrency` instead of a hardcoded COP formatter.

Closes #2089

## Test plan
- [ ] MX tenant `/finanzas/gastos/crear`: amount prefix shows **MXN** (not `$`)
- [ ] CO tenant: amount prefix shows **COP**
- [ ] Edit + instance amount inputs match
- [ ] Amount summary still uses `formatCurrency` correctly

## Validation evidence
```
Plan hints.tests: none — UI wiring only; no bun build/lint
rg: hardcoded $ removed from listed gastos amount inputs; currencyCode wired
```

## wr-context
See `.wr/2089.yaml` on this branch (LLM contract; local/gitignored).

Made with [Cursor](https://cursor.com)