### PR TITLE
fix(billing): declutter checkout step 2 email confirmation (#2203)

### DIFF
--- a/.wr/2203.yaml
+++ b/.wr/2203.yaml
@@ -1,0 +1,34 @@
+issue: 2203
+title: "fix(billing): declutter checkout step 2 email confirmation"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2203-declutter-checkout-step2
+
+paths:
+  - pages/gestion/billing/index.vue
+
+# i18n: reuse billing.seePlanDetails / hidePlanDetails from #2201 — no new keys
+
+ac:
+  - Step 2 compact: plan · cycle · price (+ billedMonthly line)
+  - Full quota dump not shown by default (remove or Ver detalle)
+  - Email + Paddle CTA primary
+  - No 1.000.000 sentinel noise in collapsed view
+  - Subscribe flow still reaches Paddle
+
+out_of_scope:
+  - step 1 picker, API, compare matrix
+
+hints:
+  entry: "wizardStep === 2 block ~1196 in billing/index.vue"
+  pattern: "reuse seePlanDetails / hidePlanDetails from #2201; drop quotaRowsForPlan grid by default"
+  tests: "none targeted — manual AC"
+
+risk:
+  sensitive: false
+  areas: [billing-ui]
+
+skip:
+  audits: [color, typography]

--- a/pages/gestion/billing/index.vue
+++ b/pages/gestion/billing/index.vue
@@ -136,6 +136,7 @@ const PLAN_CARD_HIGHLIGHT_KEYS: BillingQuotaKey[] = [
 ]
 
 const expandedPlanDetails = ref<Record<string, boolean>>({})
+const step2ShowPlanDetails = ref(false)
 
 const quotaRowsForPlan = (plan: BillingPlan) =>
   quotaDisplayConfig
@@ -164,6 +165,12 @@ const highlightQuotaRows = (plan: BillingPlan, opts?: { includeScanLimit?: boole
   if (preferred.length > 0) return preferred.slice(0, budget)
   return rows.slice(0, budget)
 }
+
+/** Step 2 expand: skip unlimited sentinels and "not included" zeros — avoid 1.000.000 noise. */
+const checkoutDetailQuotaRows = (plan: BillingPlan) =>
+  quotaRowsForPlan(plan).filter(
+    (row) => row.limit > 0 && row.limit < BILLING_UNLIMITED_SENTINEL,
+  )
 
 const isRecommendedPlan = (plan: BillingPlan) => plan.slug === PRO_PLAN_SLUG
 
@@ -403,6 +410,7 @@ const selectPlan = (plan: BillingPlan) => {
   }
   selectedPlan.value = plan
   subscribeError.value = null
+  step2ShowPlanDetails.value = false
   wizardStep.value = 2
 }
 
@@ -1204,8 +1212,8 @@ watch(() => currentTenant.value?.id, async () => {
               <p class="text-sm text-text-secondary">{{ t('billing.emailReceiptHint') }}</p>
             </div>
 
-            <!-- Plan summary -->
-            <div class="bg-surface-secondary rounded-xl p-4">
+            <!-- Plan summary (compact — quotas behind optional detail, #2203) -->
+            <div class="bg-surface-secondary rounded-xl p-4 space-y-3">
               <div class="flex justify-between items-center gap-4">
                 <div>
                   <p class="text-sm font-semibold text-text-primary">{{ selectedPlan.name }} · {{ t('billing.monthly') }}</p>
@@ -1215,9 +1223,24 @@ watch(() => currentTenant.value?.id, async () => {
                   {{ offerMonthlyLabel }}
                 </p>
               </div>
-              <div v-if="quotaRowsForPlan(selectedPlan).length > 0" class="mt-4 pt-4 border-t border-border grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2">
+              <button
+                v-if="checkoutDetailQuotaRows(selectedPlan).length > 0"
+                type="button"
+                class="text-xs font-medium text-primary hover:underline"
+                @click="step2ShowPlanDetails = !step2ShowPlanDetails"
+              >
+                {{
+                  step2ShowPlanDetails
+                    ? t('billing.hidePlanDetails')
+                    : t('billing.seePlanDetails')
+                }}
+              </button>
+              <div
+                v-if="step2ShowPlanDetails"
+                class="pt-3 border-t border-border grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2"
+              >
                 <div
-                  v-for="quota in quotaRowsForPlan(selectedPlan)"
+                  v-for="quota in checkoutDetailQuotaRows(selectedPlan)"
                   :key="quota.key"
                   class="text-xs text-text-secondary"
                 >


### PR DESCRIPTION
## Summary
- Step 2 shows compact plan · monthly · price only by default
- Quotas behind “Ver detalle”, filtering out unlimited (1.000.000) noise
- Email + Paddle CTA remain the focus

Closes #2203

## Test plan
- [ ] Open subscribe → choose Pro → step 2 has no quota wall
- [ ] “Ver detalle” shows finite quotas only
- [ ] Pay with Paddle still works

## Validation evidence
```
# Front: no targeted unit test for this wizard step (manual AC per .wr/2203.yaml)
# Visual/flow check: step 2 no longer renders quotaRowsForPlan by default
```

## wr-context
See `.wr/2203.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)