### PR TITLE
fix(crm): use tenant currency on wallet recharge amount label

### DIFF
--- a/.wr/2153.yaml
+++ b/.wr/2153.yaml
@@ -1,0 +1,45 @@
+issue: 2153
+title: "fix(crm): use tenant currency on wallet recharge amount label"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2153-wallet-recharge-currency
+
+paths:
+  - components/analitica/WalletRechargeModal.vue
+  - i18n/locales/en/analitica.json
+  - i18n/locales/es/analitica.json
+  - i18n/locales/pt/analitica.json
+  - i18n/locales/fr/analitica.json
+  - i18n/locales/de/analitica.json
+  - i18n/locales/zh/analitica.json
+  - i18n/locales/ar/analitica.json
+  - i18n/locales/hi/analitica.json
+  - .wr/2153.yaml
+
+ac:
+  - "Wallet recharge amount label uses tenant currencyCode"
+  - "i18n analitica.customerDetail.wallet.amount uses {currency} in all locales"
+  - "WalletRechargeModal passes currencyCode into t()"
+  - "Verified on /crm/clientes/[id] for non-COP tenant"
+
+out_of_scope:
+  - API *_cop field renames
+  - recharge payment logic
+  - movement table column renames
+
+hints:
+  entry: "components/analitica/WalletRechargeModal.vue"
+  pattern: "OpenSaleModal #2151: t(..., { currency: currencyCode })"
+  tests: "python i18n static check; no build/lint"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "ready-for-review + wr-review"

--- a/components/analitica/WalletRechargeModal.vue
+++ b/components/analitica/WalletRechargeModal.vue
@@ -66,7 +66,7 @@
           </div>
 
           <div class="flex flex-col gap-1.5">
-            <label for="wallet-amount" class="text-sm font-medium text-text-primary">{{ t('analitica.customerDetail.wallet.amount') }}</label>
+            <label for="wallet-amount" class="text-sm font-medium text-text-primary">{{ t('analitica.customerDetail.wallet.amount', { currency: currencyCode }) }}</label>
             <input
               id="wallet-amount"
               v-model.number="amount"
@@ -170,7 +170,7 @@ const emit = defineEmits<Emits>()
 
 const { show: showToast } = useToast()
 const { t } = useI18n({ useScope: 'global' })
-const { formatCurrency } = useFormatters()
+const { formatCurrency, currencyCode } = useFormatters()
 
 const open = computed({
   get: () => props.modelValue,

--- a/i18n/locales/ar/analitica.json
+++ b/i18n/locales/ar/analitica.json
@@ -349,7 +349,7 @@
         "rechargeAria": "شحن محفظة العميل",
         "rechargeTitle": "شحن المحفظة",
         "currentBalance": "الرصيد الحالي",
-        "amount": "المبلغ (COP)",
+        "amount": "المبلغ ({currency})",
         "selectMethod": "تحديد طريقة",
         "notesPlaceholder": "مثال: شحن نقدي...",
         "submitRecharge": "تسجيل الشحن",

--- a/i18n/locales/de/analitica.json
+++ b/i18n/locales/de/analitica.json
@@ -349,7 +349,7 @@
         "rechargeAria": "Kunden-Wallet aufladen",
         "rechargeTitle": "Wallet aufladen",
         "currentBalance": "Aktueller Saldo",
-        "amount": "Betrag (COP)",
+        "amount": "Betrag ({currency})",
         "selectMethod": "Methode auswählen",
         "notesPlaceholder": "Z.B. Baraufladung...",
         "submitRecharge": "Aufladung registrieren",

--- a/i18n/locales/en/analitica.json
+++ b/i18n/locales/en/analitica.json
@@ -355,7 +355,7 @@
         "rechargeAria": "Recharge customer wallet",
         "rechargeTitle": "Recharge wallet",
         "currentBalance": "Current balance",
-        "amount": "Amount (COP)",
+        "amount": "Amount ({currency})",
         "selectMethod": "Select method",
         "notesPlaceholder": "Ex. Cash recharge...",
         "submitRecharge": "Register recharge",

--- a/i18n/locales/es/analitica.json
+++ b/i18n/locales/es/analitica.json
@@ -355,7 +355,7 @@
         "rechargeAria": "Recargar billetera del cliente",
         "rechargeTitle": "Recargar billetera",
         "currentBalance": "Saldo actual",
-        "amount": "Monto (COP)",
+        "amount": "Monto ({currency})",
         "selectMethod": "Seleccionar método",
         "notesPlaceholder": "Ej. Recarga en efectivo...",
         "submitRecharge": "Registrar recarga",

--- a/i18n/locales/fr/analitica.json
+++ b/i18n/locales/fr/analitica.json
@@ -349,7 +349,7 @@
         "rechargeAria": "Recharger le portefeuille du client",
         "rechargeTitle": "Recharger le portefeuille",
         "currentBalance": "Solde actuel",
-        "amount": "Montant (COP)",
+        "amount": "Montant ({currency})",
         "selectMethod": "Sélectionner la méthode",
         "notesPlaceholder": "Ex. Recharge en espèces...",
         "submitRecharge": "Enregistrer la recharge",

--- a/i18n/locales/hi/analitica.json
+++ b/i18n/locales/hi/analitica.json
@@ -349,7 +349,7 @@
         "rechargeAria": "ग्राहक का वॉलेट रिचार्ज करें",
         "rechargeTitle": "वॉलेट रिचार्ज करें",
         "currentBalance": "वर्तमान शेष",
-        "amount": "राशि (COP)",
+        "amount": "राशि ({currency})",
         "selectMethod": "तरीका चुनें",
         "notesPlaceholder": "उदा. नकद रिचार्ज...",
         "submitRecharge": "रिचार्ज दर्ज करें",

--- a/i18n/locales/pt/analitica.json
+++ b/i18n/locales/pt/analitica.json
@@ -349,7 +349,7 @@
         "rechargeAria": "Recarregar carteira do cliente",
         "rechargeTitle": "Recarregar carteira",
         "currentBalance": "Saldo atual",
-        "amount": "Valor (COP)",
+        "amount": "Valor ({currency})",
         "selectMethod": "Selecionar método",
         "notesPlaceholder": "Ex: Recarga em dinheiro...",
         "submitRecharge": "Registrar recarga",

--- a/i18n/locales/zh/analitica.json
+++ b/i18n/locales/zh/analitica.json
@@ -349,7 +349,7 @@
         "rechargeAria": "为客户钱包充值",
         "rechargeTitle": "钱包充值",
         "currentBalance": "当前余额",
-        "amount": "金额 (COP)",
+        "amount": "金额 ({currency})",
         "selectMethod": "选择方式",
         "notesPlaceholder": "例如：现金充值...",
         "submitRecharge": "登记充值",


### PR DESCRIPTION
## Summary
- Wallet recharge amount label uses tenant `currencyCode` (e.g. `Monto (MXN)`) instead of hardcoded COP
- All `analitica.customerDetail.wallet.amount` locale strings use `{currency}`

Closes #2153

## Test plan
- [ ] Open `/crm/clientes/[id]` → Recargar billetera on a non-COP tenant
- [ ] Amount label matches balance currency (e.g. both MXN)
- [ ] Submit still works unchanged

## Validation evidence
```text
$ python3  # parse analitica.json wallet.amount
OK en/es/pt/fr/de/zh/ar/hi -> Amount/Monto/... ({currency})
PASS
```
No targeted front unit tests; build/lint not run (WARO policy).

## wr-context
See `.wr/2153.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)