### PR TITLE
ui: polish PrintFormatChooserModal visual hierarchy

### DIFF
--- a/.wr/2160.yaml
+++ b/.wr/2160.yaml
@@ -1,0 +1,39 @@
+issue: 2160
+title: "ui: polish PrintFormatChooserModal visual hierarchy"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2160-print-format-chooser-polish
+
+paths:
+  - components/ui/PrintFormatChooserModal.vue
+  - .wr/2160.yaml
+
+ac:
+  - "Ticket/document options are distinct cards with icon + title + hint"
+  - "Cancel is visually secondary"
+  - "Existing WARO tokens only"
+  - "a11y dialog/focus/Esc/hit targets preserved"
+  - "select/cancel emit contract unchanged"
+  - "Spot-check on compras-directas print chooser"
+
+out_of_scope:
+  - print content
+  - i18n rewrites
+  - print pipeline redesign
+
+hints:
+  entry: "components/ui/PrintFormatChooserModal.vue"
+  pattern: "icon well primary/10; quieter cancel"
+  tests: "python static asserts; no build/lint"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "ready-for-review + wr-review"

--- a/components/ui/PrintFormatChooserModal.vue
+++ b/components/ui/PrintFormatChooserModal.vue
@@ -19,43 +19,96 @@
         @keydown.esc="cancel"
       >
         <div
-          class="relative bg-surface rounded-2xl shadow-xl border border-border w-full max-w-md p-6"
+          class="relative w-full max-w-md overflow-hidden rounded-2xl border border-border bg-surface shadow-xl"
           @click.stop
         >
-          <h3 :id="titleId" class="text-xl font-bold text-text-primary text-center mb-2">
-            {{ title }}
-          </h3>
-          <p :id="messageId" class="text-sm text-text-secondary text-center leading-relaxed mb-6">
-            {{ message }}
-          </p>
+          <div class="border-b border-border bg-surface-secondary/40 px-6 py-5 text-center">
+            <h3
+              :id="titleId"
+              class="text-lg font-bold tracking-tight text-text-primary"
+            >
+              {{ title }}
+            </h3>
+            <p
+              :id="messageId"
+              class="mt-1.5 text-sm leading-relaxed text-text-secondary"
+            >
+              {{ message }}
+            </p>
+          </div>
 
-          <div class="flex flex-col gap-2 mb-4">
+          <div class="space-y-3 p-5 sm:p-6">
             <button
               ref="firstOption"
               type="button"
-              class="w-full min-h-[48px] px-4 py-3 rounded-lg border-2 border-border text-start hover:border-primary hover:bg-primary/5 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition-all"
+              class="group flex w-full min-h-[56px] items-start gap-3 rounded-xl border border-border bg-surface px-3.5 py-3.5 text-start transition-all hover:border-primary/50 hover:bg-primary/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
               @click="pick('ticket')"
             >
-              <span class="block text-sm font-semibold text-text-primary">{{ ticketLabel }}</span>
-              <span class="block text-xs text-text-secondary mt-0.5">{{ ticketHint }}</span>
+              <span
+                class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary transition-colors group-hover:bg-primary/15"
+                aria-hidden="true"
+              >
+                <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.5h16.5M4.5 4.5v15a.75.75 0 0 0 .75.75h13.5a.75.75 0 0 0 .75-.75v-15M8.25 8.25h7.5M8.25 12h7.5M8.25 15.75h4.5" />
+                </svg>
+              </span>
+              <span class="min-w-0 flex-1 pt-0.5">
+                <span class="block text-sm font-semibold text-text-primary">{{ ticketLabel }}</span>
+                <span class="mt-0.5 block text-xs leading-snug text-text-secondary">{{ ticketHint }}</span>
+              </span>
+              <svg
+                class="mt-2 h-4 w-4 shrink-0 text-text-tertiary transition-colors group-hover:text-primary"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="2"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+              </svg>
             </button>
+
             <button
               type="button"
-              class="w-full min-h-[48px] px-4 py-3 rounded-lg border-2 border-border text-start hover:border-primary hover:bg-primary/5 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition-all"
+              class="group flex w-full min-h-[56px] items-start gap-3 rounded-xl border border-border bg-surface px-3.5 py-3.5 text-start transition-all hover:border-primary/50 hover:bg-primary/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
               @click="pick('document')"
             >
-              <span class="block text-sm font-semibold text-text-primary">{{ documentLabel }}</span>
-              <span class="block text-xs text-text-secondary mt-0.5">{{ documentHint }}</span>
+              <span
+                class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary transition-colors group-hover:bg-primary/15"
+                aria-hidden="true"
+              >
+                <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+                </svg>
+              </span>
+              <span class="min-w-0 flex-1 pt-0.5">
+                <span class="block text-sm font-semibold text-text-primary">{{ documentLabel }}</span>
+                <span class="mt-0.5 block text-xs leading-snug text-text-secondary">{{ documentHint }}</span>
+              </span>
+              <svg
+                class="mt-2 h-4 w-4 shrink-0 text-text-tertiary transition-colors group-hover:text-primary"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="2"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+              </svg>
             </button>
           </div>
 
-          <button
-            type="button"
-            class="w-full min-h-[44px] py-3 px-4 border-2 border-border rounded-lg text-text-primary font-medium hover:bg-background focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 transition-all"
-            @click="cancel"
-          >
-            {{ cancelLabel }}
-          </button>
+          <div class="border-t border-border px-5 py-4 sm:px-6">
+            <button
+              type="button"
+              class="w-full min-h-[44px] rounded-xl px-4 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-secondary hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+              @click="cancel"
+            >
+              {{ cancelLabel }}
+            </button>
+          </div>
         </div>
       </div>
     </Transition>


### PR DESCRIPTION
## Summary
- Shared print-format chooser now uses icon option cards with clearer type hierarchy
- Cancel is a quieter secondary action; dialog a11y and emit contract unchanged

Closes #2160

## Test plan
- [ ] Open print chooser on `/abastecimiento/compras-directas/[id]` — options look distinct
- [ ] Cancel / Esc / backdrop still dismiss
- [ ] Ticket and document still print correctly
- [ ] Spot-check gastos (or another consumer) if convenient

## Validation evidence
```text
$ python3  # assert dialog a11y + icon cards + quieter cancel
PASS: hierarchy polish + a11y contract preserved
```
No targeted unit tests; build/lint not run (WARO policy).

## wr-context
See `.wr/2160.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)