### PR TITLE
ui(compras/gastos): cash-origin Contado/Crédito-style cards

### DIFF
--- a/.wr/2164.yaml
+++ b/.wr/2164.yaml
@@ -1,0 +1,35 @@
+issue: 2164
+title: "ui(compras/gastos): cash-origin as Contado/Crédito-style option cards"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2164-cash-origin-cards
+risk: low
+
+paths:
+  - pages/abastecimiento/compras-directas/crear.vue
+  - pages/abastecimiento/compras-directas/[id]/editar.vue
+  - pages/finanzas/gastos/crear.vue
+  - pages/finanzas/gastos/[id]/editar.vue
+  - .wr/2164.yaml
+
+ac:
+  - "Compra directa crear/editar: cash origin = 2 option cards like Contado/Crédito"
+  - "Gastos crear/editar: same cards when cash selected"
+  - "Help copy kept; default from_cash_drawer true; payload unchanged"
+  - "radiogroup/radio/aria-checked a11y"
+
+out_of_scope:
+  - API / from_cash_drawer contract
+  - gastos Contado/Crédito select → cards
+  - PaymentForm restyle
+  - arqueo math
+
+hints:
+  entry: "compras-directas/crear Tipo de pago cards ~175"
+  pattern: "grid-cols-2 radiogroup border-primary bg-primary/8"
+  tests: "node --test utils/paymentDefaults.purchaseFilter.test.ts; static rg no radio inputs"
+
+skip:
+  audits: [ux, color, typography]

--- a/pages/abastecimiento/compras-directas/[id]/editar.vue
+++ b/pages/abastecimiento/compras-directas/[id]/editar.vue
@@ -513,18 +513,38 @@
                   </div>
 
                   <div v-if="hasPaymentSelected && isCashPaymentSelected" class="space-y-1.5">
-                    <label class="block text-sm font-medium text-text-secondary">
+                    <span class="block text-sm font-medium text-text-secondary">
                       {{ t('abastecimiento.compraDirectaDetalle.fromCashDrawerLabel') }}
-                    </label>
-                    <div class="flex flex-col gap-2 sm:flex-row sm:gap-4">
-                      <label class="inline-flex items-center gap-2 text-sm text-text-primary cursor-pointer">
-                        <input v-model="form.from_cash_drawer" type="radio" :value="true" class="text-primary" />
+                    </span>
+                    <div
+                      class="grid grid-cols-2 gap-2"
+                      role="radiogroup"
+                      :aria-label="t('abastecimiento.compraDirectaDetalle.fromCashDrawerLabel')"
+                    >
+                      <button
+                        type="button"
+                        role="radio"
+                        :aria-checked="form.from_cash_drawer === true"
+                        class="h-10 min-h-[40px] rounded-lg border px-2 text-sm font-medium text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                        :class="form.from_cash_drawer === true
+                          ? 'border-primary bg-primary/8'
+                          : 'border-border bg-background hover:border-primary/40'"
+                        @click="form.from_cash_drawer = true"
+                      >
                         {{ t('abastecimiento.compraDirectaDetalle.fromCashDrawerYes') }}
-                      </label>
-                      <label class="inline-flex items-center gap-2 text-sm text-text-primary cursor-pointer">
-                        <input v-model="form.from_cash_drawer" type="radio" :value="false" class="text-primary" />
+                      </button>
+                      <button
+                        type="button"
+                        role="radio"
+                        :aria-checked="form.from_cash_drawer === false"
+                        class="h-10 min-h-[40px] rounded-lg border px-2 text-sm font-medium text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                        :class="form.from_cash_drawer === false
+                          ? 'border-primary bg-primary/8'
+                          : 'border-border bg-background hover:border-primary/40'"
+                        @click="form.from_cash_drawer = false"
+                      >
                         {{ t('abastecimiento.compraDirectaDetalle.fromCashDrawerNo') }}
-                      </label>
+                      </button>
                     </div>
                     <p class="text-xs text-text-secondary">
                       {{ t('abastecimiento.compraDirectaDetalle.fromCashDrawerHelp') }}

--- a/pages/abastecimiento/compras-directas/crear.vue
+++ b/pages/abastecimiento/compras-directas/crear.vue
@@ -533,18 +533,38 @@
                 </div>
 
                 <div v-if="hasPaymentSelected && isCashPaymentSelected" class="space-y-1.5">
-                  <label class="block text-sm font-medium text-text-primary">
+                  <span class="block text-sm font-medium text-text-primary">
                     {{ t('abastecimiento.compraDirectaDetalle.fromCashDrawerLabel') }}
-                  </label>
-                  <div class="flex flex-col gap-2 sm:flex-row sm:gap-4">
-                    <label class="inline-flex items-center gap-2 text-sm text-text-primary cursor-pointer">
-                      <input v-model="form.from_cash_drawer" type="radio" :value="true" class="text-primary" />
+                  </span>
+                  <div
+                    class="grid grid-cols-2 gap-2"
+                    role="radiogroup"
+                    :aria-label="t('abastecimiento.compraDirectaDetalle.fromCashDrawerLabel')"
+                  >
+                    <button
+                      type="button"
+                      role="radio"
+                      :aria-checked="form.from_cash_drawer === true"
+                      class="h-10 min-h-[40px] rounded-lg border px-2 text-sm font-medium text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                      :class="form.from_cash_drawer === true
+                        ? 'border-primary bg-primary/8'
+                        : 'border-border bg-background hover:border-primary/40'"
+                      @click="form.from_cash_drawer = true"
+                    >
                       {{ t('abastecimiento.compraDirectaDetalle.fromCashDrawerYes') }}
-                    </label>
-                    <label class="inline-flex items-center gap-2 text-sm text-text-primary cursor-pointer">
-                      <input v-model="form.from_cash_drawer" type="radio" :value="false" class="text-primary" />
+                    </button>
+                    <button
+                      type="button"
+                      role="radio"
+                      :aria-checked="form.from_cash_drawer === false"
+                      class="h-10 min-h-[40px] rounded-lg border px-2 text-sm font-medium text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                      :class="form.from_cash_drawer === false
+                        ? 'border-primary bg-primary/8'
+                        : 'border-border bg-background hover:border-primary/40'"
+                      @click="form.from_cash_drawer = false"
+                    >
                       {{ t('abastecimiento.compraDirectaDetalle.fromCashDrawerNo') }}
-                    </label>
+                    </button>
                   </div>
                   <p class="text-xs text-text-secondary">
                     {{ t('abastecimiento.compraDirectaDetalle.fromCashDrawerHelp') }}

--- a/pages/finanzas/gastos/[id]/editar.vue
+++ b/pages/finanzas/gastos/[id]/editar.vue
@@ -112,18 +112,38 @@
               </div>
 
               <div v-if="isCashMethodSelected" class="space-y-1.5">
-                <label class="block text-sm font-medium text-text-primary">
+                <span class="block text-sm font-medium text-text-primary">
                   {{ t('finanzas.gastos.fromCashDrawerLabel') }}
-                </label>
-                <div class="flex flex-col gap-2 sm:flex-row sm:gap-4">
-                  <label class="inline-flex items-center gap-2 text-sm text-text-primary cursor-pointer">
-                    <input v-model="form.fromCashDrawer" type="radio" :value="true" class="text-primary" />
+                </span>
+                <div
+                  class="grid grid-cols-2 gap-2"
+                  role="radiogroup"
+                  :aria-label="t('finanzas.gastos.fromCashDrawerLabel')"
+                >
+                  <button
+                    type="button"
+                    role="radio"
+                    :aria-checked="form.fromCashDrawer === true"
+                    class="h-10 min-h-[40px] rounded-lg border px-2 text-sm font-medium text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                    :class="form.fromCashDrawer === true
+                      ? 'border-primary bg-primary/8'
+                      : 'border-border bg-background hover:border-primary/40'"
+                    @click="form.fromCashDrawer = true"
+                  >
                     {{ t('finanzas.gastos.fromCashDrawerYes') }}
-                  </label>
-                  <label class="inline-flex items-center gap-2 text-sm text-text-primary cursor-pointer">
-                    <input v-model="form.fromCashDrawer" type="radio" :value="false" class="text-primary" />
+                  </button>
+                  <button
+                    type="button"
+                    role="radio"
+                    :aria-checked="form.fromCashDrawer === false"
+                    class="h-10 min-h-[40px] rounded-lg border px-2 text-sm font-medium text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                    :class="form.fromCashDrawer === false
+                      ? 'border-primary bg-primary/8'
+                      : 'border-border bg-background hover:border-primary/40'"
+                    @click="form.fromCashDrawer = false"
+                  >
                     {{ t('finanzas.gastos.fromCashDrawerNo') }}
-                  </label>
+                  </button>
                 </div>
                 <p class="text-xs text-text-secondary">{{ t('finanzas.gastos.fromCashDrawerHelp') }}</p>
               </div>

--- a/pages/finanzas/gastos/crear.vue
+++ b/pages/finanzas/gastos/crear.vue
@@ -107,18 +107,38 @@
                 v-if="form.paymentType === 'contado' && isCashMethodSelected"
                 class="space-y-1.5"
               >
-                <label class="block text-sm font-medium text-text-primary">
+                <span class="block text-sm font-medium text-text-primary">
                   {{ t('finanzas.gastos.fromCashDrawerLabel') }}
-                </label>
-                <div class="flex flex-col gap-2 sm:flex-row sm:gap-4">
-                  <label class="inline-flex items-center gap-2 text-sm text-text-primary cursor-pointer">
-                    <input v-model="form.fromCashDrawer" type="radio" :value="true" class="text-primary" />
+                </span>
+                <div
+                  class="grid grid-cols-2 gap-2"
+                  role="radiogroup"
+                  :aria-label="t('finanzas.gastos.fromCashDrawerLabel')"
+                >
+                  <button
+                    type="button"
+                    role="radio"
+                    :aria-checked="form.fromCashDrawer === true"
+                    class="h-10 min-h-[40px] rounded-lg border px-2 text-sm font-medium text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                    :class="form.fromCashDrawer === true
+                      ? 'border-primary bg-primary/8'
+                      : 'border-border bg-background hover:border-primary/40'"
+                    @click="form.fromCashDrawer = true"
+                  >
                     {{ t('finanzas.gastos.fromCashDrawerYes') }}
-                  </label>
-                  <label class="inline-flex items-center gap-2 text-sm text-text-primary cursor-pointer">
-                    <input v-model="form.fromCashDrawer" type="radio" :value="false" class="text-primary" />
+                  </button>
+                  <button
+                    type="button"
+                    role="radio"
+                    :aria-checked="form.fromCashDrawer === false"
+                    class="h-10 min-h-[40px] rounded-lg border px-2 text-sm font-medium text-text-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                    :class="form.fromCashDrawer === false
+                      ? 'border-primary bg-primary/8'
+                      : 'border-border bg-background hover:border-primary/40'"
+                    @click="form.fromCashDrawer = false"
+                  >
                     {{ t('finanzas.gastos.fromCashDrawerNo') }}
-                  </label>
+                  </button>
                 </div>
                 <p class="text-xs text-text-secondary">{{ t('finanzas.gastos.fromCashDrawerHelp') }}</p>
               </div>


### PR DESCRIPTION
## Summary
- Cash origin on direct-purchase create/edit uses the same 2 option cards as Contado/Crédito
- Same pattern on expense create/edit when cash is selected
- `from_cash_drawer` default/payload and arqueo help copy unchanged

Closes #2164

## Test plan
- [ ] Compra directa crear: Contado + efectivo → two cards; toggle both; submit
- [ ] Compra directa editar: same
- [ ] Gasto crear Contado + efectivo → same cards
- [ ] Gasto editar: same
- [ ] Confirm help text still visible

## Validation evidence
```text
$ node --test utils/paymentDefaults.purchaseFilter.test.ts
# tests 5
# suites 2
# pass 5
# fail 0

$ rg -n 'type="radio"' (scoped 4 pages) → OK: no type=radio
$ card pattern role=radiogroup + border-primary bg-primary/8 present on all 4
```

## wr-context
See `.wr/2164.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)