### PR TITLE
test(billing): capabilities.wompi false after deprecation (#798)

### DIFF
--- a/composables/useTenantFinancialProfile.test.ts
+++ b/composables/useTenantFinancialProfile.test.ts
@@ -36,7 +36,7 @@ const response: TenantFinancialProfileResponse = {
     colombia_payroll: true,
     matias_dian: true,
     cop_wallet: true,
-    wompi: true,
+    wompi: false,
     fixed_cop_discounts: true,
   },
   eligibility: { eligible: true, lock_type: 'none', reason_codes: [] },


### PR DESCRIPTION
## Summary
- Align `useTenantFinancialProfile` fixture with API `capabilities.wompi: false` (Paddle-only #798)
- Legacy Wompi presentation labels unchanged (read-only history)

Refs uno0uno/api-warolabs#798

## Test plan
- [ ] Confirm billing history still shows processed-by-Wompi for legacy events

## Validation evidence

```
  ---
  duration_ms: 0.130458
  type: 'test'
  ...
# Subtest: formats SaaS offer amounts and annual savings
ok 7 - formats SaaS offer amounts and annual savings
  ---
  duration_ms: 31.944833
  type: 'test'
  ...
# Subtest: prefers paddle transaction id over wompi for event refs
ok 8 - prefers paddle transaction id over wompi for event refs
  ---
  duration_ms: 0.216042
  type: 'test'
  ...
1..8
# tests 13
# suites 1
# pass 13
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 334.04025
```

Made with [Cursor](https://cursor.com)