### PR TITLE
fix(finanzas): tenant currency and date display on Pagos

### DIFF
--- a/.wr/2119.yaml
+++ b/.wr/2119.yaml
@@ -1,0 +1,40 @@
+# Compact Codex plan for wr-fast #2119. Keep <=80 lines.
+issue: 2119
+title: "fix(finanzas): tenant currency and date display on Pagos payment UI"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2119-pagos-tenant-currency
+
+paths:
+  - components/payments/PaymentForm.vue
+  - pages/finanzas/pagos/index.vue
+  - utils/currencyDisplay.test.ts
+  - .wr/2119.yaml
+
+ac:
+  - PaymentForm uses useFormatters currencyCode + formatCurrency (no hardcoded COP/$)
+  - Pagos pending/paid amounts use tenant formatCurrency
+  - Pagos dates use formatCalendarDate and whitespace-nowrap
+  - Gastos spot-check only if already OK
+  - currencyDisplay tests still pass (MXN covered)
+
+out_of_scope:
+  - API / FX / multi-currency ledger
+  - Epic #2109 payables behavior changes
+
+hints:
+  entry: "components/payments/PaymentForm.vue formatCurrency COP hardcode; pages/finanzas/pagos/index.vue monto raw + formatDate"
+  pattern: "pages/finanzas/gastos/crear.vue:66 currencyCode prefix + useFormatters"
+  tests: "node --import tsx --test utils/currencyDisplay.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "ready-for-review + wr-review"

--- a/components/payments/PaymentForm.vue
+++ b/components/payments/PaymentForm.vue
@@ -59,13 +59,13 @@
             <div>
               <label class="block text-sm font-medium text-text-primary mb-2">Monto Pagado *</label>
               <div class="relative">
-                <span class="absolute start-4 top-1/2 -translate-y-1/2 text-text-secondary">$</span>
+                <span class="absolute start-3 top-1/2 -translate-y-1/2 text-xs font-medium text-text-secondary pointer-events-none">{{ currencyCode }}</span>
                 <UiDecimalInput
                   v-model="formData.payment_amount"
                   :min="0.01"
                   :precision="2"
                   required
-                  class="w-full ps-8 pe-4 py-2.5 bg-background border-2 border-border rounded-lg text-text-primary focus:border-primary transition-colors"
+                  class="w-full ps-12 pe-4 py-2.5 bg-background border-2 border-border rounded-lg text-text-primary focus:border-primary transition-colors"
                   placeholder="0.00"
                 />
               </div>
@@ -241,6 +241,7 @@ const formData = ref({
 
 const selectedFiles = ref<File[]>([])
 const { todayISO, timeHHMMFromISO, combineDateAndTimeISO } = useTenantTimezone()
+const { formatCurrency, currencyCode } = useFormatters()
 const {
   data: paymentMethodsData,
   error: paymentMethodsError,
@@ -303,14 +304,6 @@ function payEndpoint(id: string): string {
   return props.payableKind === 'expense'
     ? `/api/finance/expenses/${id}/pay`
     : `/api/suppliers/purchases/${id}/pay`
-}
-
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat('es-CO', {
-    style: 'currency',
-    currency: 'COP',
-    minimumFractionDigits: 0
-  }).format(value)
 }
 
 function formatPaymentOptionLabel(label: string, glAccountCode?: string | null): string {

--- a/pages/finanzas/pagos/index.vue
+++ b/pages/finanzas/pagos/index.vue
@@ -106,13 +106,25 @@
               <span :class="['text-sm font-bold text-text-primary', { 'animate-pulse': row.isHighlighted }]">{{ row.orden }}</span>
             </template>
 
+            <template #cell-fechaOrden="{ row }">
+              <span class="text-sm text-text-secondary whitespace-nowrap">{{ row.fechaOrden }}</span>
+            </template>
+
             <template #cell-factura="{ row }">
               <span class="text-sm text-text-secondary">{{ row.factura }}</span>
             </template>
 
+            <template #cell-fechaFactura="{ row }">
+              <span class="text-sm text-text-secondary whitespace-nowrap">{{ row.fechaFactura }}</span>
+            </template>
+
+            <template #cell-monto="{ row }">
+              <span class="text-sm font-medium text-text-primary whitespace-nowrap tabular-nums">{{ formatCurrency(row.monto) }}</span>
+            </template>
+
             <template #cell-vencimiento="{ row }">
               <span v-if="row.vencimiento" :class="[
-                'px-2 py-1 rounded text-xs',
+                'px-2 py-1 rounded text-xs whitespace-nowrap',
                 row.estaVencido ? 'bg-destructive/10 text-destructive' : 'bg-warning/10 text-warning'
               ]">
                 {{ row.vencimiento }}
@@ -176,15 +188,19 @@
             </template>
 
             <template #cell-fechaOrden="{ row }">
-              <span :class="['text-sm text-text-secondary', { 'animate-pulse': row.isHighlighted }]">{{ row.fechaOrden }}</span>
+              <span :class="['text-sm text-text-secondary whitespace-nowrap', { 'animate-pulse': row.isHighlighted }]">{{ row.fechaOrden }}</span>
             </template>
 
             <template #cell-factura="{ row }">
               <span class="text-sm text-text-secondary">{{ row.factura }}</span>
             </template>
 
+            <template #cell-fechaFactura="{ row }">
+              <span class="text-sm text-text-secondary whitespace-nowrap">{{ row.fechaFactura }}</span>
+            </template>
+
             <template #cell-montoPagado="{ row }">
-              <span class="text-sm font-bold text-primary">{{ formatCurrency(row.montoPagado) }}</span>
+              <span class="text-sm font-bold text-primary whitespace-nowrap tabular-nums">{{ formatCurrency(row.montoPagado) }}</span>
             </template>
 
             <template #cell-metodo="{ row }">
@@ -435,13 +451,13 @@ const pendingTableData = computed(() => {
   const purchases = pendingPurchases.value.map(purchase => ({
     tipo: t('finanzas.pagos.typePurchase'),
     orden: purchase.purchase_number,
-    fecha: formatDate(purchase.purchase_date),
-    fechaOrden: formatDate(purchase.purchase_date),
+    fecha: formatCalendarDate(purchase.purchase_date),
+    fechaOrden: formatCalendarDate(purchase.purchase_date),
     proveedor: getSupplierName(purchase),
     factura: purchase.invoice_number || '-',
-    fechaFactura: formatDate(purchase.invoice_date),
+    fechaFactura: formatCalendarDate(purchase.invoice_date),
     monto: parseFloat(purchase.invoice_amount || '0') || (parseFloat(purchase.total_amount || '0') + parseFloat(purchase.tax_amount || '0')),
-    vencimiento: formatDate(purchase.payment_due_date),
+    vencimiento: formatCalendarDate(purchase.payment_due_date),
     estaVencido: isOverdue(purchase.payment_due_date),
     purchaseData: { ...purchase, payableKind: 'purchase' },
     isHighlighted: highlightId.value === purchase.id,
@@ -449,8 +465,8 @@ const pendingTableData = computed(() => {
   const expenses = pendingExpensePayables.value.map((expense: any) => ({
     tipo: t('finanzas.pagos.typeExpense'),
     orden: expense.expenseNumber || expense.expense_number || expense.id,
-    fecha: formatDate(expense.transactionDate || expense.transaction_date),
-    fechaOrden: formatDate(expense.transactionDate || expense.transaction_date),
+    fecha: formatCalendarDate(expense.transactionDate || expense.transaction_date),
+    fechaOrden: formatCalendarDate(expense.transactionDate || expense.transaction_date),
     proveedor: expense.description || expense.category?.categoryName || t('finanzas.pagos.typeExpense'),
     factura: '-',
     fechaFactura: '-',
@@ -466,11 +482,11 @@ const pendingTableData = computed(() => {
 const paidTableData = computed(() => {
   return paidPurchases.value.map(purchase => ({
     orden: purchase.purchase_number,
-    fecha: formatDate(purchase.purchase_date),
-    fechaOrden: formatDate(purchase.purchase_date),
+    fecha: formatCalendarDate(purchase.purchase_date),
+    fechaOrden: formatCalendarDate(purchase.purchase_date),
     proveedor: getSupplierName(purchase),
     factura: purchase.invoice_number || '-',
-    fechaFactura: formatDate(purchase.invoice_date),
+    fechaFactura: formatCalendarDate(purchase.invoice_date),
     montoPagado: parseFloat(purchase.payment_amount || purchase.invoice_amount || '0') || (parseFloat(purchase.total_amount || '0') + parseFloat(purchase.tax_amount || '0')),
     fechaPago: formatDate(purchase.payment_date_final || purchase.payment_date || purchase.paid_at),
     metodo: formatPaymentMethod(purchase.payment_method_final || purchase.payment_method),
@@ -568,7 +584,7 @@ function getSupplierName(purchase: any): string {
   return supplier?.name || t('common.nA')
 }
 
-const { formatDate: _fmtDate, formatCurrency } = useFormatters()
+const { formatDate: _fmtDate, formatCalendarDate, formatCurrency } = useFormatters()
 function formatDate(dateString: string | null | undefined): string {
   return _fmtDate(dateString)
 }

--- a/pages/finanzas/pagos/index.vue
+++ b/pages/finanzas/pagos/index.vue
@@ -203,6 +203,10 @@
               <span class="text-sm font-bold text-primary whitespace-nowrap tabular-nums">{{ formatCurrency(row.montoPagado) }}</span>
             </template>
 
+            <template #cell-fechaPago="{ row }">
+              <span class="text-sm text-text-secondary whitespace-nowrap">{{ row.fechaPago }}</span>
+            </template>
+
             <template #cell-metodo="{ row }">
               <span class="text-sm text-text-secondary">{{ row.metodo || '-' }}</span>
             </template>
@@ -427,7 +431,7 @@ const pendingColumns = computed(() => [
   { key: 'proveedor', title: t('finanzas.pagos.colProvider'), sortable: true, align: 'left' as const, class: 'font-normal' },
   { key: 'factura', title: t('finanzas.pagos.colInvoice'), sortable: false, align: 'left' as const, class: 'font-normal' },
   { key: 'fechaFactura', title: t('finanzas.pagos.colInvoiceDate'), sortable: false, align: 'left' as const, class: 'font-normal' },
-  { key: 'monto', title: t('finanzas.pagos.colAmount'), sortable: true, align: 'right' as const, format: 'currency' as const, class: 'font-normal' },
+  { key: 'monto', title: t('finanzas.pagos.colAmount'), sortable: true, align: 'right' as const, class: 'font-normal' },
   { key: 'vencimiento', title: t('finanzas.pagos.colDue'), sortable: true, align: 'left' as const, class: 'font-normal' },
   { key: 'acciones', title: t('finanzas.common.actions'), sortable: false, align: 'center' as const, class: 'font-normal' }
 ])
@@ -438,8 +442,8 @@ const paidColumns = computed(() => [
   { key: 'proveedor', title: t('finanzas.pagos.colProvider'), sortable: true, align: 'left' as const, class: 'font-normal' },
   { key: 'factura', title: t('finanzas.pagos.colInvoice'), sortable: false, align: 'left' as const, class: 'font-normal' },
   { key: 'fechaFactura', title: t('finanzas.pagos.colInvoiceDate'), sortable: false, align: 'left' as const, class: 'font-normal' },
-  { key: 'montoPagado', title: t('finanzas.pagos.colPaid'), sortable: true, align: 'right' as const, format: 'currency' as const, class: 'font-normal' },
-  { key: 'fechaPago', title: t('finanzas.pagos.colPaymentDate'), sortable: true, align: 'left' as const, format: 'text' as const, class: 'font-normal' },
+  { key: 'montoPagado', title: t('finanzas.pagos.colPaid'), sortable: true, align: 'right' as const, class: 'font-normal' },
+  { key: 'fechaPago', title: t('finanzas.pagos.colPaymentDate'), sortable: true, align: 'left' as const, class: 'font-normal' },
   { key: 'metodo', title: t('finanzas.pagos.colMethod'), sortable: false, align: 'left' as const, class: 'font-normal' },
   { key: 'estado', title: t('finanzas.pagos.colStatus'), sortable: false, align: 'center' as const, class: 'font-normal' }
 ])

--- a/utils/currencyDisplay.test.ts
+++ b/utils/currencyDisplay.test.ts
@@ -144,6 +144,16 @@ describe('formatMoney', () => {
       currency: 'EUR', locale: 'de', minorUnits: 2, notation: 'compact',
     }), expected)
   })
+
+  it('formats MXN amounts on a single line for Pagos table cells', () => {
+    const formatted = formatMoney(900, { currency: 'MXN', locale: 'es', minorUnits: 2 })
+    assert.equal(formatted.includes('\n'), false)
+    assert.match(formatted, /900/)
+    assert.notEqual(
+      formatted,
+      formatMoney(900, { currency: 'COP', locale: 'es', minorUnits: 0 }),
+    )
+  })
 })
 
 describe('normalizeMinorUnits', () => {


### PR DESCRIPTION
## Summary
- PaymentForm uses tenant `currencyCode` / `formatCurrency` (no hardcoded COP/`$`)
- Pagos pending/paid amounts and calendar dates use `useFormatters` with `whitespace-nowrap`
- Extends `currencyDisplay` MXN single-line coverage

Closes #2119

## Test plan
- [ ] MX tenant: open Pagos pending row — amount shows MXN, fecha compra is full date not `3`
- [ ] Open Registrar pago / slideover — input prefix + totals use tenant currency
- [ ] Spot-check gastos edit still shows `currencyCode`

## Validation evidence
```
$ bunx tsx --test utils/currencyDisplay.test.ts
# tests 16
# suites 6
# pass 16
# fail 0
```

## wr-context
See `.wr/2119.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)