### PR TITLE
feat(onboarding): suggest country from locale on register

### DIFF
--- a/components/Auth/RegistrationForm.vue
+++ b/components/Auth/RegistrationForm.vue
@@ -322,6 +322,7 @@ import {
   writePublicCtaAttribution,
   writeVerifiedPublicCtaAttribution,
 } from '~/utils/publicCta'
+import { suggestCountryFromLocale } from '~/utils/countryLocale'
 import { trackOnboardingEvent } from '~/utils/onboardingAnalytics'
 import {
   countryNeedsJurisdiction,
@@ -348,7 +349,7 @@ const { t, locale } = useI18n()
 const route = useRoute()
 const authStore = useAuthStore()
 const toast = useToast()
-const { syncAuthenticatedLocale } = useAppLocale()
+const { syncAuthenticatedLocale, locale: appLocale } = useAppLocale()
 const { public: { baseUrl } } = useRuntimeConfig()
 
 const email = ref('')
@@ -684,6 +685,16 @@ onMounted(async () => {
       taxJurisdictionCode.value = ''
     } else if (!compatibleCurrencies.value.includes(baseCurrencyCode.value)) {
       baseCurrencyCode.value = compatibleCurrencies.value[0] || ''
+    }
+    if (!businessCountryCode.value) {
+      const suggested = suggestCountryFromLocale(appLocale.value)
+      if (suggested && registrationCatalog.value.some(option => option.country_code === suggested)) {
+        businessCountryCode.value = suggested
+        baseCurrencyCode.value = (
+          registrationCatalog.value.find(option => option.country_code === suggested)?.currency_codes[0]
+          || ''
+        )
+      }
     }
     if (!needsJurisdiction.value
       || !jurisdictionOptions.value.some(option => option.code === taxJurisdictionCode.value)) {

--- a/utils/countryLocale.test.ts
+++ b/utils/countryLocale.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { localeFromCountry, suggestCountryFromLocale } from './countryLocale.ts'
+
+test('localeFromCountry maps CO/US/BR and LATAM', () => {
+  assert.equal(localeFromCountry('CO'), 'es')
+  assert.equal(localeFromCountry('US'), 'en')
+  assert.equal(localeFromCountry('BR'), 'pt')
+  assert.equal(localeFromCountry('MX'), 'es')
+  assert.equal(localeFromCountry('DE'), 'es')
+  assert.equal(localeFromCountry(''), 'es')
+  assert.equal(localeFromCountry(null), 'es')
+  assert.equal(localeFromCountry(' us '), 'en')
+})
+
+test('suggestCountryFromLocale maps cookie locales; others null', () => {
+  assert.equal(suggestCountryFromLocale('en'), 'US')
+  assert.equal(suggestCountryFromLocale('en-US'), 'US')
+  assert.equal(suggestCountryFromLocale('es'), 'CO')
+  assert.equal(suggestCountryFromLocale('pt'), 'BR')
+  assert.equal(suggestCountryFromLocale('fr'), null)
+  assert.equal(suggestCountryFromLocale('xx'), null)
+  assert.equal(suggestCountryFromLocale(null), null)
+})

--- a/utils/countryLocale.ts
+++ b/utils/countryLocale.ts
@@ -1,0 +1,42 @@
+import {
+  normalizeEnabledAppLocale,
+  type AppLocaleCode,
+} from './appLocales.ts'
+
+/** Spanish-speaking markets in the registration catalog (epic #2100 v1). */
+export const ES_LATAM_COUNTRY_CODES = new Set([
+  'CO',
+  'MX',
+  'CR',
+  'UY',
+  'CL',
+  'PE',
+  'AR',
+  'DO',
+  'PA',
+  'ES',
+])
+
+/**
+ * Default UI locale for a business country.
+ * Align with api_warocol.com/app/core/country_locale.py.
+ */
+export function localeFromCountry(countryCode?: string | null): AppLocaleCode {
+  const code = String(countryCode || '').trim().toUpperCase()
+  if (code === 'US') return 'en'
+  if (code === 'BR') return 'pt'
+  if (ES_LATAM_COUNTRY_CODES.has(code)) return 'es'
+  return 'es'
+}
+
+/**
+ * Suggest a business country when the draft country is empty.
+ * User override always wins; only en/es/pt map to US/CO/BR.
+ */
+export function suggestCountryFromLocale(locale?: string | null): string | null {
+  const code = normalizeEnabledAppLocale(locale)
+  if (code === 'en') return 'US'
+  if (code === 'es') return 'CO'
+  if (code === 'pt') return 'BR'
+  return null
+}


### PR DESCRIPTION
## Summary
- Add front country→locale helpers aligned with API (`localeFromCountry`, `suggestCountryFromLocale`).
- When registration draft has no business country, suggest US/CO/BR from active `waro_locale`.
- Locale persistence on profile + tenant is in the companion API PR.

Closes #2103

Companion API: https://github.com/uno0uno/api-warolabs/pull/775

## Test plan
- [ ] Empty draft + `waro_locale=en` → country suggests US (user can switch to CO)
- [ ] Stored draft country is not overwritten
- [ ] After register with US (API deployed), session locale is `en`

## Validation evidence
```text
node --test utils/countryLocale.test.ts
# tests 2
# pass 2
# fail 0

API companion:
venv/bin/pytest tests/test_country_locale.py tests/test_onboarding_registration.py -q
11 passed
```

## Manual path
Register after visiting an EN article (cookie set by #2101) → US suggested → complete verify → confirm preferred_locale + ui_locale = en (requires API PR #775).