### PR TITLE
fix(abastecimiento): drop contraentrega from direct purchases

### DIFF
--- a/pages/abastecimiento/compras-directas/[id]/editar.vue
+++ b/pages/abastecimiento/compras-directas/[id]/editar.vue
@@ -333,7 +333,7 @@
                 Tipo de pago
               </span>
               <div
-                class="grid grid-cols-3 gap-2"
+                class="grid grid-cols-2 gap-2"
                 role="radiogroup"
                 aria-label="Tipo de pago"
               >
@@ -469,7 +469,7 @@
                 </p>
               </div>
 
-              <!-- Contado / contraentrega: proof -->
+              <!-- Contado: proof (crédito pays later in Pagos) -->
               <div
                 v-else
                 class="border border-border rounded-xl p-4 bg-background space-y-4"
@@ -896,7 +896,6 @@ const form = ref({
 const paymentTypeOptions = [
   { value: 'credito', label: 'Crédito' },
   { value: 'contado', label: 'Contado' },
-  { value: 'contraentrega', label: 'Contraentrega' },
 ] as const
 
 // Payment methods
@@ -963,6 +962,10 @@ watch(originalPurchase, (purchase) => {
     form.value.payment_reference = purchase.payment_reference || ''
     // Contado without method is invalid on load — normalize to crédito
     if (form.value.payment_type === 'contado' && !form.value.payment_method && !form.value.payment_method_id) {
+      form.value.payment_type = 'credito'
+    }
+    // Contraentrega duplicates crédito on direct purchases — fold into crédito
+    if (form.value.payment_type === 'contraentrega') {
       form.value.payment_type = 'credito'
     }
     // Crédito must not keep a leftover method (marks paid / wrong GL)

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -177,7 +177,7 @@
                   Tipo de pago
                 </span>
                 <div
-                  class="grid grid-cols-3 gap-2"
+                  class="grid grid-cols-2 gap-2"
                   role="radiogroup"
                   aria-label="Tipo de pago"
                 >
@@ -492,7 +492,7 @@
                 </p>
               </div>
 
-              <!-- Contado / contraentrega: proof block -->
+              <!-- Contado: proof block (crédito pays later in Pagos) -->
               <div
                 v-else
                 class="border border-border rounded-xl p-4 bg-background space-y-4"
@@ -1066,6 +1066,7 @@ const getPaymentTypeText = (type: string) => {
   const types: Record<string, string> = {
     contado: 'Contado',
     credito: 'Crédito',
+    // Legacy rows only — option removed from create/edit
     contraentrega: 'Contraentrega',
   }
   return types[type] || type
@@ -1074,7 +1075,6 @@ const getPaymentTypeText = (type: string) => {
 const paymentTypeOptions = [
   { value: 'credito', label: 'Crédito' },
   { value: 'contado', label: 'Contado' },
-  { value: 'contraentrega', label: 'Contraentrega' },
 ] as const
 
 const getPurchaseUnitOptions = (ingredientId: string) => {


### PR DESCRIPTION
## Summary
- Remove Contraentrega from direct purchase create/edit (same unpaid path as crédito)
- Normalize legacy `contraentrega` rows to crédito when editing
- Gastos already only supports contado | crédito — unchanged
- Formal OC still has contraentrega (remisión / anticipo) — out of scope

## Test plan
- [ ] Create direct purchase: only Crédito and Contado chips
- [ ] Contado still requires payment method; crédito hides proof
- [ ] Edit a legacy contraentrega purchase → shows as Crédito


Made with [Cursor](https://cursor.com)