### PR TITLE
fix(billing): hide duplicate Mi Plan CTA on Paddle thank-you ready

### DIFF
--- a/pages/billing/confirmacion.vue
+++ b/pages/billing/confirmacion.vue
@@ -31,6 +31,7 @@
           {{ pollingStatus ? t('billing.validating') : t('billing.paddleThankYouRefresh') }}
         </button>
         <NuxtLink
+          v-if="thankYouPhase !== 'ready'"
           to="/gestion/billing"
           class="inline-flex min-h-11 items-center justify-center rounded-md border border-border px-5 py-2 text-sm font-semibold text-text-primary"
         >


### PR DESCRIPTION
## Summary
- On thank-you `ready` state, show a single primary **Volver a Mi Plan** button.
- Keep secondary Mi Plan link only while activating / timeout (with Refresh).

## Test plan
- [ ] Complete sandbox checkout → ready screen shows one Mi Plan CTA
- [ ] Activating / timeout still shows Refresh + secondary Volver a Mi Plan

## Validation evidence
```
# UI wiring only — ready CTA is exclusive; secondary gated by thankYouPhase !== 'ready'
rg -n "thankYouPhase !== 'ready'" pages/billing/confirmacion.vue
```

Made with [Cursor](https://cursor.com)