### PR TITLE
fix(ui): avoid stacked overlay on delete confirm (#2191)

### DIFF
--- a/pages/abastecimiento/compras-directas/[id]/index.vue
+++ b/pages/abastecimiento/compras-directas/[id]/index.vue
@@ -1,13 +1,9 @@
 <template>
   <div class="page-layout">
     <UiSubmitBusyOverlay
-      :busy="isSaving || isUploading || isDeleting"
-      :label="isDeleting
-        ? t('abastecimiento.compraDirectaDetalle.deleting')
-        : (isSaving ? t('abastecimiento.compraDirectaDetalle.saving') : t('abastecimiento.compraDirectaDetalle.uploading'))"
-      :hint="isDeleting
-        ? t('abastecimiento.compraDirectaDetalle.deletingHint')
-        : (isSaving ? t('abastecimiento.compraDirectaDetalle.savingHint') : t('abastecimiento.compraDirectaDetalle.uploadingHint'))"
+      :busy="isSaving || isUploading"
+      :label="isSaving ? t('abastecimiento.compraDirectaDetalle.saving') : t('abastecimiento.compraDirectaDetalle.uploading')"
+      :hint="isSaving ? t('abastecimiento.compraDirectaDetalle.savingHint') : t('abastecimiento.compraDirectaDetalle.uploadingHint')"
       variant="glass"
       indicator="matrix"
     />

--- a/pages/finanzas/gastos/[id]/index.vue
+++ b/pages/finanzas/gastos/[id]/index.vue
@@ -2,8 +2,8 @@
   <div class="page-layout">
     <UiSubmitBusyOverlay
       :busy="isSubmitting"
-      :label="isDeleting ? t('finanzas.gastos.deleting') : t('finanzas.gastos.updating')"
-      :hint="isDeleting ? t('finanzas.gastos.deletingBody') : t('finanzas.gastos.updatingBody')"
+      :label="t('finanzas.gastos.updating')"
+      :hint="t('finanzas.gastos.updatingBody')"
       variant="glass"
       indicator="matrix"
     />
@@ -1266,7 +1266,6 @@ const performDeleteExpense = async () => {
   if (isDeleting.value) return
 
   isDeleting.value = true
-  isSubmitting.value = true
   try {
     await $fetch(`/api/finance/expenses/${expenseId}`, {
       method: 'DELETE'
@@ -1282,7 +1281,6 @@ const performDeleteExpense = async () => {
     alert(error?.data?.detail || t('finanzas.gastos.deleteError'))
   } finally {
     isDeleting.value = false
-    isSubmitting.value = false
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- Expense detail: delete no longer sets `isSubmitting`, so `UiSubmitBusyOverlay` stays off while the confirm modal shows loading
- Direct-purchase detail: overlay `busy` is save/upload only; delete loading stays on the confirm modal
- List pages unchanged (modal-only already)

Closes #2191

## Test plan
- [ ] Gasto detail → Eliminar → confirm: only modal loading (no full-page glass overlay)
- [ ] Compra directa detail → same
- [ ] Cancel still closes without DELETE
- [ ] Failed DELETE clears modal loading and shows error
- [ ] Successful DELETE navigates away
- [ ] Save/update on those pages still shows the busy overlay as before


Made with [Cursor](https://cursor.com)