### PR TITLE
feat(blog): locale-aware meta and og from article lang/country

### DIFF
--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { resolveArticleMarket } from '~/utils/articleMarket'
+
 definePageMeta({ layout: 'blog' })
 
 const route = useRoute()
@@ -59,10 +61,17 @@ const { data: articleData, pending, error: fetchError } = useAsyncData<ArticleRe
 
 const article = computed(() => articleData.value?.data || null)
 
+const articleMarket = computed(() =>
+  resolveArticleMarket({
+    lang: article.value?.lang,
+    country: article.value?.country,
+  }),
+)
+
 // Format date
 const formatDate = (dateString: string) => {
   const date = new Date(dateString)
-  return date.toLocaleDateString('es-ES', {
+  return date.toLocaleDateString(articleMarket.value.localeTag, {
     year: 'numeric',
     month: 'long',
     day: 'numeric'
@@ -89,83 +98,86 @@ const siteUrl = config.public.siteUrl || 'https://warocol.com'
 // SoftwareApplication declares WARO as Point of Sale Software so Google and
 // LLMs (ChatGPT, Gemini, Perplexity) classify WARO as a POS rather than as a
 // connector to one — addresses the misclassification surfaced by GSC analysis.
-const articleSchema = computed(() => ({
-  '@context': 'https://schema.org',
-  '@graph': [
-    {
-      '@type': 'Article',
-      headline: article.value?.meta_title || article.value?.title || '',
-      description: article.value?.meta_descripcion || article.value?.description || '',
-      image: article.value?.cover || article.value?.thumbnail || '',
-      datePublished: article.value?.created_at || '',
-      dateModified: article.value?.updated_at || article.value?.created_at || '',
-      author: {
-        '@type': 'Person',
-        name: article.value?.author_info?.name || article.value?.author_name || 'WARO Colombia'
+const articleSchema = computed(() => {
+  const market = articleMarket.value
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Article',
+        headline: article.value?.meta_title || article.value?.title || '',
+        description: article.value?.meta_descripcion || article.value?.description || '',
+        image: article.value?.cover || article.value?.thumbnail || '',
+        datePublished: article.value?.created_at || '',
+        dateModified: article.value?.updated_at || article.value?.created_at || '',
+        author: {
+          '@type': 'Person',
+          name: article.value?.author_info?.name || article.value?.author_name || 'WARO Colombia'
+        },
+        publisher: { '@id': `${siteUrl}#organization` },
+        url: `${siteUrl}/blog/${article.value?.slug || ''}`,
+        keywords: article.value?.tags || '',
+        inLanguage: market.inLanguage
       },
-      publisher: { '@id': `${siteUrl}#organization` },
-      url: `${siteUrl}/blog/${article.value?.slug || ''}`,
-      keywords: article.value?.tags || '',
-      inLanguage: 'es-CO'
-    },
-    {
-      '@type': 'Organization',
-      '@id': `${siteUrl}#organization`,
-      name: 'WARO Colombia',
-      url: siteUrl,
-      sameAs: ['https://warocol.com']
-    },
-    {
-      '@type': 'SoftwareApplication',
-      '@id': `${siteUrl}#waro-pos`,
-      name: 'WARO',
-      alternateName: 'WARO POS',
-      applicationCategory: 'Point of Sale Software',
-      applicationSubCategory: 'Restaurant POS',
-      operatingSystem: 'Web, iOS, Android',
-      url: siteUrl,
-      publisher: { '@id': `${siteUrl}#organization` },
-      offers: {
-        '@type': 'Offer',
-        price: '95900',
-        priceCurrency: 'COP',
-        availability: 'https://schema.org/InStock',
-        priceSpecification: {
-          '@type': 'UnitPriceSpecification',
-          price: '7992',
-          priceCurrency: 'COP',
-          billingDuration: 'P1M',
-          description: 'Equivalente mensual del plan anual de $95.900 COP'
+      {
+        '@type': 'Organization',
+        '@id': `${siteUrl}#organization`,
+        name: 'WARO Colombia',
+        url: siteUrl,
+        sameAs: ['https://warocol.com']
+      },
+      {
+        '@type': 'SoftwareApplication',
+        '@id': `${siteUrl}#waro-pos`,
+        name: 'WARO',
+        alternateName: 'WARO POS',
+        applicationCategory: 'Point of Sale Software',
+        applicationSubCategory: 'Restaurant POS',
+        operatingSystem: 'Web, iOS, Android',
+        url: siteUrl,
+        publisher: { '@id': `${siteUrl}#organization` },
+        offers: {
+          '@type': 'Offer',
+          price: market.annualPrice,
+          priceCurrency: market.currency,
+          availability: 'https://schema.org/InStock',
+          priceSpecification: {
+            '@type': 'UnitPriceSpecification',
+            price: market.monthlyPrice,
+            priceCurrency: market.currency,
+            billingDuration: 'P1M',
+            description: market.monthlyOfferDescription
+          }
+        },
+        featureList: [
+          'Punto de venta con catálogo y modificadores',
+          'Plano de mesas con estados en tiempo real',
+          'KDS para cocina con estaciones personalizadas',
+          'Cobro parcial multi-método',
+          'Propinas con atribución a mesero (Ley 1935/2018)',
+          'Inventario por receta con descuento automático',
+          'Facturación electrónica DIAN nativa',
+          'Bitácora de números quemados DIAN',
+          'Arqueo de caja por plantilla de turno',
+          'Programa de fidelización Waros nativo',
+          'Pedido por QR en mesa',
+          'Domicilios propios sin comisión'
+        ],
+        areaServed: {
+          '@type': 'Country',
+          name: market.areaServedName
         }
-      },
-      featureList: [
-        'Punto de venta con catálogo y modificadores',
-        'Plano de mesas con estados en tiempo real',
-        'KDS para cocina con estaciones personalizadas',
-        'Cobro parcial multi-método',
-        'Propinas con atribución a mesero (Ley 1935/2018)',
-        'Inventario por receta con descuento automático',
-        'Facturación electrónica DIAN nativa',
-        'Bitácora de números quemados DIAN',
-        'Arqueo de caja por plantilla de turno',
-        'Programa de fidelización Waros nativo',
-        'Pedido por QR en mesa',
-        'Domicilios propios sin comisión'
-      ],
-      areaServed: {
-        '@type': 'Country',
-        name: 'Colombia'
       }
-    }
-  ]
-}))
+    ]
+  }
+})
 
 useSeoMeta({
   title: () => article.value?.meta_title || article.value?.title || 'Artículo | Waro Colombia',
   description: () => article.value?.meta_descripcion || article.value?.description || '',
   ogType: 'article',
   ogSiteName: 'Waro Colombia',
-  ogLocale: 'es_CO',
+  ogLocale: () => articleMarket.value.ogLocale,
   ogTitle: () => article.value?.meta_title || article.value?.title || '',
   ogDescription: () => article.value?.meta_descripcion || article.value?.description || '',
   ogImage: () => article.value?.cover || article.value?.thumbnail || '',

--- a/utils/articleMarket.test.ts
+++ b/utils/articleMarket.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  normalizeArticleCountry,
+  resolveArticleMarket,
+} from './articleMarket.ts'
+
+test('defaults unknown or empty country to CO', () => {
+  assert.equal(normalizeArticleCountry(null), 'CO')
+  assert.equal(normalizeArticleCountry(''), 'CO')
+  assert.equal(normalizeArticleCountry('Mexico'), 'CO')
+  assert.equal(normalizeArticleCountry('Colombia'), 'CO')
+  assert.equal(normalizeArticleCountry('CO'), 'CO')
+})
+
+test('accepts US country aliases', () => {
+  assert.equal(normalizeArticleCountry('US'), 'US')
+  assert.equal(normalizeArticleCountry('USA'), 'US')
+  assert.equal(normalizeArticleCountry('United States'), 'US')
+  assert.equal(normalizeArticleCountry('united states of america'), 'US')
+})
+
+test('keeps Colombia ES offer and locales', () => {
+  const market = resolveArticleMarket({ lang: 'es', country: 'Colombia' })
+  assert.equal(market.isUsEn, false)
+  assert.equal(market.ogLocale, 'es_CO')
+  assert.equal(market.inLanguage, 'es-CO')
+  assert.equal(market.localeTag, 'es-CO')
+  assert.equal(market.currency, 'COP')
+  assert.equal(market.annualPrice, '95900')
+  assert.equal(market.monthlyPrice, '7992')
+  assert.equal(market.areaServedName, 'Colombia')
+})
+
+test('maps US English articles to USD offer and en_US meta', () => {
+  const market = resolveArticleMarket({ lang: 'en', country: 'United States' })
+  assert.equal(market.isUsEn, true)
+  assert.equal(market.ogLocale, 'en_US')
+  assert.equal(market.inLanguage, 'en-US')
+  assert.equal(market.currency, 'USD')
+  assert.equal(market.annualPrice, '300')
+  assert.equal(market.monthlyPrice, '25')
+  assert.equal(market.annualPriceLabel, 'USD $300/year')
+  assert.equal(market.areaServedName, 'United States')
+})
+
+test('requires both English lang and US country for USD market', () => {
+  assert.equal(resolveArticleMarket({ lang: 'en', country: 'Colombia' }).isUsEn, false)
+  assert.equal(resolveArticleMarket({ lang: 'es', country: 'US' }).isUsEn, false)
+  assert.equal(resolveArticleMarket({ lang: 'en-US', country: 'USA' }).isUsEn, true)
+  assert.equal(resolveArticleMarket({}).currency, 'COP')
+})

--- a/utils/articleMarket.ts
+++ b/utils/articleMarket.ts
@@ -1,0 +1,87 @@
+export type ArticleMarketCode = 'CO' | 'US'
+
+export interface ArticleMarketInput {
+  lang?: string | null
+  country?: string | null
+}
+
+export interface ArticleMarket {
+  market: ArticleMarketCode
+  localeTag: string
+  ogLocale: string
+  inLanguage: string
+  currency: 'COP' | 'USD'
+  annualPrice: string
+  monthlyPrice: string
+  annualPriceLabel: string
+  monthlyOfferDescription: string
+  isUsEn: boolean
+  areaServedName: string
+}
+
+const CO_MARKET: ArticleMarket = Object.freeze({
+  market: 'CO',
+  localeTag: 'es-CO',
+  ogLocale: 'es_CO',
+  inLanguage: 'es-CO',
+  currency: 'COP',
+  annualPrice: '95900',
+  monthlyPrice: '7992',
+  annualPriceLabel: 'COP 95.900/año',
+  monthlyOfferDescription: 'Equivalente mensual del plan anual de $95.900 COP',
+  isUsEn: false,
+  areaServedName: 'Colombia',
+})
+
+const US_MARKET: ArticleMarket = Object.freeze({
+  market: 'US',
+  localeTag: 'en-US',
+  ogLocale: 'en_US',
+  inLanguage: 'en-US',
+  currency: 'USD',
+  annualPrice: '300',
+  monthlyPrice: '25',
+  annualPriceLabel: 'USD $300/year',
+  monthlyOfferDescription: 'Monthly equivalent of the USD $300/year plan',
+  isUsEn: true,
+  areaServedName: 'United States',
+})
+
+/** Normalize free-text article.country to a market code. Unknown → CO (current DB default). */
+export function normalizeArticleCountry(country?: string | null): ArticleMarketCode {
+  const raw = String(country || '').trim().toLowerCase()
+  if (!raw) return 'CO'
+
+  if (
+    raw === 'us'
+    || raw === 'usa'
+    || raw === 'united states'
+    || raw === 'united states of america'
+    || raw === 'u.s.'
+    || raw === 'u.s.a.'
+  ) {
+    return 'US'
+  }
+
+  if (raw === 'co' || raw === 'colombia' || raw === 'col') {
+    return 'CO'
+  }
+
+  return 'CO'
+}
+
+/**
+ * Resolve marketing/SEO market from article.lang + article.country.
+ * USD/EN surfaces only when language is English and country maps to US.
+ */
+export function resolveArticleMarket(input: ArticleMarketInput = {}): ArticleMarket {
+  const lang = String(input.lang || '').trim().toLowerCase()
+  const isEn = lang === 'en' || lang.startsWith('en-') || lang.startsWith('en_')
+  const country = normalizeArticleCountry(input.country)
+
+  if (isEn && country === 'US') {
+    return US_MARKET
+  }
+
+  return CO_MARKET
+}


### PR DESCRIPTION
## Summary
- Add `resolveArticleMarket` for article `lang` + `country` (US/EN → USD $300; CO/ES → COP 95.900).
- Wire blog `[slug]` SEO: `ogLocale`, `inLanguage`, Offer schema, `areaServed`, date locale.
- Unit tests cover CO default, US aliases, and EN+US requirement.

Closes #2094

## Validation evidence
```text
$ node --test utils/articleMarket.test.ts
# tests 5
# pass 5
# fail 0
```

EN article verification: no published EN rows yet — covered by unit fixtures (per plan).

## Test plan
- [ ] Open an existing ES Colombia blog slug — `og:locale` stays `es_CO`; JSON-LD Offer remains COP `95900`
- [ ] With fixture/lang override mentally: `en` + `United States` → `en_US` + USD `300`
- [ ] Confirm CTA copy unchanged (batch #2095)


Made with [Cursor](https://cursor.com)