### PR TITLE
docs(nav): reduce sidebar link overload and align README index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,45 +1,41 @@
 # Documentación WARO Colombia
 
-Guías de uso de la plataforma, organizadas por sección.
+Guías de uso de la plataforma, organizadas como en el menú de documentación.
 
 ---
 
 ## Para restauranteros
 
 ### Inicio
-- [Primeros pasos](./usuarios/primeros-pasos.md) — login, recorrido del dashboard y orden de configuración inicial
+- [Primeros pasos](./usuarios/primeros-pasos.md) — login y orden recomendado para empezar
+- [Índice de usuario](./usuarios.md) — módulos por grupo (Principal, Herramientas, Cuenta)
 
-### Menú
-- [Recetas](./usuarios/menu/recetas.md) — qué es una receta base y cómo crearla
-- [Crear producto](./usuarios/menu/crear-producto.md) — cómo agregar un producto al menú
-- [Modificadores](./usuarios/menu/modificadores.md) — opciones para personalizar productos (tamaños, extras, salsas)
+### Principal
+- [POS](./usuarios/pos.md) — pedidos presenciales y cobro en caja
+- [Ventas](./usuarios/ventas.md) — historial de órdenes y reportes
+- [Despacho](./usuarios/despacho.md) — pedidos online (domicilios y recogida)
 
-### Inventario
-- [Registrar ajuste](./usuarios/inventario/registrar-ajuste.md) — corregir el stock de un ingrediente
-- [Ver movimientos](./usuarios/inventario/ver-movimientos.md) — historial de entradas y salidas
+### Herramientas
+- [Analítica Ventas](./usuarios/analitica.md) — métricas de ventas y tendencias
+- [Finanzas](./usuarios/finanzas.md) — arqueo, cartera, gastos y contabilidad
+- [Facturación](./usuarios/facturacion.md) — facturación electrónica DIAN
+- [Menú](./usuarios/menu.md) — recetas, productos y modificadores
+- [Operaciones](./usuarios/operaciones.md) — cocina, mesas y turnos
+- [Abastecimiento](./usuarios/abastecimiento.md) — proveedores, compras y stock
+- [Equipo](./usuarios/equipo.md) — miembros, salarios y nómina
 
-### Compras
-- [Gestionar proveedores](./usuarios/compras/gestionar-proveedores.md) — registrar y administrar proveedores
-- [Crear orden de compra](./usuarios/compras/crear-orden-compra.md) — pedido formal a un proveedor
+### Cuenta
+- [Mi Negocio](./usuarios/negocio.md) — perfil público y pedidos online
+- [Mi Plan](./usuarios/mi-plan.md) — suscripción y uso de IA
 
-### Equipo
-- [Agregar empleado](./usuarios/equipo/agregar-empleado.md) — invitar un miembro y configurar su rol y salario
-- [Registrar pago](./usuarios/equipo/registrar-pago.md) — registrar el pago de salario a un empleado
-
-### Analítica
-- [Leer el dashboard](./usuarios/analitica/leer-dashboard.md) — entender las métricas de ventas, rentabilidad y clientes
-
-### POS
-- [Procesar una venta](./usuarios/pos/procesar-venta.md) — tomar un pedido presencial y cobrarlo
+### Dev
+- [Integraciones](./dev.md) — API pública
+- [CLI](./cli.md) — herramientas de línea de comandos
 
 ---
 
 ## Orden recomendado para empezar
 
 1. [Primeros pasos](./usuarios/primeros-pasos.md)
-2. [Recetas](./usuarios/menu/recetas.md)
-3. [Crear producto](./usuarios/menu/crear-producto.md)
-4. [Modificadores](./usuarios/menu/modificadores.md) *(si aplica)*
-5. [Gestionar proveedores](./usuarios/compras/gestionar-proveedores.md)
-6. [Agregar empleado](./usuarios/equipo/agregar-empleado.md)
-7. [Procesar una venta](./usuarios/pos/procesar-venta.md)
+2. [Menú](./usuarios/menu.md)
+3. [POS](./usuarios/pos.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Guías de uso de la plataforma, organizadas como en el menú de documentación.
 
 ### Inicio
 - [Primeros pasos](./usuarios/primeros-pasos.md) — login y orden recomendado para empezar
-- [Índice de usuario](./usuarios.md) — módulos por grupo (Principal, Herramientas, Cuenta)
+- [Índice de usuario](./usuarios.md) — módulos por grupo (Principal, Herramientas, Cuenta y Dev)
 
 ### Principal
 - [POS](./usuarios/pos.md) — pedidos presenciales y cobro en caja

--- a/docs/usuarios.md
+++ b/docs/usuarios.md
@@ -2,13 +2,13 @@
 
 Bienvenido a la documentación de WARO. Aquí encuentras todo lo que necesitas para operar tu restaurante día a día.
 
-La documentación replica la estructura del menú lateral de la plataforma: tres grupos (Principal, Herramientas, Cuenta) con sus módulos.
+La documentación replica la estructura del menú lateral: Primeros pasos, luego Principal, Herramientas, Cuenta y Dev.
 
 ---
 
 ## Primeros pasos
 
-- [Primeros pasos](./usuarios/primeros-pasos) — configuración inicial de tu cuenta
+- [Primeros pasos](./usuarios/primeros-pasos) — login y orden recomendado para empezar
 
 ---
 
@@ -31,7 +31,6 @@ La documentación replica la estructura del menú lateral de la plataforma: tres
 | [Operaciones](./usuarios/operaciones) | Comandas & cocina, mesas, personalización y propinas |
 | [Abastecimiento](./usuarios/abastecimiento) | Proveedores, compras, stock, ajustes, ingredientes propios y calidad de datos |
 | [Equipo](./usuarios/equipo) | Miembros, salarios, nómina y perfil de meseros |
-| [Integraciones](../dev) | API pública para construir integraciones |
 
 ## Cuenta
 
@@ -39,3 +38,10 @@ La documentación replica la estructura del menú lateral de la plataforma: tres
 |--------|------------------|
 | [Mi Negocio](./usuarios/negocio) | Perfil público, horarios, contacto y configuración de pedidos online |
 | [Mi Plan](./usuarios/mi-plan) | Suscripción, historial de pagos y uso de IA |
+
+## Dev
+
+| Recurso | Para qué |
+|---------|----------|
+| [Integraciones](./dev) | API pública para construir integraciones |
+| [CLI](./cli) | Herramientas de línea de comandos |

--- a/layouts/docs.vue
+++ b/layouts/docs.vue
@@ -29,6 +29,7 @@ type NavEntry   = NavSection | NavItem
 const nav: NavEntry[] = [
   { label: 'Primeros pasos',  path: '/docs/usuarios/primeros-pasos', icon: BookOpenIcon },
 
+  { section: 'Principal' },
   { label: 'POS',             path: '/docs/usuarios/pos',            icon: ComputerDesktopIcon },
   { label: 'Ventas',          path: '/docs/usuarios/ventas',         icon: ShoppingCartIcon },
   { label: 'Despacho',        path: '/docs/usuarios/despacho',       icon: MapPinIcon },
@@ -41,13 +42,13 @@ const nav: NavEntry[] = [
   { label: 'Operaciones',      path: '/docs/usuarios/operaciones',   icon: AdjustmentsHorizontalIcon },
   { label: 'Abastecimiento',   path: '/docs/usuarios/abastecimiento', icon: TruckIcon },
   { label: 'Equipo',           path: '/docs/usuarios/equipo',        icon: UserGroupIcon },
-  { label: 'Integraciones',    path: '/docs/dev',                    icon: CodeBracketIcon },
 
   { section: 'Cuenta' },
   { label: 'Mi Negocio',      path: '/docs/usuarios/negocio',        icon: BuildingStorefrontIcon },
   { label: 'Mi Plan',         path: '/docs/usuarios/mi-plan',        icon: CreditCardIcon },
 
   { section: 'Dev' },
+  { label: 'Integraciones',    path: '/docs/dev',                    icon: CodeBracketIcon },
   { label: 'CLI',             path: '/docs/cli',                     icon: CommandLineIcon },
 ]
 


### PR DESCRIPTION
## Summary
- Sidebar: Primeros pasos → Principal → Herramientas → Cuenta → Dev; Integraciones moved to Dev
- Rewrite `docs/README.md` to module landings (remove dead inventario/compras/pos/analitica leaf links)
- Align `docs/usuarios.md` with the same groups

Closes #2168 (batch 2 of #2166)

## Test plan
- [ ] Desktop docs sidebar shows Principal + Dev/Integraciones
- [ ] Mobile Contenido sheet still lists all module links
- [ ] Spot-check README / usuarios index links open real docs pages

## Validation evidence
```
=== nav order ===
Primeros pasos → Principal (POS/Ventas/Despacho) → Herramientas (no Integraciones) → Cuenta → Dev (Integraciones, CLI)

=== README dead paths ===
(all README ./ links resolve)

=== mobile still filters sections ===
nav.filter(i => !i.section) retained at layouts/docs.vue:159
```

Made with [Cursor](https://cursor.com)