### PR TITLE
fix(pos): open-sale slideover + sale-detail meta cards

### DIFF
--- a/.wr/2149.yaml
+++ b/.wr/2149.yaml
@@ -1,0 +1,39 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 2149
+title: "Open-sale slideover + rebalance sale-detail meta cards"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2149-open-sale-slideover
+
+paths:
+  - components/pos/OpenSaleModal.vue
+  - pages/ventas/[id].vue
+
+ac:
+  - OpenSaleModal is right slideover on desktop (md:end-0, max-w-md, full height)
+  - Mobile remains bottom sheet; amount/description/CTAs preserved
+  - POS and /ventas/crear pick up slideover via shared component
+  - /ventas/[id] meta row rebalanced (phone folded into customer; asymmetric grid)
+  - Payment highlight readable without dominating
+
+out_of_scope:
+  - Open-sale API / business rules
+  - Accounting or credit balances
+  - New i18n keys unless required
+
+hints:
+  entry: "components/pos/OpenSaleModal.vue shell; pages/ventas/[id].vue Order Info Grid"
+  pattern: "Mirror CustomerIdentificationModal Teleport + panel transition (#2008)"
+  tests: "static asserts — no OpenSaleModal unit test"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [color, typography]
+
+next:
+  after_pr: "ready-for-review + wr-review"

--- a/components/pos/OpenSaleModal.vue
+++ b/components/pos/OpenSaleModal.vue
@@ -57,7 +57,7 @@
             <button
               type="button"
               :aria-label="t('common.close')"
-              class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+              class="flex-shrink-0 flex items-center justify-center min-h-[44px] min-w-[44px] rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
               @click="handleClose"
             >
               <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
@@ -67,7 +67,7 @@
           </div>
         </div>
 
-        <form class="flex-1 overflow-y-auto px-6 py-5 space-y-4" @submit.prevent="handleSubmit">
+        <form id="open-sale-form" class="flex-1 overflow-y-auto px-6 py-5 space-y-4" @submit.prevent="handleSubmit">
           <div>
             <label for="open-sale-amount" class="block text-sm font-medium text-text-primary mb-1.5">
               {{ t('pos.openSale.amountLabel') }} <span class="text-destructive">*</span>
@@ -112,10 +112,10 @@
             {{ t('common.cancel') }}
           </button>
           <button
-            type="button"
+            type="submit"
+            form="open-sale-form"
             :disabled="isSubmitting"
             class="flex-1 min-h-[44px] px-4 py-3 rounded-xl bg-action-primary-bg text-action-primary-text font-semibold hover:opacity-90 active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-            @click="handleSubmit"
           >
             {{ isSubmitting ? t('pos.openSale.adding') : resolvedConfirmLabel }}
           </button>

--- a/components/pos/OpenSaleModal.vue
+++ b/components/pos/OpenSaleModal.vue
@@ -1,38 +1,73 @@
 <template>
-  <Transition name="sheet">
-    <div
-      v-if="modelValue"
-      class="fixed inset-0 z-[60] flex items-end md:items-center justify-center md:p-4 bg-overlay-backdrop/50"
-      @click.self="handleClose"
+  <!-- Teleport + slideover chrome matches CustomerIdentificationModal / bodega (#2149) -->
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-200"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
     >
       <div
-        class="bottom-sheet-panel bg-surface w-full md:max-w-md border border-border flex flex-col rounded-t-2xl md:rounded-2xl shadow-2xl"
+        v-if="modelValue"
+        class="fixed inset-0 z-[60] bg-overlay-backdrop/40"
+        aria-hidden="true"
+        @click="handleClose"
+      />
+    </Transition>
+
+    <Transition name="panel">
+      <div
+        v-if="modelValue"
+        class="fixed z-[61] flex flex-col bg-surface shadow-2xl
+               inset-x-0 bottom-0 rounded-t-2xl max-h-[92dvh]
+               md:inset-y-0 md:end-0 md:bottom-auto md:start-auto md:inset-x-auto
+               md:rounded-none md:w-full md:max-w-md md:max-h-none md:h-full
+               md:border-s md:border-border"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="t('pos.openSale.title')"
         @click.stop
       >
         <div class="flex justify-center pt-3 pb-1 md:hidden flex-shrink-0" aria-hidden="true">
           <div class="w-10 h-1 rounded-full bg-border" />
         </div>
 
-        <div class="p-5 border-b border-border flex items-center justify-between flex-shrink-0">
-          <div>
-            <h2 class="text-xl font-bold text-text-primary">{{ t('pos.openSale.title') }}</h2>
-            <p class="text-sm text-text-secondary mt-0.5">
-              {{ productLine }}
-            </p>
+        <div class="flex-shrink-0 bg-surface-secondary/40 border-b border-border px-6 py-4">
+          <div class="flex items-start justify-between gap-3">
+            <div class="flex items-center gap-3 min-w-0 flex-1">
+              <div
+                class="flex-shrink-0 w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center text-primary"
+                aria-hidden="true"
+              >
+                <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m6-6H6" />
+                </svg>
+              </div>
+              <div class="min-w-0">
+                <h2 class="text-base font-bold text-text-primary leading-tight">
+                  {{ t('pos.openSale.title') }}
+                </h2>
+                <p class="text-xs text-text-secondary leading-snug mt-0.5">
+                  {{ productLine }}
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              :aria-label="t('common.close')"
+              class="flex-shrink-0 flex items-center justify-center h-8 w-8 rounded-lg text-text-tertiary hover:bg-surface-secondary hover:text-text-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+              @click="handleClose"
+            >
+              <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+              </svg>
+            </button>
           </div>
-          <button
-            type="button"
-            :aria-label="t('common.close')"
-            class="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-xl text-text-secondary hover:bg-surface-secondary hover:text-text-primary transition-colors"
-            @click="handleClose"
-          >
-            <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
-            </svg>
-          </button>
         </div>
 
-        <form class="p-5 space-y-4" @submit.prevent="handleSubmit">
+        <form class="flex-1 overflow-y-auto px-6 py-5 space-y-4" @submit.prevent="handleSubmit">
           <div>
             <label for="open-sale-amount" class="block text-sm font-medium text-text-primary mb-1.5">
               {{ t('pos.openSale.amountLabel') }} <span class="text-destructive">*</span>
@@ -66,27 +101,28 @@
           </div>
 
           <p v-if="errorMessage" class="text-sm text-state-danger-text" role="alert">{{ errorMessage }}</p>
-
-          <div class="flex gap-2 pt-1">
-            <button
-              type="button"
-              class="min-h-[44px] px-4 py-3 rounded-xl border border-border text-text-secondary font-medium hover:bg-surface-secondary transition-colors"
-              @click="handleClose"
-            >
-              {{ t('common.cancel') }}
-            </button>
-            <button
-              type="submit"
-              :disabled="isSubmitting"
-              class="flex-1 min-h-[44px] px-4 py-3 rounded-xl bg-action-primary-bg text-action-primary-text font-semibold hover:opacity-90 active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {{ isSubmitting ? t('pos.openSale.adding') : resolvedConfirmLabel }}
-            </button>
-          </div>
         </form>
+
+        <div class="flex-shrink-0 border-t border-border px-6 py-4 flex gap-2 bg-surface">
+          <button
+            type="button"
+            class="min-h-[44px] px-4 py-3 rounded-xl border border-border text-text-secondary font-medium hover:bg-surface-secondary transition-colors"
+            @click="handleClose"
+          >
+            {{ t('common.cancel') }}
+          </button>
+          <button
+            type="button"
+            :disabled="isSubmitting"
+            class="flex-1 min-h-[44px] px-4 py-3 rounded-xl bg-action-primary-bg text-action-primary-text font-semibold hover:opacity-90 active:scale-[0.98] transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+            @click="handleSubmit"
+          >
+            {{ isSubmitting ? t('pos.openSale.adding') : resolvedConfirmLabel }}
+          </button>
+        </div>
       </div>
-    </div>
-  </Transition>
+    </Transition>
+  </Teleport>
 </template>
 
 <script setup lang="ts">
@@ -169,12 +205,21 @@ defineExpose({ clearSubmitting: () => { isSubmitting.value = false } })
 </script>
 
 <style scoped>
-.sheet-enter-active,
-.sheet-leave-active {
-  transition: opacity 0.15s ease;
+/* Match CustomerIdentificationModal / bodega slideover (#2149) */
+.panel-enter-active,
+.panel-leave-active {
+  transition: transform 250ms ease;
 }
-.sheet-enter-from,
-.sheet-leave-to {
-  opacity: 0;
+
+.panel-enter-from,
+.panel-leave-to {
+  transform: translateY(100%);
+}
+
+@media (min-width: 768px) {
+  .panel-enter-from,
+  .panel-leave-to {
+    transform: translateX(100%);
+  }
 }
 </style>

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -1118,15 +1118,19 @@ onUnmounted(() => {
 
     <!-- Order Details -->
     <div v-else class="space-y-6">
-      <!-- Order Info Grid -->
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
-        <!-- Customer Name -->
-        <div
-          class="bg-surface border border-border rounded-xl p-4"
-        >
+      <!-- Order Info Grid — customer denser; phone folded in (#2149) -->
+      <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)] gap-4">
+        <!-- Customer + phone -->
+        <div class="bg-surface border border-border rounded-xl p-4 md:col-span-2 xl:col-span-1">
           <p class="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">{{ t('ventas.detail.saleCustomer') }}</p>
-          <p class="text-lg font-bold text-text-primary">
+          <p class="text-base font-bold text-text-primary leading-snug break-words">
             {{ saleCustomerCardLabel }}
+          </p>
+          <p
+            class="mt-1 text-sm font-medium tabular-nums"
+            :class="saleCustomerIdentity.contact.phone ? 'text-text-primary' : 'text-text-tertiary'"
+          >
+            {{ saleCustomerIdentity.contact.phone || t('ventas.common.sinTelefono') }}
           </p>
           <p
             v-if="saleCustomerIdentity.contact.email && saleCustomerIdentity.contact.email !== preInvoiceContactLabel"
@@ -1148,19 +1152,6 @@ onUnmounted(() => {
           </p>
         </div>
 
-        <!-- Customer Phone -->
-        <div
-          class="bg-surface border border-border rounded-xl p-4"
-        >
-          <p class="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">{{ t('ventas.common.telefono') }}</p>
-          <p
-            class="text-lg font-bold"
-            :class="saleCustomerIdentity.contact.phone ? 'text-text-primary' : 'text-text-tertiary'"
-          >
-            {{ saleCustomerIdentity.contact.phone || t('ventas.common.sinTelefono') }}
-          </p>
-        </div>
-
         <!-- Waiter (checkout / mesa close attribution — #663/#665/#666) -->
         <div
           class="bg-surface border border-border rounded-xl p-4"
@@ -1169,24 +1160,24 @@ onUnmounted(() => {
           <NuxtLink
             v-if="order.served_by_member_id"
             :to="`/equipo/miembros/${order.served_by_member_id}`"
-            class="text-lg font-bold text-primary hover:underline"
+            class="text-base font-bold text-primary hover:underline"
           >
             {{ order.served_by_member_name || t('ventas.detail.assigned') }}
           </NuxtLink>
-          <p v-else class="text-lg font-bold text-text-tertiary">
+          <p v-else class="text-base font-bold text-text-tertiary">
             {{ t('ventas.detail.unassigned') }}
           </p>
         </div>
 
         <!-- Payment Method -->
         <component :is="order.split_payments && order.split_payments.length > 0 ? 'button' : 'div'"
-          class="bg-surface border-2 border-info rounded-xl p-4 text-start w-full"
-          :class="order.split_payments && order.split_payments.length > 0 ? 'hover:bg-surface-secondary/50 transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-info/30' : ''"
+          class="border border-info/50 bg-info/5 rounded-xl p-4 text-start w-full"
+          :class="order.split_payments && order.split_payments.length > 0 ? 'hover:bg-info/10 transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-info/30' : ''"
           @click="order.split_payments && order.split_payments.length > 0 ? showSplitPaymentsPanel = true : null"
           :aria-label="order.split_payments && order.split_payments.length > 0 ? t('ventas.detail.viewSplitDetail') : undefined">
           <p class="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">{{ t('ventas.common.metodoPago') }}</p>
           <div class="flex items-center justify-between gap-2">
-            <p class="text-lg font-bold text-info leading-tight">
+            <p class="text-base font-bold text-info leading-tight">
               <template v-if="order.split_payments && order.split_payments.length > 0">
                 {{ t('ventas.detail.splitPaymentLabel', { count: order.split_payments.length }) }}
               </template>
@@ -1205,11 +1196,11 @@ onUnmounted(() => {
           v-if="order.status === 'pending'"
           type="button"
           @click="openFinalizeSalePanel"
-          class="bg-status-success-bg border-2 border-status-success-text/30 rounded-xl p-4 text-start w-full hover:bg-status-success-text hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-status-success-text/30 group"
+          class="bg-status-success-bg border border-status-success-text/30 rounded-xl p-4 text-start w-full hover:bg-status-success-text hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-status-success-text/30 group md:col-span-2 xl:col-span-4 order-last"
         >
           <p class="text-xs font-semibold uppercase tracking-wider mb-2">{{ t('ventas.detail.pendingAction') }}</p>
           <div class="flex items-center justify-between gap-3">
-            <span class="text-lg font-bold leading-tight">{{ t('ventas.detail.finalizeSale') }}</span>
+            <span class="text-base font-bold leading-tight">{{ t('ventas.detail.finalizeSale') }}</span>
             <svg class="w-5 h-5 flex-shrink-0 transition-transform group-hover:translate-x-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
             </svg>


### PR DESCRIPTION
## Summary
- Convert Venta libre from centered modal to ingredient/bodega-style right slideover (mobile bottom sheet kept); shared by POS and `/ventas/crear`.
- Rebalance `/ventas/[id]` meta row: fold phone into customer, asymmetric grid, softer payment highlight.

Closes #2149

## Test plan
- [ ] POS: Venta libre opens as right slideover on desktop; bottom sheet on mobile
- [ ] `/ventas/crear`: same slideover; amount/description/add still work
- [ ] `/ventas/[id]`: meta cards look balanced; credit payment still highlighted; phone visible under customer

## Validation evidence
```text
$ python3 static assert
STATIC_OK open-sale slideover + meta card rebalance
```
No OpenSaleModal unit test in repo.

## wr-context
See `.wr/2149.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)