### PR TITLE
feat(billing): abandon pending checkout CTA (#2210)

### DIFF
--- a/composables/useBilling.ts
+++ b/composables/useBilling.ts
@@ -643,6 +643,14 @@ export const useBilling = (options: { overview?: boolean } = {}) => {
     onSettled: () => cache.invalidateQueries({ key: ['billing'] }),
   })
 
+  const abandonPendingCheckoutMutation = useMutation({
+    mutation: () =>
+      $fetch<{ status: string }>('/api/billing/subscription/abandon-checkout', {
+        method: 'POST',
+      }),
+    onSettled: () => cache.invalidateQueries({ key: ['billing'] }),
+  })
+
   // ── Derived data ──────────────────────────────────────────────────────────────
   const usageHistory = computed<ScanMonthlyEntry[]>(() => usageHistoryData.value ?? [])
   const events = computed<BillingEvent[]>(() => eventsData.value?.events ?? [])
@@ -756,6 +764,15 @@ export const useBilling = (options: { overview?: boolean } = {}) => {
     }
   }
 
+  const abandonPendingCheckout = async (): Promise<boolean> => {
+    try {
+      await abandonPendingCheckoutMutation.mutateAsync()
+      return true
+    } catch {
+      return false
+    }
+  }
+
   return {
     plans,
     priceOffer,
@@ -780,5 +797,6 @@ export const useBilling = (options: { overview?: boolean } = {}) => {
     subscribe,
     subscribeOrThrow,
     cancelSubscription,
+    abandonPendingCheckout,
   }
 }

--- a/i18n/locales/en/shell.json
+++ b/i18n/locales/en/shell.json
@@ -442,7 +442,11 @@
     "openPaymentLink": "Open payment link",
     "monthlySubscription": "Monthly subscription · Billed every month",
     "perMonth": "/ month",
-    "billedMonthly": "Recurring charge · Renews monthly"
+    "billedMonthly": "Recurring charge · Renews monthly",
+    "abandonCheckout": "Cancel attempt",
+    "abandonCheckoutConfirm": "Cancel this payment attempt? You will return to the Starter plan and can choose a plan again.",
+    "abandonCheckoutError": "Could not cancel the payment attempt. Please try again.",
+    "eventCheckoutAbandoned": "Checkout abandoned"
   },
   "terms": {
     "title": "Terms and Conditions",

--- a/i18n/locales/es/shell.json
+++ b/i18n/locales/es/shell.json
@@ -442,7 +442,11 @@
     "openPaymentLink": "Abrir enlace de pago",
     "monthlySubscription": "Suscripción mensual · Cobro cada mes",
     "perMonth": "/ mes",
-    "billedMonthly": "Cobro recurrente · Renovación mensual"
+    "billedMonthly": "Cobro recurrente · Renovación mensual",
+    "abandonCheckout": "Cancelar intento",
+    "abandonCheckoutConfirm": "¿Cancelar este intento de pago? Volverás al plan Starter y podrás elegir un plan de nuevo.",
+    "abandonCheckoutError": "No se pudo cancelar el intento de pago. Intenta de nuevo.",
+    "eventCheckoutAbandoned": "Checkout abandonado"
   },
   "terms": {
     "title": "Términos y Condiciones",

--- a/pages/gestion/billing/index.vue
+++ b/pages/gestion/billing/index.vue
@@ -33,7 +33,7 @@ useHead({ title: () => t('billing.paymentHistoryTitle') })
 
 const {
   plans, priceOffer, subscription, accessStatus, events, eventsTotal, loading, isRefreshing, error,
-  fetchPlans, fetchMyEvents, fetchBillingOverview, subscribeOrThrow,
+  fetchPlans, fetchMyEvents, fetchBillingOverview, subscribeOrThrow, abandonPendingCheckout,
 } = useBilling()
 
 const { currentTenant } = useTenantReactive()
@@ -463,6 +463,30 @@ const handleExistingCheckout = async (checkoutUrl?: string | null) => {
   checkoutRedirecting.value = false
 }
 
+const abandoningCheckout = ref(false)
+const handleAbandonPendingCheckout = async () => {
+  if (!import.meta.client) return
+  const ok = window.confirm(t('billing.abandonCheckoutConfirm'))
+  if (!ok) return
+  abandoningCheckout.value = true
+  billingActionError.value = null
+  try {
+    const abandoned = await abandonPendingCheckout()
+    if (!abandoned) {
+      billingActionError.value = t('billing.abandonCheckoutError')
+      return
+    }
+    await Promise.all([
+      fetchBillingOverview(),
+      accessStore.load(),
+    ])
+  } catch {
+    billingActionError.value = t('billing.abandonCheckoutError')
+  } finally {
+    abandoningCheckout.value = false
+  }
+}
+
 // ── Should show subscribe/reactivate button ──────────────────────
 const isAccessBlocked = computed(() => accessStatus.value?.level === 'blocked')
 const hasExistingCheckout = computed(() => !!subscription.value?.checkout_url)
@@ -668,6 +692,7 @@ const pastDueAlert = computed(() => {
 const eventStyle = (type: string) => {
   const map: Record<string, { badge: string; label: string }> = {
     subscribe_initiated:    { badge: 'bg-surface-secondary text-text-secondary',        label: t('billing.eventSubscribeInitiated') },
+    checkout_abandoned:     { badge: 'bg-surface-secondary text-text-secondary',        label: t('billing.eventCheckoutAbandoned') },
     gift_granted:           { badge: 'bg-status-info-bg text-status-info-text',         label: t('billing.eventGiftGranted') },
     subscription_created:   { badge: 'bg-status-info-bg text-status-info-text',         label: t('billing.eventSubscriptionCreated') },
     subscription_renewed:   { badge: 'bg-status-success-bg text-status-success-text',   label: t('billing.eventRenewal') },
@@ -748,16 +773,28 @@ watch(() => currentTenant.value?.id, async () => {
               {{ primaryBillingActionLabel }}
             </button>
 
-            <!-- Pending: complete payment -->
-            <button
+            <!-- Pending: complete payment or abandon (#2210) -->
+            <div
               v-else-if="!showBillingRecoveryAlert && subscription?.status === 'pending' && subscription.checkout_url"
-              type="button"
-              :disabled="checkoutRedirecting"
-              @click="handleExistingCheckout(subscription.checkout_url)"
-              class="min-h-[36px] px-4 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 active:scale-95 transition-all flex items-center"
+              class="flex flex-wrap items-center gap-2"
             >
-              {{ checkoutRedirecting ? t('billing.validating') : t('billing.completePayment') }}
-            </button>
+              <button
+                type="button"
+                :disabled="checkoutRedirecting || abandoningCheckout"
+                @click="handleExistingCheckout(subscription.checkout_url)"
+                class="min-h-[36px] px-4 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 active:scale-95 transition-all flex items-center disabled:opacity-50"
+              >
+                {{ checkoutRedirecting ? t('billing.validating') : t('billing.completePayment') }}
+              </button>
+              <button
+                type="button"
+                :disabled="checkoutRedirecting || abandoningCheckout"
+                @click="handleAbandonPendingCheckout"
+                class="min-h-[36px] px-4 rounded-lg border border-border text-text-primary text-sm font-semibold hover:bg-surface-secondary active:scale-95 transition-all disabled:opacity-50"
+              >
+                {{ abandoningCheckout ? t('billing.validating') : t('billing.abandonCheckout') }}
+              </button>
+            </div>
           </div>
         </div>
 

--- a/utils/billingPresentation.test.ts
+++ b/utils/billingPresentation.test.ts
@@ -44,6 +44,17 @@ test('pending subscription without checkout can restart payment', () => {
   assert.equal(shouldShowBillingRecoveryAlert(state), false)
 })
 
+test('after abandon (no subscription) can start billing again', () => {
+  const state = {
+    subscriptionStatus: null,
+    checkoutUrl: null,
+    accessLevel: 'starter',
+  }
+
+  assert.equal(canStartBillingSubscription(state), true)
+  assert.equal(shouldShowBillingRecoveryAlert(state), false)
+})
+
 test('active subscription does not expose subscription actions', () => {
   const state = {
     subscriptionStatus: 'active',


### PR DESCRIPTION
## Summary
- “Cancelar intento” next to Completar pago on pending checkout
- Calls `POST /billing/subscription/abandon-checkout` (API companion)
- Refreshes billing + access → Starter; subscribe available again

Closes #2210  
Epic: #2207  
API companion: https://github.com/uno0uno/api-warolabs/pull/817

## Test plan
- [x] `node --test utils/billingPresentation.test.ts`
- [ ] Smoke with API #817: abandon pending → Starter → new subscribe

## Validation evidence
```
  duration_ms: 0.264083
  type: 'test'
  ...
1..8
# tests 8
# suites 0
# pass 8
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 1939.523292
```

Made with [Cursor](https://cursor.com)