### PR TITLE
fix(billing): use UiConfirmActionModal for abandon checkout

### DIFF
--- a/.wr/2215.yaml
+++ b/.wr/2215.yaml
@@ -1,0 +1,40 @@
+# Compact Codex plan for wr-fast #2215.
+issue: 2215
+title: "Replace abandon-checkout browser confirm with UiConfirmActionModal"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2215-abandon-confirm-modal
+
+paths:
+  - pages/gestion/billing/index.vue
+  - i18n/locales/es/shell.json
+  - i18n/locales/en/shell.json
+  - .wr/2215.yaml
+
+ac:
+  - "Cancelar intento opens UiConfirmActionModal (not window.confirm)"
+  - "Confirm runs abandon flow; dismiss leaves pending unchanged"
+  - "i18n title/message/labels; loading while abandoningCheckout"
+  - "Completar pago CTAs unchanged"
+
+out_of_scope:
+  - abandon API (#2210)
+  - Paddle checkout URLs
+  - other window.confirm outside Mi Plan
+
+hints:
+  entry: "openAbandonConfirm + UiConfirmActionModal"
+  pattern: "pages/abastecimiento/proveedor/[id].vue destructive loading modal"
+  tests: "none (UI wiring; no existing billing modal unit test)"
+
+risk:
+  sensitive: false
+  areas: [billing-ui]
+
+skip:
+  audits: [color, typography]
+
+next:
+  after_pr: "ready-for-review"

--- a/i18n/locales/en/shell.json
+++ b/i18n/locales/en/shell.json
@@ -444,7 +444,8 @@
     "perMonth": "/ month",
     "billedMonthly": "Recurring charge · Renews monthly",
     "abandonCheckout": "Cancel attempt",
-    "abandonCheckoutConfirm": "Cancel this payment attempt? You will return to the Starter plan and can choose a plan again.",
+    "abandonCheckoutTitle": "Cancel payment attempt",
+    "abandonCheckoutConfirm": "You will cancel this payment attempt, return to the Starter plan, and can choose a plan again.",
     "abandonCheckoutError": "Could not cancel the payment attempt. Please try again.",
     "eventCheckoutAbandoned": "Checkout abandoned"
   },

--- a/i18n/locales/es/shell.json
+++ b/i18n/locales/es/shell.json
@@ -444,7 +444,8 @@
     "perMonth": "/ mes",
     "billedMonthly": "Cobro recurrente · Renovación mensual",
     "abandonCheckout": "Cancelar intento",
-    "abandonCheckoutConfirm": "¿Cancelar este intento de pago? Volverás al plan Starter y podrás elegir un plan de nuevo.",
+    "abandonCheckoutTitle": "Cancelar intento de pago",
+    "abandonCheckoutConfirm": "Cancelarás este intento de pago, volverás al plan Starter y podrás elegir un plan de nuevo.",
     "abandonCheckoutError": "No se pudo cancelar el intento de pago. Intenta de nuevo.",
     "eventCheckoutAbandoned": "Checkout abandonado"
   },

--- a/pages/gestion/billing/index.vue
+++ b/pages/gestion/billing/index.vue
@@ -479,6 +479,7 @@ const handleAbandonPendingCheckout = async () => {
   try {
     const abandoned = await abandonPendingCheckout()
     if (!abandoned) {
+      abandonConfirmOpen.value = false
       billingActionError.value = t('billing.abandonCheckoutError')
       return
     }
@@ -488,6 +489,7 @@ const handleAbandonPendingCheckout = async () => {
       accessStore.load(),
     ])
   } catch {
+    abandonConfirmOpen.value = false
     billingActionError.value = t('billing.abandonCheckoutError')
   } finally {
     abandoningCheckout.value = false

--- a/pages/gestion/billing/index.vue
+++ b/pages/gestion/billing/index.vue
@@ -464,10 +464,16 @@ const handleExistingCheckout = async (checkoutUrl?: string | null) => {
 }
 
 const abandoningCheckout = ref(false)
+const abandonConfirmOpen = ref(false)
+
+const openAbandonConfirm = () => {
+  if (abandoningCheckout.value) return
+  billingActionError.value = null
+  abandonConfirmOpen.value = true
+}
+
 const handleAbandonPendingCheckout = async () => {
-  if (!import.meta.client) return
-  const ok = window.confirm(t('billing.abandonCheckoutConfirm'))
-  if (!ok) return
+  if (!import.meta.client || abandoningCheckout.value) return
   abandoningCheckout.value = true
   billingActionError.value = null
   try {
@@ -476,6 +482,7 @@ const handleAbandonPendingCheckout = async () => {
       billingActionError.value = t('billing.abandonCheckoutError')
       return
     }
+    abandonConfirmOpen.value = false
     await Promise.all([
       fetchBillingOverview(),
       accessStore.load(),
@@ -790,10 +797,10 @@ watch(() => currentTenant.value?.id, async () => {
               <button
                 type="button"
                 :disabled="checkoutRedirecting || abandoningCheckout"
-                @click="handleAbandonPendingCheckout"
+                @click="openAbandonConfirm"
                 class="min-h-[36px] px-4 rounded-lg border border-border text-text-primary text-sm font-semibold hover:bg-surface-secondary active:scale-95 transition-all disabled:opacity-50"
               >
-                {{ abandoningCheckout ? t('billing.validating') : t('billing.abandonCheckout') }}
+                {{ t('billing.abandonCheckout') }}
               </button>
             </div>
           </div>
@@ -1524,6 +1531,18 @@ watch(() => currentTenant.value?.id, async () => {
       </div>
     </Transition>
     </Teleport>
+
+    <UiConfirmActionModal
+      v-model="abandonConfirmOpen"
+      :title="t('billing.abandonCheckoutTitle')"
+      :message="t('billing.abandonCheckoutConfirm')"
+      :confirm-label="t('billing.abandonCheckout')"
+      :cancel-label="t('billing.close')"
+      :loading-label="t('billing.validating')"
+      variant="destructive"
+      :loading="abandoningCheckout"
+      @confirm="handleAbandonPendingCheckout"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- Replace `window.confirm` on **Cancelar intento** with `UiConfirmActionModal` (destructive + loading).
- Add i18n title/message keys for the modal; dismiss leaves pending checkout unchanged.

Closes #2215

## Test plan
- [ ] Pending Pro checkout → Cancelar intento opens WARO modal (not native confirm)
- [ ] Confirm abandons checkout and returns to Starter
- [ ] Dismiss/Cerrar leaves pending + Completar pago intact
- [ ] Confirm button shows loading while request runs

## Validation evidence
```
rg -n "window\.confirm" pages/gestion/billing/index.vue
(none — ok)

rg -n "UiConfirmActionModal|openAbandonConfirm" pages/gestion/billing/index.vue
# modal wired + openAbandonConfirm

node -e "... i18n keys ..."
i18n keys ok

node --test utils/billingPresentation.test.ts
# tests 9
# pass 9
```

## wr-context
See `.wr/2215.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)