### PR TITLE
fix(i18n): localize GLOBAL chart class/group account names

### DIFF
--- a/i18n/locales/en/finanzas.json
+++ b/i18n/locales/en/finanzas.json
@@ -774,6 +774,18 @@
         "costs": "Costs"
       },
       "systemAccounts": {
+        "assets": "Assets",
+        "currentAssets": "Current assets",
+        "liabilities": "Liabilities",
+        "currentLiabilities": "Current liabilities",
+        "equity": "Equity",
+        "equityDetails": "Equity",
+        "income": "Income",
+        "operatingRevenue": "Operating revenue",
+        "expenses": "Expenses",
+        "operatingExpenses": "Operating expenses",
+        "costs": "Costs",
+        "cogsDetails": "Cost of goods sold details",
         "cash": "Cash",
         "bank": "Bank",
         "accountsReceivable": "Accounts receivable",

--- a/i18n/locales/es/finanzas.json
+++ b/i18n/locales/es/finanzas.json
@@ -774,6 +774,18 @@
         "costs": "Costos"
       },
       "systemAccounts": {
+        "assets": "Activos",
+        "currentAssets": "Activos corrientes",
+        "liabilities": "Pasivos",
+        "currentLiabilities": "Pasivos corrientes",
+        "equity": "Patrimonio",
+        "equityDetails": "Patrimonio",
+        "income": "Ingresos",
+        "operatingRevenue": "Ingresos operativos",
+        "expenses": "Gastos",
+        "operatingExpenses": "Gastos operativos",
+        "costs": "Costos",
+        "cogsDetails": "Detalle costo de ventas",
         "cash": "Efectivo",
         "bank": "Banco",
         "accountsReceivable": "Cuentas por cobrar",

--- a/pages/finanzas/contabilidad/cuentas/[id].vue
+++ b/pages/finanzas/contabilidad/cuentas/[id].vue
@@ -94,7 +94,7 @@ const account = computed<TenantAccount | null>(() =>
   accountsData.value?.data?.find(a => a.id === accountId.value) ?? null
 )
 const displayAccountName = (acct: { code: string; name: string }) =>
-  localizeSystemAccountName(acct, key => t(key))
+  localizeSystemAccountName(acct, key => t(key), { isColombiaPuc: isColombiaPuc.value })
 const accountDisplayName = computed(() =>
   account.value ? displayAccountName(account.value) : '',
 )

--- a/pages/finanzas/contabilidad/cuentas/index.vue
+++ b/pages/finanzas/contabilidad/cuentas/index.vue
@@ -4,9 +4,6 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import MetricCard from '~/components/shared/MetricCard.vue'
 import { getAccountLevel, getAccountLevelKey, getAccountLevelVariant, localizeSystemAccountName } from '~/utils/accountingDisplay'
 
-const displayAccountName = (account: { code: string; name: string }) =>
-  localizeSystemAccountName(account, key => t(key))
-
 definePageMeta({ layout: 'dashboard', module: 'finanzas' })
 useHead({ title: () => t('finanzas.contabilidad.accountsTitle') })
 
@@ -16,6 +13,9 @@ const { addDaysISO, dateAtNoon, isoFromDate, monthBounds, timezone, todayISO } =
 const { formatCalendarDate, formatCurrency } = useFormatters()
 const formatAmount = (v: number) => formatCurrency(v ?? 0)
 const { isColombiaPuc } = useTenantFinancialProfile()
+
+const displayAccountName = (account: { code: string; name: string }) =>
+  localizeSystemAccountName(account, key => t(key), { isColombiaPuc: isColombiaPuc.value })
 
 // ── View toggle ────────────────────────────────────────────────────────────
 const showAll = ref(false)

--- a/utils/accountingDisplay.test.ts
+++ b/utils/accountingDisplay.test.ts
@@ -27,6 +27,7 @@ describe('localizeSystemAccountName', () => {
     if (key === 'finanzas.contabilidad.systemAccounts.taxPayable') return 'Impuestos por pagar'
     if (key === 'finanzas.contabilidad.systemAccounts.assets') return 'Activos'
     if (key === 'finanzas.contabilidad.systemAccounts.currentAssets') return 'Activos corrientes'
+    if (key === 'finanzas.contabilidad.systemAccounts.expenses') return 'Gastos'
     return key
   }
 
@@ -40,6 +41,25 @@ describe('localizeSystemAccountName', () => {
     assert.equal(
       localizeSystemAccountName({ code: '10', name: 'Current assets' }, t),
       'Activos corrientes',
+    )
+  })
+
+  it('keeps CO PUC class stored names when isColombiaPuc (#2137)', () => {
+    assert.equal(
+      localizeSystemAccountName(
+        { code: '5', name: 'Gastos operacionales de administración' },
+        t,
+        { isColombiaPuc: true },
+      ),
+      'Gastos operacionales de administración',
+    )
+    assert.equal(
+      localizeSystemAccountName(
+        { code: '1', name: 'Activo' },
+        t,
+        { isColombiaPuc: true },
+      ),
+      'Activo',
     )
   })
 

--- a/utils/accountingDisplay.test.ts
+++ b/utils/accountingDisplay.test.ts
@@ -25,12 +25,22 @@ describe('localizeSystemAccountName', () => {
   const t = (key: string) => {
     if (key === 'finanzas.contabilidad.systemAccounts.cash') return 'Efectivo'
     if (key === 'finanzas.contabilidad.systemAccounts.taxPayable') return 'Impuestos por pagar'
+    if (key === 'finanzas.contabilidad.systemAccounts.assets') return 'Activos'
+    if (key === 'finanzas.contabilidad.systemAccounts.currentAssets') return 'Activos corrientes'
     return key
   }
 
   it('maps known global managerial codes via i18n', () => {
     assert.equal(localizeSystemAccountName({ code: '1000', name: 'Cash' }, t), 'Efectivo')
     assert.equal(localizeSystemAccountName({ code: '2100', name: 'Tax payable' }, t), 'Impuestos por pagar')
+  })
+
+  it('maps GLOBAL class and group header codes via i18n (#2137)', () => {
+    assert.equal(localizeSystemAccountName({ code: '1', name: 'Assets' }, t), 'Activos')
+    assert.equal(
+      localizeSystemAccountName({ code: '10', name: 'Current assets' }, t),
+      'Activos corrientes',
+    )
   })
 
   it('keeps CO PUC / custom stored names when code is not in the global map', () => {
@@ -41,6 +51,10 @@ describe('localizeSystemAccountName', () => {
     assert.equal(
       localizeSystemAccountName({ code: '100005', name: 'Caja secundaria' }, t),
       'Caja secundaria',
+    )
+    assert.equal(
+      localizeSystemAccountName({ code: '101005', name: 'NEQUI' }, t),
+      'NEQUI',
     )
   })
 })

--- a/utils/accountingDisplay.ts
+++ b/utils/accountingDisplay.ts
@@ -1,5 +1,19 @@
 /** Global managerial chart codes (non-CO). CO PUC uses different codes — left as stored. */
 export const GLOBAL_SYSTEM_ACCOUNT_I18N_KEYS: Record<string, string> = {
+  // Class / group headers (were left as English DB names)
+  '1': 'assets',
+  '10': 'currentAssets',
+  '2': 'liabilities',
+  '20': 'currentLiabilities',
+  '3': 'equity',
+  '30': 'equityDetails',
+  '4': 'income',
+  '40': 'operatingRevenue',
+  '5': 'expenses',
+  '50': 'operatingExpenses',
+  '6': 'costs',
+  '60': 'cogsDetails',
+  // Detail system accounts
   '1000': 'cash',
   '1010': 'bank',
   '1100': 'accountsReceivable',

--- a/utils/accountingDisplay.ts
+++ b/utils/accountingDisplay.ts
@@ -1,6 +1,5 @@
-/** Global managerial chart codes (non-CO). CO PUC uses different codes — left as stored. */
-export const GLOBAL_SYSTEM_ACCOUNT_I18N_KEYS: Record<string, string> = {
-  // Class / group headers (were left as English DB names)
+/** GLOBAL class/group codes — collide with CO PUC class codes (1–6); gate via isColombiaPuc. */
+export const GLOBAL_CLASS_GROUP_I18N_KEYS: Record<string, string> = {
   '1': 'assets',
   '10': 'currentAssets',
   '2': 'liabilities',
@@ -13,7 +12,10 @@ export const GLOBAL_SYSTEM_ACCOUNT_I18N_KEYS: Record<string, string> = {
   '50': 'operatingExpenses',
   '6': 'costs',
   '60': 'cogsDetails',
-  // Detail system accounts
+}
+
+/** Global managerial detail codes (non-CO). Safe for all localizations. */
+export const GLOBAL_DETAIL_I18N_KEYS: Record<string, string> = {
   '1000': 'cash',
   '1010': 'bank',
   '1100': 'accountsReceivable',
@@ -28,18 +30,32 @@ export const GLOBAL_SYSTEM_ACCOUNT_I18N_KEYS: Record<string, string> = {
   '6000': 'costOfGoodsSold',
 }
 
+/** Full GLOBAL map (details + class/group). Prefer localizeSystemAccountName with isColombiaPuc. */
+export const GLOBAL_SYSTEM_ACCOUNT_I18N_KEYS: Record<string, string> = {
+  ...GLOBAL_CLASS_GROUP_I18N_KEYS,
+  ...GLOBAL_DETAIL_I18N_KEYS,
+}
+
 export type AccountNameSource = {
   code?: string | null
   name?: string | null
 }
 
+export type LocalizeSystemAccountOptions = {
+  /** When true, skip class/group code remaps that collide with CO PUC (1–6). */
+  isColombiaPuc?: boolean
+}
+
 export const localizeSystemAccountName = (
   account: AccountNameSource,
   translate: (key: string) => string,
+  options: LocalizeSystemAccountOptions = {},
 ): string => {
   const stored = String(account.name ?? '').trim()
   const code = String(account.code ?? '').trim()
-  const slug = GLOBAL_SYSTEM_ACCOUNT_I18N_KEYS[code]
+  const slug = options.isColombiaPuc
+    ? GLOBAL_DETAIL_I18N_KEYS[code]
+    : GLOBAL_SYSTEM_ACCOUNT_I18N_KEYS[code]
   if (!slug) return stored
   return translate(`finanzas.contabilidad.systemAccounts.${slug}`)
 }


### PR DESCRIPTION
## Summary
- Extend `GLOBAL_SYSTEM_ACCOUNT_I18N_KEYS` for class/group codes (`1`, `10`, `2`, …)
- Add es/en `systemAccounts` labels aligned with `classes.*`
- Unit tests for class + group + custom codes

Closes #2137

## Test plan
- [ ] GLOBAL tenant, UI es: class/group rows show Activos / Activos corrientes (not Assets)
- [ ] Detail rows still localized; custom e.g. NEQUI unchanged
- [ ] Locale en still shows English labels

## Validation evidence
```
$ node --test utils/accountingDisplay.test.ts
# tests 5
# suites 2
# pass 5
# fail 0
```

## wr-context
See `.wr/2137.yaml` locally (gitignored LLM contract).

Made with [Cursor](https://cursor.com)