### PR TITLE
feat(billing): monthly pricing CTA (#808)

### DIFF
--- a/composables/useBilling.ts
+++ b/composables/useBilling.ts
@@ -628,7 +628,7 @@ export const useBilling = (options: { overview?: boolean } = {}) => {
   // ── Mutations ─────────────────────────────────────────────────────────────────
 
   const subscribeMutation = useMutation({
-    mutation: (payload: { plan_id: string; billing_cycle: 'annual'; payer_email?: string }) =>
+    mutation: (payload: { plan_id: string; billing_cycle: 'monthly'; payer_email?: string }) =>
       $fetch<SubscribeResult>('/api/billing/subscribe', { method: 'POST', body: payload }),
     onSettled: () => cache.invalidateQueries({ key: ['billing'] }),
   })
@@ -725,7 +725,7 @@ export const useBilling = (options: { overview?: boolean } = {}) => {
 
   const subscribe = async (
     plan_id: string,
-    billing_cycle: 'annual',
+    billing_cycle: 'monthly' = 'monthly',
     payer_email?: string
   ): Promise<SubscribeResult | null> => {
     try {
@@ -737,7 +737,7 @@ export const useBilling = (options: { overview?: boolean } = {}) => {
 
   const subscribeOrThrow = (
     plan_id: string,
-    billing_cycle: 'annual',
+    billing_cycle: 'monthly' = 'monthly',
     payer_email?: string
   ): Promise<SubscribeResult> =>
     subscribeMutation.mutateAsync({ plan_id, billing_cycle, payer_email })

--- a/i18n/locales/ar/shell.json
+++ b/i18n/locales/ar/shell.json
@@ -370,7 +370,10 @@
     "wompiReference": "مرجع Wompi",
     "copyReference": "نسخ المرجع",
     "paymentLink": "رابط الدفع",
-    "openPaymentLink": "فتح رابط الدفع"
+    "openPaymentLink": "فتح رابط الدفع",
+    "monthlySubscription": "اشتراك شهري · يُفوتر كل شهر",
+    "perMonth": "/ شهر",
+    "billedMonthly": "رسوم متكررة · تجديد شهري"
   },
   "terms": {
     "title": "الشروط والأحكام",

--- a/i18n/locales/de/shell.json
+++ b/i18n/locales/de/shell.json
@@ -370,7 +370,10 @@
     "wompiReference": "Wompi-Referenz",
     "copyReference": "Referenz kopieren",
     "paymentLink": "Zahlungslink",
-    "openPaymentLink": "Zahlungslink öffnen"
+    "openPaymentLink": "Zahlungslink öffnen",
+    "monthlySubscription": "Monatsabonnement · Monatliche Abrechnung",
+    "perMonth": "/ Monat",
+    "billedMonthly": "Wiederkehrende Zahlung · Monatliche Verlängerung"
   },
   "terms": {
     "title": "Allgemeine Geschäftsbedingungen",

--- a/i18n/locales/en/shell.json
+++ b/i18n/locales/en/shell.json
@@ -434,7 +434,10 @@
     "wompiReference": "Wompi reference",
     "copyReference": "Copy reference",
     "paymentLink": "Payment link",
-    "openPaymentLink": "Open payment link"
+    "openPaymentLink": "Open payment link",
+    "monthlySubscription": "Monthly subscription · Billed every month",
+    "perMonth": "/ month",
+    "billedMonthly": "Recurring charge · Renews monthly"
   },
   "terms": {
     "title": "Terms and Conditions",

--- a/i18n/locales/es/shell.json
+++ b/i18n/locales/es/shell.json
@@ -434,7 +434,10 @@
     "wompiReference": "Enlace Wompi",
     "copyReference": "Copiar referencia",
     "paymentLink": "Enlace de pago",
-    "openPaymentLink": "Abrir enlace de pago"
+    "openPaymentLink": "Abrir enlace de pago",
+    "monthlySubscription": "Suscripción mensual · Cobro cada mes",
+    "perMonth": "/ mes",
+    "billedMonthly": "Cobro recurrente · Renovación mensual"
   },
   "terms": {
     "title": "Términos y Condiciones",

--- a/i18n/locales/fr/shell.json
+++ b/i18n/locales/fr/shell.json
@@ -370,7 +370,10 @@
     "wompiReference": "Lien Wompi",
     "copyReference": "Copier la référence",
     "paymentLink": "Lien de paiement",
-    "openPaymentLink": "Ouvrir le lien de paiement"
+    "openPaymentLink": "Ouvrir le lien de paiement",
+    "monthlySubscription": "Abonnement mensuel · Facturé chaque mois",
+    "perMonth": "/ mois",
+    "billedMonthly": "Paiement récurrent · Renouvellement mensuel"
   },
   "terms": {
     "title": "Conditions Générales",

--- a/i18n/locales/hi/shell.json
+++ b/i18n/locales/hi/shell.json
@@ -370,7 +370,10 @@
     "wompiReference": "Wompi संदर्भ",
     "copyReference": "संदर्भ कॉपी करें",
     "paymentLink": "भुगतान लिंक",
-    "openPaymentLink": "भुगतान लिंक खोलें"
+    "openPaymentLink": "भुगतान लिंक खोलें",
+    "monthlySubscription": "मासिक सदस्यता · हर महीने बिल",
+    "perMonth": "/ माह",
+    "billedMonthly": "आवर्ती शुल्क · मासिक नवीनीकरण"
   },
   "terms": {
     "title": "नियम और शर्तें",

--- a/i18n/locales/pt/shell.json
+++ b/i18n/locales/pt/shell.json
@@ -370,7 +370,10 @@
     "wompiReference": "Link Wompi",
     "copyReference": "Copiar referência",
     "paymentLink": "Link de pagamento",
-    "openPaymentLink": "Abrir link de pagamento"
+    "openPaymentLink": "Abrir link de pagamento",
+    "monthlySubscription": "Assinatura mensal · Cobrança todo mês",
+    "perMonth": "/ mês",
+    "billedMonthly": "Cobrança recorrente · Renovação mensal"
   },
   "terms": {
     "title": "Termos e Condições",

--- a/i18n/locales/zh/shell.json
+++ b/i18n/locales/zh/shell.json
@@ -370,7 +370,10 @@
     "wompiReference": "Wompi 链接",
     "copyReference": "复制链接",
     "paymentLink": "付款链接",
-    "openPaymentLink": "打开付款链接"
+    "openPaymentLink": "打开付款链接",
+    "monthlySubscription": "月度订阅 · 按月计费",
+    "perMonth": "/ 月",
+    "billedMonthly": "循环扣费 · 按月续订"
   },
   "terms": {
     "title": "条款与条件",

--- a/pages/gestion/billing/index.vue
+++ b/pages/gestion/billing/index.vue
@@ -5,7 +5,6 @@ import {
   canStartBillingSubscription,
   shouldShowBillingRecoveryAlert,
   formatBillingOfferAmount,
-  billingOfferAnnualSavings,
   billingEventProviderRef,
   billingEventProviderLabelKey,
 } from '~/utils/billingPresentation'
@@ -377,7 +376,7 @@ const handleSubscribe = async () => {
   }
 
   try {
-    const result = await subscribeOrThrow(selectedPlan.value.id, 'annual', payerEmail.value)
+    const result = await subscribeOrThrow(selectedPlan.value.id, 'monthly', payerEmail.value)
     if (!result?.checkout_url) {
       subscribeError.value = t('billing.paymentStartError')
       return
@@ -531,16 +530,9 @@ const formatOffer = (amount: number, currency?: string) =>
     toNumberLocaleTag(locale.value),
   )
 
-const offerAnnualLabel = computed(() => {
+const offerMonthlyLabel = computed(() => {
   if (!priceOffer.value) return '—'
-  return formatOffer(priceOffer.value.annual_amount, priceOffer.value.currency)
-})
-
-const offerSavingsLabel = computed(() => {
-  if (!priceOffer.value) return null
-  const saved = billingOfferAnnualSavings(priceOffer.value)
-  if (saved <= 0) return null
-  return formatOffer(saved, priceOffer.value.currency)
+  return formatOffer(priceOffer.value.monthly_amount, priceOffer.value.currency)
 })
 
 const cycleLabel = computed(() => {
@@ -798,8 +790,8 @@ watch(() => currentTenant.value?.id, async () => {
               <div class="flex flex-col items-center gap-0.5 py-1">
                 <span class="text-xs font-semibold uppercase tracking-widest text-primary">{{ proPlan.name }}</span>
                 <span class="text-sm font-bold text-text-primary leading-tight">
-                  {{ offerAnnualLabel }}
-                  <span class="text-[11px] font-normal text-text-secondary">{{ t('billing.perYear') }}</span>
+                  {{ offerMonthlyLabel }}
+                  <span class="text-[11px] font-normal text-text-secondary">{{ t('billing.perMonth') }}</span>
                 </span>
               </div>
             </template>
@@ -986,7 +978,7 @@ watch(() => currentTenant.value?.id, async () => {
           <!-- ── STEP 1: Plan selection ── -->
           <template v-if="wizardStep === 1">
             <p class="text-sm text-text-secondary text-center leading-relaxed">
-              {{ t('billing.annualSubscription') }}
+              {{ t('billing.monthlySubscription') }}
             </p>
 
             <!-- Plans loading -->
@@ -1015,13 +1007,10 @@ watch(() => currentTenant.value?.id, async () => {
                 <div>
                   <div class="flex items-end gap-1">
                     <span class="text-3xl font-bold text-text-primary">
-                      {{ offerAnnualLabel }}
+                      {{ offerMonthlyLabel }}
                     </span>
-                    <span class="text-sm text-text-secondary mb-1">{{ t('billing.perYear') }}</span>
+                    <span class="text-sm text-text-secondary mb-1">{{ t('billing.perMonth') }}</span>
                   </div>
-                  <p v-if="offerSavingsLabel" class="text-sm text-status-success-text font-medium mt-0.5">
-                    {{ t('billing.youSave', { amount: offerSavingsLabel }) }}
-                  </p>
                 </div>
 
                 <ul class="space-y-1.5 flex-1">
@@ -1087,11 +1076,11 @@ watch(() => currentTenant.value?.id, async () => {
             <div class="bg-surface-secondary rounded-xl p-4">
               <div class="flex justify-between items-center gap-4">
                 <div>
-                  <p class="text-sm font-semibold text-text-primary">{{ selectedPlan.name }} · {{ t('billing.annual') }}</p>
-                  <p class="text-xs text-text-secondary mt-0.5">{{ t('billing.oneTimeTwelveMonths') }}</p>
+                  <p class="text-sm font-semibold text-text-primary">{{ selectedPlan.name }} · {{ t('billing.monthly') }}</p>
+                  <p class="text-xs text-text-secondary mt-0.5">{{ t('billing.billedMonthly') }}</p>
                 </div>
                 <p class="text-xl font-bold text-text-primary">
-                  {{ offerAnnualLabel }}
+                  {{ offerMonthlyLabel }}
                 </p>
               </div>
               <div v-if="quotaRowsForPlan(selectedPlan).length > 0" class="mt-4 pt-4 border-t border-border grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2">

--- a/utils/billingPresentation.test.ts
+++ b/utils/billingPresentation.test.ts
@@ -65,7 +65,7 @@ test('cancelled, expired and overdue subscriptions use recovery alert', () => {
   }
 })
 
-test('formats SaaS offer amounts and annual savings', () => {
+test('formats SaaS offer monthly amounts and legacy annual savings helper', () => {
   const offer: BillingPriceOffer = {
     segment: 'usd_9',
     currency: 'USD',
@@ -75,7 +75,8 @@ test('formats SaaS offer amounts and annual savings', () => {
     annual_amount: 90,
   }
   assert.equal(billingOfferAnnualSavings(offer), 18)
-  assert.match(formatBillingOfferAmount(90, 'USD', 'en-US'), /\$90/)
+  assert.match(formatBillingOfferAmount(9, 'USD', 'en-US'), /\$9/)
+  assert.match(formatBillingOfferAmount(30, 'EUR', 'en-US'), /€30/)
 })
 
 test('prefers paddle transaction id over wompi for event refs', () => {

--- a/utils/billingPresentation.ts
+++ b/utils/billingPresentation.ts
@@ -45,7 +45,7 @@ export const formatBillingOfferAmount = (
     maximumFractionDigits: 2,
   }).format(amount)
 
-/** Annual list is 10× monthly → two months “saved” vs paying monthly. */
+/** Legacy annual 10× list — two months “saved” vs paying monthly (display-only helper). */
 export const billingOfferAnnualSavings = (offer: BillingPriceOffer | null | undefined) =>
   offer ? offer.monthly_amount * 2 : 0
 


### PR DESCRIPTION
## Summary
- Billing UI shows regional **monthly** list prices (`monthly_amount`) with /mo copy
- `subscribe` / `subscribeOrThrow` send `billing_cycle: 'monthly'` (matches API #807)
- Legacy annual cycle label still shown for existing annual subscriptions
- Confirmation page unchanged (pending until Paddle webhook)

Closes uno0uno/api-warolabs#808

## Test plan
- [x] `bun test utils/billingPresentation.test.ts`
- [ ] Manual: open Mi plan → subscribe wizard shows /mo amount and completes checkout redirect

## Validation evidence
```
bun test utils/billingPresentation.test.ts
7 pass
0 fail
```

Made with [Cursor](https://cursor.com)