### PR TITLE
fix(ventas): hide FE card unless Colombia invoicing is ready

### DIFF
--- a/.wr/2147.yaml
+++ b/.wr/2147.yaml
@@ -1,0 +1,39 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 2147
+title: "Hide electronic invoice section on sale detail unless Colombia FE is ready"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2147-sale-detail-fe-gate
+
+paths:
+  - pages/ventas/[id].vue
+
+ac:
+  - Sale detail hides FE section for non-Colombia / non–FE-ready tenants, including credit-only sales
+  - Colombia without invoicing_ready also hides FE section (incl. credit-only)
+  - Colombia FE-ready keeps emit / credit-only unavailable / accepted-invoice flows
+  - Historical invoiceData still renders when present
+  - Matias/DIAN copy gates via isMatiasDian unchanged
+
+out_of_scope:
+  - API invoicing readiness (already requires CO + Matias)
+  - POS checkout redesign
+  - Enabling FE for Mexico
+  - i18n copy changes (not required)
+
+hints:
+  entry: "pages/ventas/[id].vue#shouldShowInvoiceSection"
+  pattern: "Gate isCreditOnlyInvoiceBlocked behind isInvoicingReady; keep invoiceData always visible"
+  tests: "none — static assert on shouldShowInvoiceSection (no page unit test)"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "ready-for-review + wr-review"

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -423,13 +423,16 @@ const orderEmailLabel = computed(() => {
   const n = order.value?.order_number
   return n != null ? `#${n}` : t('ventas.detail.emailInvoiceCta')
 })
+/** FE card: historical invoice always; otherwise only when Colombia FE is ready. */
 const shouldShowInvoiceSection = computed(() => Boolean(
   invoiceData.value
-    || isCreditOnlyInvoiceBlocked.value
     || (
       isInvoicingReady.value
       && !isReadinessLoading.value
-      && orderHasInvoiceCustomer.value
+      && (
+        isCreditOnlyInvoiceBlocked.value
+        || orderHasInvoiceCustomer.value
+      )
     ),
 ))
 const invoiceSectionTransitionKey = computed(() => {
@@ -1310,9 +1313,9 @@ onUnmounted(() => {
 
       <!-- Electronic Invoice Section — visible when:
            (a) the order already has an emitted invoice (historical data), OR
-           (b) the tenant has DIAN invoicing configured and ready and the order
-               has an associated customer. Payment method is not part of this gate.
-           Otherwise hidden entirely (matches the POS checkout guard pattern). -->
+           (b) tenant FE is ready (Colombia + Matias) and either credit-only
+               blocked messaging applies or the order has a customer for emit.
+           Non–FE-ready tenants (e.g. MX) never see this card (#2147). -->
       <Transition name="slide-down" mode="out-in" appear>
         <div
           v-if="shouldShowInvoiceSection"


### PR DESCRIPTION
## Summary
- Gate `/ventas/[id]` electronic-invoice section on `invoicing_ready` so MX (and other non–FE-ready tenants) no longer see “Factura electrónica no disponible” on credit-only sales.
- Keep historical `invoiceData` visible; Colombia FE-ready emit / credit-only flows unchanged.

Closes #2147

## Test plan
- [ ] MX (or any non–FE-ready) credit-only sale detail: no electronic-invoice card
- [ ] CO without FE ready: same — card hidden
- [ ] CO FE ready + customer: emit CTA still works
- [ ] CO FE ready + credit-only: unavailable banner still works
- [ ] Accepted invoice history still shows

## Validation evidence
```text
$ python3 static gate assert
STATIC_OK shouldShowInvoiceSection gated by isInvoicingReady
```
No page unit test exists for `pages/ventas/[id].vue`.

## wr-context
See `.wr/2147.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)