### PR TITLE
feat(ventas): match POS product grid and tenant currency in Open Sale

### DIFF
--- a/.wr/2151.yaml
+++ b/.wr/2151.yaml
@@ -1,0 +1,46 @@
+issue: 2151
+title: "feat(ventas): match POS product grid on /ventas/crear and tenant currency in Open Sale"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2151-crear-grid-open-sale-currency
+
+paths:
+  - pages/ventas/crear.vue
+  - components/pos/OpenSaleModal.vue
+  - i18n/locales/en/pos.json
+  - i18n/locales/es/pos.json
+  - i18n/locales/pt/pos.json
+  - i18n/locales/fr/pos.json
+  - i18n/locales/de/pos.json
+  - i18n/locales/zh/pos.json
+  - i18n/locales/ar/pos.json
+  - i18n/locales/hi/pos.json
+  - .wr/2151.yaml
+
+ac:
+  - "/ventas/crear product cards use POS grid breakpoints (grid-cols-3 sm:grid-cols-4 md:grid-cols-5)"
+  - "Open Sale amount label uses tenant currencyCode via i18n param, not hardcoded COP"
+  - "All locale amountLabel strings use {currency} placeholder"
+  - "Verified on /ventas/crear and POS Open Sale entry"
+
+out_of_scope:
+  - cart panel chrome / discount-split WIP (stashed)
+  - API changes
+  - amountCop keys elsewhere
+
+hints:
+  entry: "components/pos/OpenSaleModal.vue + pages/ventas/crear.vue product grid"
+  pattern: "useFormatters().currencyCode; pages/pos/index.vue:2105 grid"
+  tests: "none targeted; no build/lint"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "ready-for-review + wr-review"

--- a/components/pos/OpenSaleModal.vue
+++ b/components/pos/OpenSaleModal.vue
@@ -70,7 +70,7 @@
         <form id="open-sale-form" class="flex-1 overflow-y-auto px-6 py-5 space-y-4" @submit.prevent="handleSubmit">
           <div>
             <label for="open-sale-amount" class="block text-sm font-medium text-text-primary mb-1.5">
-              {{ t('pos.openSale.amountLabel') }} <span class="text-destructive">*</span>
+              {{ t('pos.openSale.amountLabel', { currency: currencyCode }) }} <span class="text-destructive">*</span>
             </label>
             <input
               id="open-sale-amount"
@@ -128,6 +128,8 @@
 <script setup lang="ts">
 const { t } = useI18n({ useScope: 'global' })
 import { ref, watch, nextTick, computed } from 'vue'
+
+const { currencyCode } = useFormatters()
 
 const props = withDefaults(
   defineProps<{

--- a/i18n/locales/ar/pos.json
+++ b/i18n/locales/ar/pos.json
@@ -57,7 +57,7 @@
       "title": "بيع حر",
       "productPrefix": "المنتج: {name}",
       "customAmount": "مبلغ مخصص",
-      "amountLabel": "المبلغ (COP)",
+      "amountLabel": "المبلغ ({currency})",
       "amountPlaceholder": "مثال: 25000",
       "description": "الوصف",
       "optional": "(اختياري)",

--- a/i18n/locales/de/pos.json
+++ b/i18n/locales/de/pos.json
@@ -57,7 +57,7 @@
       "title": "Freier Verkauf",
       "productPrefix": "Produkt: {name}",
       "customAmount": "Benutzerdefinierter Betrag",
-      "amountLabel": "Betrag (COP)",
+      "amountLabel": "Betrag ({currency})",
       "amountPlaceholder": "z.B. 25000",
       "description": "Beschreibung",
       "optional": "(optional)",

--- a/i18n/locales/en/pos.json
+++ b/i18n/locales/en/pos.json
@@ -57,7 +57,7 @@
       "title": "Open sale",
       "productPrefix": "Product: {name}",
       "customAmount": "Custom amount",
-      "amountLabel": "Amount (COP)",
+      "amountLabel": "Amount ({currency})",
       "amountPlaceholder": "e.g. 25000",
       "description": "Description",
       "optional": "(optional)",

--- a/i18n/locales/es/pos.json
+++ b/i18n/locales/es/pos.json
@@ -57,7 +57,7 @@
       "title": "Venta libre",
       "productPrefix": "Producto: {name}",
       "customAmount": "Monto personalizado",
-      "amountLabel": "Monto (COP)",
+      "amountLabel": "Monto ({currency})",
       "amountPlaceholder": "Ej. 25000",
       "description": "Descripción",
       "optional": "(opcional)",

--- a/i18n/locales/fr/pos.json
+++ b/i18n/locales/fr/pos.json
@@ -57,7 +57,7 @@
       "title": "Vente libre",
       "productPrefix": "Produit : {name}",
       "customAmount": "Montant personnalisé",
-      "amountLabel": "Montant (COP)",
+      "amountLabel": "Montant ({currency})",
       "amountPlaceholder": "Ex. 25000",
       "description": "Description",
       "optional": "(facultatif)",

--- a/i18n/locales/hi/pos.json
+++ b/i18n/locales/hi/pos.json
@@ -57,7 +57,7 @@
       "title": "खुली बिक्री",
       "productPrefix": "उत्पाद: {name}",
       "customAmount": "कस्टम राशि",
-      "amountLabel": "राशि (COP)",
+      "amountLabel": "राशि ({currency})",
       "amountPlaceholder": "उदा. 25000",
       "description": "विवरण",
       "optional": "(वैकल्पिक)",

--- a/i18n/locales/pt/pos.json
+++ b/i18n/locales/pt/pos.json
@@ -57,7 +57,7 @@
       "title": "Venda livre",
       "productPrefix": "Produto: {name}",
       "customAmount": "Valor personalizado",
-      "amountLabel": "Valor (COP)",
+      "amountLabel": "Valor ({currency})",
       "amountPlaceholder": "Ex: 25000",
       "description": "Descrição",
       "optional": "(opcional)",

--- a/i18n/locales/zh/pos.json
+++ b/i18n/locales/zh/pos.json
@@ -57,7 +57,7 @@
       "title": "自定义销售",
       "productPrefix": "产品: {name}",
       "customAmount": "自定义金额",
-      "amountLabel": "金额 (COP)",
+      "amountLabel": "金额 ({currency})",
       "amountPlaceholder": "例如 25000",
       "description": "描述",
       "optional": "(可选)",

--- a/pages/ventas/crear.vue
+++ b/pages/ventas/crear.vue
@@ -889,7 +889,7 @@ async function submit() {
           </div>
 
           <!-- Product Grid -->
-          <div v-else class="order-3 grid grid-cols-3 sm:grid-cols-4 md:grid-cols-3 lg:grid-cols-2 xl:grid-cols-3 gap-2 md:gap-4 p-1 pb-4 min-w-0">
+          <div v-else class="order-3 grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2 md:gap-4 p-1 pb-4 min-w-0">
             <div
               v-for="product in filteredProducts"
               :key="product.id"


### PR DESCRIPTION
## Summary
- `/ventas/crear` product cards now use the same responsive grid as POS (`grid-cols-3 sm:grid-cols-4 md:grid-cols-5`)
- Open Sale slideover amount label uses tenant `currencyCode` via `{currency}` i18n param (no hardcoded COP)

Closes #2151

## Test plan
- [ ] On `/ventas/crear`, product card columns match POS density at sm/md breakpoints
- [ ] Open Open Sale from `/ventas/crear` — amount label shows tenant currency (e.g. MXN)
- [ ] Open Open Sale from POS — same currency label
- [ ] Switch tenant currency if available and confirm label updates

## Validation evidence
```text
$ python3 - <<'PY'  # parse i18n + require {currency}, reject COP
...
OK ... Amount ({currency}) / Monto ({currency}) / ...
PASS
```
No targeted front unit tests for this UI; build/lint not run (WARO policy).

## wr-context
See `.wr/2151.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)