### PR TITLE
fix(auth): sanitize login errors via i18n keys

### DIFF
--- a/.wr/2225.yaml
+++ b/.wr/2225.yaml
@@ -1,0 +1,48 @@
+# Compact plan for wr-exec / wr-fast. Keep <=80 lines.
+issue: 2225
+title: "Login: sanitize errors + i18n on verification-code step"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2225-login-error-i18n
+parent_epic: uno0uno/warocol.com#2224
+
+paths:
+  - components/Auth/LoginForm.vue
+  - i18n/locales/es/shell.json
+  - i18n/locales/en/shell.json
+  - utils/authLoginErrors.ts
+  - utils/authLoginErrors.test.ts
+
+ac:
+  - Magic-link send failure never shows raw API/proxy message; uses i18n
+  - Verify-code failure never shows raw err.message; uses i18n
+  - Code-step UI stays on existing auth.* keys; EN locale shows English errors
+  - Map by status / known API message / network → magicLinkError | invalidCode | new network/rateLimit keys
+  - Keep isInternalAccessDeniedError path unchanged
+  - Unit tests for mapper; manual ES+EN login fail + bad code
+
+out_of_scope:
+  - Menu pagination (#2226)
+  - Auth email HTML templates
+  - Registration / invitation / customer-verify (unless tiny shared util is reused later)
+  - API message/code changes (front-first; no api_warocol.com PR)
+
+hints:
+  entry: "LoginForm handleSubmit catch ~261; verifyCode catch ~316"
+  pattern: "Keep getInternalAccessDeniedMessage; never assign err.data.message to UI"
+  api_messages: "Invalid or expired verification code; Failed to send magic link; Verification failed"
+  i18n_existing: "auth.magicLinkError, auth.invalidCode, auth.codeRequired, auth.authError"
+  tests: "node --test utils/authLoginErrors.test.ts"
+
+risk:
+  sensitive: true
+  areas: [auth]
+  review: false
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "/wr-next uno0uno/warocol.com#2224"

--- a/components/Auth/LoginForm.vue
+++ b/components/Auth/LoginForm.vue
@@ -149,6 +149,7 @@ import {
   getInternalAccessDeniedMessage,
   isInternalAccessDeniedError,
 } from '~/utils/internalAccess'
+import { resolveAuthLoginErrorKey } from '~/utils/authLoginErrors'
 import { isOnboardingEntrySession } from '~/utils/onboardingFlow'
 import { prefillRegistrationEmail } from '~/utils/registrationFlow'
 
@@ -258,7 +259,7 @@ async function handleSubmit() {
       showCustomerPortalLink.value = true
       error.value = getInternalAccessDeniedMessage()
     } else {
-      error.value = err?.data?.message || err?.message || t('auth.magicLinkError')
+      error.value = t(resolveAuthLoginErrorKey(err, 'magic_link'))
     }
   } finally {
     loading.value = false
@@ -313,7 +314,7 @@ async function verifyCode() {
       error.value = getInternalAccessDeniedMessage()
       return
     }
-    error.value = err.message || t('auth.invalidCode')
+    error.value = t(resolveAuthLoginErrorKey(err, 'verify_code'))
   } finally {
     verifyingCode.value = false
   }

--- a/i18n/locales/en/shell.json
+++ b/i18n/locales/en/shell.json
@@ -549,6 +549,8 @@
     "customerPortal": "Go to customer portal",
     "codeSentToast": "Code sent to your email",
     "magicLinkError": "Could not send the magic link. Please try again.",
+    "networkError": "Connection problem. Check your internet and try again.",
+    "rateLimited": "Too many attempts. Wait a moment and try again.",
     "codeRequired": "Enter a 6-digit code",
     "accessGranted": "Access granted! Redirecting...",
     "invalidCode": "Invalid or expired code",

--- a/i18n/locales/es/shell.json
+++ b/i18n/locales/es/shell.json
@@ -549,6 +549,8 @@
     "customerPortal": "Ir al portal de clientes",
     "codeSentToast": "Código enviado a tu email",
     "magicLinkError": "Error al enviar el magic link. Intenta nuevamente.",
+    "networkError": "Problema de conexión. Revisa tu internet e intenta de nuevo.",
+    "rateLimited": "Demasiados intentos. Espera un momento e intenta de nuevo.",
     "codeRequired": "Ingresa un código de 6 dígitos",
     "accessGranted": "¡Acceso autorizado! Redirigiendo...",
     "invalidCode": "Código inválido o expirado",

--- a/utils/authLoginErrors.test.ts
+++ b/utils/authLoginErrors.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  extractAuthLoginRawMessage,
+  extractAuthLoginStatus,
+  resolveAuthLoginErrorKey,
+} from './authLoginErrors.ts'
+
+test('never returns raw API message — only i18n keys', () => {
+  const key = resolveAuthLoginErrorKey(
+    { statusCode: 500, data: { message: 'psycopg2.OperationalError: connection refused at /app/db.py:42' } },
+    'magic_link',
+  )
+  assert.equal(key, 'auth.magicLinkError')
+  assert.equal(key.startsWith('auth.'), true)
+})
+
+test('maps invalid verification code API message to invalidCode', () => {
+  assert.equal(
+    resolveAuthLoginErrorKey(
+      { statusCode: 401, data: { message: 'Invalid or expired verification code' } },
+      'verify_code',
+    ),
+    'auth.invalidCode',
+  )
+})
+
+test('maps Spanish-looking code errors to invalidCode (no raw display)', () => {
+  assert.equal(
+    resolveAuthLoginErrorKey(
+      { statusCode: 400, data: { message: 'Código inválido o expirado' } },
+      'verify_code',
+    ),
+    'auth.invalidCode',
+  )
+})
+
+test('maps failed magic link send to magicLinkError', () => {
+  assert.equal(
+    resolveAuthLoginErrorKey(
+      { statusCode: 400, data: { message: 'Failed to send magic link' } },
+      'magic_link',
+    ),
+    'auth.magicLinkError',
+  )
+})
+
+test('maps 429 to rateLimited', () => {
+  assert.equal(
+    resolveAuthLoginErrorKey({ statusCode: 429, data: { message: 'Too many requests' } }, 'magic_link'),
+    'auth.rateLimited',
+  )
+})
+
+test('maps network-ish failures without status to networkError', () => {
+  assert.equal(
+    resolveAuthLoginErrorKey({ message: 'Failed to fetch' }, 'magic_link'),
+    'auth.networkError',
+  )
+  assert.equal(
+    resolveAuthLoginErrorKey({}, 'verify_code'),
+    'auth.networkError',
+  )
+})
+
+test('extractors read ofetch-shaped errors', () => {
+  const err = {
+    statusCode: 401,
+    data: { message: 'Invalid or expired verification code' },
+  }
+  assert.equal(extractAuthLoginStatus(err), 401)
+  assert.equal(extractAuthLoginRawMessage(err), 'Invalid or expired verification code')
+})

--- a/utils/authLoginErrors.ts
+++ b/utils/authLoginErrors.ts
@@ -12,18 +12,6 @@ export type AuthLoginErrorKey =
   | 'auth.rateLimited'
   | 'auth.authError'
 
-const INVALID_CODE_NEEDLES = [
-  'invalid or expired verification code',
-  'invalid or expired token',
-  'verification failed',
-  'invalid code',
-  'expired code',
-  'código inválido',
-  'codigo invalido',
-  'código expirado',
-  'codigo expirado',
-]
-
 const SEND_FAIL_NEEDLES = [
   'failed to send magic link',
   'failed to send',

--- a/utils/authLoginErrors.ts
+++ b/utils/authLoginErrors.ts
@@ -1,0 +1,136 @@
+/**
+ * Map login / verify-code fetch failures to safe auth.* i18n keys.
+ * Never return raw API `message` / `detail` for UI display (#2225).
+ */
+
+export type AuthLoginErrorKind = 'magic_link' | 'verify_code'
+
+export type AuthLoginErrorKey =
+  | 'auth.magicLinkError'
+  | 'auth.invalidCode'
+  | 'auth.networkError'
+  | 'auth.rateLimited'
+  | 'auth.authError'
+
+const INVALID_CODE_NEEDLES = [
+  'invalid or expired verification code',
+  'invalid or expired token',
+  'verification failed',
+  'invalid code',
+  'expired code',
+  'código inválido',
+  'codigo invalido',
+  'código expirado',
+  'codigo expirado',
+]
+
+const SEND_FAIL_NEEDLES = [
+  'failed to send magic link',
+  'failed to send',
+]
+
+function asRecord (input: unknown): Record<string, unknown> | null {
+  if (!input || typeof input !== 'object') return null
+  return input as Record<string, unknown>
+}
+
+function nestedData (input: unknown): Record<string, unknown> | null {
+  const root = asRecord(input)
+  if (!root) return null
+  return asRecord(root.data)
+    ?? asRecord(asRecord(root.response)?._data)
+    ?? asRecord(root)
+}
+
+export function extractAuthLoginStatus (input: unknown): number | null {
+  const root = asRecord(input)
+  if (!root) return null
+  const data = nestedData(input)
+  const candidates = [
+    root.statusCode,
+    root.status,
+    asRecord(root.response)?.status,
+    data?.status_code,
+  ]
+  for (const value of candidates) {
+    const n = Number(value)
+    if (Number.isFinite(n) && n > 0) return n
+  }
+  return null
+}
+
+export function extractAuthLoginRawMessage (input: unknown): string {
+  const root = asRecord(input)
+  const data = nestedData(input)
+  const candidates = [
+    data?.message,
+    data?.detail,
+    data?.error,
+    root?.message,
+    root?.statusMessage,
+  ]
+  for (const value of candidates) {
+    if (typeof value === 'string' && value.trim()) return value.trim()
+    if (Array.isArray(value) && value.length) {
+      // FastAPI validation detail array
+      const first = value[0]
+      if (typeof first === 'string') return first
+      const msg = asRecord(first)?.msg
+      if (typeof msg === 'string') return msg
+    }
+  }
+  return ''
+}
+
+function messageMatches (message: string, needles: string[]): boolean {
+  const lower = message.toLowerCase()
+  return needles.some((needle) => lower.includes(needle))
+}
+
+/**
+ * Resolve a user-facing i18n key for login magic-link or verify-code failures.
+ */
+export function resolveAuthLoginErrorKey (
+  input: unknown,
+  kind: AuthLoginErrorKind,
+): AuthLoginErrorKey {
+  const status = extractAuthLoginStatus(input)
+  const message = extractAuthLoginRawMessage(input)
+
+  if (status === 429 || messageMatches(message, ['rate limit', 'too many', 'demasiadas'])) {
+    return 'auth.rateLimited'
+  }
+
+  // Network / CORS / offline — ofetch often has no HTTP status
+  if (status === null) {
+    const looksFetch =
+      messageMatches(message, ['fetch', 'network', 'failed to fetch', 'load failed', 'econnrefused'])
+      || (typeof input === 'object' && input !== null && 'cause' in (input as object))
+    if (looksFetch || !message) return 'auth.networkError'
+  }
+
+  if (status !== null && status >= 500) {
+    return kind === 'verify_code' ? 'auth.invalidCode' : 'auth.magicLinkError'
+  }
+
+  if (kind === 'verify_code') {
+    if (
+      status === 400
+      || status === 401
+      || status === 404
+      || messageMatches(message, INVALID_CODE_NEEDLES)
+    ) {
+      return 'auth.invalidCode'
+    }
+    return 'auth.invalidCode'
+  }
+
+  // magic_link send
+  if (status === 400 || status === 422 || messageMatches(message, SEND_FAIL_NEEDLES)) {
+    return 'auth.magicLinkError'
+  }
+  if (status === 401 || status === 403) {
+    return 'auth.authError'
+  }
+  return 'auth.magicLinkError'
+}

--- a/utils/authLoginErrors.ts
+++ b/utils/authLoginErrors.ts
@@ -97,7 +97,7 @@ export function resolveAuthLoginErrorKey (
   const status = extractAuthLoginStatus(input)
   const message = extractAuthLoginRawMessage(input)
 
-  if (status === 429 || messageMatches(message, ['rate limit', 'too many', 'demasiadas'])) {
+  if (status === 429 || messageMatches(message, ['rate limit', 'too many', 'demasiado', 'demasiados', 'demasiadas'])) {
     return 'auth.rateLimited'
   }
 
@@ -110,18 +110,10 @@ export function resolveAuthLoginErrorKey (
   }
 
   if (status !== null && status >= 500) {
-    return kind === 'verify_code' ? 'auth.invalidCode' : 'auth.magicLinkError'
+    return kind === 'verify_code' ? 'auth.authError' : 'auth.magicLinkError'
   }
 
   if (kind === 'verify_code') {
-    if (
-      status === 400
-      || status === 401
-      || status === 404
-      || messageMatches(message, INVALID_CODE_NEEDLES)
-    ) {
-      return 'auth.invalidCode'
-    }
     return 'auth.invalidCode'
   }
 


### PR DESCRIPTION
## Summary
- Add `resolveAuthLoginErrorKey` so `/auth/login` never renders raw API/proxy messages
- Wire magic-link send and verify-code catches to i18n (`magicLinkError`, `invalidCode`, `networkError`, `rateLimited`)
- Unit tests for status/message mapping (including Spanish API strings → key only)

Closes #2225

## Validation evidence
```
ok 6 - maps network-ish failures without status to networkError
  ---
  duration_ms: 0.117834
  type: 'test'
  ...
# Subtest: extractors read ofetch-shaped errors
ok 7 - extractors read ofetch-shaped errors
  ---
  duration_ms: 0.103667
  type: 'test'
  ...
1..7
# tests 7
# suites 0
# pass 7
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 167.289584
```

## Test plan
- [ ] EN locale: force magic-link failure → English i18n, no FastAPI/SQL text
- [ ] EN locale: wrong OTP → English invalid/expired, not Spanish API leftover
- [ ] ES locale: same flows show Spanish i18n keys
- [ ] Internal-access-denied path still shows portal link

## wr-context
See `.wr/2225.yaml` on this branch (LLM contract).