### PR TITLE
fix(crm): progressive load on customer detail

### DIFF
--- a/.wr/2230.yaml
+++ b/.wr/2230.yaml
@@ -1,0 +1,40 @@
+# Compact plan for wr-fast #2230. Keep <=80 lines.
+issue: 2230
+title: "CRM customer detail: progressive/optimistic load"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2230-crm-customer-progressive-load
+
+paths:
+  - pages/crm/clientes/[id].vue
+
+ac:
+  - Cold load: centered loader only until first payload (no blank forever)
+  - Refetch (dates/page/tenant): keep content; header matrix via registerProgressiveLoading
+  - Main payload via Pinia Colada useQuery (not blocking useAsyncData pending)
+  - Error/not-found still clear when no customer
+  - Manual: open customer from list without full-page flash on revisit/filter change
+
+out_of_scope:
+  - CRM list redesign / index.vue seeding unless trivial
+  - Cartera/wallet mutation UX
+  - API contract changes
+
+hints:
+  entry: "pages/crm/clientes/[id].vue useAsyncData ~63 + v-if isLoading ~459"
+  pattern: "pages/finanzas/gastos/[id]/index.vue — useQuery + isLoading=!data&&!error + isRefreshing + registerProgressiveLoading"
+  list: "index.vue already useQuery progressive; detail should match"
+  replace_refresh: "refresh() calls → refetch()"
+  tests: "manual smoke only (no unit harness for this page)"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: ""

--- a/pages/crm/clientes/[id].vue
+++ b/pages/crm/clientes/[id].vue
@@ -82,6 +82,8 @@ const {
   }),
   enabled: () => !!currentTenant.value && !!customerId.value,
   staleTime: 30_000,
+  // Keep last successful payload while filters/page change keys (#2230)
+  placeholderData: (previousData) => previousData,
 })
 
 const isLoading = computed(() => !apiData.value && !fetchError.value)

--- a/pages/crm/clientes/[id].vue
+++ b/pages/crm/clientes/[id].vue
@@ -466,7 +466,7 @@ onMounted(() => {
 onUnmounted(() => {
   setShowBackButton?.(false)
   setBackHandler?.(undefined)
-  clearRefreshHandler()
+  clearRefreshHandler(refetch)
 })
 </script>
 

--- a/pages/crm/clientes/[id].vue
+++ b/pages/crm/clientes/[id].vue
@@ -59,22 +59,36 @@ const ordersOpen = ref(true)
 const carteraOpen = ref(false)
 const walletOpen = ref(false)
 
-// ── Data fetch ────────────────────────────────────────────────────────────
-const { data: apiData, pending: isLoading, error: fetchError, refresh } = useAsyncData(
-  `customer-detail-${customerId.value}`,
-  () => $fetch(`/api/orders/customers/${customerId.value}`, {
+// ── Data fetch (progressive / optimistic — #2230) ─────────────────────────
+const {
+  data: apiData,
+  asyncStatus: detailAsyncStatus,
+  error: fetchError,
+  refetch,
+} = useQuery({
+  key: () => ['crm', 'customer-detail', currentTenant.value?.id, customerId.value, {
+    from: dateRange.value.from,
+    to: dateRange.value.to,
+    page: ordersPage.value,
+    per_page: TABLE_PAGE_SIZE,
+  }],
+  query: () => $fetch(`/api/orders/customers/${customerId.value}`, {
     params: {
       date_from: dateRange.value.from || undefined,
       date_to: dateRange.value.to || undefined,
       page: ordersPage.value,
       per_page: TABLE_PAGE_SIZE,
-    }
+    },
   }),
-  {
-    server: false,
-    watch: [currentTenant, dateRangeDates, ordersPage],
-  }
-)
+  enabled: () => !!currentTenant.value && !!customerId.value,
+  staleTime: 30_000,
+})
+
+const isLoading = computed(() => !apiData.value && !fetchError.value)
+const isRefreshing = computed(() => detailAsyncStatus.value === 'loading' && apiData.value != null)
+
+const { setRefreshHandler, clearRefreshHandler, registerProgressiveLoading } = useLayoutActions()
+registerProgressiveLoading(isRefreshing)
 
 const customer = computed(() => (apiData.value as any)?.customer || null)
 const realEmail = computed(() => {
@@ -256,7 +270,7 @@ const saveEdit = async () => {
       }
     })
     showEditForm.value = false
-    await refresh()
+    await refetch()
   } catch (err: any) {
     editError.value = err?.data?.detail || t('analitica.customerDetail.editError')
   } finally {
@@ -314,7 +328,7 @@ const warosBalance = computed(() => warosSummary.value?.current_balance ?? 0)
 
 const onWarosAssigned = async (payload: { newBalance: number }) => {
   // Refetch main data to get updated Waros balance + transactions
-  await refresh()
+  await refetch()
 }
 
 const formatWarosDate = (isoDate: string) => {
@@ -443,25 +457,27 @@ const submitPayment = async () => {
 onMounted(() => {
   setShowBackButton?.(true)
   setBackHandler?.(goBack)
+  setRefreshHandler(refetch)
   fetchCartera()
 })
 
 onUnmounted(() => {
   setShowBackButton?.(false)
   setBackHandler?.(undefined)
+  clearRefreshHandler()
 })
 </script>
 
 <template>
   <div class="space-y-4">
 
-    <!-- Loading -->
+    <!-- Cold load only — refetches keep content + header matrix (#2230) -->
     <div v-if="isLoading" class="flex items-center justify-center min-h-[400px]">
       <CommonsTheCustomLoader size="large" />
     </div>
 
     <!-- 404 / Error -->
-    <div v-else-if="fetchError || (!isLoading && !customer)" class="flex flex-col items-center justify-center min-h-[400px] gap-4">
+    <div v-else-if="fetchError || !customer" class="flex flex-col items-center justify-center min-h-[400px] gap-4">
       <p class="text-xl font-semibold text-text-primary">{{ t('analitica.customerDetail.notFound') }}</p>
       <p class="text-sm text-text-secondary">{{ (fetchError as any)?.message || t('analitica.customerDetail.notFoundSub') }}</p>
       <button @click="goBack" class="bg-primary text-primary-foreground px-6 py-2 rounded-lg hover:bg-primary/90 transition-colors min-h-[44px]">


### PR DESCRIPTION
## Summary
- Migrate `/crm/clientes/[id]` main fetch from blocking `useAsyncData` to Pinia Colada `useQuery`
- Cold load keeps centered loader; refetches keep content and use `registerProgressiveLoading`
- Header refresh wired to `refetch`

Closes #2230

## Test plan
- [ ] Open a customer from `/crm/clientes` — first visit may loader once
- [ ] Change date range or orders page — no full-page blank; header matrix while updating
- [ ] Revisit same customer within staleTime — no full-page flash
- [ ] Unknown id still shows not-found

## Validation evidence
```
OK static checks for progressive customer detail
- useQuery + registerProgressiveLoading + refetch wired
- full-page loader gated on isLoading (!data && !error)
```

## wr-context
See `.wr/2230.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)