### PR TITLE
fix(ui): delete button nowrap + leave detail immediately (#2193)

### DIFF
--- a/pages/abastecimiento/compras-directas/[id]/index.vue
+++ b/pages/abastecimiento/compras-directas/[id]/index.vue
@@ -120,11 +120,11 @@
           </h3>
 
           <!-- Edit / Delete -->
-          <div v-if="!isEditMode" class="flex items-center gap-2">
+          <div v-if="!isEditMode" class="flex items-center gap-2 shrink-0">
             <button
               type="button"
               @click="enterEditMode"
-              class="px-3 py-1.5 text-xs font-medium text-primary border border-primary rounded-lg hover:bg-primary/10 transition-colors flex items-center space-x-1"
+              class="px-3 py-1.5 text-xs font-medium text-primary border border-primary rounded-lg hover:bg-primary/10 transition-colors flex items-center space-x-1 whitespace-nowrap shrink-0"
             >
               <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
@@ -133,7 +133,7 @@
             </button>
             <button
               type="button"
-              class="px-3 py-1.5 text-xs font-medium text-destructive border-2 border-border rounded-lg hover:border-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50"
+              class="px-3 py-1.5 text-xs font-medium text-destructive border-2 border-border rounded-lg hover:border-destructive hover:bg-destructive/10 transition-colors whitespace-nowrap shrink-0 disabled:opacity-50"
               :disabled="isDeleting"
               :aria-label="t('abastecimiento.compraDirectaDetalle.deleteAria')"
               @click="requestDeletePurchase"
@@ -866,9 +866,11 @@ async function performDeletePurchase() {
       method: 'DELETE',
     })
     showDeleteConfirm.value = false
+    // Navigate first — invalidating the detail query while still on this page
+    // briefly shows CommonsTheErrorState ("unavailable") before leave.
+    await navigateTo('/abastecimiento/compras-directas', { replace: true })
     cache.invalidateQueries({ key: ['suppliers', 'direct-purchases'] })
     cache.invalidateQueries({ key: ['purchase-direct', purchaseId] })
-    await navigateTo('/abastecimiento/compras-directas')
   } catch (error: any) {
     console.error('Error deleting direct purchase:', error)
     showDeleteConfirm.value = false

--- a/pages/finanzas/gastos/[id]/index.vue
+++ b/pages/finanzas/gastos/[id]/index.vue
@@ -128,11 +128,11 @@
                 </svg>
                 <span>{{ t('finanzas.gastos.detailTitle') }}</span>
               </h3>
-              <div v-if="!isEditing" class="flex items-center gap-2">
+              <div v-if="!isEditing" class="flex items-center gap-2 shrink-0">
                 <button
                   type="button"
                   @click="startEditing"
-                  class="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 text-sm font-medium"
+                  class="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 text-sm font-medium whitespace-nowrap shrink-0"
                 >
                   {{ t('common.edit') }}
                 </button>
@@ -140,7 +140,7 @@
                   type="button"
                   @click="requestDeleteExpense"
                   :disabled="isDeleting"
-                  class="px-4 py-2 bg-surface border-2 border-border text-destructive rounded-lg hover:border-destructive hover:bg-destructive/10 text-sm font-medium disabled:opacity-50"
+                  class="px-4 py-2 bg-surface border-2 border-border text-destructive rounded-lg hover:border-destructive hover:bg-destructive/10 text-sm font-medium whitespace-nowrap shrink-0 disabled:opacity-50"
                 >
                   {{ t('finanzas.common.delete') }}
                 </button>
@@ -1272,9 +1272,11 @@ const performDeleteExpense = async () => {
     })
 
     showDeleteConfirm.value = false
+    // Navigate first — invalidating the detail query while still on this page
+    // briefly shows CommonsTheErrorState ("unavailable") before leave.
+    await navigateTo('/finanzas/gastos', { replace: true })
     cache.invalidateQueries({ key: ['finance', 'expenses'] })
     cache.invalidateQueries({ key: ['expense', expenseId] })
-    await navigateTo('/finanzas/gastos')
   } catch (error: any) {
     console.error('Error deleting expense:', error)
     showDeleteConfirm.value = false


### PR DESCRIPTION
## Summary
- Add `whitespace-nowrap shrink-0` to Edit/Delete on expense and direct-purchase detail
- After successful DELETE, `navigateTo` list with `replace: true` **before** invalidating detail cache (avoids unavailable/error flash)
- No i18n changes

Closes #2193

## Test plan
- [ ] Gasto detail: Eliminar stays one line next to Editar
- [ ] Compra directa detail: same
- [ ] Delete gasto → lands on `/finanzas/gastos` without error/unavailable flash
- [ ] Delete compra → lands on `/abastecimiento/compras-directas` without flash
- [ ] Failed DELETE still shows alert and stays on detail

## Validation evidence
```text
$ rg -n "whitespace-nowrap|navigateTo\('/finanzas/gastos'|navigateTo\('/abastecimiento/compras-directas'" pages/finanzas/gastos/[id]/index.vue pages/abastecimiento/compras-directas/[id]/index.vue
... whitespace-nowrap on Edit/Delete buttons (both pages)
... await navigateTo('/finanzas/gastos', { replace: true }) then invalidateQueries
... await navigateTo('/abastecimiento/compras-directas', { replace: true }) then invalidateQueries
```
No unit target for this UI-only change.

## wr-context
See `.wr/2193.yaml` locally (gitignored LLM contract).

Made with [Cursor](https://cursor.com)