### PR TITLE
feat(billing): inline Paddle checkout on confirmacion (#2209)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ NODE_BUILD_MAX_OLD_SPACE_SIZE=6144
 
 # Google Tag Manager
 NUXT_PUBLIC_GTM_CONTAINER_ID="GTM-XXXXXXX"
+
+# Paddle.js (Billing checkout on /billing/confirmacion)
+NUXT_PUBLIC_PADDLE_CLIENT_TOKEN=
+NUXT_PUBLIC_PADDLE_ENVIRONMENT=sandbox

--- a/composables/usePaddleCheckout.ts
+++ b/composables/usePaddleCheckout.ts
@@ -41,6 +41,7 @@ declare global {
 
 let scriptPromise: Promise<void> | null = null
 let initializedToken: string | null = null
+let activeEventHandler: ((event: PaddleEvent) => void) | null = null
 
 function loadPaddleScript (): Promise<void> {
   if (!import.meta.client) return Promise.resolve()
@@ -95,7 +96,7 @@ export function usePaddleCheckout () {
     return raw === 'production' || raw === 'live' ? 'production' : 'sandbox'
   })
 
-  async function ensureInitialized (eventCallback?: (event: PaddleEvent) => void) {
+  async function ensureInitialized () {
     const token = clientToken.value
     if (!token) {
       throw new Error('missing_paddle_client_token')
@@ -110,7 +111,9 @@ export function usePaddleCheckout () {
       }
       paddle.Initialize({
         token,
-        eventCallback,
+        eventCallback: (event) => {
+          activeEventHandler?.(event)
+        },
       })
       initializedToken = token
     }
@@ -138,9 +141,10 @@ export function usePaddleCheckout () {
     }
 
     const displayMode = options?.displayMode || 'inline'
+    // Paddle.js frameTarget is a CSS class name (not an element id).
     const frameTarget = options?.frameTarget || PADDLE_INLINE_FRAME_ID
 
-    const paddle = await ensureInitialized((event) => {
+    activeEventHandler = (event) => {
       const name = event.name || event.type || ''
       if (name === 'checkout.completed') {
         markPaddleTransactionDone(transactionId)
@@ -151,7 +155,9 @@ export function usePaddleCheckout () {
         const detail = String(event.data?.error || event.data?.message || name)
         handlers?.onError?.(detail)
       }
-    })
+    }
+
+    const paddle = await ensureInitialized()
 
     const settings: PaddleCheckoutOpenOptions['settings'] = {
       displayMode,

--- a/composables/usePaddleCheckout.ts
+++ b/composables/usePaddleCheckout.ts
@@ -1,0 +1,180 @@
+/**
+ * Paddle.js Billing checkout helper (#2209).
+ * Opens an existing transaction via ?_ptxn= / Checkout.open({ transactionId }).
+ * Default display mode is inline (full page), not overlay.
+ */
+const PADDLE_JS_SRC = 'https://cdn.paddle.com/paddle/v2/paddle.js'
+const DONE_KEY_PREFIX = 'waro_paddle_txn_done:'
+export const PADDLE_INLINE_FRAME_ID = 'waro-paddle-checkout-frame'
+
+type PaddleEvent = {
+  name?: string
+  type?: string
+  data?: Record<string, unknown>
+}
+
+type PaddleCheckoutOpenOptions = {
+  transactionId: string
+  settings?: {
+    displayMode?: 'overlay' | 'inline'
+    theme?: 'light' | 'dark'
+    frameTarget?: string
+    frameInitialHeight?: string | number
+    frameStyle?: string
+  }
+}
+
+type PaddleApi = {
+  Environment: { set: (env: 'sandbox' | 'production') => void }
+  Initialize: (opts: {
+    token: string
+    eventCallback?: (event: PaddleEvent) => void
+  }) => void
+  Checkout: { open: (opts: PaddleCheckoutOpenOptions) => void }
+}
+
+declare global {
+  interface Window {
+    Paddle?: PaddleApi
+  }
+}
+
+let scriptPromise: Promise<void> | null = null
+let initializedToken: string | null = null
+
+function loadPaddleScript (): Promise<void> {
+  if (!import.meta.client) return Promise.resolve()
+  if (window.Paddle) return Promise.resolve()
+  if (scriptPromise) return scriptPromise
+  scriptPromise = new Promise((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(`script[src="${PADDLE_JS_SRC}"]`)
+    if (existing) {
+      existing.addEventListener('load', () => resolve())
+      existing.addEventListener('error', () => reject(new Error('Paddle.js failed to load')))
+      if (window.Paddle) resolve()
+      return
+    }
+    const script = document.createElement('script')
+    script.src = PADDLE_JS_SRC
+    script.async = true
+    script.onload = () => resolve()
+    script.onerror = () => reject(new Error('Paddle.js failed to load'))
+    document.head.appendChild(script)
+  })
+  return scriptPromise
+}
+
+function txnDoneKey (transactionId: string) {
+  return `${DONE_KEY_PREFIX}${transactionId}`
+}
+
+export function isPaddleTransactionMarkedDone (transactionId: string): boolean {
+  if (!import.meta.client) return false
+  try {
+    return sessionStorage.getItem(txnDoneKey(transactionId)) === '1'
+  } catch {
+    return false
+  }
+}
+
+export function markPaddleTransactionDone (transactionId: string) {
+  if (!import.meta.client) return
+  try {
+    sessionStorage.setItem(txnDoneKey(transactionId), '1')
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
+export function usePaddleCheckout () {
+  const config = useRuntimeConfig()
+
+  const clientToken = computed(() => String(config.public.paddleClientToken || '').trim())
+  const paddleEnv = computed(() => {
+    const raw = String(config.public.paddleEnvironment || 'sandbox').trim().toLowerCase()
+    return raw === 'production' || raw === 'live' ? 'production' : 'sandbox'
+  })
+
+  async function ensureInitialized (eventCallback?: (event: PaddleEvent) => void) {
+    const token = clientToken.value
+    if (!token) {
+      throw new Error('missing_paddle_client_token')
+    }
+    await loadPaddleScript()
+    const paddle = window.Paddle
+    if (!paddle) throw new Error('paddle_js_unavailable')
+
+    if (initializedToken !== token) {
+      if (paddleEnv.value === 'sandbox') {
+        paddle.Environment.set('sandbox')
+      }
+      paddle.Initialize({
+        token,
+        eventCallback,
+      })
+      initializedToken = token
+    }
+    return paddle
+  }
+
+  async function openTransactionCheckout (
+    transactionId: string,
+    handlers?: {
+      onCompleted?: () => void
+      onClosed?: () => void
+      onError?: (message: string) => void
+    },
+    options?: {
+      displayMode?: 'overlay' | 'inline'
+      frameTarget?: string
+    },
+  ) {
+    if (!transactionId.startsWith('txn_')) {
+      throw new Error('invalid_paddle_transaction_id')
+    }
+    if (isPaddleTransactionMarkedDone(transactionId)) {
+      handlers?.onCompleted?.()
+      return { opened: false as const, reason: 'already_done' as const }
+    }
+
+    const displayMode = options?.displayMode || 'inline'
+    const frameTarget = options?.frameTarget || PADDLE_INLINE_FRAME_ID
+
+    const paddle = await ensureInitialized((event) => {
+      const name = event.name || event.type || ''
+      if (name === 'checkout.completed') {
+        markPaddleTransactionDone(transactionId)
+        handlers?.onCompleted?.()
+      } else if (name === 'checkout.closed') {
+        handlers?.onClosed?.()
+      } else if (name === 'checkout.error' || name === 'checkout.warning') {
+        const detail = String(event.data?.error || event.data?.message || name)
+        handlers?.onError?.(detail)
+      }
+    })
+
+    const settings: PaddleCheckoutOpenOptions['settings'] = {
+      displayMode,
+      theme: 'light',
+    }
+    if (displayMode === 'inline') {
+      settings.frameTarget = frameTarget
+      settings.frameInitialHeight = 520
+      settings.frameStyle = 'width: 100%; min-width: 286px; background-color: transparent; border: none;'
+    }
+
+    paddle.Checkout.open({
+      transactionId,
+      settings,
+    })
+    return { opened: true as const, reason: 'opened' as const }
+  }
+
+  return {
+    clientToken,
+    paddleEnv,
+    openTransactionCheckout,
+    isPaddleTransactionMarkedDone,
+    markPaddleTransactionDone,
+  }
+}

--- a/i18n/locales/en/shell.json
+++ b/i18n/locales/en/shell.json
@@ -443,7 +443,6 @@
     "monthlySubscription": "Monthly subscription · Billed every month",
     "perMonth": "/ month",
     "billedMonthly": "Recurring charge · Renews monthly",
-    "continuePaddleCheckout": "Continue Paddle checkout",
     "paddleCheckoutPendingDescription": "Complete payment in the form below. When it finishes, we will update your plan automatically.",
     "paddleTokenMissing": "Paddle client token is missing (NUXT_PUBLIC_PADDLE_CLIENT_TOKEN).",
     "paddleCheckoutOpenError": "Could not open Paddle checkout. Please try again.",

--- a/i18n/locales/en/shell.json
+++ b/i18n/locales/en/shell.json
@@ -442,7 +442,12 @@
     "openPaymentLink": "Open payment link",
     "monthlySubscription": "Monthly subscription · Billed every month",
     "perMonth": "/ month",
-    "billedMonthly": "Recurring charge · Renews monthly"
+    "billedMonthly": "Recurring charge · Renews monthly",
+    "continuePaddleCheckout": "Continue Paddle checkout",
+    "paddleCheckoutPendingDescription": "Complete payment in the form below. When it finishes, we will update your plan automatically.",
+    "paddleTokenMissing": "Paddle client token is missing (NUXT_PUBLIC_PADDLE_CLIENT_TOKEN).",
+    "paddleCheckoutOpenError": "Could not open Paddle checkout. Please try again.",
+    "backToBilling": "Back to My Plan"
   },
   "terms": {
     "title": "Terms and Conditions",

--- a/i18n/locales/es/shell.json
+++ b/i18n/locales/es/shell.json
@@ -443,7 +443,6 @@
     "monthlySubscription": "Suscripción mensual · Cobro cada mes",
     "perMonth": "/ mes",
     "billedMonthly": "Cobro recurrente · Renovación mensual",
-    "continuePaddleCheckout": "Continuar pago con Paddle",
     "paddleCheckoutPendingDescription": "Completa el pago en el formulario de abajo. Cuando termine, actualizaremos tu plan automáticamente.",
     "paddleTokenMissing": "Falta configurar el token de Paddle (NUXT_PUBLIC_PADDLE_CLIENT_TOKEN).",
     "paddleCheckoutOpenError": "No se pudo abrir el checkout de Paddle. Intenta de nuevo.",

--- a/i18n/locales/es/shell.json
+++ b/i18n/locales/es/shell.json
@@ -442,7 +442,12 @@
     "openPaymentLink": "Abrir enlace de pago",
     "monthlySubscription": "Suscripción mensual · Cobro cada mes",
     "perMonth": "/ mes",
-    "billedMonthly": "Cobro recurrente · Renovación mensual"
+    "billedMonthly": "Cobro recurrente · Renovación mensual",
+    "continuePaddleCheckout": "Continuar pago con Paddle",
+    "paddleCheckoutPendingDescription": "Completa el pago en el formulario de abajo. Cuando termine, actualizaremos tu plan automáticamente.",
+    "paddleTokenMissing": "Falta configurar el token de Paddle (NUXT_PUBLIC_PADDLE_CLIENT_TOKEN).",
+    "paddleCheckoutOpenError": "No se pudo abrir el checkout de Paddle. Intenta de nuevo.",
+    "backToBilling": "Volver a Mi Plan"
   },
   "terms": {
     "title": "Términos y Condiciones",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -184,7 +184,10 @@ export default defineNuxtConfig({
       instagramUrl: process.env.NUXT_PUBLIC_INSTAGRAM_URL || '',
       schemaDescription: process.env.NUXT_PUBLIC_SCHEMA_DESCRIPTION || '',
       // Google Tag Manager
-      gtmContainerId: process.env.NUXT_PUBLIC_GTM_CONTAINER_ID || ''
+      gtmContainerId: process.env.NUXT_PUBLIC_GTM_CONTAINER_ID || '',
+      // Paddle.js Billing (#2209) — client-side token only (test_… / live_…)
+      paddleClientToken: process.env.NUXT_PUBLIC_PADDLE_CLIENT_TOKEN || '',
+      paddleEnvironment: process.env.NUXT_PUBLIC_PADDLE_ENVIRONMENT || 'sandbox',
     }
   },
   app: {

--- a/pages/billing/confirmacion.vue
+++ b/pages/billing/confirmacion.vue
@@ -16,8 +16,7 @@
       <p v-if="errorMessage" class="mt-3 text-sm text-status-danger-text" role="alert">{{ errorMessage }}</p>
     </div>
     <div
-      :id="PADDLE_INLINE_FRAME_ID"
-      class="min-h-[520px] w-full rounded-xl border border-border bg-surface p-2 sm:p-4"
+      :class="[PADDLE_INLINE_FRAME_ID, 'min-h-[520px] w-full rounded-xl border border-border bg-surface p-2 sm:p-4']"
       aria-live="polite"
     />
     <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-center">

--- a/pages/billing/confirmacion.vue
+++ b/pages/billing/confirmacion.vue
@@ -3,6 +3,41 @@
     <CommonsTheCustomLoader size="large" />
   </div>
 
+  <!-- Inline Paddle pay surface (#2209) — full page, not overlay modal -->
+  <div
+    v-else-if="showInlineCheckout"
+    class="mx-auto w-full max-w-3xl px-4 py-8 sm:px-6"
+  >
+    <div class="mb-6 text-center">
+      <h1 class="text-2xl font-bold text-text-primary">{{ t('onboarding.paymentPendingTitle') }}</h1>
+      <p class="mt-2 text-sm leading-6 text-text-secondary">
+        {{ t('billing.paddleCheckoutPendingDescription') }}
+      </p>
+      <p v-if="errorMessage" class="mt-3 text-sm text-status-danger-text" role="alert">{{ errorMessage }}</p>
+    </div>
+    <div
+      :id="PADDLE_INLINE_FRAME_ID"
+      class="min-h-[520px] w-full rounded-xl border border-border bg-surface p-2 sm:p-4"
+      aria-live="polite"
+    />
+    <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-center">
+      <button
+        v-if="isOnboardingReturn"
+        type="button"
+        class="min-h-11 rounded-md border border-border px-5 py-2 text-sm font-semibold text-text-primary"
+        @click="checkReturn"
+      >
+        {{ t('onboarding.paymentRefresh') }}
+      </button>
+      <NuxtLink
+        to="/gestion/billing"
+        class="inline-flex min-h-11 items-center justify-center rounded-md border border-border px-5 py-2 text-sm font-semibold text-text-primary"
+      >
+        {{ t('billing.backToBilling') }}
+      </NuxtLink>
+    </div>
+  </div>
+
   <div v-else class="mx-auto flex min-h-[420px] max-w-lg items-center justify-center">
     <div class="w-full rounded-xl border border-border bg-surface p-6 text-center shadow-sm sm:p-8">
       <component :is="icon" class="mx-auto h-14 w-14" :class="iconClass" aria-hidden="true" />
@@ -14,7 +49,7 @@
         <button
           v-if="isOnboardingReturn && view !== 'failed'"
           type="button"
-          class="min-h-11 rounded-md bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground"
+          class="min-h-11 rounded-md border border-border px-5 py-2 text-sm font-semibold text-text-primary"
           @click="checkReturn"
         >
           {{ t('onboarding.paymentRefresh') }}
@@ -48,6 +83,11 @@ import {
   writeCheckoutContext,
   type OnboardingCheckoutContext,
 } from '~/utils/onboardingPayment'
+import {
+  isPaddleTransactionMarkedDone,
+  PADDLE_INLINE_FRAME_ID,
+  usePaddleCheckout,
+} from '~/composables/usePaddleCheckout'
 
 // The API remains the auth boundary. This meta only lets pending sessions reach
 // the payment return page (Paddle / legacy Wompi) without weakening operational guards.
@@ -62,12 +102,26 @@ const tenantsStore = useTenantsStore()
 const accessStore = useAccessStore()
 const cache = useQueryCache()
 const { loadStatus, loadPaymentStatus } = useOnboarding()
+const { openTransactionCheckout, clientToken } = usePaddleCheckout()
 
 const view = ref<ReturnView>('loading')
 const errorMessage = ref('')
 const isOnboardingReturn = ref(false)
 const checkoutContext = ref<OnboardingCheckoutContext | null>(null)
 const returnAttemptId = ref<string | null>(null)
+const paddleTxnId = ref<string | null>(null)
+const openingCheckout = ref(false)
+const paddleCheckoutDone = ref(false)
+const inlineCheckoutMounted = ref(false)
+
+const showInlineCheckout = computed(() =>
+  Boolean(
+    paddleTxnId.value
+    && !paddleCheckoutDone.value
+    && inlineCheckoutMounted.value
+    && (view.value === 'pending' || view.value === 'failed' || view.value === 'unknown'),
+  ),
+)
 
 const icon = computed(() => view.value === 'approved'
   ? CheckCircleIcon
@@ -85,10 +139,19 @@ const title = computed(() => view.value === 'approved'
 const description = computed(() => view.value === 'approved'
   ? t('onboarding.paymentApprovedDescription')
   : view.value === 'pending'
-    ? t('onboarding.paymentPendingDescription')
+    ? (paddleTxnId.value
+        ? t('billing.paddleCheckoutPendingDescription')
+        : t('onboarding.paymentPendingDescription'))
     : view.value === 'failed'
       ? t('onboarding.paymentFailedDescription')
       : t('onboarding.paymentUnknownDescription'))
+
+const readPaddleTxnFromRoute = () => {
+  const paddleTxn = typeof route.query.paddle_txn === 'string'
+    ? route.query.paddle_txn
+    : (typeof route.query._ptxn === 'string' ? route.query._ptxn : null)
+  return paddleTxn && paddleTxn.startsWith('txn_') ? paddleTxn : null
+}
 
 const refreshActivatedSession = async () => {
   const session = await authStore.refreshSession()
@@ -99,9 +162,65 @@ const refreshActivatedSession = async () => {
   return true
 }
 
+const openPaddleInline = async () => {
+  const txn = paddleTxnId.value
+  if (!txn || !import.meta.client) return
+  if (!clientToken.value) {
+    errorMessage.value = t('billing.paddleTokenMissing')
+    view.value = 'unknown'
+    inlineCheckoutMounted.value = false
+    return
+  }
+  if (isPaddleTransactionMarkedDone(txn)) {
+    paddleCheckoutDone.value = true
+    inlineCheckoutMounted.value = false
+    view.value = 'pending'
+    await cache.invalidateQueries({ key: ['billing'] })
+    return
+  }
+  openingCheckout.value = true
+  errorMessage.value = ''
+  view.value = 'pending'
+  inlineCheckoutMounted.value = true
+  try {
+    // Wait for the frame target to exist in the DOM
+    await nextTick()
+    await openTransactionCheckout(txn, {
+      onCompleted: async () => {
+        paddleCheckoutDone.value = true
+        inlineCheckoutMounted.value = false
+        view.value = 'pending'
+        await cache.invalidateQueries({ key: ['billing'] })
+      },
+      onClosed: () => {
+        view.value = 'pending'
+      },
+      onError: (message) => {
+        errorMessage.value = message
+      },
+    }, {
+      displayMode: 'inline',
+      frameTarget: PADDLE_INLINE_FRAME_ID,
+    })
+  } catch (err: any) {
+    const code = String(err?.message || err || '')
+    errorMessage.value = code === 'missing_paddle_client_token'
+      ? t('billing.paddleTokenMissing')
+      : t('billing.paddleCheckoutOpenError')
+    view.value = 'unknown'
+    inlineCheckoutMounted.value = false
+  } finally {
+    openingCheckout.value = false
+  }
+}
+
 const checkOnboardingReturn = async () => {
   const context = checkoutContext.value
   const attemptId = returnAttemptId.value || context?.attemptId
+  if (paddleTxnId.value) {
+    await openPaddleInline()
+    return
+  }
   if (!attemptId) {
     view.value = 'unknown'
     return
@@ -132,19 +251,13 @@ const checkOnboardingReturn = async () => {
 
 const checkLegacyReturn = async () => {
   const transactionId = typeof route.query.id === 'string' ? route.query.id : null
-  const paddleTxn = typeof route.query.paddle_txn === 'string'
-    ? route.query.paddle_txn
-    : (typeof route.query._ptxn === 'string' ? route.query._ptxn : null)
 
-  // Paddle checkout return: webhook activates asynchronously — show pending.
-  if (!transactionId && paddleTxn) {
-    view.value = 'pending'
-    await cache.invalidateQueries({ key: ['billing'] })
+  if (!transactionId && paddleTxnId.value) {
+    await openPaddleInline()
     return
   }
 
   if (!transactionId) {
-    // No provider query id (common Paddle redirect) — treat as pending confirmation.
     view.value = 'pending'
     await cache.invalidateQueries({ key: ['billing'] })
     return
@@ -165,6 +278,7 @@ const checkLegacyReturn = async () => {
 const checkReturn = async () => {
   view.value = 'loading'
   errorMessage.value = ''
+  paddleTxnId.value = readPaddleTxnFromRoute()
   try {
     const session = await authStore.refreshSession()
     if (isPendingOnboardingSession(session) || isActiveOnboardingSetupSession(session)) {
@@ -176,6 +290,12 @@ const checkReturn = async () => {
     isOnboardingReturn.value = false
     await checkLegacyReturn()
   } catch (err: any) {
+    // Still open Paddle when ?_ptxn= is present — checkout does not require session.
+    if (paddleTxnId.value) {
+      isOnboardingReturn.value = false
+      await openPaddleInline()
+      return
+    }
     isOnboardingReturn.value = true
     errorMessage.value = t('onboarding.paymentSessionError')
     view.value = 'unknown'

--- a/pages/gestion/billing/index.vue
+++ b/pages/gestion/billing/index.vue
@@ -17,6 +17,7 @@ import {
   formatBillingOfferAmount,
   billingEventProviderRef,
   billingEventProviderLabelKey,
+  normalizeLocalPaddleCheckoutUrl,
 } from '~/utils/billingPresentation'
 
 interface Column {
@@ -436,7 +437,7 @@ const handleSubscribe = async () => {
       return
     }
     clearBillingIntent()
-    await navigateTo(result.checkout_url, { external: true })
+    await navigateTo(normalizeLocalPaddleCheckoutUrl(result.checkout_url), { external: true })
   } catch (err) {
     if (isTermsAcceptanceRequiredError(err)) {
       await redirectToTermsAcceptance()
@@ -459,7 +460,7 @@ const handleExistingCheckout = async (checkoutUrl?: string | null) => {
     return
   }
 
-  await navigateTo(checkoutUrl, { external: true })
+  await navigateTo(normalizeLocalPaddleCheckoutUrl(checkoutUrl), { external: true })
   checkoutRedirecting.value = false
 }
 

--- a/utils/billingPresentation.test.ts
+++ b/utils/billingPresentation.test.ts
@@ -7,6 +7,7 @@ import {
   billingOfferAnnualSavings,
   canStartBillingSubscription,
   formatBillingOfferAmount,
+  normalizeLocalPaddleCheckoutUrl,
   shouldShowBillingRecoveryAlert,
   type BillingPriceOffer,
 } from './billingPresentation.ts'
@@ -94,5 +95,18 @@ test('prefers paddle transaction id over wompi for event refs', () => {
   assert.equal(
     billingEventProviderLabelKey({ wompi_transaction_id: 'txn_w' }),
     'billing.processedByWompi',
+  )
+})
+
+test('normalizes local paddle checkout urls to http without waro-colombia prefix', () => {
+  assert.equal(
+    normalizeLocalPaddleCheckoutUrl(
+      'https://localhost:8080/waro-colombia/billing/confirmacion?_ptxn=txn_x',
+    ),
+    'http://localhost:8080/billing/confirmacion?_ptxn=txn_x',
+  )
+  assert.equal(
+    normalizeLocalPaddleCheckoutUrl('https://warocol.com/billing/confirmacion?_ptxn=txn_x'),
+    'https://warocol.com/billing/confirmacion?_ptxn=txn_x',
   )
 })

--- a/utils/billingPresentation.ts
+++ b/utils/billingPresentation.ts
@@ -63,3 +63,24 @@ export const billingEventProviderLabelKey = (metadata: Record<string, unknown> |
   if (metadata.wompi_transaction_id || metadata.provider === 'wompi') return 'billing.processedByWompi'
   return 'billing.processedByProvider'
 }
+
+/**
+ * Paddle may return https://localhost even when the default payment link is http.
+ * Local Nuxt has no TLS — force http and drop a mistaken /waro-colombia prefix (#2205).
+ */
+export function normalizeLocalPaddleCheckoutUrl (url: string): string {
+  try {
+    const parsed = new URL(url)
+    const localHost = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1'
+    if (!localHost) return url
+    parsed.protocol = 'http:'
+    if (parsed.pathname === '/waro-colombia') {
+      parsed.pathname = '/'
+    } else if (parsed.pathname.startsWith('/waro-colombia/')) {
+      parsed.pathname = parsed.pathname.slice('/waro-colombia'.length) || '/'
+    }
+    return parsed.toString()
+  } catch {
+    return url
+  }
+}


### PR DESCRIPTION
## Summary
- Outcome C (epic #2207 / #2208): transaction `_ptxn` links stay on WARO; pay with **Paddle.js inline** (not overlay, not `pay.paddle.io`).
- `/billing/confirmacion` mounts an inline checkout frame for `?_ptxn=` / `paddle_txn=`.
- Billing redirects use `normalizeLocalPaddleCheckoutUrl` (local https→http).
- **Supersedes** overlay PR #2206 / #2205.

Closes #2209  
Epic: #2207

## Test plan
- [x] `node --test utils/billingPresentation.test.ts`
- [ ] Smoke: sandbox subscribe → confirmacion shows inline form (needs `NUXT_PUBLIC_PADDLE_CLIENT_TOKEN`)
- [ ] After pay + webhook → subscription active

## Validation evidence
```
  duration_ms: 0.991916
  type: 'test'
  ...
1..8
# tests 8
# suites 0
# pass 8
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 651.22475
```

Made with [Cursor](https://cursor.com)