### PR TITLE
fix(menu): page-size select and venta libre status overflow

### DIFF
--- a/i18n/locales/en/menu.json
+++ b/i18n/locales/en/menu.json
@@ -76,6 +76,7 @@
       "notApplicable": "Not applicable",
       "noMargin": "No margin",
       "customizeOpenSale": "Enable or disable open sale in Operations → Customize",
+      "openSaleStatusShort": "Customize",
       "editProduct": "Edit product",
       "pagination": "Pagination",
       "showingProducts": "Showing {start} to {end} of {total} products",

--- a/i18n/locales/es/menu.json
+++ b/i18n/locales/es/menu.json
@@ -76,6 +76,7 @@
       "notApplicable": "No aplica",
       "noMargin": "Sin margen",
       "customizeOpenSale": "Activa o desactiva venta libre en Operaciones → Personalizar",
+      "openSaleStatusShort": "Personalizar",
       "editProduct": "Editar producto",
       "pagination": "Paginación",
       "showingProducts": "Mostrando {start} a {end} de {total} productos",

--- a/pages/menu/modificadores/index.vue
+++ b/pages/menu/modificadores/index.vue
@@ -184,19 +184,21 @@
           <select
             id="menu-modificadores-page-size"
             :value="itemsPerPage"
-            class="min-h-[36px] min-w-[4.75rem] appearance-none rounded-lg border border-border bg-surface ps-2.5 pe-8 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring cursor-pointer [&::-ms-expand]:hidden"
+            class="min-h-[36px] min-w-[4.75rem] appearance-none bg-none rounded-lg border border-border bg-surface ps-2.5 pe-8 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring cursor-pointer [&::-ms-expand]:hidden"
+            style="-webkit-appearance: none; -moz-appearance: none; appearance: none; background-image: none;"
             @change="onItemsPerPageChange"
           >
             <option v-for="size in pageSizeOptions" :key="size" :value="size">{{ size }}</option>
           </select>
           <svg
-            class="pointer-events-none absolute end-2 top-1/2 h-4 w-4 -translate-y-1/2 text-text-secondary"
+            class="pointer-events-none absolute end-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-text-secondary"
             fill="none"
             stroke="currentColor"
+            stroke-width="2"
             viewBox="0 0 24 24"
             aria-hidden="true"
           >
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
           </svg>
         </div>
       </div>

--- a/pages/menu/modificadores/index.vue
+++ b/pages/menu/modificadores/index.vue
@@ -176,18 +176,29 @@
       v-if="(groupsData?.total ?? 0) > 0"
       class="flex flex-col gap-2 px-1 py-2 sm:flex-row sm:items-center sm:justify-between"
     >
-      <div class="flex items-center gap-2">
+      <div class="relative flex items-center gap-2">
         <label for="menu-modificadores-page-size" class="text-sm text-text-secondary whitespace-nowrap">
           {{ t('menu.common.rowsPerPage') }}
         </label>
-        <select
-          id="menu-modificadores-page-size"
-          :value="itemsPerPage"
-          class="min-h-[36px] rounded-lg border border-border bg-surface px-2 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring"
-          @change="onItemsPerPageChange"
-        >
-          <option v-for="size in pageSizeOptions" :key="size" :value="size">{{ size }}</option>
-        </select>
+        <div class="relative">
+          <select
+            id="menu-modificadores-page-size"
+            :value="itemsPerPage"
+            class="min-h-[36px] min-w-[4.75rem] appearance-none rounded-lg border border-border bg-surface ps-2.5 pe-8 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring cursor-pointer [&::-ms-expand]:hidden"
+            @change="onItemsPerPageChange"
+          >
+            <option v-for="size in pageSizeOptions" :key="size" :value="size">{{ size }}</option>
+          </select>
+          <svg
+            class="pointer-events-none absolute end-2 top-1/2 h-4 w-4 -translate-y-1/2 text-text-secondary"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </div>
       </div>
 
       <template v-if="(groupsData?.total ?? 0) > itemsPerPage">

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -403,11 +403,12 @@
                 />
                 <UiStatusBadge
                   v-if="isOpenSaleShell(item)"
-                  :value="t('menu.productos.customizeOpenSale')"
+                  :value="t('menu.productos.openSaleStatusShort')"
                   :title="t('menu.productos.customizeOpenSale')"
                   format="text"
                   variant="secondary"
                   size="sm"
+                  class="whitespace-nowrap"
                 />
                 <UiStatusBadge
                   v-else
@@ -603,12 +604,12 @@
             <div class="flex justify-center">
               <UiStatusBadge
                 v-if="isOpenSaleShell(item)"
-                :value="t('menu.productos.customizeOpenSale')"
+                :value="t('menu.productos.openSaleStatusShort')"
                 :title="t('menu.productos.customizeOpenSale')"
                 format="text"
                 variant="secondary"
                 size="sm"
-                class="whitespace-nowrap max-w-[7rem]"
+                class="whitespace-nowrap"
               />
               <UiStatusBadge
                 v-else
@@ -775,18 +776,29 @@
           v-if="productsData.total > 0"
           class="mt-4 bg-white px-4 py-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between border border-titan-200 rounded-lg"
         >
-          <div class="flex items-center gap-2">
+          <div class="relative flex items-center gap-2">
             <label for="menu-productos-page-size" class="text-sm text-titan-700 whitespace-nowrap">
               {{ t('menu.common.rowsPerPage') }}
             </label>
-            <select
-              id="menu-productos-page-size"
-              :value="itemsPerPage"
-              class="min-h-[36px] rounded-md border border-titan-200 bg-white px-2 text-sm text-titan-700 focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring"
-              @change="onItemsPerPageChange"
-            >
-              <option v-for="size in pageSizeOptions" :key="size" :value="size">{{ size }}</option>
-            </select>
+            <div class="relative">
+              <select
+                id="menu-productos-page-size"
+                :value="itemsPerPage"
+                class="min-h-[36px] min-w-[4.75rem] appearance-none rounded-md border border-titan-200 bg-white ps-2.5 pe-8 text-sm text-titan-700 focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring cursor-pointer [&::-ms-expand]:hidden"
+                @change="onItemsPerPageChange"
+              >
+                <option v-for="size in pageSizeOptions" :key="size" :value="size">{{ size }}</option>
+              </select>
+              <svg
+                class="pointer-events-none absolute end-2 top-1/2 h-4 w-4 -translate-y-1/2 text-titan-500"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
+            </div>
           </div>
 
           <template v-if="productsData.total > itemsPerPage">

--- a/pages/menu/productos/index.vue
+++ b/pages/menu/productos/index.vue
@@ -784,19 +784,21 @@
               <select
                 id="menu-productos-page-size"
                 :value="itemsPerPage"
-                class="min-h-[36px] min-w-[4.75rem] appearance-none rounded-md border border-titan-200 bg-white ps-2.5 pe-8 text-sm text-titan-700 focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring cursor-pointer [&::-ms-expand]:hidden"
+                class="min-h-[36px] min-w-[4.75rem] appearance-none bg-none rounded-md border border-titan-200 bg-white ps-2.5 pe-8 text-sm text-titan-700 focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring cursor-pointer [&::-ms-expand]:hidden"
+                style="-webkit-appearance: none; -moz-appearance: none; appearance: none; background-image: none;"
                 @change="onItemsPerPageChange"
               >
                 <option v-for="size in pageSizeOptions" :key="size" :value="size">{{ size }}</option>
               </select>
               <svg
-                class="pointer-events-none absolute end-2 top-1/2 h-4 w-4 -translate-y-1/2 text-titan-500"
+                class="pointer-events-none absolute end-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-titan-500"
                 fill="none"
                 stroke="currentColor"
+                stroke-width="2"
                 viewBox="0 0 24 24"
                 aria-hidden="true"
               >
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
               </svg>
             </div>
           </div>

--- a/pages/menu/recetas/index.vue
+++ b/pages/menu/recetas/index.vue
@@ -125,18 +125,29 @@
           v-if="productsData.total > 0"
           class="flex flex-col gap-2 px-1 py-2 sm:flex-row sm:items-center sm:justify-between"
         >
-          <div class="flex items-center gap-2">
+          <div class="relative flex items-center gap-2">
             <label for="menu-recetas-page-size" class="text-sm text-text-secondary whitespace-nowrap">
               {{ t('menu.common.rowsPerPage') }}
             </label>
-            <select
-              id="menu-recetas-page-size"
-              :value="itemsPerPage"
-              class="min-h-[36px] rounded-lg border border-border bg-surface px-2 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring"
-              @change="onItemsPerPageChange"
-            >
-              <option v-for="size in pageSizeOptions" :key="size" :value="size">{{ size }}</option>
-            </select>
+            <div class="relative">
+              <select
+                id="menu-recetas-page-size"
+                :value="itemsPerPage"
+                class="min-h-[36px] min-w-[4.75rem] appearance-none rounded-lg border border-border bg-surface ps-2.5 pe-8 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring cursor-pointer [&::-ms-expand]:hidden"
+                @change="onItemsPerPageChange"
+              >
+                <option v-for="size in pageSizeOptions" :key="size" :value="size">{{ size }}</option>
+              </select>
+              <svg
+                class="pointer-events-none absolute end-2 top-1/2 h-4 w-4 -translate-y-1/2 text-text-secondary"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
+            </div>
           </div>
 
           <template v-if="productsData.total > itemsPerPage">

--- a/pages/menu/recetas/index.vue
+++ b/pages/menu/recetas/index.vue
@@ -133,19 +133,21 @@
               <select
                 id="menu-recetas-page-size"
                 :value="itemsPerPage"
-                class="min-h-[36px] min-w-[4.75rem] appearance-none rounded-lg border border-border bg-surface ps-2.5 pe-8 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring cursor-pointer [&::-ms-expand]:hidden"
+                class="min-h-[36px] min-w-[4.75rem] appearance-none bg-none rounded-lg border border-border bg-surface ps-2.5 pe-8 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring cursor-pointer [&::-ms-expand]:hidden"
+                style="-webkit-appearance: none; -moz-appearance: none; appearance: none; background-image: none;"
                 @change="onItemsPerPageChange"
               >
                 <option v-for="size in pageSizeOptions" :key="size" :value="size">{{ size }}</option>
               </select>
               <svg
-                class="pointer-events-none absolute end-2 top-1/2 h-4 w-4 -translate-y-1/2 text-text-secondary"
+                class="pointer-events-none absolute end-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-text-secondary"
                 fill="none"
                 stroke="currentColor"
+                stroke-width="2"
                 viewBox="0 0 24 24"
                 aria-hidden="true"
               >
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
               </svg>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Fix garbled overlapping digits in **Filas por página** (`appearance-none`, min-width, custom chevron) on productos/recetas/modificadores
- Replace overflowing venta libre ESTADO help text with short **Personalizar** badge (full hint in `title`); gear in Acciones unchanged

## Test plan
- [ ] `/menu/productos` — page-size shows a clear `20` (or 10/30) without overlap
- [ ] Venta Libre ESTADO shows short badge, not the long sentence; hover still shows full hint
- [ ] Same page-size control on recetas and modificadores


Made with [Cursor](https://cursor.com)