### PR TITLE
feat(ventas): show sale date under order items on sale detail

### DIFF
--- a/.wr/2156.yaml
+++ b/.wr/2156.yaml
@@ -1,0 +1,38 @@
+issue: 2156
+title: "feat(ventas): show sale date on /ventas/[id] near order items"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2156-sale-detail-date
+
+paths:
+  - pages/ventas/[id].vue
+  - .wr/2156.yaml
+
+ac:
+  - "Sale datetime visible under/beside Items de la orden heading"
+  - "Uses saleReceiptSoldAt priority (completed_at || closed_at || created_at || updated_at)"
+  - "Hidden when no date available"
+  - "Label via ventas.common.fecha (no new i18n required)"
+
+out_of_scope:
+  - editing sale date
+  - API changes
+  - meta card redesign
+  - receipt printer changes
+
+hints:
+  entry: "pages/ventas/[id].vue order items header ~1800"
+  pattern: "saleReceiptSoldAt computed ~728"
+  tests: "static rg check for saleReceiptSoldAt under orderItemsTitle; no build/lint"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "ready-for-review + wr-review"

--- a/pages/ventas/[id].vue
+++ b/pages/ventas/[id].vue
@@ -1799,11 +1799,17 @@ onUnmounted(() => {
 
       <!-- Order Items -->
       <div class="bg-surface border border-border rounded-xl overflow-hidden">
-        <div class="p-6 border-b border-border flex justify-between items-center">
-          <h2 class="text-lg font-semibold text-text-primary">{{ t('ventas.detail.orderItemsTitle', { count: order.items_count }) }}</h2>
+        <div class="p-6 border-b border-border flex justify-between items-start gap-3">
+          <div class="min-w-0">
+            <h2 class="text-lg font-semibold text-text-primary">{{ t('ventas.detail.orderItemsTitle', { count: order.items_count }) }}</h2>
+            <p v-if="saleReceiptSoldAt" class="mt-1 text-sm text-text-secondary">
+              <span class="font-medium text-text-tertiary">{{ t('ventas.common.fecha') }}:</span>
+              {{ saleReceiptSoldAt }}
+            </p>
+          </div>
 
           <!-- Edit/Save Buttons -->
-          <div class="flex gap-2">
+          <div class="flex gap-2 shrink-0">
             <template v-if="!isEditMode">
               <button @click="enterEditMode"
                 class="px-4 py-2 bg-primary hover:bg-primary/90 text-primary-foreground rounded-lg text-sm font-medium transition-colors flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Shows sale datetime under `Items de la orden` on `/ventas/[id]`
- Reuses `saleReceiptSoldAt` (`completed_at || closed_at || created_at || updated_at`) and `ventas.common.fecha`

Closes #2156

## Test plan
- [ ] Open a completed sale detail — date appears under order items title
- [ ] Confirm date matches receipt/ticket sold-at
- [ ] If an order somehow has no timestamps, date line is hidden

## Validation evidence
```text
$ python3  # assert saleReceiptSoldAt + ventas.common.fecha under orderItemsTitle
PASS: date line under orderItemsTitle
```
No targeted unit tests; build/lint not run (WARO policy).

## wr-context
See `.wr/2156.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)