### PR TITLE
fix(billing): keep confirmacion open for Paddle _ptxn on setup sessions

### DIFF
--- a/.wr/2217.yaml
+++ b/.wr/2217.yaml
@@ -1,0 +1,41 @@
+# Compact Codex plan for wr-fast #2217.
+issue: 2217
+title: "Don't redirect confirmacion to Mi Plan when ?_ptxn= is present"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2217-confirmacion-ptxn-no-redirect
+
+paths:
+  - pages/billing/confirmacion.vue
+  - utils/onboardingFlow.ts
+  - utils/onboardingFlow.test.ts
+  - .wr/2217.yaml
+
+ac:
+  - "With ?_ptxn=txn_… active+setup stays on confirmacion and opens Paddle inline"
+  - "Without txn id, active+setup still redirects to Mi Plan"
+  - "Pending onboarding / no-_ptxn paths unchanged"
+  - "Unit test for shouldOpenPaddleInsteadOfSetupRedirect"
+
+out_of_scope:
+  - Paddle dashboard / https forcing
+  - normalizeLocalPaddleCheckoutUrl (#2211)
+  - abandon modal (#2215)
+  - API access (#2213)
+
+hints:
+  entry: "checkReturn before refreshActivatedSession"
+  pattern: "shouldOpenPaddleInsteadOfSetupRedirect then openPaddleInline"
+  tests: "node --test utils/onboardingFlow.test.ts"
+
+risk:
+  sensitive: false
+  areas: [billing-ui, onboarding]
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "ready-for-review"

--- a/pages/billing/confirmacion.vue
+++ b/pages/billing/confirmacion.vue
@@ -74,7 +74,7 @@
 
 <script setup lang="ts">
 import { CheckCircleIcon, ClockIcon, ExclamationTriangleIcon } from '@heroicons/vue/24/outline'
-import { isActiveOnboardingSetupSession, isPendingOnboardingSession } from '~/utils/onboardingFlow'
+import { isActiveOnboardingSetupSession, isPendingOnboardingSession, shouldOpenPaddleInsteadOfSetupRedirect } from '~/utils/onboardingFlow'
 import {
   clearCheckoutContext,
   isUuid,
@@ -282,6 +282,11 @@ const checkReturn = async () => {
     const session = await authStore.refreshSession()
     if (isPendingOnboardingSession(session) || isActiveOnboardingSetupSession(session)) {
       isOnboardingReturn.value = true
+      // Starter/setup + pending Pro checkout: open Paddle, do not bounce to Mi Plan (#2217)
+      if (shouldOpenPaddleInsteadOfSetupRedirect(paddleTxnId.value)) {
+        await openPaddleInline()
+        return
+      }
       if (isActiveOnboardingSetupSession(session) && await refreshActivatedSession()) return
       await checkOnboardingReturn()
       return

--- a/utils/onboardingFlow.test.ts
+++ b/utils/onboardingFlow.test.ts
@@ -11,6 +11,7 @@ import {
   isPendingBillingPath,
   isPendingOnboardingSession,
   normalizeOnboardingNextStep,
+  shouldOpenPaddleInsteadOfSetupRedirect,
 } from './onboardingFlow.ts'
 
 test('classifies active, pending, customer and anonymous sessions', () => {
@@ -56,6 +57,15 @@ test('allows pending sessions to stay on billing and payment return paths', () =
   assert.equal(isPendingBillingPath('/gestion/billing/uso'), true)
   assert.equal(isPendingBillingPath('/billing/confirmacion'), true)
   assert.equal(isPendingBillingPath('/ventas'), false)
+})
+
+test('open Paddle txn skips active+setup redirect to Mi Plan (#2217)', () => {
+  assert.equal(shouldOpenPaddleInsteadOfSetupRedirect('txn_01abc'), true)
+  assert.equal(shouldOpenPaddleInsteadOfSetupRedirect('txn_01kzrq05y0tqp70djn7r8n0dxw'), true)
+  assert.equal(shouldOpenPaddleInsteadOfSetupRedirect(null), false)
+  assert.equal(shouldOpenPaddleInsteadOfSetupRedirect(undefined), false)
+  assert.equal(shouldOpenPaddleInsteadOfSetupRedirect(''), false)
+  assert.equal(shouldOpenPaddleInsteadOfSetupRedirect('not-a-txn'), false)
 })
 
 test('normalizes onboarding steps safely', () => {

--- a/utils/onboardingFlow.ts
+++ b/utils/onboardingFlow.ts
@@ -47,6 +47,14 @@ export const isActiveOnboardingSetupSession = (session: unknown) =>
   && getSessionLifecycle(session) === 'active'
   && normalizeOnboardingNextStep(getSessionNextStep(session)) === 'setup'
 
+/**
+ * Payment return with an open Paddle txn must open checkout, not bounce
+ * active+setup (Starter) sessions to Mi Plan (#2217).
+ */
+export const shouldOpenPaddleInsteadOfSetupRedirect = (
+  paddleTxnId: string | null | undefined,
+) => Boolean(paddleTxnId && String(paddleTxnId).startsWith('txn_'))
+
 export const isOnboardingEntrySession = (session: unknown) =>
   isPendingOnboardingSession(session)
 


### PR DESCRIPTION
## Summary
- Starter / `active`+`setup` sessions with `?_ptxn=` open Paddle inline instead of redirecting to Mi Plan.
- Without a txn id, the existing post-activation redirect to `/gestion/billing` is unchanged.

Closes #2217

## Test plan
- [ ] Starter tenant + pending Pro → Completar pago → stay on confirmacion with inline Paddle
- [ ] Confirmacion without `_ptxn` for active+setup still goes to Mi Plan when that path applies
- [ ] Pending onboarding payment return without txn still works

## Validation evidence
```
node --test utils/onboardingFlow.test.ts
# pass (includes shouldOpenPaddleInsteadOfSetupRedirect #2217)
```

## wr-context
See `.wr/2217.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)