### PR TITLE
feat(menu): page-size selector on list pages

### DIFF
--- a/.wr/2226.yaml
+++ b/.wr/2226.yaml
@@ -1,0 +1,48 @@
+# Compact plan for wr-exec. Keep <=80 lines.
+issue: 2226
+title: "Menu: page-size selector on productos, recetas, modificadores"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2226-menu-page-size
+parent_epic: uno0uno/warocol.com#2224
+
+paths:
+  - pages/menu/productos/index.vue
+  - pages/menu/recetas/index.vue
+  - pages/menu/modificadores/index.vue
+  - i18n/locales/es/menu.json
+  - i18n/locales/en/menu.json
+
+ac:
+  - Default itemsPerPage remains 20 on all three lists
+  - Select options 10 / 20 / 30; change resets currentPage to 1 (query key already includes limit → refetch)
+  - Page-size control visible when total > 0 (not only when total > itemsPerPage)
+  - Pagination nav can stay behind existing total > itemsPerPage gate
+  - i18n ES/EN label e.g. menu.*.rowsPerPage or shared menu.rowsPerPage
+  - No API contract change (existing limit query param)
+
+out_of_scope:
+  - Login / auth (#2225)
+  - Other modules’ pagination
+  - New design-system pagination component
+  - Persist page size in localStorage
+
+hints:
+  entry: "itemsPerPage = ref(20) — productos:~1000, recetas:~312, modificadores:~340"
+  pattern: "Inline <select> near each pagination footer; mirror local button/border styles"
+  query: "useQuery key already has limit: itemsPerPage — changing size refetches"
+  show_gate: "productos:774; recetas:124; modificadores:175 currently hide whole footer if total <= limit"
+  tests: "manual — switch 10/20/30 on each list with >20 rows; confirm page resets to 1"
+
+risk:
+  sensitive: false
+  areas: []
+  review: false
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "/wr-next uno0uno/warocol.com#2224"

--- a/i18n/locales/en/menu.json
+++ b/i18n/locales/en/menu.json
@@ -34,7 +34,8 @@
       "guardado": "Saved",
       "active": "Active",
       "inactive": "Inactive",
-      "incompatibleUnitError": "Select a compatible unit for each warehouse item."
+      "incompatibleUnitError": "Select a compatible unit for each warehouse item.",
+      "rowsPerPage": "Rows per page"
     },
     "productos": {
       "editMode": "Edit mode",

--- a/i18n/locales/es/menu.json
+++ b/i18n/locales/es/menu.json
@@ -34,7 +34,8 @@
       "guardado": "Guardado",
       "active": "Activa",
       "inactive": "Inactiva",
-      "incompatibleUnitError": "Selecciona una unidad compatible para cada artículo de bodega."
+      "incompatibleUnitError": "Selecciona una unidad compatible para cada artículo de bodega.",
+      "rowsPerPage": "Filas por página"
     },
     "productos": {
       "editMode": "Modo edición",

--- a/pages/menu/modificadores/index.vue
+++ b/pages/menu/modificadores/index.vue
@@ -172,7 +172,25 @@
       </template>
     </UiResponsiveDataView>
 
-    <div v-if="(groupsData?.total ?? 0) > itemsPerPage" class="flex items-center justify-end px-1 py-2">
+    <div
+      v-if="(groupsData?.total ?? 0) > 0"
+      class="flex flex-col gap-2 px-1 py-2 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div class="flex items-center gap-2">
+        <label for="menu-modificadores-page-size" class="text-sm text-text-secondary whitespace-nowrap">
+          {{ t('menu.common.rowsPerPage') }}
+        </label>
+        <select
+          id="menu-modificadores-page-size"
+          :value="itemsPerPage"
+          class="min-h-[36px] rounded-lg border border-border bg-surface px-2 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring"
+          @change="onItemsPerPageChange"
+        >
+          <option v-for="size in pageSizeOptions" :key="size" :value="size">{{ size }}</option>
+        </select>
+      </div>
+
+      <template v-if="(groupsData?.total ?? 0) > itemsPerPage">
       <div class="flex flex-1 justify-between sm:hidden">
         <button
           @click="previousPage"
@@ -193,7 +211,7 @@
           {{ t('menu.modificadores.next') }}
         </button>
       </div>
-      <div class="hidden sm:flex sm:flex-1 sm:items-center sm:justify-end">
+      <div class="hidden sm:flex sm:items-center sm:justify-end">
           <nav class="relative z-0 inline-flex items-center gap-1" :aria-label="t('menu.modificadores.pagination')">
             <button
               @click="previousPage"
@@ -222,6 +240,7 @@
             </button>
           </nav>
       </div>
+      </template>
     </div>
 
     <!-- Detalles expandidos (solo desktop) -->
@@ -338,6 +357,14 @@ const {
 
 const currentPage = ref(1)
 const itemsPerPage = ref(20)
+const pageSizeOptions = [10, 20, 30] as const
+
+const onItemsPerPageChange = (event: Event) => {
+  const next = Number((event.target as HTMLSelectElement).value)
+  if (!(pageSizeOptions as readonly number[]).includes(next)) return
+  itemsPerPage.value = next
+  currentPage.value = 1
+}
 const expandedRows = ref(new Set())
 const requiredFilter = ref<'required' | 'optional' | ''>('')
 const requiredHeaderOptions = computed(() => [

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -770,8 +770,26 @@
           </template>
         </UiResponsiveDataView>
 
-        <!-- Pagination -->
-        <div v-if="productsData.total > itemsPerPage" class="mt-4 bg-white px-4 py-3 flex items-center justify-between border border-titan-200 rounded-lg">
+        <!-- Pagination + page size (#2226) -->
+        <div
+          v-if="productsData.total > 0"
+          class="mt-4 bg-white px-4 py-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between border border-titan-200 rounded-lg"
+        >
+          <div class="flex items-center gap-2">
+            <label for="menu-productos-page-size" class="text-sm text-titan-700 whitespace-nowrap">
+              {{ t('menu.common.rowsPerPage') }}
+            </label>
+            <select
+              id="menu-productos-page-size"
+              :value="itemsPerPage"
+              class="min-h-[36px] rounded-md border border-titan-200 bg-white px-2 text-sm text-titan-700 focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring"
+              @change="onItemsPerPageChange"
+            >
+              <option v-for="size in pageSizeOptions" :key="size" :value="size">{{ size }}</option>
+            </select>
+          </div>
+
+          <template v-if="productsData.total > itemsPerPage">
           <div class="flex-1 flex justify-between sm:hidden">
             <button
               @click="previousPage"
@@ -792,7 +810,7 @@
               {{ t('common.next') }}
             </button>
           </div>
-          <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+          <div class="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between sm:gap-4">
             <div>
               <p class="text-sm text-titan-700">
                 {{ t('menu.productos.showingProducts', { start: startItem, end: endItem, total: productsData.total }) }}
@@ -839,6 +857,7 @@
               </nav>
             </div>
           </div>
+          </template>
         </div>
       </div>
     </div>
@@ -998,6 +1017,14 @@ let syncingProductTypeRoute = false
 
 const currentPage = ref(1)
 const itemsPerPage = ref(20)
+const pageSizeOptions = [10, 20, 30] as const
+
+const onItemsPerPageChange = (event: Event) => {
+  const next = Number((event.target as HTMLSelectElement).value)
+  if (!(pageSizeOptions as readonly number[]).includes(next)) return
+  itemsPerPage.value = next
+  currentPage.value = 1
+}
 
 const productTypeHeaderFilter = computed({
   get: () => (normalizeProductTypeFilter(productTypeFilter.value) === 'all' ? '' : productTypeFilter.value),

--- a/pages/menu/recetas/index.vue
+++ b/pages/menu/recetas/index.vue
@@ -120,8 +120,26 @@
           </template>
         </UiResponsiveDataView>
 
-        <!-- Pagination -->
-        <div v-if="productsData.total > itemsPerPage" class="flex items-center justify-end px-1 py-2">
+        <!-- Pagination + page size (#2226) -->
+        <div
+          v-if="productsData.total > 0"
+          class="flex flex-col gap-2 px-1 py-2 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div class="flex items-center gap-2">
+            <label for="menu-recetas-page-size" class="text-sm text-text-secondary whitespace-nowrap">
+              {{ t('menu.common.rowsPerPage') }}
+            </label>
+            <select
+              id="menu-recetas-page-size"
+              :value="itemsPerPage"
+              class="min-h-[36px] rounded-lg border border-border bg-surface px-2 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring"
+              @change="onItemsPerPageChange"
+            >
+              <option v-for="size in pageSizeOptions" :key="size" :value="size">{{ size }}</option>
+            </select>
+          </div>
+
+          <template v-if="productsData.total > itemsPerPage">
           <div class="flex flex-1 justify-between sm:hidden">
             <button
               @click="previousPage"
@@ -142,7 +160,7 @@
               {{ t('menu.recetas.next') }}
             </button>
           </div>
-          <div class="hidden sm:flex sm:flex-1 sm:items-center sm:justify-end">
+          <div class="hidden sm:flex sm:items-center sm:justify-end">
               <nav class="relative z-0 inline-flex items-center gap-1" aria-label="Pagination">
                 <button
                   @click="previousPage"
@@ -171,6 +189,7 @@
                 </button>
               </nav>
           </div>
+          </template>
         </div>
 
         <!-- Detalles expandidos (solo desktop) -->
@@ -310,6 +329,14 @@ const {
 
 const currentPage = ref(1)
 const itemsPerPage = ref(20)
+const pageSizeOptions = [10, 20, 30] as const
+
+const onItemsPerPageChange = (event: Event) => {
+  const next = Number((event.target as HTMLSelectElement).value)
+  if (!(pageSizeOptions as readonly number[]).includes(next)) return
+  itemsPerPage.value = next
+  currentPage.value = 1
+}
 const expandedRows = ref(new Set())
 const statusFilter = ref<'active' | 'inactive' | ''>('')
 const statusHeaderOptions = [


### PR DESCRIPTION
## Summary
- Add 10/20/30 page-size select on menu productos, recetas, and modificadores (default 20)
- Changing size resets to page 1; existing query `limit` refetches
- Show control when `total > 0`; pagination nav still when `total > itemsPerPage`
- i18n ES/EN `menu.common.rowsPerPage`

Closes #2226

## Validation evidence
```
OK
- es rowsPerPage='Filas por página'
- en rowsPerPage='Rows per page'
- productos: page-size selector + default 20 OK
- recetas: page-size selector + default 20 OK
- modificadores: page-size selector + default 20 OK
```

## Test plan
- [ ] Productos: switch 10/20/30 with >20 rows; page resets to 1
- [ ] Recetas: same
- [ ] Modificadores: same
- [ ] Lists with ≤20 rows still show the page-size control

## wr-context
See `.wr/2226.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)