### PR TITLE
fix(abastecimiento): cash-drawer toggle i18n on Compra Directa

### DIFF
--- a/pages/abastecimiento/compras-directas/[id]/editar.vue
+++ b/pages/abastecimiento/compras-directas/[id]/editar.vue
@@ -860,6 +860,7 @@ import { usePaymentLabel } from '~/composables/usePaymentLabel'
 import { usePaymentSelectValue } from '~/composables/usePaymentSelectValue'
 import { mergePosPaymentGroupsFromApi, isCashPaymentSlug, readFromCashDrawer } from '~/utils/paymentDefaults'
 
+const { t } = useI18n({ useScope: 'global' })
 const { todayISO, dateAtNoon, isoFromDate, timeHHMMFromISO, combineDateAndTimeISO } = useTenantTimezone()
 const {
   formatCurrency,

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -789,6 +789,7 @@ import { useInlineCatalogProductLink } from '@/composables/useInlineCatalogProdu
 import { useFormatters } from '~/composables/useFormatters'
 import { localeToNumberFormatTag, normalizeCurrencyCode } from '~/utils/currencyDisplay'
 
+const { t } = useI18n({ useScope: 'global' })
 const { todayISO, dateAtNoon } = useTenantTimezone()
 const {
   formatCurrency,


### PR DESCRIPTION
## Summary
- Adds `useI18n` in Compra Directa crear/editar so `t()` resolves when Efectivo is selected
- Fixes missing Origen del efectivo / payment proof fields caused by a render crash

## Test plan
- [ ] Nueva Compra Directa → Contado → Método Efectivo
- [ ] Verify Origen del efectivo radios + Referencia/Fecha/Adjuntar appear
- [ ] Editar CD con pago Efectivo shows the same toggle


Made with [Cursor](https://cursor.com)