### PR TITLE
fix(abastecimiento): hide payment proof on credit direct purchases

### DIFF
--- a/pages/abastecimiento/compras-directas/[id]/editar.vue
+++ b/pages/abastecimiento/compras-directas/[id]/editar.vue
@@ -318,30 +318,65 @@
 
         <!-- Step 2: Documentos -->
         <div v-else-if="currentStep === 2" key="step-2" class="bg-surface border-border border rounded-lg">
-          <div class="p-4 sm:p-6">
-            <h3 class="text-base sm:text-lg font-semibold text-text-primary mb-2">Documentos</h3>
-            <p class="text-sm text-text-secondary mb-6">Agrega o actualiza factura y comprobante de pago</p>
+          <div class="p-4 sm:p-6 space-y-6">
+            <div>
+              <h3 class="text-base sm:text-lg font-semibold text-text-primary mb-1">Documentos</h3>
+              <p class="text-sm text-text-secondary">
+                {{ form.payment_type === 'credito'
+                  ? 'Actualiza la factura; el pago se registra después en Pagos'
+                  : 'Agrega o actualiza factura y comprobante de pago' }}
+              </p>
+            </div>
 
-            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div>
+              <span class="block text-sm font-medium text-text-primary mb-2">
+                Tipo de pago
+              </span>
+              <div
+                class="grid grid-cols-3 gap-2"
+                role="radiogroup"
+                aria-label="Tipo de pago"
+              >
+                <button
+                  v-for="option in paymentTypeOptions"
+                  :key="option.value"
+                  type="button"
+                  role="radio"
+                  :aria-checked="form.payment_type === option.value"
+                  class="min-h-[52px] rounded-xl border-2 px-2 py-2 text-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                  :class="form.payment_type === option.value
+                    ? 'border-primary bg-primary/8'
+                    : 'border-border bg-background hover:border-primary/40'"
+                  @click="form.payment_type = option.value"
+                >
+                  <span class="block text-sm font-semibold text-text-primary leading-snug">{{ option.label }}</span>
+                  <span class="block mt-0.5 text-[11px] text-text-tertiary leading-tight">{{ option.hint }}</span>
+                </button>
+              </div>
+              <p v-if="form.payment_type === 'contado' && !hasPaymentSelected" class="mt-1.5 text-xs text-warning">
+                Elige un método en Comprobante de pago, o cambia a Crédito.
+              </p>
+            </div>
+
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
               <!-- Factura Section -->
-              <div class="border-2 border-border rounded-lg p-4 bg-background/50">
-                <h4 class="font-semibold text-text-primary mb-4 flex items-center gap-2">
+              <div class="border border-border rounded-xl p-4 bg-background space-y-4">
+                <h4 class="font-semibold text-text-primary flex items-center gap-2">
                   <DocumentTextIcon class="w-5 h-5 text-primary" />
                   Factura
                 </h4>
 
-                <div class="space-y-4">
-                  <div>
-                    <label class="block text-sm font-medium text-text-secondary mb-2">
-                      Numero de Factura
-                    </label>
-                    <input
-                      v-model="form.invoice_number"
-                      type="text"
-                      class="input-base w-full px-4 py-2"
-                      placeholder="Ej: FV-12345"
-                    />
-                  </div>
+                <div>
+                  <label class="block text-sm font-medium text-text-secondary mb-2">
+                    Numero de Factura
+                  </label>
+                  <input
+                    v-model="form.invoice_number"
+                    type="text"
+                    class="input-base w-full px-4 py-2"
+                    placeholder="Ej: FV-12345"
+                  />
+                </div>
 
                   <!-- Existing Attachments -->
                   <div v-if="existingInvoiceAttachments.length > 0">
@@ -419,35 +454,38 @@
                       </div>
                     </div>
                   </div>
-                </div>
               </div>
 
-              <!-- Tipo de pago (always) + Comprobante only when paying now (#2128) -->
-              <div class="border-2 border-border rounded-lg p-4 bg-background/50 space-y-4">
-                <div>
-                  <label class="block text-sm font-medium text-text-secondary mb-2">
-                    Tipo de pago
-                  </label>
-                  <select
-                    v-model="form.payment_type"
-                    class="input-base w-full px-4 py-2"
-                  >
-                    <option value="credito">Credito - Pago Diferido</option>
-                    <option value="contado">Contado - Pago Inmediato</option>
-                    <option value="contraentrega">Contraentrega</option>
-                  </select>
-                  <p v-if="form.payment_type === 'contado' && !hasPaymentSelected" class="mt-1.5 text-xs text-warning">
-                    Contado exige un método de pago. Sin pago, usa Crédito.
-                  </p>
-                  <p v-else-if="form.payment_type === 'credito'" class="mt-1.5 text-xs text-text-secondary">
-                    El pago se registra después en Pagos. No se adjunta comprobante aquí.
-                  </p>
+              <!-- Crédito: deferred pay panel -->
+              <div
+                v-if="form.payment_type === 'credito'"
+                class="border border-dashed border-border rounded-xl p-4 bg-surface-secondary/40 flex flex-col justify-center gap-2 min-h-[140px]"
+              >
+                <div class="flex items-center gap-2 text-text-secondary">
+                  <CreditCardIcon class="w-5 h-5 flex-shrink-0" aria-hidden="true" />
+                  <h4 class="font-semibold text-text-primary">Pago diferido</h4>
                 </div>
+                <p class="text-sm text-text-secondary leading-relaxed">
+                  Esta compra quedará pendiente. Registra el pago después en <span class="font-medium text-text-primary">Finanzas → Pagos</span>.
+                </p>
+              </div>
 
-                <div v-if="form.payment_type !== 'credito'" class="space-y-4 pt-2 border-t border-border">
+              <!-- Contado / contraentrega: proof -->
+              <div
+                v-else
+                class="border border-border rounded-xl p-4 bg-background space-y-4"
+              >
                   <h4 class="font-semibold text-text-primary flex items-center gap-2">
                     <CreditCardIcon class="w-5 h-5 text-primary" />
-                    Comprobante de Pago
+                    Comprobante de pago
+                    <span
+                      v-if="form.payment_type === 'contado'"
+                      class="text-xs font-medium text-destructive"
+                    >*</span>
+                    <span
+                      v-else
+                      class="ms-auto text-xs font-normal text-text-tertiary"
+                    >Opcional</span>
                   </h4>
 
                   <div>
@@ -563,12 +601,11 @@
                       </div>
                     </div>
                   </div>
-                </div>
               </div>
             </div>
 
             <!-- Notes -->
-            <div class="mt-6">
+            <div>
               <label class="block text-sm font-medium text-text-primary mb-2">
                 Notas Generales
               </label>
@@ -856,6 +893,12 @@ const form = ref({
   payment_files: [] as File[],
   items: [] as PurchaseItem[]
 })
+
+const paymentTypeOptions = [
+  { value: 'credito', label: 'Crédito', hint: 'Pagas después' },
+  { value: 'contado', label: 'Contado', hint: 'Pagas ahora' },
+  { value: 'contraentrega', label: 'Contraentrega', hint: 'Al recibir' },
+] as const
 
 // Payment methods
 const { data: paymentMethodsData } = useFetch<{ success: boolean; data: import('~/utils/paymentDefaults').PosPaymentGroup[] }>(

--- a/pages/abastecimiento/compras-directas/[id]/editar.vue
+++ b/pages/abastecimiento/compras-directas/[id]/editar.vue
@@ -343,14 +343,13 @@
                   type="button"
                   role="radio"
                   :aria-checked="form.payment_type === option.value"
-                  class="min-h-[52px] rounded-xl border-2 px-2 py-2 text-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                  class="h-10 min-h-[40px] rounded-lg border px-2 text-sm font-medium text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
                   :class="form.payment_type === option.value
                     ? 'border-primary bg-primary/8'
                     : 'border-border bg-background hover:border-primary/40'"
                   @click="form.payment_type = option.value"
                 >
-                  <span class="block text-sm font-semibold text-text-primary leading-snug">{{ option.label }}</span>
-                  <span class="block mt-0.5 text-[11px] text-text-tertiary leading-tight">{{ option.hint }}</span>
+                  {{ option.label }}
                 </button>
               </div>
               <p v-if="form.payment_type === 'contado' && !hasPaymentSelected" class="mt-1.5 text-xs text-warning">
@@ -895,9 +894,9 @@ const form = ref({
 })
 
 const paymentTypeOptions = [
-  { value: 'credito', label: 'Crédito', hint: 'Pagas después' },
-  { value: 'contado', label: 'Contado', hint: 'Pagas ahora' },
-  { value: 'contraentrega', label: 'Contraentrega', hint: 'Al recibir' },
+  { value: 'credito', label: 'Crédito' },
+  { value: 'contado', label: 'Contado' },
+  { value: 'contraentrega', label: 'Contraentrega' },
 ] as const
 
 // Payment methods

--- a/pages/abastecimiento/compras-directas/[id]/editar.vue
+++ b/pages/abastecimiento/compras-directas/[id]/editar.vue
@@ -422,30 +422,33 @@
                 </div>
               </div>
 
-              <!-- Comprobante de Pago Section -->
-              <div class="border-2 border-border rounded-lg p-4 bg-background/50">
-                <h4 class="font-semibold text-text-primary mb-4 flex items-center gap-2">
-                  <CreditCardIcon class="w-5 h-5 text-primary" />
-                  Comprobante de Pago
-                </h4>
+              <!-- Tipo de pago (always) + Comprobante only when paying now (#2128) -->
+              <div class="border-2 border-border rounded-lg p-4 bg-background/50 space-y-4">
+                <div>
+                  <label class="block text-sm font-medium text-text-secondary mb-2">
+                    Tipo de pago
+                  </label>
+                  <select
+                    v-model="form.payment_type"
+                    class="input-base w-full px-4 py-2"
+                  >
+                    <option value="credito">Credito - Pago Diferido</option>
+                    <option value="contado">Contado - Pago Inmediato</option>
+                    <option value="contraentrega">Contraentrega</option>
+                  </select>
+                  <p v-if="form.payment_type === 'contado' && !hasPaymentSelected" class="mt-1.5 text-xs text-warning">
+                    Contado exige un método de pago. Sin pago, usa Crédito.
+                  </p>
+                  <p v-else-if="form.payment_type === 'credito'" class="mt-1.5 text-xs text-text-secondary">
+                    El pago se registra después en Pagos. No se adjunta comprobante aquí.
+                  </p>
+                </div>
 
-                <div class="space-y-4">
-                  <div>
-                    <label class="block text-sm font-medium text-text-secondary mb-2">
-                      Tipo de pago
-                    </label>
-                    <select
-                      v-model="form.payment_type"
-                      class="input-base w-full px-4 py-2"
-                    >
-                      <option value="credito">Credito - Pago Diferido</option>
-                      <option value="contado">Contado - Pago Inmediato</option>
-                      <option value="contraentrega">Contraentrega</option>
-                    </select>
-                    <p v-if="form.payment_type === 'contado' && !hasPaymentSelected" class="mt-1.5 text-xs text-warning">
-                      Contado exige un método de pago. Sin pago, usa Crédito.
-                    </p>
-                  </div>
+                <div v-if="form.payment_type !== 'credito'" class="space-y-4 pt-2 border-t border-border">
+                  <h4 class="font-semibold text-text-primary flex items-center gap-2">
+                    <CreditCardIcon class="w-5 h-5 text-primary" />
+                    Comprobante de Pago
+                  </h4>
 
                   <div>
                     <label class="block text-sm font-medium text-text-secondary mb-2">
@@ -690,7 +693,10 @@
           </div>
 
           <!-- Documents Summary -->
-          <div v-if="form.invoice_number || hasPaymentSelected || form.invoice_files.length || form.payment_files.length" class="px-4 sm:px-6 md:px-8 py-4 sm:py-6 border-t border-border bg-background/50">
+          <div
+            v-if="form.invoice_number || form.invoice_files.length || (form.payment_type !== 'credito' && (hasPaymentSelected || form.payment_files.length))"
+            class="px-4 sm:px-6 md:px-8 py-4 sm:py-6 border-t border-border bg-background/50"
+          >
             <p class="text-xs font-semibold text-text-secondary uppercase tracking-wide mb-3">Documentos</p>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div v-if="form.invoice_number || form.invoice_files.length">
@@ -699,7 +705,7 @@
                 <p v-if="existingInvoiceAttachments.length" class="text-xs text-success mt-1">{{ existingInvoiceAttachments.length }} archivo(s) existente(s)</p>
                 <p v-if="form.invoice_files.length" class="text-xs text-primary mt-1">+ {{ form.invoice_files.length }} archivo(s) nuevo(s)</p>
               </div>
-              <div v-if="hasPaymentSelected || form.payment_files.length">
+              <div v-if="form.payment_type !== 'credito' && (hasPaymentSelected || form.payment_files.length)">
                 <p class="text-sm text-text-secondary">Pago:</p>
                 <p v-if="hasPaymentSelected" class="font-medium text-text-primary">{{ resolvePaymentLabel(form.payment_method, form.payment_method_id) }}</p>
                 <p v-if="form.payment_reference" class="text-xs text-text-secondary">Ref: {{ form.payment_reference }}</p>
@@ -862,6 +868,20 @@ const paymentGroups = computed(() =>
 const { resolveLabel: resolvePaymentLabel } = usePaymentLabel(paymentGroups)
 const { paymentSelectValue, hasPaymentSelected } = usePaymentSelectValue(form, paymentGroups)
 
+const clearPaymentProof = () => {
+  form.value.payment_method = ''
+  form.value.payment_method_id = null
+  form.value.payment_reference = ''
+  form.value.payment_files = []
+}
+
+watch(
+  () => form.value.payment_type,
+  (type) => {
+    if (type === 'credito') clearPaymentProof()
+  },
+)
+
 watch(hasPaymentSelected, (selected) => {
   if (selected) return
   form.value.payment_reference = ''
@@ -902,6 +922,10 @@ watch(originalPurchase, (purchase) => {
     // Contado without method is invalid on load — normalize to crédito
     if (form.value.payment_type === 'contado' && !form.value.payment_method && !form.value.payment_method_id) {
       form.value.payment_type = 'credito'
+    }
+    // Crédito must not keep a leftover method (marks paid / wrong GL)
+    if (form.value.payment_type === 'credito') {
+      clearPaymentProof()
     }
     form.value.items = (purchase.items || []).map((item: any) => {
       const purchaseQty = item.purchase_quantity || item.quantity || 1
@@ -1145,6 +1169,9 @@ const handleSubmit = async () => {
   isSubmitting.value = true
 
   try {
+    const isCredit = form.value.payment_type === 'credito'
+    if (isCredit) clearPaymentProof()
+
     // 1. Prepare JSON payload for update
     const payload = {
       items_data: JSON.stringify(form.value.items.map(item => ({
@@ -1160,11 +1187,11 @@ const handleSubmit = async () => {
       notes: form.value.notes,
       invoice_number: form.value.invoice_number,
       payment_type: form.value.payment_type,
-      payment_method: form.value.payment_method || null,
-      payment_method_id: form.value.payment_method_id || null,
-      payment_reference: form.value.payment_reference || null,
-      payment_amount: form.value.payment_method ? Number(totalAmount.value) : null,
-      payment_date: form.value.payment_method ? tenantNowISO() : null
+      payment_method: isCredit ? null : (form.value.payment_method || null),
+      payment_method_id: isCredit ? null : (form.value.payment_method_id || null),
+      payment_reference: isCredit ? null : (form.value.payment_reference || null),
+      payment_amount: !isCredit && form.value.payment_method ? Number(totalAmount.value) : null,
+      payment_date: !isCredit && form.value.payment_method ? tenantNowISO() : null
     }
 
     // 2. Update Direct Purchase (PUT - JSON)
@@ -1177,7 +1204,7 @@ const handleSubmit = async () => {
     })
 
     // 3. Upload files if present (POST - Multipart)
-    if ((form.value.invoice_files?.length > 0 || form.value.payment_files?.length > 0) && response.data?.id) {
+    if ((form.value.invoice_files?.length > 0 || (!isCredit && form.value.payment_files?.length > 0)) && response.data?.id) {
       try {
         const formData = new FormData()
         
@@ -1185,7 +1212,7 @@ const handleSubmit = async () => {
           form.value.invoice_files.forEach(file => formData.append('invoice_files', file))
         }
         
-        if (form.value.payment_files?.length) {
+        if (!isCredit && form.value.payment_files?.length) {
           form.value.payment_files.forEach(file => formData.append('payment_files', file))
         }
 

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -174,22 +174,32 @@
               </div>
 
               <div>
-                <label class="block text-sm font-medium text-text-primary mb-2">
+                <span class="block text-sm font-medium text-text-primary mb-2">
                   Tipo de pago
-                </label>
-                <select
-                  v-model="form.payment_type"
-                  class="input-base w-full px-4 py-2"
+                </span>
+                <div
+                  class="grid grid-cols-3 gap-2"
+                  role="radiogroup"
+                  aria-label="Tipo de pago"
                 >
-                  <option value="credito">Credito - Pago Diferido</option>
-                  <option value="contado">Contado - Pago Inmediato</option>
-                  <option value="contraentrega">Contraentrega</option>
-                </select>
+                  <button
+                    v-for="option in paymentTypeOptions"
+                    :key="option.value"
+                    type="button"
+                    role="radio"
+                    :aria-checked="form.payment_type === option.value"
+                    class="min-h-[52px] rounded-xl border-2 px-2 py-2 text-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                    :class="form.payment_type === option.value
+                      ? 'border-primary bg-primary/8'
+                      : 'border-border bg-background hover:border-primary/40'"
+                    @click="form.payment_type = option.value"
+                  >
+                    <span class="block text-sm font-semibold text-text-primary leading-snug">{{ option.label }}</span>
+                    <span class="block mt-0.5 text-[11px] text-text-tertiary leading-tight">{{ option.hint }}</span>
+                  </button>
+                </div>
                 <p v-if="form.payment_type === 'contado' && !hasPaymentSelected" class="mt-1.5 text-xs text-warning">
-                  Contado exige un método de pago en Comprobante de Pago. Sin pago, usa Crédito.
-                </p>
-                <p v-else-if="form.payment_type === 'credito'" class="mt-1.5 text-xs text-text-secondary">
-                  El pago se registra después en Pagos. No se adjunta comprobante aquí.
+                  Elige un método en Comprobante de pago, o cambia a Crédito.
                 </p>
               </div>
 
@@ -442,11 +452,13 @@
 
             <UiFormSection
               title="Documentos"
-              description="Opcional — puedes agregar la factura y comprobante ahora o después"
+              :description="form.payment_type === 'credito'
+                ? 'Opcional — factura ahora; el pago se registra después en Pagos'
+                : 'Opcional — puedes agregar factura y comprobante ahora o después'"
             >
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
               <!-- Factura Section -->
-              <div class="border-2 border-border rounded-lg p-4 bg-background space-y-4">
+              <div class="border border-border rounded-xl p-4 bg-background space-y-4">
                 <h4 class="text-base font-semibold text-text-primary flex items-center gap-2">
                   <DocumentTextIcon class="w-5 h-5 text-primary flex-shrink-0" />
                   Factura
@@ -468,13 +480,36 @@
                 </div>
               </div>
 
-              <!-- Comprobante de Pago: only when paying now (#2128 — hide on crédito) -->
+              <!-- Crédito: quiet deferred-pay panel (keeps grid balanced) -->
               <div
-                v-if="form.payment_type !== 'credito'"
-                class="border-2 border-border rounded-lg p-4 bg-background space-y-4"
-              >                <h4 class="text-base font-semibold text-text-primary flex items-center gap-2">
+                v-if="form.payment_type === 'credito'"
+                class="border border-dashed border-border rounded-xl p-4 bg-surface-secondary/40 flex flex-col justify-center gap-2 min-h-[140px]"
+              >
+                <div class="flex items-center gap-2 text-text-secondary">
+                  <CreditCardIcon class="w-5 h-5 flex-shrink-0" aria-hidden="true" />
+                  <h4 class="text-base font-semibold text-text-primary">Pago diferido</h4>
+                </div>
+                <p class="text-sm text-text-secondary leading-relaxed">
+                  Esta compra quedará pendiente. Registra el pago después en <span class="font-medium text-text-primary">Finanzas → Pagos</span>.
+                </p>
+              </div>
+
+              <!-- Contado / contraentrega: proof block -->
+              <div
+                v-else
+                class="border border-border rounded-xl p-4 bg-background space-y-4"
+              >
+                <h4 class="text-base font-semibold text-text-primary flex items-center gap-2">
                   <CreditCardIcon class="w-5 h-5 text-primary flex-shrink-0" />
-                  Comprobante de Pago
+                  Comprobante de pago
+                  <span
+                    v-if="form.payment_type === 'contado'"
+                    class="text-xs font-medium text-destructive"
+                  >*</span>
+                  <span
+                    v-else
+                    class="ms-auto text-xs font-normal text-text-tertiary"
+                  >Opcional</span>
                 </h4>
 
                 <div>
@@ -1031,14 +1066,18 @@ const getIngredientName = (id: string) => {
 
 const getPaymentTypeText = (type: string) => {
   const types: Record<string, string> = {
-    'contado': 'Contado - Pago Inmediato',
-    'credito': 'Credito - Pago Diferido',
-    'contraentrega': 'Contraentrega'
+    contado: 'Contado',
+    credito: 'Crédito',
+    contraentrega: 'Contraentrega',
   }
   return types[type] || type
 }
 
-
+const paymentTypeOptions = [
+  { value: 'credito', label: 'Crédito', hint: 'Pagas después' },
+  { value: 'contado', label: 'Contado', hint: 'Pagas ahora' },
+  { value: 'contraentrega', label: 'Contraentrega', hint: 'Al recibir' },
+] as const
 
 const getPurchaseUnitOptions = (ingredientId: string) => {
   if (!ingredientId) return []

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -76,23 +76,25 @@
                     type="file"
                     class="hidden"
                     accept="image/*"
-                    capture="environment"
                     @change="handleScanFileSelect"
                   />
                   <button
                     type="button"
                     :disabled="isScanning || isQuotaExceeded || isScanBlocked"
                     @click="scanFileInput?.click()"
-                    class="px-2.5 py-2 sm:px-3 bg-shell-icon-bg text-shell-icon-text rounded-lg hover:bg-shell-icon-hover-bg transition-all focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5 flex-shrink-0 min-h-[44px]"
-                    :aria-label="isScanBlocked ? 'Escaneo deshabilitado — suscripción inactiva' : isQuotaExceeded ? 'Escaneo deshabilitado — cuota agotada' : isScanning ? currentPhrase : 'Leer factura con IA'"
-                    :title="isScanBlocked ? 'Suscripción inactiva — renueva tu plan para escanear' : isQuotaExceeded ? 'Cuota de escaneos agotada — actualiza tu plan' : undefined"
+                    class="px-3 py-2 bg-primary/10 text-primary border border-primary/25 rounded-lg hover:bg-primary/15 transition-all focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 flex-shrink-0 min-h-[44px]"
+                    :aria-label="scanButtonAriaLabel"
+                    :title="isScanBlocked ? 'Suscripción inactiva — renueva tu plan para escanear' : isQuotaExceeded ? 'Cuota de escaneos agotada — actualiza tu plan' : 'Toma una foto o elige una imagen de la galería'"
                   >
-                    <svg v-if="!isScanning" class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
-                    </svg>
+                    <span v-if="!isScanning" class="relative flex-shrink-0" aria-hidden="true">
+                      <CameraIcon class="w-5 h-5" />
+                      <SparklesIcon class="w-3 h-3 absolute -top-1 -end-1 text-primary" />
+                    </span>
                     <UiLoadingDots v-else size="9px" />
-                    <span class="hidden sm:inline">{{ isScanning ? currentPhrase : 'Leer factura con IA' }}</span>
-                    <span class="inline sm:hidden">{{ isScanning ? '...' : 'IA' }}</span>
+                    <span class="flex flex-col items-start leading-tight text-start">
+                      <span class="font-semibold">{{ isScanning ? currentPhrase : 'Escanear factura' }}</span>
+                      <span v-if="!isScanning" class="text-[10px] font-normal text-primary/80">Foto o galería · IA</span>
+                    </span>
                   </button>
                 </div>
               </template>
@@ -121,7 +123,7 @@
             </div>
 
             <p class="text-xs text-text-secondary mb-3 sm:mb-4">
-              Sube una <strong>foto o imagen</strong> de la factura de compra (OCR). No importa archivos XML/ZIP de factura electrónica DIAN.
+              Toma una <strong>foto</strong> o elige una imagen de la <strong>galería</strong>; la IA lee la factura y precarga ítems. No importa XML/ZIP de DIAN.
             </p>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4">
@@ -748,7 +750,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
-import { TrashIcon, DocumentTextIcon, CreditCardIcon, CheckCircleIcon } from '@heroicons/vue/24/outline'
+import { TrashIcon, DocumentTextIcon, CreditCardIcon, CheckCircleIcon, CameraIcon, SparklesIcon } from '@heroicons/vue/24/outline'
 import { es } from 'date-fns/locale'
 import { format as fnsFormat } from 'date-fns'
 import { useBilling } from '@/composables/useBilling'
@@ -1330,6 +1332,13 @@ const { accessStatus } = useBilling()
 const isScanBlocked = computed(() =>
   ['read_only', 'blocked'].includes(accessStatus.value?.level ?? '')
 )
+
+const scanButtonAriaLabel = computed(() => {
+  if (isScanBlocked.value) return 'Escaneo deshabilitado — suscripción inactiva'
+  if (isQuotaExceeded.value) return 'Escaneo deshabilitado — cuota agotada'
+  if (isScanning.value) return currentPhrase.value
+  return 'Escanear factura con IA: tomar foto o elegir de la galería'
+})
 
 // Quota exceeded modal
 const showQuotaModal = ref(false)

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -91,10 +91,7 @@
                       <SparklesIcon class="w-3 h-3 absolute -top-1 -end-1 text-primary" />
                     </span>
                     <UiLoadingDots v-else size="9px" />
-                    <span class="flex flex-col items-start leading-tight text-start">
-                      <span class="font-semibold">{{ isScanning ? currentPhrase : 'Escanear factura' }}</span>
-                      <span v-if="!isScanning" class="text-[10px] font-normal text-primary/80">Foto o galería · IA</span>
-                    </span>
+                    <span class="font-semibold">{{ isScanning ? currentPhrase : 'Escanear factura con IA' }}</span>
                   </button>
                 </div>
               </template>
@@ -190,14 +187,13 @@
                     type="button"
                     role="radio"
                     :aria-checked="form.payment_type === option.value"
-                    class="min-h-[52px] rounded-xl border-2 px-2 py-2 text-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                    class="h-10 min-h-[40px] rounded-lg border px-2 text-sm font-medium text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
                     :class="form.payment_type === option.value
                       ? 'border-primary bg-primary/8'
                       : 'border-border bg-background hover:border-primary/40'"
                     @click="form.payment_type = option.value"
                   >
-                    <span class="block text-sm font-semibold text-text-primary leading-snug">{{ option.label }}</span>
-                    <span class="block mt-0.5 text-[11px] text-text-tertiary leading-tight">{{ option.hint }}</span>
+                    {{ option.label }}
                   </button>
                 </div>
                 <p v-if="form.payment_type === 'contado' && !hasPaymentSelected" class="mt-1.5 text-xs text-warning">
@@ -1076,9 +1072,9 @@ const getPaymentTypeText = (type: string) => {
 }
 
 const paymentTypeOptions = [
-  { value: 'credito', label: 'Crédito', hint: 'Pagas después' },
-  { value: 'contado', label: 'Contado', hint: 'Pagas ahora' },
-  { value: 'contraentrega', label: 'Contraentrega', hint: 'Al recibir' },
+  { value: 'credito', label: 'Crédito' },
+  { value: 'contado', label: 'Contado' },
+  { value: 'contraentrega', label: 'Contraentrega' },
 ] as const
 
 const getPurchaseUnitOptions = (ingredientId: string) => {

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -186,7 +186,10 @@
                   <option value="contraentrega">Contraentrega</option>
                 </select>
                 <p v-if="form.payment_type === 'contado' && !hasPaymentSelected" class="mt-1.5 text-xs text-warning">
-                  Contado exige un método de pago abajo. Sin pago, usa Crédito.
+                  Contado exige un método de pago en Comprobante de Pago. Sin pago, usa Crédito.
+                </p>
+                <p v-else-if="form.payment_type === 'credito'" class="mt-1.5 text-xs text-text-secondary">
+                  El pago se registra después en Pagos. No se adjunta comprobante aquí.
                 </p>
               </div>
 
@@ -465,9 +468,11 @@
                 </div>
               </div>
 
-              <!-- Comprobante de Pago Section -->
-              <div class="border-2 border-border rounded-lg p-4 bg-background space-y-4">
-                <h4 class="text-base font-semibold text-text-primary flex items-center gap-2">
+              <!-- Comprobante de Pago: only when paying now (#2128 — hide on crédito) -->
+              <div
+                v-if="form.payment_type !== 'credito'"
+                class="border-2 border-border rounded-lg p-4 bg-background space-y-4"
+              >                <h4 class="text-base font-semibold text-text-primary flex items-center gap-2">
                   <CreditCardIcon class="w-5 h-5 text-primary flex-shrink-0" />
                   Comprobante de Pago
                 </h4>
@@ -558,11 +563,11 @@
                     <p class="text-xs font-medium text-text-secondary">Pago</p>
                     <p class="text-xs font-semibold text-text-primary">{{ getPaymentTypeText(form.payment_type) }}</p>
                   </div>
-                  <div v-if="hasPaymentSelected" class="flex justify-between items-center">
+                  <div v-if="hasPaymentSelected && form.payment_type !== 'credito'" class="flex justify-between items-center">
                     <p class="text-xs font-medium text-text-secondary">Método</p>
                     <p class="text-xs font-semibold text-text-primary">{{ resolvePaymentLabel(form.payment_method, form.payment_method_id) }}</p>
                   </div>
-                  <div v-if="hasPaymentSelected" class="flex justify-between items-center">
+                  <div v-if="hasPaymentSelected && form.payment_type !== 'credito'" class="flex justify-between items-center">
                     <p class="text-xs font-medium text-text-secondary">Fecha pago</p>
                     <p class="text-xs font-semibold text-text-primary">
                       {{ form.payment_date ? fnsFormat(form.payment_date, 'dd/MM/yy', { locale: es }) : '-' }}
@@ -571,7 +576,7 @@
                 </div>
 
                 <!-- Documentos -->
-                <div v-if="form.invoice_number || form.invoice_files.length || form.payment_files.length" class="p-4 space-y-2">
+                <div v-if="form.invoice_number || form.invoice_files.length || (form.payment_type !== 'credito' && form.payment_files.length)" class="p-4 space-y-2">
                   <p class="text-xs font-semibold text-text-secondary mb-2">Documentos</p>
                   <div v-if="form.invoice_number" class="flex items-center gap-2 text-xs">
                     <svg class="w-3.5 h-3.5 text-success flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -580,7 +585,7 @@
                     <span class="text-text-primary font-medium">{{ form.invoice_number }}</span>
                     <span v-if="form.invoice_files.length" class="text-success">· {{ form.invoice_files.length }} adjunto(s)</span>
                   </div>
-                  <div v-if="form.payment_reference" class="flex items-center gap-2 text-xs">
+                  <div v-if="form.payment_type !== 'credito' && form.payment_reference" class="flex items-center gap-2 text-xs">
                     <svg class="w-3.5 h-3.5 text-success flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"/>
                     </svg>
@@ -824,6 +829,21 @@ const paymentGroups = computed(() =>
 )
 const { resolveLabel: resolvePaymentLabel } = usePaymentLabel(paymentGroups)
 const { paymentSelectValue, hasPaymentSelected } = usePaymentSelectValue(form, paymentGroups)
+
+const clearPaymentProof = () => {
+  form.value.payment_method = ''
+  form.value.payment_method_id = null
+  form.value.payment_reference = ''
+  form.value.payment_date = null
+  form.value.payment_files = []
+}
+
+watch(
+  () => form.value.payment_type,
+  (type) => {
+    if (type === 'credito') clearPaymentProof()
+  },
+)
 
 watch(hasPaymentSelected, (selected) => {
   if (selected) {
@@ -1654,7 +1674,7 @@ const handleSubmit = async () => {
     if (form.value.purchase_date) payload.purchase_date = purchaseDatePayloadISO(form.value.purchase_date)
     if (form.value.notes) payload.notes = form.value.notes
     if (form.value.invoice_number) payload.invoice_number = form.value.invoice_number
-    if (form.value.payment_method) {
+    if (form.value.payment_type !== 'credito' && form.value.payment_method) {
       payload.payment_method = form.value.payment_method
       if (form.value.payment_method_id) {
         payload.payment_method_id = form.value.payment_method_id
@@ -1675,11 +1695,13 @@ const handleSubmit = async () => {
 
     if (response.success) {
       // Upload files if present
-      if ((form.value.invoice_files.length > 0 || form.value.payment_files.length > 0) && response.data?.id) {
+      if ((form.value.invoice_files.length > 0 || (form.value.payment_type !== 'credito' && form.value.payment_files.length > 0)) && response.data?.id) {
         try {
           const formData = new FormData()
           form.value.invoice_files.forEach((file) => formData.append('invoice_files', file))
-          form.value.payment_files.forEach((file) => formData.append('payment_files', file))
+          if (form.value.payment_type !== 'credito') {
+            form.value.payment_files.forEach((file) => formData.append('payment_files', file))
+          }
 
           await $fetch(`/api/suppliers/purchases/direct/${response.data.id}/attachments`, {
             method: 'POST',


### PR DESCRIPTION
## Summary
- Hide Comprobante de Pago when payment type is crédito on create and edit direct purchases
- Clearing crédito clears method/reference/date/files so submit stays on the unpaid AP path
- Contado/contraentrega keep the proof block; summary omits payment method on crédito

Closes #2128

## Test plan
- [ ] Create direct purchase as Crédito — no Comprobante block; save unpaid
- [ ] Switch Contado → Crédito after selecting a method — fields clear
- [ ] Contado still requires method; Contraentrega shows optional proof
- [ ] Edit a credit purchase — tipo de pago visible, no method; summary without método

## wr-context
Local `.wr/2128.yaml` (gitignored).

Made with [Cursor](https://cursor.com)