### PR TITLE
docs(i18n): chrome translations + locale-aware docs-content loader

### DIFF
--- a/i18n/locales/ar/docs.json
+++ b/i18n/locales/ar/docs.json
@@ -1,0 +1,33 @@
+{
+  "docs": {
+    "nav": {
+      "primerosPasos": "الخطوات الأولى",
+      "pos": "نقطة البيع",
+      "ventas": "المبيعات",
+      "despacho": "التوصيل",
+      "analitica": "تحليلات المبيعات",
+      "finanzas": "المالية",
+      "facturacion": "الفوترة",
+      "menu": "القائمة",
+      "operaciones": "العمليات",
+      "abastecimiento": "التوريد",
+      "equipo": "الفريق",
+      "negocio": "نشاطي",
+      "miPlan": "خطتي",
+      "integraciones": "التكاملات",
+      "cli": "CLI"
+    },
+    "section": {
+      "principal": "الرئيسي",
+      "herramientas": "الأدوات",
+      "cuenta": "الحساب",
+      "dev": "Dev"
+    },
+    "tocTitle": "في هذه الصفحة",
+    "sheetTitle": "المحتوى",
+    "loading": "جاري التحميل...",
+    "notFound": "المستند غير موجود.",
+    "backToIndex": "العودة إلى الفهرس",
+    "fallbackTitle": "التوثيق"
+  }
+}

--- a/i18n/locales/de/docs.json
+++ b/i18n/locales/de/docs.json
@@ -1,0 +1,33 @@
+{
+  "docs": {
+    "nav": {
+      "primerosPasos": "Erste Schritte",
+      "pos": "POS",
+      "ventas": "Verkäufe",
+      "despacho": "Versand",
+      "analitica": "Verkaufsanalytik",
+      "finanzas": "Finanzen",
+      "facturacion": "Rechnungsstellung",
+      "menu": "Menü",
+      "operaciones": "Betrieb",
+      "abastecimiento": "Beschaffung",
+      "equipo": "Team",
+      "negocio": "Mein Geschäft",
+      "miPlan": "Mein Plan",
+      "integraciones": "Integrationen",
+      "cli": "CLI"
+    },
+    "section": {
+      "principal": "Hauptbereich",
+      "herramientas": "Werkzeuge",
+      "cuenta": "Konto",
+      "dev": "Dev"
+    },
+    "tocTitle": "Auf dieser Seite",
+    "sheetTitle": "Inhalt",
+    "loading": "Wird geladen...",
+    "notFound": "Dokument nicht gefunden.",
+    "backToIndex": "Zurück zum Index",
+    "fallbackTitle": "Dokumentation"
+  }
+}

--- a/i18n/locales/en/docs.json
+++ b/i18n/locales/en/docs.json
@@ -1,0 +1,33 @@
+{
+  "docs": {
+    "nav": {
+      "primerosPasos": "Getting started",
+      "pos": "POS",
+      "ventas": "Sales",
+      "despacho": "Dispatch",
+      "analitica": "Sales analytics",
+      "finanzas": "Finance",
+      "facturacion": "Invoicing",
+      "menu": "Menu",
+      "operaciones": "Operations",
+      "abastecimiento": "Supply",
+      "equipo": "Team",
+      "negocio": "My business",
+      "miPlan": "My plan",
+      "integraciones": "Integrations",
+      "cli": "CLI"
+    },
+    "section": {
+      "principal": "Main",
+      "herramientas": "Tools",
+      "cuenta": "Account",
+      "dev": "Dev"
+    },
+    "tocTitle": "On this page",
+    "sheetTitle": "Contents",
+    "loading": "Loading...",
+    "notFound": "Document not found.",
+    "backToIndex": "Back to index",
+    "fallbackTitle": "Documentation"
+  }
+}

--- a/i18n/locales/es/docs.json
+++ b/i18n/locales/es/docs.json
@@ -1,0 +1,33 @@
+{
+  "docs": {
+    "nav": {
+      "primerosPasos": "Primeros pasos",
+      "pos": "POS",
+      "ventas": "Ventas",
+      "despacho": "Despacho",
+      "analitica": "Analítica Ventas",
+      "finanzas": "Finanzas",
+      "facturacion": "Facturación",
+      "menu": "Menú",
+      "operaciones": "Operaciones",
+      "abastecimiento": "Abastecimiento",
+      "equipo": "Equipo",
+      "negocio": "Mi Negocio",
+      "miPlan": "Mi Plan",
+      "integraciones": "Integraciones",
+      "cli": "CLI"
+    },
+    "section": {
+      "principal": "Principal",
+      "herramientas": "Herramientas",
+      "cuenta": "Cuenta",
+      "dev": "Dev"
+    },
+    "tocTitle": "En esta página",
+    "sheetTitle": "Contenido",
+    "loading": "Cargando...",
+    "notFound": "Documento no encontrado.",
+    "backToIndex": "Volver al índice",
+    "fallbackTitle": "Documentación"
+  }
+}

--- a/i18n/locales/fr/docs.json
+++ b/i18n/locales/fr/docs.json
@@ -1,0 +1,33 @@
+{
+  "docs": {
+    "nav": {
+      "primerosPasos": "Premiers pas",
+      "pos": "POS",
+      "ventas": "Ventes",
+      "despacho": "Expédition",
+      "analitica": "Analytique ventes",
+      "finanzas": "Finances",
+      "facturacion": "Facturation",
+      "menu": "Menu",
+      "operaciones": "Opérations",
+      "abastecimiento": "Approvisionnement",
+      "equipo": "Équipe",
+      "negocio": "Mon entreprise",
+      "miPlan": "Mon forfait",
+      "integraciones": "Intégrations",
+      "cli": "CLI"
+    },
+    "section": {
+      "principal": "Principal",
+      "herramientas": "Outils",
+      "cuenta": "Compte",
+      "dev": "Dev"
+    },
+    "tocTitle": "Sur cette page",
+    "sheetTitle": "Contenu",
+    "loading": "Chargement...",
+    "notFound": "Document introuvable.",
+    "backToIndex": "Retour à l'index",
+    "fallbackTitle": "Documentation"
+  }
+}

--- a/i18n/locales/hi/docs.json
+++ b/i18n/locales/hi/docs.json
@@ -1,0 +1,33 @@
+{
+  "docs": {
+    "nav": {
+      "primerosPasos": "शुरुआत",
+      "pos": "POS",
+      "ventas": "बिक्री",
+      "despacho": "डिस्पैच",
+      "analitica": "बिक्री विश्लेषण",
+      "finanzas": "वित्त",
+      "facturacion": "इनवॉइसिंग",
+      "menu": "मेनू",
+      "operaciones": "संचालन",
+      "abastecimiento": "आपूर्ति",
+      "equipo": "टीम",
+      "negocio": "मेरा व्यवसाय",
+      "miPlan": "मेरा प्लान",
+      "integraciones": "इंटीग्रेशन",
+      "cli": "CLI"
+    },
+    "section": {
+      "principal": "मुख्य",
+      "herramientas": "टूल्स",
+      "cuenta": "खाता",
+      "dev": "Dev"
+    },
+    "tocTitle": "इस पृष्ठ पर",
+    "sheetTitle": "सामग्री",
+    "loading": "लोड हो रहा है...",
+    "notFound": "दस्तावेज़ नहीं मिला।",
+    "backToIndex": "सूची पर वापस जाएँ",
+    "fallbackTitle": "दस्तावेज़ीकरण"
+  }
+}

--- a/i18n/locales/pt/docs.json
+++ b/i18n/locales/pt/docs.json
@@ -1,0 +1,33 @@
+{
+  "docs": {
+    "nav": {
+      "primerosPasos": "Primeiros passos",
+      "pos": "POS",
+      "ventas": "Vendas",
+      "despacho": "Despacho",
+      "analitica": "Analítica de vendas",
+      "finanzas": "Finanças",
+      "facturacion": "Faturação",
+      "menu": "Cardápio",
+      "operaciones": "Operações",
+      "abastecimiento": "Abastecimento",
+      "equipo": "Equipe",
+      "negocio": "Meu negócio",
+      "miPlan": "Meu plano",
+      "integraciones": "Integrações",
+      "cli": "CLI"
+    },
+    "section": {
+      "principal": "Principal",
+      "herramientas": "Ferramentas",
+      "cuenta": "Conta",
+      "dev": "Dev"
+    },
+    "tocTitle": "Nesta página",
+    "sheetTitle": "Conteúdo",
+    "loading": "Carregando...",
+    "notFound": "Documento não encontrado.",
+    "backToIndex": "Voltar ao índice",
+    "fallbackTitle": "Documentação"
+  }
+}

--- a/i18n/locales/zh/docs.json
+++ b/i18n/locales/zh/docs.json
@@ -1,0 +1,33 @@
+{
+  "docs": {
+    "nav": {
+      "primerosPasos": "入门指南",
+      "pos": "POS",
+      "ventas": "销售",
+      "despacho": "配送",
+      "analitica": "销售分析",
+      "finanzas": "财务",
+      "facturacion": "开票",
+      "menu": "菜单",
+      "operaciones": "运营",
+      "abastecimiento": "采购补给",
+      "equipo": "团队",
+      "negocio": "我的店铺",
+      "miPlan": "我的套餐",
+      "integraciones": "集成",
+      "cli": "CLI"
+    },
+    "section": {
+      "principal": "主要",
+      "herramientas": "工具",
+      "cuenta": "账户",
+      "dev": "Dev"
+    },
+    "tocTitle": "本页内容",
+    "sheetTitle": "目录",
+    "loading": "加载中...",
+    "notFound": "未找到文档。",
+    "backToIndex": "返回目录",
+    "fallbackTitle": "文档"
+  }
+}

--- a/layouts/docs.vue
+++ b/layouts/docs.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
-const route = useRoute()
-
 import Header from '~/components/layout/Header.vue'
 import BottomNav from '~/components/layout/BottomNav.vue'
 import { useDocsNav } from '~/composables/useDocsNav'
+import { getLocaleDirection } from '~/utils/appLocales'
 import {
   BookOpenIcon,
   CodeBracketIcon,
@@ -22,35 +21,54 @@ import {
   CreditCardIcon,
 } from '@heroicons/vue/24/outline'
 
-type NavSection = { section: string; path?: undefined; icon?: undefined; label?: undefined }
-type NavItem    = { label: string; path: string; icon: unknown; section?: undefined }
-type NavEntry   = NavSection | NavItem
+const route = useRoute()
+const { t, locale } = useI18n()
 
-const nav: NavEntry[] = [
-  { label: 'Primeros pasos',  path: '/docs/usuarios/primeros-pasos', icon: BookOpenIcon },
+type NavSection = { sectionKey: string; path?: undefined; icon?: undefined; labelKey?: undefined }
+type NavItem = { labelKey: string; path: string; icon: unknown; sectionKey?: undefined }
+type NavEntry = NavSection | NavItem
 
-  { section: 'Principal' },
-  { label: 'POS',             path: '/docs/usuarios/pos',            icon: ComputerDesktopIcon },
-  { label: 'Ventas',          path: '/docs/usuarios/ventas',         icon: ShoppingCartIcon },
-  { label: 'Despacho',        path: '/docs/usuarios/despacho',       icon: MapPinIcon },
+const navEntries: NavEntry[] = [
+  { labelKey: 'docs.nav.primerosPasos', path: '/docs/usuarios/primeros-pasos', icon: BookOpenIcon },
 
-  { section: 'Herramientas' },
-  { label: 'Analítica Ventas', path: '/docs/usuarios/analitica',     icon: ChartBarIcon },
-  { label: 'Finanzas',         path: '/docs/usuarios/finanzas',      icon: BanknotesIcon },
-  { label: 'Facturación',      path: '/docs/usuarios/facturacion',   icon: DocumentTextIcon },
-  { label: 'Menú',             path: '/docs/usuarios/menu',          icon: CubeIcon },
-  { label: 'Operaciones',      path: '/docs/usuarios/operaciones',   icon: AdjustmentsHorizontalIcon },
-  { label: 'Abastecimiento',   path: '/docs/usuarios/abastecimiento', icon: TruckIcon },
-  { label: 'Equipo',           path: '/docs/usuarios/equipo',        icon: UserGroupIcon },
+  { sectionKey: 'docs.section.principal' },
+  { labelKey: 'docs.nav.pos', path: '/docs/usuarios/pos', icon: ComputerDesktopIcon },
+  { labelKey: 'docs.nav.ventas', path: '/docs/usuarios/ventas', icon: ShoppingCartIcon },
+  { labelKey: 'docs.nav.despacho', path: '/docs/usuarios/despacho', icon: MapPinIcon },
 
-  { section: 'Cuenta' },
-  { label: 'Mi Negocio',      path: '/docs/usuarios/negocio',        icon: BuildingStorefrontIcon },
-  { label: 'Mi Plan',         path: '/docs/usuarios/mi-plan',        icon: CreditCardIcon },
+  { sectionKey: 'docs.section.herramientas' },
+  { labelKey: 'docs.nav.analitica', path: '/docs/usuarios/analitica', icon: ChartBarIcon },
+  { labelKey: 'docs.nav.finanzas', path: '/docs/usuarios/finanzas', icon: BanknotesIcon },
+  { labelKey: 'docs.nav.facturacion', path: '/docs/usuarios/facturacion', icon: DocumentTextIcon },
+  { labelKey: 'docs.nav.menu', path: '/docs/usuarios/menu', icon: CubeIcon },
+  { labelKey: 'docs.nav.operaciones', path: '/docs/usuarios/operaciones', icon: AdjustmentsHorizontalIcon },
+  { labelKey: 'docs.nav.abastecimiento', path: '/docs/usuarios/abastecimiento', icon: TruckIcon },
+  { labelKey: 'docs.nav.equipo', path: '/docs/usuarios/equipo', icon: UserGroupIcon },
 
-  { section: 'Dev' },
-  { label: 'Integraciones',    path: '/docs/dev',                    icon: CodeBracketIcon },
-  { label: 'CLI',             path: '/docs/cli',                     icon: CommandLineIcon },
+  { sectionKey: 'docs.section.cuenta' },
+  { labelKey: 'docs.nav.negocio', path: '/docs/usuarios/negocio', icon: BuildingStorefrontIcon },
+  { labelKey: 'docs.nav.miPlan', path: '/docs/usuarios/mi-plan', icon: CreditCardIcon },
+
+  { sectionKey: 'docs.section.dev' },
+  { labelKey: 'docs.nav.integraciones', path: '/docs/dev', icon: CodeBracketIcon },
+  { labelKey: 'docs.nav.cli', path: '/docs/cli', icon: CommandLineIcon },
 ]
+
+const nav = computed(() =>
+  navEntries.map((item) => {
+    if (item.sectionKey) {
+      return { section: t(item.sectionKey), sectionKey: item.sectionKey }
+    }
+    return {
+      label: t(item.labelKey!),
+      labelKey: item.labelKey,
+      path: item.path!,
+      icon: item.icon,
+    }
+  }),
+)
+
+const docsDir = computed(() => getLocaleDirection(locale.value))
 
 function isActive(path: string) {
   return route.path === path
@@ -90,7 +108,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="docs-shell bg-surface">
+  <div class="docs-shell bg-surface" :dir="docsDir">
     <NuxtLoadingIndicator />
 
     <Header />
@@ -103,9 +121,9 @@ onMounted(() => {
           <nav class="docs-nav">
 
             <template v-for="item in nav">
-              <div v-if="item.section" :key="item.section" class="docs-nav-section">{{ item.section }}</div>
+              <div v-if="'section' in item && item.section" :key="item.sectionKey" class="docs-nav-section">{{ item.section }}</div>
               <NuxtLink
-                v-else
+                v-else-if="'path' in item && item.path"
                 :key="item.path"
                 :to="item.path"
                 class="docs-nav-item"
@@ -131,7 +149,7 @@ onMounted(() => {
       <!-- TOC derecho — solo desktop cuando hay headings -->
       <aside v-if="headings.length > 0" class="docs-toc">
         <div class="docs-toc-inner">
-          <p class="docs-toc-title">En esta página</p>
+          <p class="docs-toc-title">{{ t('docs.tocTitle') }}</p>
           <nav class="docs-toc-rail">
             <a
               v-for="h in headings"
@@ -150,13 +168,13 @@ onMounted(() => {
     </div>
 
     <!-- Bottom sheet nav — solo mobile -->
-    <UiBottomSheetModal v-model="showDocsNav" title="Contenido" max-height="lg">
+    <UiBottomSheetModal v-model="showDocsNav" :title="t('docs.sheetTitle')" max-height="lg">
       <div class="sheet-v2">
 
         <!-- Nav grid — click navega directamente -->
         <div class="sheet-grid">
           <NuxtLink
-            v-for="item in nav.filter(i => !i.section)"
+            v-for="item in nav.filter((i): i is { label: string; path: string; icon: unknown; labelKey: string } => 'path' in i && !!i.path)"
             :key="item.path"
             :to="item.path"
             class="sheet-grid-item"

--- a/pages/docs/[...slug].vue
+++ b/pages/docs/[...slug].vue
@@ -5,6 +5,7 @@ import MarkdownIt from 'markdown-it'
 definePageMeta({ layout: 'docs' })
 
 const route = useRoute()
+const { t, locale } = useI18n()
 const { headings } = useDocsToc()
 
 const slug = computed(() => {
@@ -12,7 +13,10 @@ const slug = computed(() => {
   return Array.isArray(parts) ? parts.join('/') : parts || 'README'
 })
 
-const { data, error, status } = await useFetch(() => `/docs-content/${slug.value}`)
+const { data, error, status, refresh } = await useFetch(
+  () => `/docs-content/${slug.value}?locale=${locale.value}`,
+  { watch: [locale, slug] },
+)
 
 const md = new MarkdownIt({ html: false, linkify: true, typographer: true })
 
@@ -54,7 +58,7 @@ watch(data, () => {
 
 const pageTitle = computed(() => {
   const match = (data.value?.content as string || '').match(/^#\s+(.+)/m)
-  return match ? match[1] : 'Documentación'
+  return match ? match[1] : t('docs.fallbackTitle')
 })
 
 const displayedTitle = ref('')
@@ -94,19 +98,21 @@ function handleClick(e: MouseEvent) {
   }
   navigateTo(`/docs/${resolved}`)
 }
+
+watch(locale, () => { void refresh() })
 </script>
 
 <template>
   <!-- Loading -->
   <div v-if="status === 'pending'" class="flex items-center justify-center min-h-[40vh]">
-    <p class="text-sm text-text-tertiary">Cargando...</p>
+    <p class="text-sm text-text-tertiary">{{ t('docs.loading') }}</p>
   </div>
 
   <!-- 404 -->
   <div v-else-if="error" class="flex flex-col items-center justify-center min-h-[40vh] gap-4">
-    <p class="text-text-secondary">Documento no encontrado.</p>
+    <p class="text-text-secondary">{{ t('docs.notFound') }}</p>
     <NuxtLink to="/docs" class="text-sm text-badge-primary-text hover:underline">
-      Volver al índice
+      {{ t('docs.backToIndex') }}
     </NuxtLink>
   </div>
 

--- a/pages/docs/[...slug].vue
+++ b/pages/docs/[...slug].vue
@@ -13,7 +13,7 @@ const slug = computed(() => {
   return Array.isArray(parts) ? parts.join('/') : parts || 'README'
 })
 
-const { data, error, status, refresh } = await useFetch(
+const { data, error, status } = await useFetch(
   () => `/docs-content/${slug.value}?locale=${locale.value}`,
   { watch: [locale, slug] },
 )
@@ -98,8 +98,6 @@ function handleClick(e: MouseEvent) {
   }
   navigateTo(`/docs/${resolved}`)
 }
-
-watch(locale, () => { void refresh() })
 </script>
 
 <template>

--- a/server/routes/docs-content/[...path].get.ts
+++ b/server/routes/docs-content/[...path].get.ts
@@ -1,26 +1,60 @@
 import { readFile } from 'fs/promises'
 import { resolve } from 'path'
+import { ALL_APP_LOCALES, DEFAULT_APP_LOCALE, type AppLocaleCode } from '~/utils/appLocales'
+
+
+function normalizeDocsLocale(raw: unknown): AppLocaleCode {
+  const code = typeof raw === 'string' ? raw.trim().toLowerCase() : ''
+  return (ALL_APP_LOCALES as readonly string[]).includes(code)
+    ? (code as AppLocaleCode)
+    : DEFAULT_APP_LOCALE
+}
+
+async function readDocsMarkdown(
+  storage: ReturnType<typeof useStorage>,
+  relativeKey: string,
+): Promise<string | null> {
+  const stored = await storage.getItem(relativeKey)
+  if (typeof stored === 'string' && stored.length > 0) return stored
+  if (stored != null) return String(stored)
+
+  try {
+    const filePath = resolve(process.cwd(), 'docs', relativeKey)
+    return await readFile(filePath, 'utf-8')
+  } catch {
+    return null
+  }
+}
 
 export default defineEventHandler(async (event) => {
   const path = getRouterParam(event, 'path') || 'README'
+  const query = getQuery(event)
+  const locale = normalizeDocsLocale(query.locale)
 
   // Sanitize: no path traversal
   const sanitized = path.replace(/\.\./g, '').replace(/^\/+/, '').replace(/\.md$/, '')
-  const key = `${sanitized}.md`
-
-  // 1. Try serverAssets storage (works in production after build)
   const storage = useStorage('assets:docs')
-  const stored = await storage.getItem(key)
-  if (stored) {
-    return { content: stored as string, path: sanitized }
+
+  const candidates: Array<{ key: string; locale: AppLocaleCode | 'legacy' }> = [
+    { key: `${locale}/${sanitized}.md`, locale },
+  ]
+  if (locale !== DEFAULT_APP_LOCALE) {
+    candidates.push({ key: `${DEFAULT_APP_LOCALE}/${sanitized}.md`, locale: DEFAULT_APP_LOCALE })
+  }
+  candidates.push({ key: `${sanitized}.md`, locale: 'legacy' })
+
+  for (const candidate of candidates) {
+    const content = await readDocsMarkdown(storage, candidate.key)
+    if (content != null) {
+      const resolvedLocale = candidate.locale === 'legacy' ? DEFAULT_APP_LOCALE : candidate.locale
+      return {
+        content,
+        path: sanitized,
+        locale: resolvedLocale,
+        fallback: resolvedLocale !== locale,
+      }
+    }
   }
 
-  // 2. Fallback: read from filesystem (works in dev without restart)
-  try {
-    const filePath = resolve(process.cwd(), 'docs', `${sanitized}.md`)
-    const content = await readFile(filePath, 'utf-8')
-    return { content, path: sanitized }
-  } catch {
-    throw createError({ statusCode: 404, message: 'Documento no encontrado' })
-  }
+  throw createError({ statusCode: 404, message: 'Document not found' })
 })

--- a/utils/appLocales.test.ts
+++ b/utils/appLocales.test.ts
@@ -34,6 +34,7 @@ describe('app locale catalog', () => {
 
   it('loads the personal profile message domain', () => {
     assert.ok(LOCALE_MESSAGE_FILES.includes('perfil.json'))
+    assert.ok(LOCALE_MESSAGE_FILES.includes('docs.json'))
   })
 
   it('maps language, numeric tags, and RTL direction', () => {

--- a/utils/appLocales.ts
+++ b/utils/appLocales.ts
@@ -14,6 +14,7 @@ export const LOCALE_MESSAGE_FILES = [
   'crm.json',
   'equipo.json',
   'perfil.json',
+  'docs.json',
 ] as const
 
 export const APP_LOCALE_DEFINITIONS = [


### PR DESCRIPTION
## Summary
- Add `docs.json` for es/en/pt/fr/de/hi/zh/ar and register in `LOCALE_MESSAGE_FILES`
- Docs sidebar/TOC/sheet/loading/404 use `t()`; shell respects RTL `dir`
- `/docs-content` resolves `docs/{locale}/…` → `docs/es/…` → legacy `docs/…` with `fallback` flag
- Docs page refetches when header locale changes

Closes #2174 (batch 1 of #2173)

## Test plan
- [ ] Open `/docs/usuarios/primeros-pasos`, switch header to English — chrome EN, body ES (fallback)
- [ ] Switch back to Español — chrome + body ES, `fallback: false`
- [ ] Mobile Contenido sheet titles translate
- [ ] Arabic sets `dir=rtl` on docs shell

## Validation evidence
```
=== es ===
locale es fallback False

=== en ===
locale es fallback True
title_line # Primeros pasos

=== pt ===
locale es fallback True

en chrome: Getting started
docs.json OK for all 8 locales (15 nav keys each)
```

Made with [Cursor](https://cursor.com)