### PR TITLE
fix(billing): hide expired alert while Pro checkout is pending

### DIFF
--- a/.wr/2213.yaml
+++ b/.wr/2213.yaml
@@ -1,0 +1,40 @@
+# Compact Codex plan for wr-fast #2213 (front).
+issue: 2213
+title: "Keep Starter access while first Pro checkout is pending"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2213-pending-starter-access
+
+paths:
+  - pages/gestion/billing/index.vue
+  - utils/billingPresentation.test.ts
+  - .wr/2213.yaml
+
+ac:
+  - "Mi Plan does not show subscription-expired banner for pending checkout"
+  - "pastDueAlert gated by shouldShowBillingRecoveryAlert (excludes pending)"
+  - "Completar pago / Cancelar intento still available via existing CTAs"
+  - "presentation tests cover pending + starter access"
+
+out_of_scope:
+  - abandon-checkout (#2210)
+  - inline Paddle (#2209)
+  - Hosted Checkout
+  - API access logic (companion PR)
+
+hints:
+  entry: "pastDueAlert + shouldShowBillingRecoveryAlert"
+  pattern: "utils/billingPresentation.ts:shouldShowBillingRecoveryAlert"
+  tests: "node --test utils/billingPresentation.test.ts"
+
+risk:
+  sensitive: true
+  areas: [payments, billing-ui]
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "Merge with API companion; human /wr-review recommended"

--- a/pages/gestion/billing/index.vue
+++ b/pages/gestion/billing/index.vue
@@ -658,7 +658,8 @@ const subscriptionStatusStyle = computed(() =>
 )
 
 const pastDueAlert = computed(() => {
-  if (!subscription.value || (subscription.value.status !== 'past_due' && !isBillingBlocked.value)) return null
+  // Align with shouldShowBillingRecoveryAlert: never treat pending checkout as "expired".
+  if (!subscription.value || !showBillingRecoveryAlert.value) return null
 
   if (isBillingBlocked.value) {
     return {

--- a/utils/billingPresentation.test.ts
+++ b/utils/billingPresentation.test.ts
@@ -30,7 +30,19 @@ test('pending subscription with checkout completes the existing payment', () => 
   }
 
   assert.equal(canStartBillingSubscription(state), false)
+  // First Pro checkout or renew-pending: Completar pago CTA, not expired banner (#2213)
   assert.equal(shouldShowBillingRecoveryAlert(state), false)
+})
+
+test('first Pro pending with starter access hides recovery/expired alert', () => {
+  assert.equal(
+    shouldShowBillingRecoveryAlert({
+      subscriptionStatus: 'pending',
+      checkoutUrl: 'https://checkout.example.test',
+      accessLevel: 'starter',
+    }),
+    false,
+  )
 })
 
 test('pending subscription without checkout can restart payment', () => {


### PR DESCRIPTION
## Summary
- Mi Plan no longer shows the “subscription expired” recovery banner for `pending` checkout (aligned with `shouldShowBillingRecoveryAlert`).
- Completar pago / Cancelar intento CTAs remain available.
- Companion API PR keeps Starter access during first Pro pending checkout.

Closes #2213

## Test plan
- [ ] Trial/Starter → Pro pending: no expired banner; Completar pago / Cancelar intento visible
- [ ] past_due / cancelled / expired still show recovery alert
- [ ] With API companion: POS usable during first pending

## Validation evidence
```
node --test utils/billingPresentation.test.ts
# tests 9
# pass 9
```

## wr-context
See `.wr/2213.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)