### PR TITLE
fix(menu): InlineDots when setting default purchase unit

### DIFF
--- a/.wr/2234.yaml
+++ b/.wr/2234.yaml
@@ -1,0 +1,42 @@
+# Compact plan for wr-fast #2234. Keep <=80 lines.
+issue: 2234
+title: "Purchase units: InlineDots feedback when setting default"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2234-purchase-unit-default-dots
+
+paths:
+  - components/ingredientes/IngredientPurchaseUnitsField.vue
+  - i18n/locales/es/abastecimiento.json
+  - i18n/locales/en/abastecimiento.json
+
+ac:
+  - Edit Predeterminar shows CommonsInlineDots on that row until PUT+refresh done
+  - While setting default, disable other Predeterminar/delete on the list
+  - Create-mode draft setDefault stays sync (no dots)
+  - Default badge moves after refresh
+  - Manual smoke on resale product with multiple PUs
+
+out_of_scope:
+  - Catalog chip label redesign
+  - Conversion math
+  - Create-mode draft UX beyond sync default
+
+hints:
+  entry: "IngredientPurchaseUnitsField setDefaultUnit ~547"
+  pattern: "CategoriaPanel CommonsInlineDots busy button; deletingUnitId already used for delete"
+  state: "settingDefaultUnitId ref; swap Predeterminar label with dots when matching id"
+  tests: "manual / static assert settingDefaultUnitId + CommonsInlineDots in edit row"
+  i18n: "abastecimiento.glossary.settingDefaultAria"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: ""

--- a/components/ingredientes/IngredientPurchaseUnitsField.vue
+++ b/components/ingredientes/IngredientPurchaseUnitsField.vue
@@ -145,20 +145,34 @@
         <div v-for="u in existingUnits" :key="u.id" class="flex items-center justify-between px-3 py-2 gap-2">
           <div class="flex items-center gap-2 min-w-0 flex-1">
             <span class="text-sm text-text-primary truncate">{{ u.purchase_unit_label }}</span>
+            <span
+              v-if="settingDefaultUnitId === u.id"
+              class="inline-flex items-center gap-1.5 text-[10px] text-primary bg-primary/10 rounded px-1.5 py-0.5 flex-shrink-0 min-h-[22px]"
+            >
+              <CommonsInlineDots
+                :size="4"
+                color="currentColor"
+                :aria-label="t('abastecimiento.glossary.settingDefaultAria')"
+              />
+            </span>
             <button
-              v-if="!u.is_default"
+              v-else-if="!u.is_default"
               type="button"
-              class="text-[10px] text-text-tertiary border border-border rounded px-1.5 py-0.5 hover:text-primary hover:border-primary transition-colors flex-shrink-0"
+              :disabled="listActionsLocked"
+              class="text-[10px] text-text-tertiary border border-border rounded px-1.5 py-0.5 hover:text-primary hover:border-primary transition-colors flex-shrink-0 disabled:opacity-40 disabled:pointer-events-none"
               @click="setDefaultUnit(u.id)"
             >
               {{ t('abastecimiento.glossary.setDefault') }}
             </button>
-            <span v-else class="text-[10px] text-primary bg-primary/10 rounded px-1.5 py-0.5 flex-shrink-0">{{ t('abastecimiento.glossary.default') }}</span>
+            <span
+              v-else
+              class="text-[10px] text-primary bg-primary/10 rounded px-1.5 py-0.5 flex-shrink-0"
+            >{{ t('abastecimiento.glossary.default') }}</span>
           </div>
           <span class="text-xs text-text-tertiary font-mono flex-shrink-0 text-end">{{ formatUnitFactorLabel(u.conversion_factor) }}</span>
           <button
             type="button"
-            :disabled="deletingUnitId === u.id"
+            :disabled="listActionsLocked || deletingUnitId === u.id"
             :aria-label="t('abastecimiento.glossary.removeUnit', { name: u.purchase_unit_label })"
             class="text-text-tertiary hover:text-destructive transition-colors disabled:opacity-40 flex-shrink-0"
             @click="deleteUnit(u.id)"
@@ -386,8 +400,13 @@ const existingUnits = ref<any[]>([])
 const loading = ref(false)
 const savingUnit = ref(false)
 const deletingUnitId = ref<string | null>(null)
+const settingDefaultUnitId = ref<string | null>(null)
 const formError = ref('')
 const newUnit = ref({ purchase_unit_label: '', conversion_factor: null as number | null })
+
+const listActionsLocked = computed(() =>
+  settingDefaultUnitId.value != null || deletingUnitId.value != null || savingUnit.value,
+)
 
 function formatConversionFactor(value: number | string | null | undefined) {
   return formatDomainQuantity(value, CONVERSION_PRECISION, normalizeUiLocale(locale.value))
@@ -545,16 +564,21 @@ async function addSuggestionPurchaseUnit(suggestion: PurchaseUnitSuggestion) {
 }
 
 async function setDefaultUnit(unitId: string) {
+  if (listActionsLocked.value) return
+  settingDefaultUnitId.value = unitId
   try {
     await $fetch(`/api/suppliers/ingredient-purchase-units/${unitId}`, {
       method: 'PUT',
       body: { is_default: true },
     })
     await refreshPurchaseUnits()
-  } catch { /* ignore */ }
+  } catch { /* ignore */ } finally {
+    settingDefaultUnitId.value = null
+  }
 }
 
 async function deleteUnit(unitId: string) {
+  if (listActionsLocked.value) return
   deletingUnitId.value = unitId
   try {
     await $fetch(`/api/suppliers/ingredient-purchase-units/${unitId}`, { method: 'DELETE' })

--- a/i18n/locales/en/abastecimiento.json
+++ b/i18n/locales/en/abastecimiento.json
@@ -601,6 +601,7 @@
       "purchaseUnits": "Purchase units",
       "setDefault": "Set default",
       "default": "Default",
+      "settingDefaultAria": "Updating default purchase unit",
       "removeUnit": "Remove unit {name}",
       "addUnit": "Add unit",
       "newPurchaseUnit": "New purchase unit",

--- a/i18n/locales/es/abastecimiento.json
+++ b/i18n/locales/es/abastecimiento.json
@@ -601,6 +601,7 @@
       "purchaseUnits": "Unidades de compra",
       "setDefault": "Predeterminar",
       "default": "predeterminado",
+      "settingDefaultAria": "Actualizando unidad predeterminada",
       "removeUnit": "Eliminar unidad {name}",
       "addUnit": "Agregar unidad",
       "newPurchaseUnit": "Nueva unidad de compra",


### PR DESCRIPTION
## Summary
- Edit-mode **Predeterminar** shows `CommonsInlineDots` on that row until PUT + refresh complete
- Other Predeterminar / delete actions stay disabled while busy
- Create-mode draft default remains sync

Closes #2234

## Test plan
- [ ] Resale product with 2+ purchase units — click Predeterminar — see dots, then badge moves
- [ ] While busy, other Predeterminar / delete disabled
- [ ] Create-mode draft Predeterminar still instant

## Validation evidence
```
$ python3 (static assert)
OK static checks for #2234
- settingDefaultUnitId + CommonsInlineDots on edit Predeterminar row
- listActionsLocked disables other Predeterminar/delete while busy
- create-mode draft Predeterminar unchanged (sync, no dots)
- i18n settingDefaultAria ES/EN
```

## wr-context
See `.wr/2234.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)