### PR TITLE
fix(docs): stop double /docs/ links and restore docs chrome i18n

### DIFF
--- a/pages/docs/[...slug].vue
+++ b/pages/docs/[...slug].vue
@@ -88,15 +88,7 @@ function handleClick(e: MouseEvent) {
   const href = anchor.getAttribute('href')
   if (!href || href.startsWith('http') || href.startsWith('#')) return
   e.preventDefault()
-  const currentDir = slug.value.split('/').slice(0, -1).join('/')
-  let resolved = href.replace(/\.md$/, '')
-  if (resolved.startsWith('./')) {
-    resolved = resolved.slice(2)
-    resolved = currentDir ? `${currentDir}/${resolved}` : resolved
-  } else if (!resolved.startsWith('/')) {
-    resolved = currentDir ? `${currentDir}/${resolved}` : resolved
-  }
-  navigateTo(`/docs/${resolved}`)
+  navigateTo(resolveDocsNavigatePath(href, slug.value))
 }
 </script>
 

--- a/utils/docsLinks.test.ts
+++ b/utils/docsLinks.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { resolveDocsNavigatePath } from './docsLinks.ts'
+
+test('absolute /docs links are not double-prefixed', () => {
+  assert.equal(
+    resolveDocsNavigatePath('/docs/usuarios/menu', 'usuarios/primeros-pasos'),
+    '/docs/usuarios/menu',
+  )
+  assert.equal(
+    resolveDocsNavigatePath('/docs/usuarios/operaciones/mesas#pedido-por-qr-en-mesa', 'usuarios/menu/productos'),
+    '/docs/usuarios/operaciones/mesas#pedido-por-qr-en-mesa',
+  )
+})
+
+test('relative ./ and bare paths resolve under current slug dir', () => {
+  assert.equal(
+    resolveDocsNavigatePath('./menu/recetas', 'usuarios/menu'),
+    '/docs/usuarios/menu/recetas',
+  )
+  assert.equal(
+    resolveDocsNavigatePath('./recetas.md', 'usuarios/menu/productos'),
+    '/docs/usuarios/menu/recetas',
+  )
+  assert.equal(
+    resolveDocsNavigatePath('registrar-venta.md', 'usuarios/ventas/propinas'),
+    '/docs/usuarios/ventas/registrar-venta',
+  )
+})
+
+test('parent ../ segments normalize', () => {
+  assert.equal(
+    resolveDocsNavigatePath('../despacho#pedidos-en-mesa-qr', 'usuarios/operaciones/mesas'),
+    '/docs/usuarios/despacho#pedidos-en-mesa-qr',
+  )
+  // From usuarios/menu/productos, ../../ climbs out of usuarios/ (same as browser path normalize)
+  assert.equal(
+    resolveDocsNavigatePath('../../operaciones/mesas', 'usuarios/menu/productos'),
+    '/docs/operaciones/mesas',
+  )
+  assert.equal(
+    resolveDocsNavigatePath('../operaciones/mesas', 'usuarios/menu/productos'),
+    '/docs/usuarios/operaciones/mesas',
+  )
+})

--- a/utils/docsLinks.ts
+++ b/utils/docsLinks.ts
@@ -1,0 +1,37 @@
+/**
+ * Resolve an in-docs markdown href to a Nuxt path under /docs.
+ * Absolute `/docs/...` links must not be prefixed again.
+ */
+export function resolveDocsNavigatePath(href: string, currentSlug: string): string {
+  const raw = href.trim()
+  if (!raw || raw.startsWith('http') || raw.startsWith('#')) return raw
+
+  const hashIndex = raw.indexOf('#')
+  const pathWithMd = hashIndex >= 0 ? raw.slice(0, hashIndex) : raw
+  const hash = hashIndex >= 0 ? raw.slice(hashIndex) : ''
+  let path = pathWithMd.replace(/\.md$/i, '')
+
+  if (path === '/docs' || path.startsWith('/docs/')) {
+    return `${path.replace(/\/{2,}/g, '/')}${hash}`
+  }
+
+  if (path.startsWith('/')) {
+    return `${path}${hash}`
+  }
+
+  const currentDir = currentSlug.split('/').filter(Boolean).slice(0, -1).join('/')
+  if (path.startsWith('./')) path = path.slice(2)
+
+  const joined = currentDir ? `${currentDir}/${path}` : path
+  const parts: string[] = []
+  for (const segment of joined.split('/')) {
+    if (!segment || segment === '.') continue
+    if (segment === '..') {
+      parts.pop()
+      continue
+    }
+    parts.push(segment)
+  }
+
+  return `/docs/${parts.join('/')}${hash}`
+}


### PR DESCRIPTION
## Summary
- Normalize in-docs markdown hrefs so absolute `/docs/...` links no longer navigate to `/docs//docs/...`
- Preserve `./` and `../` resolution under the current slug
- Confirm `docs.json` is in locale message files (chrome keys); local Nuxt needed a restart to pick it up

Closes #2183

## Test plan
- [x] Unit tests for `resolveDocsNavigatePath`
- [x] After Nuxt restart, payload includes `docs.json`
- [ ] Click Menú from primeros-pasos → `/docs/usuarios/menu` loads
- [ ] Sidebar shows “Primeros pasos” (not `docs.nav.primerosPasos`)

## Validation evidence

```text
$ node --experimental-strip-types --test utils/docsLinks.test.ts
# tests 3
# pass 3
# fail 0
```

```text
$ curl -s http://127.0.0.1:8080/docs/usuarios/primeros-pasos | …
docs.json True
menu:200
```

## wr-context
See `.wr/2183.yaml` on this branch (LLM contract; gitignored locally).

Made with [Cursor](https://cursor.com)