### PR TITLE
test(billing): capabilities.wompi false after deprecation (#798)

### DIFF
--- a/composables/useTenantFinancialProfile.test.ts
+++ b/composables/useTenantFinancialProfile.test.ts
@@ -36,7 +36,7 @@ const response: TenantFinancialProfileResponse = {
     colombia_payroll: true,
     matias_dian: true,
     cop_wallet: true,
-    wompi: true,
+    wompi: false,
     fixed_cop_discounts: true,
   },
   eligibility: { eligible: true, lock_type: 'none', reason_codes: [] },


### PR DESCRIPTION
## Summary
- Align `useTenantFinancialProfile` fixture with API `capabilities.wompi: false`
- Legacy Wompi presentation labels unchanged

Supersedes closed stacked PR #2198 (base deleted after #2197 merge). Rebased onto main.

Refs uno0uno/api-warolabs#798

## Test plan
- [ ] Billing history still shows processed-by-Wompi for legacy events

Made with [Cursor](https://cursor.com)