### PR TITLE
chore(ops): healthcheck + autoheal for warocol-nuxt hang recovery

### DIFF
--- a/.wr/2133.yaml
+++ b/.wr/2133.yaml
@@ -1,0 +1,42 @@
+# Compact Codex plan for wr-fast #2133. Keep <=80 lines.
+issue: 2133
+title: "chore(ops): add Docker HEALTHCHECK so warocol-nuxt restarts on hang"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2133-nuxt-healthcheck
+
+paths:
+  - server/routes/health.get.ts
+  - server/routes/health.get.test.mjs
+  - Dockerfile
+  - docker-compose.prod.yml
+  - .wr/2133.yaml
+
+ac:
+  - HEALTHCHECK probes HTTP on app port (~30s)
+  - Hang (TCP up, HTTP dead) → unhealthy within a few intervals
+  - Unhealthy → auto restart (autoheal + label); restart policy alone is not enough
+  - Deploy note: one-time recreate for healthcheck/autoheal
+  - No Postgres / Fluent Bit / API changes
+
+out_of_scope:
+  - Nitro request logging
+  - SSE notifications stream hardening
+  - Memory limits / nginx alerts
+
+hints:
+  entry: "server/routes/health.get.ts → GET /health (not /api/*)"
+  pattern: "docker-compose.prod.yml restart: unless-stopped; /api/** proxied in nuxt.config"
+  tests: "node --test server/routes/health.get.test.mjs (structural)"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "server: pull + compose build + up -d (recreate once for healthcheck)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,10 @@ ENV HOST=0.0.0.0
 ENV NODE_ENV=production
 
 EXPOSE 3001
+
+# Liveness: Bun event-loop hang accepts TCP but fails HTTP (#2133).
+# Probe /health (not /api/* — that prefix is proxied to the API).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
+  CMD bun -e "fetch('http://127.0.0.1:3001/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
 CMD ["bun", ".output/server/index.mjs"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,3 +8,34 @@ services:
     environment:
       - NODE_ENV=production
     restart: unless-stopped
+    labels:
+      # willfarrell/autoheal restarts unhealthy containers (restart policy alone does not)
+      autoheal: "true"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "bun",
+          "-e",
+          "fetch('http://127.0.0.1:3001/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 40s
+
+  # Watches Docker health; restarts labeled containers when unhealthy.
+  # One-time: `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d`
+  # after pull so healthcheck + autoheal are applied (build then up remains OK).
+  autoheal:
+    image: willfarrell/autoheal:latest
+    container_name: warocol-autoheal
+    restart: unless-stopped
+    environment:
+      - AUTOHEAL_CONTAINER_LABEL=autoheal
+      - AUTOHEAL_INTERVAL=10
+      - AUTOHEAL_START_PERIOD=40
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - warolabs-network

--- a/server/routes/health.get.test.mjs
+++ b/server/routes/health.get.test.mjs
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '../..')
+
+test('health route responds with ok payload shape (source contract)', () => {
+  const routePath = join(root, 'server/routes/health.get.ts')
+  const src = readFileSync(routePath, 'utf8')
+  assert.match(src, /ok:\s*true/)
+  assert.match(src, /warocol-nuxt/)
+  // Must be /health, not under server/routes/api/ (proxied)
+  assert.ok(!routePath.includes(`${sep}api${sep}`))
+})
+
+test('Dockerfile HEALTHCHECK probes /health via bun', () => {
+  const df = readFileSync(join(root, 'Dockerfile'), 'utf8')
+  assert.match(df, /HEALTHCHECK/)
+  assert.match(df, /127\.0\.0\.1:3001\/health/)
+  assert.match(df, /interval=30s/)
+})
+
+test('prod compose: healthcheck + autoheal label + sidecar', () => {
+  const yml = readFileSync(join(root, 'docker-compose.prod.yml'), 'utf8')
+  assert.match(yml, /healthcheck:/)
+  assert.match(yml, /3001\/health/)
+  assert.match(yml, /autoheal:\s*"true"/)
+  assert.match(yml, /willfarrell\/autoheal/)
+  assert.match(yml, /AUTOHEAL_CONTAINER_LABEL=autoheal/)
+})

--- a/server/routes/health.get.ts
+++ b/server/routes/health.get.ts
@@ -1,0 +1,8 @@
+/**
+ * Lightweight liveness probe for Docker HEALTHCHECK (#2133).
+ * Must stay outside `/api/**` (Nitro proxies that prefix to the API).
+ */
+export default defineEventHandler(() => ({
+  ok: true,
+  service: 'warocol-nuxt',
+}))


### PR DESCRIPTION
## Summary
- Add lightweight `GET /health` Nitro route (outside proxied `/api/**`)
- Docker HEALTHCHECK every 30s via bun fetch to `/health`
- Add `willfarrell/autoheal` sidecar so unhealthy `warocol-nuxt` restarts automatically (`restart: unless-stopped` alone does not)

Closes #2133

## Test plan
- [ ] Deploy prod: `git pull` + compose build + `up -d` (one-time recreate picks up healthcheck/autoheal)
- [ ] `docker inspect warocol-nuxt --format '{{.State.Health.Status}}'` → healthy
- [ ] `curl -s http://127.0.0.1:3001/health` → `{\"ok\":true,...}`
- [ ] Confirm `warocol-autoheal` is running

## Validation evidence
```
$ node --test server/routes/health.get.test.mjs
ok 2 - Dockerfile HEALTHCHECK probes /health via bun
  ---
  duration_ms: 0.299625
  type: 'test'
  ...
# Subtest: prod compose: healthcheck + autoheal label + sidecar
ok 3 - prod compose: healthcheck + autoheal label + sidecar
  ---
  duration_ms: 0.438166
  type: 'test'
  ...
1..3
# tests 3
# suites 0
# pass 3
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 57.794417
```

## wr-context
See `.wr/2133.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)