### PR TITLE
feat(blog): EN BlogArticleCTA and lead modal with USD $300/year

### DIFF
--- a/components/blog/BlogArticleCTA.vue
+++ b/components/blog/BlogArticleCTA.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
 import { blogLeadSource } from '~/utils/blogLeadCta'
 
-const props = defineProps<{ slug: string }>()
+const props = defineProps<{
+  slug: string
+  lang?: string | null
+  country?: string | null
+}>()
 const leadModal = useLeadModal()
-const ctaContent = computed(() => useBlogCta(props.slug))
+const ctaContent = computed(() =>
+  useBlogCta(props.slug, 'final', { lang: props.lang, country: props.country }),
+)
 const openLeadModal = () => leadModal.open(blogLeadSource(props.slug))
 </script>
 

--- a/components/blog/BlogArticleContent.vue
+++ b/components/blog/BlogArticleContent.vue
@@ -7,12 +7,16 @@ import type { BlogLeadCtaContent } from '~/utils/blogLeadCta'
 interface Props {
   content: string
   slug?: string
+  lang?: string | null
+  country?: string | null
   showBreadcrumb?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   showBreadcrumb: true,
   slug: '',
+  lang: null,
+  country: null,
 })
 
 const md = new MarkdownIt({ html: true, linkify: true, typographer: true })
@@ -91,8 +95,9 @@ onMounted(() => {
     // Inject contextual CTA banners at natural reading breaks.
     if (props.slug) {
       const source = blogLeadSource(props.slug)
+      const marketInput = { lang: props.lang, country: props.country }
       getMidCtaTargets(articleRef.value).forEach((h2, index) => {
-        const cta = useBlogCta(props.slug, index === 0 ? 'benefit' : 'price')
+        const cta = useBlogCta(props.slug, index === 0 ? 'benefit' : 'price', marketInput)
         const banner = buildMidCta(cta, index, source)
         h2.parentNode!.insertBefore(banner, h2)
         insertedCtas.push(banner)

--- a/composables/useBlogCta.ts
+++ b/composables/useBlogCta.ts
@@ -3,12 +3,14 @@ import {
   type BlogLeadCtaContent,
   type BlogLeadCtaPlacement,
 } from '~/utils/blogLeadCta'
+import type { ArticleMarketInput } from '~/utils/articleMarket'
 
 export type BlogCtaContent = BlogLeadCtaContent
 
 export function useBlogCta(
   slug: string,
   placement: BlogLeadCtaPlacement = 'final',
+  marketInput: ArticleMarketInput = {},
 ): BlogCtaContent {
-  return getBlogLeadCta(slug, placement)
+  return getBlogLeadCta(slug, placement, marketInput)
 }

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -255,7 +255,12 @@ useHead({
       />
 
       <!-- Article Content -->
-      <BlogArticleContent :content="article.content" :slug="slug">
+      <BlogArticleContent
+        :content="article.content"
+        :slug="slug"
+        :lang="article.lang"
+        :country="article.country"
+      >
         <!-- Breadcrumb Slot -->
         <template #breadcrumb>
           <BlogBreadcrumb />
@@ -263,7 +268,11 @@ useHead({
 
         <!-- CTA Slot -->
         <template #cta>
-          <BlogArticleCTA :slug="slug" />
+          <BlogArticleCTA
+            :slug="slug"
+            :lang="article.lang"
+            :country="article.country"
+          />
         </template>
 
         <!-- Author Card Slot -->

--- a/utils/blogLeadCta.test.ts
+++ b/utils/blogLeadCta.test.ts
@@ -6,6 +6,9 @@ import {
   getBlogLeadCta,
 } from './blogLeadCta.ts'
 
+const US_EN = { lang: 'en', country: 'United States' }
+const CO_ES = { lang: 'es', country: 'Colombia' }
+
 test('maps blog slugs to pain-first lead copy', () => {
   const gastrobar = getBlogLeadCta('gastrobar-que-es', 'final')
   assert.match(gastrobar.headline, /restaurante/i)
@@ -23,6 +26,33 @@ test('shows price placement only on commercial slugs', () => {
   const informational = getBlogLeadCta('inventario-restaurante', 'price')
   assert.doesNotMatch(informational.headline, /activa después del pago/)
   assert.equal(informational.button, 'Quiero ver cómo funciona')
+})
+
+test('keeps Colombia ES COP copy when market is CO', () => {
+  const pos = getBlogLeadCta('software-pos-restaurantes', 'final', CO_ES)
+  assert.match(pos.headline, /COP 95\.900/)
+  assert.match(pos.microcopy, /Sin tarjeta/)
+
+  const price = getBlogLeadCta('precio-sistema-pos', 'price', CO_ES)
+  assert.match(price.headline, /COP 95\.900/)
+})
+
+test('shows EN CTA with USD $300/year for US English market', () => {
+  const pos = getBlogLeadCta('software-pos-restaurants', 'final', US_EN)
+  assert.match(pos.headline, /USD \$300\/year/)
+  assert.match(pos.microcopy, /No card/i)
+  assert.match(pos.button, /demo/i)
+
+  const price = getBlogLeadCta('restaurant-pos-pricing', 'price', US_EN)
+  assert.match(price.headline, /USD \$300\/year/)
+  assert.equal(price.button, 'See my options')
+})
+
+test('defaults omitted market to Colombia ES behavior', () => {
+  const omitted = getBlogLeadCta('software-pos-restaurantes', 'final')
+  const explicit = getBlogLeadCta('software-pos-restaurantes', 'final', CO_ES)
+  assert.equal(omitted.headline, explicit.headline)
+  assert.equal(omitted.microcopy, explicit.microcopy)
 })
 
 test('builds stable blog lead attribution sources', () => {

--- a/utils/blogLeadCta.ts
+++ b/utils/blogLeadCta.ts
@@ -1,3 +1,8 @@
+import {
+  resolveArticleMarket,
+  type ArticleMarket,
+  type ArticleMarketInput,
+} from './articleMarket.ts'
 import { resolveBlogCtaIntent } from './publicCta.ts'
 
 export type BlogLeadCtaPlacement = 'benefit' | 'price' | 'final'
@@ -9,12 +14,31 @@ export interface BlogLeadCtaContent {
   microcopy: string
 }
 
-const LEAD_MICROCOPY = '2 minutos. Sin tarjeta. Un asesor te contacta.'
+const LEAD_MICROCOPY_ES = '2 minutos. Sin tarjeta. Un asesor te contacta.'
+const LEAD_MICROCOPY_EN = '2 minutes. No card required. An advisor will contact you.'
 
-const COMMERCIAL_PRICE = {
-  headline: 'Plan Pro anual desde COP 95.900.',
-  body: 'POS, inventario, costos por plato y escaneo inteligente de facturas. Sin permanencia.',
-  button: 'Ver mis opciones',
+function commercialPriceEs(annualPriceLabel: string) {
+  // Keep historical Colombia copy when label is the CO default.
+  if (annualPriceLabel === 'COP 95.900/año') {
+    return {
+      headline: 'Plan Pro anual desde COP 95.900.',
+      body: 'POS, inventario, costos por plato y escaneo inteligente de facturas. Sin permanencia.',
+      button: 'Ver mis opciones',
+    }
+  }
+  return {
+    headline: `Plan Pro anual desde ${annualPriceLabel.replace(/\/año$/, '')}.`,
+    body: 'POS, inventario, costos por plato y escaneo inteligente de facturas. Sin permanencia.',
+    button: 'Ver mis opciones',
+  }
+}
+
+function commercialPriceEn(annualPriceLabel: string) {
+  return {
+    headline: `Pro plan from ${annualPriceLabel}.`,
+    body: 'POS, inventory, plate-level food cost, and smart invoice scanning. No lock-in.',
+    button: 'See my options',
+  }
 }
 
 function isCommercialSlug(slug: string): boolean {
@@ -22,8 +46,12 @@ function isCommercialSlug(slug: string): boolean {
   return intent === 'pos' || intent === 'pricing'
 }
 
-function copyForSlug(slug: string): Pick<BlogLeadCtaContent, 'headline' | 'body' | 'button'> {
+function copyForSlugEs(
+  slug: string,
+  annualPriceLabel: string,
+): Pick<BlogLeadCtaContent, 'headline' | 'body' | 'button'> {
   const s = slug.toLocaleLowerCase()
+  const commercial = commercialPriceEs(annualPriceLabel)
 
   if (/nomina|liquidacion|desprendible|prima-de-servicios|mesero|brigada/.test(s)) {
     return {
@@ -35,8 +63,8 @@ function copyForSlug(slug: string): Pick<BlogLeadCtaContent, 'headline' | 'body'
 
   if (/precio|gratis|free|full|open-source|comparativa/.test(s)) {
     return {
-      headline: COMMERCIAL_PRICE.headline,
-      body: COMMERCIAL_PRICE.body,
+      headline: commercial.headline,
+      body: commercial.body,
       button: 'Ver mis opciones',
     }
   }
@@ -72,19 +100,88 @@ function copyForSlug(slug: string): Pick<BlogLeadCtaContent, 'headline' | 'body'
   }
 }
 
-export function getBlogLeadCta(slug: string, placement: BlogLeadCtaPlacement = 'final'): BlogLeadCtaContent {
-  const base = copyForSlug(slug)
+function copyForSlugEn(
+  slug: string,
+  annualPriceLabel: string,
+): Pick<BlogLeadCtaContent, 'headline' | 'body' | 'button'> {
+  const s = slug.toLocaleLowerCase()
+  const commercial = commercialPriceEn(annualPriceLabel)
+
+  if (/nomina|liquidacion|desprendible|prima-de-servicios|mesero|brigada|payroll|tip/.test(s)) {
+    return {
+      headline: 'Stop payroll mistakes before they cost you.',
+      body: 'WARO connects shifts, sales, tips, and inventory so you can run the full restaurant operation from one place.',
+      button: 'See how it works',
+    }
+  }
+
+  if (/precio|gratis|free|full|open-source|comparativa|price|pricing/.test(s)) {
+    return {
+      headline: commercial.headline,
+      body: commercial.body,
+      button: 'See my options',
+    }
+  }
+
+  if (/food-cost|punto-de-equilibrio|arqueo|inventario|mise-en-place|costos|inventory|cost/.test(s)) {
+    return {
+      headline: 'Stop losing money to spreadsheet food cost.',
+      body: 'WARO shows plate costs, inventory, and margins in real time so you decide with data, not guesswork.',
+      button: 'I want to see how it works',
+    }
+  }
+
+  if (/software|pos|pdv|tpv|sistema-pos|contable/.test(s)) {
+    return {
+      headline: `Restaurant POS from ${annualPriceLabel}.`,
+      body: 'Sell, manage tables, inventory, costs, and supplier invoices with AI — built for restaurant operators.',
+      button: 'See a demo',
+    }
+  }
+
+  if (/administrar|ingenieria-de-menu|cocinas|corrientazo|gastrobar|nombres|manage|menu/.test(s)) {
+    return {
+      headline: 'Run your restaurant without more spreadsheets.',
+      body: 'WARO connects POS, inventory, costs, tables, and delivery in one simple panel.',
+      button: 'Get my free demo',
+    }
+  }
+
+  return {
+    headline: 'Run your restaurant with WARO.',
+    body: `POS, inventory, plate-level food cost, and smart invoice scanning from ${annualPriceLabel}.`,
+    button: 'Start free',
+  }
+}
+
+export function getBlogLeadCta(
+  slug: string,
+  placement: BlogLeadCtaPlacement = 'final',
+  marketInput: ArticleMarketInput | ArticleMarket = {},
+): BlogLeadCtaContent {
+  const market = 'isUsEn' in marketInput && 'annualPriceLabel' in marketInput
+    ? marketInput as ArticleMarket
+    : resolveArticleMarket(marketInput)
+
+  const base = market.isUsEn
+    ? copyForSlugEn(slug, market.annualPriceLabel)
+    : copyForSlugEs(slug, market.annualPriceLabel)
+
+  const microcopy = market.isUsEn ? LEAD_MICROCOPY_EN : LEAD_MICROCOPY_ES
+  const commercial = market.isUsEn
+    ? commercialPriceEn(market.annualPriceLabel)
+    : commercialPriceEs(market.annualPriceLabel)
 
   if (placement === 'price' && isCommercialSlug(slug)) {
     return {
-      ...COMMERCIAL_PRICE,
-      microcopy: LEAD_MICROCOPY,
+      ...commercial,
+      microcopy,
     }
   }
 
   return {
     ...base,
-    microcopy: LEAD_MICROCOPY,
+    microcopy,
   }
 }
 


### PR DESCRIPTION
## Summary
- Extend `getBlogLeadCta` / `useBlogCta` with article market via `resolveArticleMarket`.
- Wire `lang` + `country` from blog `[slug]` into final CTA and mid-article CTAs.
- US/EN → EN copy + **USD $300/year**; Colombia ES copy unchanged.

Closes #2095

## Validation evidence
```text
$ node --test utils/blogLeadCta.test.ts
# tests 6
# pass 6
# fail 0
```

## Test plan
- [ ] Existing ES Colombia article: Spanish CTA + COP 95.900 unchanged
- [ ] Fixture `lang=en` + `country=United States`: EN CTA + USD $300/year (final + mid)
- [ ] Lead modal still opens with `blog:{slug}` source


Made with [Cursor](https://cursor.com)