### PR TITLE
fix(finanzas): botones de caja + InlineDots en pagos

### DIFF
--- a/.wr/2143.yaml
+++ b/.wr/2143.yaml
@@ -1,0 +1,38 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 2143
+title: "fix(finanzas): botones de caja + InlineDots en pagos"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2143-payment-drawer-buttons
+
+paths:
+  - components/payments/PaymentForm.vue
+
+ac:
+  - De caja / Fuera de caja son dos botones (no radio/checkbox) con estado seleccionado visible
+  - Misma UX en registrar pago, compra directa y gastos via PaymentForm compartido
+  - Logica from_cash_drawer sin cambio de contrato
+  - Al Procesando, CommonsInlineDots (no Matrix / TheCustomLoader en submit)
+  - Accesible (teclado / aria) y usable en mobile
+
+out_of_scope:
+  - API / reglas de arqueo / GL
+  - Loader de carga de metodos de pago (TheCustomLoader full-page)
+  - Otros loaders del modulo
+
+hints:
+  entry: "components/payments/PaymentForm.vue — showCashDrawerToggle + submit buttons"
+  pattern: "components/cocina/StationPanel.vue:186 InlineDots; pages/finanzas/contabilidad/cuentas/[id].vue:809 aria-pressed group"
+  tests: "rg -n 'type=\"radio\"|CommonsInlineDots|cashDrawerButtonClass|from_cash_drawer' components/payments/PaymentForm.vue"
+
+risk:
+  sensitive: false
+  areas: [payments-ux]
+
+skip:
+  audits: [color, typography, ux-full]
+
+next:
+  after_pr: "/wr-review"

--- a/components/payments/PaymentForm.vue
+++ b/components/payments/PaymentForm.vue
@@ -47,18 +47,30 @@
             </div>
 
             <div v-if="showCashDrawerToggle" class="space-y-1.5">
-              <label class="block text-sm font-medium text-text-primary">
+              <label id="payment-cash-drawer-label" class="block text-sm font-medium text-text-primary">
                 {{ t('finanzas.paymentForm.fromCashDrawerLabel') }}
               </label>
-              <div class="flex flex-col gap-2 sm:flex-row sm:gap-4">
-                <label class="inline-flex items-center gap-2 text-sm text-text-primary cursor-pointer">
-                  <input v-model="formData.from_cash_drawer" type="radio" :value="true" class="text-primary" />
+              <div
+                class="grid grid-cols-1 gap-2 sm:grid-cols-2"
+                role="group"
+                aria-labelledby="payment-cash-drawer-label"
+              >
+                <button
+                  type="button"
+                  :aria-pressed="formData.from_cash_drawer === true"
+                  :class="cashDrawerButtonClass(true)"
+                  @click="formData.from_cash_drawer = true"
+                >
                   {{ t('finanzas.paymentForm.fromCashDrawerYes') }}
-                </label>
-                <label class="inline-flex items-center gap-2 text-sm text-text-primary cursor-pointer">
-                  <input v-model="formData.from_cash_drawer" type="radio" :value="false" class="text-primary" />
+                </button>
+                <button
+                  type="button"
+                  :aria-pressed="formData.from_cash_drawer === false"
+                  :class="cashDrawerButtonClass(false)"
+                  @click="formData.from_cash_drawer = false"
+                >
                   {{ t('finanzas.paymentForm.fromCashDrawerNo') }}
-                </label>
+                </button>
               </div>
               <p class="text-xs text-text-secondary">{{ t('finanzas.paymentForm.fromCashDrawerHelp') }}</p>
             </div>
@@ -158,9 +170,16 @@
           <!-- Actions -->
           <div class="space-y-3">
             <button type="submit" :disabled="!canSubmitPayment"
-              class="w-full py-3 bg-action-success-bg text-action-success-text rounded-lg hover:bg-action-success-hover-bg transition-colors disabled:opacity-50 flex items-center justify-center space-x-2 font-semibold shadow-lg shadow-primary/20">
-              <CommonsTheCustomLoader v-if="loading" size="small" />
-              <span>{{ submitButtonLabel }}</span>
+              class="w-full py-3 bg-action-success-bg text-action-success-text rounded-lg hover:bg-action-success-hover-bg transition-colors disabled:opacity-50 flex items-center justify-center gap-2 font-semibold shadow-lg shadow-primary/20">
+              <template v-if="loading">
+                <span>{{ submitButtonLabel }}</span>
+                <CommonsInlineDots
+                  :size="5"
+                  color="currentColor"
+                  :aria-label="t('finanzas.paymentForm.processing')"
+                />
+              </template>
+              <span v-else>{{ submitButtonLabel }}</span>
             </button>
             
             <button type="button" @click="$emit('cancel')" :disabled="loading"
@@ -194,9 +213,17 @@
         <button
           type="submit"
           :disabled="!canSubmitPayment"
-          class="h-11 flex-1 rounded-lg bg-primary text-sm font-semibold text-white transition-colors hover:bg-primary/90 disabled:opacity-50"
+          class="inline-flex h-11 flex-1 items-center justify-center gap-2 rounded-lg bg-primary text-sm font-semibold text-white transition-colors hover:bg-primary/90 disabled:opacity-50"
         >
-          <span>{{ compactSubmitButtonLabel }}</span>
+          <template v-if="loading">
+            <span>{{ compactSubmitButtonLabel }}</span>
+            <CommonsInlineDots
+              :size="5"
+              color="currentColor"
+              :aria-label="t('finanzas.paymentForm.processing')"
+            />
+          </template>
+          <span v-else>{{ compactSubmitButtonLabel }}</span>
         </button>
       </div>
     </div>
@@ -370,6 +397,16 @@ function appendDrawerFlag(payload: FormData) {
     formData.value.payment_method,
     formData.value.from_cash_drawer,
   )
+}
+
+function cashDrawerButtonClass(isFromDrawer: boolean) {
+  const selected = formData.value.from_cash_drawer === isFromDrawer
+  return [
+    'min-h-11 rounded-lg border-2 px-3 py-2.5 text-sm font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+    selected
+      ? 'border-primary bg-primary/10 text-primary'
+      : 'border-border bg-background text-text-secondary hover:border-primary/30 hover:bg-surface-secondary hover:text-text-primary',
+  ]
 }
 
 const handleSubmit = async () => {


### PR DESCRIPTION
## Summary
- Reemplaza radios «De caja / Fuera de caja» por botones segmentados con `aria-pressed` en `PaymentForm`
- Al procesar el submit usa `CommonsInlineDots` (layout completo y compacto); la lógica `from_cash_drawer` no cambia

Closes #2143

## Test plan
- [ ] Efectivo en `/finanzas/pagos/registrar`: dos botones claros; toggle no rompe submit
- [ ] Compra directa / gasto: misma UX vía `PaymentForm`
- [ ] Al enviar, ver «Procesando...» + InlineDots (no Matrix en el botón)
- [ ] Teclado / mobile: botones usables

## Validation evidence
```
rg -n 'type="radio"|CommonsInlineDots|cashDrawerButtonClass|from_cash_drawer|CommonsTheCustomLoader' components/payments/PaymentForm.vue
→ no type="radio"; InlineDots en submit (L176, L220); TheCustomLoader solo carga de métodos (L14); from_cash_drawer intacto
```

## wr-context
See `.wr/2143.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)