### PR TITLE
fix(abastecimiento): drop copy-link and enrich direct purchase prints

### DIFF
--- a/.wr/2158.yaml
+++ b/.wr/2158.yaml
@@ -1,0 +1,40 @@
+issue: 2158
+title: "fix(abastecimiento): remove copy-link on direct purchase header; enrich print ticket/document"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2158-direct-purchase-print
+
+paths:
+  - pages/abastecimiento/compras-directas/[id]/index.vue
+  - components/abastecimiento/DirectPurchasePrintTicket.vue
+  - components/abastecimiento/DirectPurchasePrintDocument.vue
+  - .wr/2158.yaml
+
+ac:
+  - "Copy-link button removed; copyPurchaseLink cleaned up"
+  - "Thermal ticket has tenant header, supplier NIT, payment+drawer detail"
+  - "HTML document has same richer meta"
+  - "Format chooser still works"
+  - "Verified on paid cash purchase with drawer/off-drawer detail"
+
+out_of_scope:
+  - API changes
+  - meta card redesign
+  - POS sale receipt components
+
+hints:
+  entry: "compras-directas/[id]/index.vue + DirectPurchasePrint*"
+  pattern: "useReceiptPrintSettings fiscal_data; purchaseCashDrawerLabel"
+  tests: "python static asserts; no build/lint"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "ready-for-review + wr-review"

--- a/components/abastecimiento/DirectPurchasePrintDocument.vue
+++ b/components/abastecimiento/DirectPurchasePrintDocument.vue
@@ -11,6 +11,8 @@ export type DirectPurchasePrintItem = {
 defineProps<{
   title: string
   purchaseNumber?: string | number | null
+  businessName?: string | null
+  businessTaxId?: string | null
   dateLabel: string
   dateValue: string
   supplierLabel: string
@@ -40,6 +42,18 @@ defineProps<{
     aria-hidden="true"
   >
     <header class="doc-header">
+      <p
+        v-if="businessName"
+        class="doc-business"
+      >
+        {{ businessName }}
+      </p>
+      <p
+        v-if="businessTaxId"
+        class="doc-business-tax"
+      >
+        NIT {{ businessTaxId }}
+      </p>
       <h1>{{ title }}</h1>
       <p
         v-if="purchaseNumber"
@@ -133,6 +147,15 @@ defineProps<{
     margin: 0;
     font-size: 18pt;
     font-weight: 700;
+  }
+  .doc-business {
+    margin: 0 0 2px;
+    font-size: 12pt;
+    font-weight: 700;
+  }
+  .doc-business-tax {
+    margin: 0 0 8px;
+    font-size: 10pt;
   }
   .doc-number {
     margin: 4px 0 0;

--- a/components/abastecimiento/DirectPurchasePrintTicket.vue
+++ b/components/abastecimiento/DirectPurchasePrintTicket.vue
@@ -11,10 +11,13 @@ export type DirectPurchasePrintItem = {
 defineProps<{
   title: string
   purchaseNumber?: string | number | null
+  businessName?: string | null
+  businessTaxId?: string | null
   dateLabel: string
   dateValue: string
   supplierLabel: string
   supplierValue: string
+  supplierTaxId?: string | null
   statusLabel: string
   statusValue: string
   paymentLabel: string
@@ -33,6 +36,18 @@ defineProps<{
     class="receipt-print-ticket direct-purchase-print-ticket"
     aria-hidden="true"
   >
+    <pre
+      v-if="businessName"
+      class="receipt-plain-pre"
+    >{{ businessName }}</pre>
+    <pre
+      v-if="businessTaxId"
+      class="receipt-plain-pre"
+    >NIT {{ businessTaxId }}</pre>
+    <pre
+      v-if="businessName || businessTaxId"
+      class="receipt-plain-pre"
+    >{{ receiptDivider() }}</pre>
     <pre class="receipt-plain-pre">{{ title }}</pre>
     <pre
       v-if="purchaseNumber"
@@ -41,6 +56,10 @@ defineProps<{
     <pre class="receipt-plain-pre">{{ receiptDivider() }}</pre>
     <pre class="receipt-plain-pre">{{ padReceiptLine(dateLabel, dateValue) }}</pre>
     <pre class="receipt-plain-pre">{{ padReceiptLine(supplierLabel, supplierValue) }}</pre>
+    <pre
+      v-if="supplierTaxId"
+      class="receipt-plain-pre"
+    >{{ padReceiptLine('NIT', supplierTaxId) }}</pre>
     <pre class="receipt-plain-pre">{{ padReceiptLine(statusLabel, statusValue) }}</pre>
     <pre class="receipt-plain-pre">{{ padReceiptLine(paymentLabel, paymentValue) }}</pre>
     <pre class="receipt-plain-pre">{{ receiptDivider() }}</pre>

--- a/pages/abastecimiento/compras-directas/[id]/index.vue
+++ b/pages/abastecimiento/compras-directas/[id]/index.vue
@@ -25,17 +25,7 @@
           :label="formatDate(purchase.purchase_date)"
           icon-path="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
         >
-          <div class="flex items-center gap-2">
-            <p class="text-lg font-semibold text-text-primary">{{ purchase.purchase_number }}</p>
-            <button @click="copyPurchaseLink"
-              class="w-8 h-8 flex items-center justify-center bg-surface-secondary rounded-md text-primary transition-colors"
-              :title="t('abastecimiento.compraDirectaDetalle.copyLink')">
-              <svg class="w-[18px] h-[18px]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                  d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-              </svg>
-            </button>
-          </div>
+          <p class="text-lg font-semibold text-text-primary">{{ purchase.purchase_number }}</p>
         </PurchasesPurchaseInfoCard>
 
         <!-- Supplier -->
@@ -664,14 +654,17 @@
       v-if="purchase"
       :title="t('abastecimiento.compraDirectaDetalle.printTitle')"
       :purchase-number="purchase.purchase_number"
+      :business-name="printBusinessName"
+      :business-tax-id="printBusinessTaxId"
       :date-label="t('abastecimiento.compraDirectaDetalle.purchaseDate')"
       :date-value="formatDate(purchase.purchase_date)"
       :supplier-label="t('abastecimiento.compraDirectaDetalle.supplier')"
       :supplier-value="purchase.supplier_name || t('abastecimiento.compraDirectaDetalle.emptySupplier')"
+      :supplier-tax-id="purchase.supplier_tax_id || null"
       :status-label="t('abastecimiento.compraDirectaDetalle.currentStatus')"
       :status-value="getStatusText(purchase.status)"
       :payment-label="t('abastecimiento.compraDirectaDetalle.paymentMethod')"
-      :payment-value="purchase.payment_method ? resolvePaymentLabel(purchase.payment_method, purchase.payment_method_id) : '—'"
+      :payment-value="printPaymentValue"
       :items="printTicketItems"
       :total-label="t('abastecimiento.compraDirectaDetalle.purchaseTotal')"
       :total-value="formatCurrency(purchase.total_amount)"
@@ -683,6 +676,8 @@
       v-if="purchase"
       :title="t('abastecimiento.compraDirectaDetalle.printTitle')"
       :purchase-number="purchase.purchase_number"
+      :business-name="printBusinessName"
+      :business-tax-id="printBusinessTaxId"
       :date-label="t('abastecimiento.compraDirectaDetalle.purchaseDate')"
       :date-value="formatDate(purchase.purchase_date)"
       :supplier-label="t('abastecimiento.compraDirectaDetalle.supplier')"
@@ -691,7 +686,7 @@
       :status-label="t('abastecimiento.compraDirectaDetalle.currentStatus')"
       :status-value="getStatusText(purchase.status)"
       :payment-label="t('abastecimiento.compraDirectaDetalle.paymentMethod')"
-      :payment-value="purchase.payment_method ? resolvePaymentLabel(purchase.payment_method, purchase.payment_method_id) : '—'"
+      :payment-value="printPaymentValue"
       :item-name-label="WAREHOUSE_COPY.warehouseItemColumn"
       :qty-label="t('abastecimiento.compraDirectaDetalle.quantityShort')"
       :unit-label="t('abastecimiento.compraDirectaDetalle.unit')"
@@ -740,6 +735,7 @@ const toast = useToast()
 const { t, locale } = useI18n({ useScope: 'global' })
 const WAREHOUSE_COPY = useWarehouseCopy()
 const { printElement: printTicketElement } = useCajaTicketPrint()
+const { settingsData } = useReceiptPrintSettings()
 const setHeaderAction = inject<(action: { label: string; ariaLabel?: string; icon?: boolean | 'printer'; iconOnly?: boolean; handler: () => void } | undefined) => void>('setHeaderAction')
 const printFormatModalOpen = ref(false)
 
@@ -795,6 +791,16 @@ const purchaseCashDrawerLabel = computed(() =>
     ? t('abastecimiento.compraDirectaDetalle.fromCashDrawerYes')
     : t('abastecimiento.compraDirectaDetalle.fromCashDrawerNo'),
 )
+const fiscalData = computed(() => settingsData.value?.data?.fiscal_data ?? null)
+const printBusinessName = computed(() => fiscalData.value?.business_name?.trim() || null)
+const printBusinessTaxId = computed(() => fiscalData.value?.nit?.trim() || null)
+const printPaymentValue = computed(() => {
+  const current = purchase.value
+  if (!current?.payment_method) return '—'
+  const method = resolvePaymentLabel(current.payment_method, current.payment_method_id)
+  if (!isPurchaseCash.value) return method
+  return `${method} · ${purchaseCashDrawerLabel.value}`
+})
 const isLoading = computed(() => !purchaseResponse.value && !fetchError.value)
 const isRefreshing = computed(() => asyncStatus.value === 'loading' && purchaseResponse.value != null)
 const refresh = refetch
@@ -1094,32 +1100,6 @@ const uploadFile = async (file: File, type: 'invoice' | 'payment') => {
     toast.error(error.data?.detail || t('abastecimiento.compraDirectaDetalle.uploadError'), { title: t('common.error') })
   } finally {
     isUploading.value = false
-  }
-}
-
-// Copy link
-const copyPurchaseLink = async () => {
-  try {
-    const baseUrl = window.location.origin
-    const purchaseUrl = `${baseUrl}/abastecimiento/compras-directas/${purchaseId}`
-
-    if (navigator.clipboard && window.isSecureContext) {
-      await navigator.clipboard.writeText(purchaseUrl)
-    } else {
-      const textArea = document.createElement('textarea')
-      textArea.value = purchaseUrl
-      textArea.style.position = 'fixed'
-      textArea.style.opacity = '0'
-      document.body.appendChild(textArea)
-      textArea.select()
-      document.execCommand('copy')
-      document.body.removeChild(textArea)
-    }
-
-    toast.success(t('abastecimiento.compraDirectaDetalle.copySuccess'), { title: t('abastecimiento.compraDirectaDetalle.copiedTitle') })
-  } catch (error) {
-    console.error('Error copying link:', error)
-    toast.error(t('abastecimiento.compraDirectaDetalle.copyError'), { title: t('common.error') })
   }
 }
 


### PR DESCRIPTION
## Summary
- Removes the copy-link button next to the purchase number on `/abastecimiento/compras-directas/[id]`
- Enriches thermal + HTML prints with tenant business header, supplier NIT (ticket), and payment · cash-drawer detail

Closes #2158

## Test plan
- [ ] Open a direct purchase detail — no copy-link icon beside purchase number
- [ ] Print ticket — shows business name/NIT when available, supplier NIT, payment with drawer/off-drawer for cash
- [ ] Print HTML document — same richer header/meta
- [ ] Format chooser still opens both formats

## Validation evidence
```text
$ python3  # assert copyPurchaseLink gone; printBusinessName/printPaymentValue/supplier-tax wired
PASS: header copy-link removed; print enriched
```
No targeted unit tests; build/lint not run (WARO policy).

## wr-context
See `.wr/2158.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)