### PR TITLE
fix(negocio): always show Horario in view (#2245)

### DIFF
--- a/.wr/2245.yaml
+++ b/.wr/2245.yaml
@@ -1,0 +1,46 @@
+# Compact plan for wr-exec. Keep <=80 lines.
+issue: 2245
+title: "Negocio: always show Horario in view (empty state)"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2245-horario-view-empty
+parent_epic: 2244
+
+paths:
+  - pages/negocio.vue
+  - i18n/locales/es/shell.json
+  - i18n/locales/en/shell.json
+  - i18n/locales/pt/shell.json
+  - i18n/locales/fr/shell.json
+  - i18n/locales/de/shell.json
+  - i18n/locales/zh/shell.json
+  - i18n/locales/ar/shell.json
+  - i18n/locales/hi/shell.json
+
+ac:
+  - Horario card visible in view when business_hours is null/empty
+  - Empty/not-configured copy uses text-text-secondary (not amber)
+  - Configured hours still show open/close + today highlight
+  - Edit-mode hours editor unchanged
+
+out_of_scope:
+  - Split edit / global Editar (#2246)
+  - API changes
+  - Redes/Contacto visibility gates
+
+hints:
+  entry: "pages/negocio.vue Horario card"
+  pattern: "gate businessProfile||isEditMode; empty via hasConfiguredBusinessHours + negocio.noHours"
+  tests: "python json key check"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "/wr-next uno0uno/warocol.com#2244"

--- a/i18n/locales/ar/shell.json
+++ b/i18n/locales/ar/shell.json
@@ -154,6 +154,7 @@
     "onlineOrders": "الطلبات عبر الإنترنت",
     "contact": "جهة الاتصال",
     "noContact": "لا توجد معلومات اتصال",
+    "noHours": "لم يتم تكوين ساعات العمل",
     "address": "العنوان",
     "neighborhood": "الحي",
     "country": "البلد",

--- a/i18n/locales/de/shell.json
+++ b/i18n/locales/de/shell.json
@@ -154,6 +154,7 @@
     "onlineOrders": "Online-Bestellungen",
     "contact": "Kontakt",
     "noContact": "Keine Kontaktinformationen",
+    "noHours": "Keine Öffnungszeiten konfiguriert",
     "address": "Adresse",
     "neighborhood": "Stadtteil",
     "country": "Land",

--- a/i18n/locales/en/shell.json
+++ b/i18n/locales/en/shell.json
@@ -159,6 +159,7 @@
     "onlineOrders": "Online orders",
     "contact": "Contact",
     "noContact": "No contact information",
+    "noHours": "No hours configured",
     "address": "Address",
     "neighborhood": "Neighborhood",
     "country": "Country",

--- a/i18n/locales/es/shell.json
+++ b/i18n/locales/es/shell.json
@@ -159,6 +159,7 @@
     "onlineOrders": "Pedidos online",
     "contact": "Contacto",
     "noContact": "Sin información de contacto",
+    "noHours": "Sin horario configurado",
     "address": "Dirección",
     "neighborhood": "Barrio",
     "country": "País",

--- a/i18n/locales/fr/shell.json
+++ b/i18n/locales/fr/shell.json
@@ -154,6 +154,7 @@
     "onlineOrders": "Commandes en ligne",
     "contact": "Contact",
     "noContact": "Aucune information de contact",
+    "noHours": "Aucun horaire configuré",
     "address": "Adresse",
     "neighborhood": "Quartier",
     "country": "Pays",

--- a/i18n/locales/hi/shell.json
+++ b/i18n/locales/hi/shell.json
@@ -154,6 +154,7 @@
     "onlineOrders": "ऑनलाइन ऑर्डर",
     "contact": "संपर्क",
     "noContact": "कोई संपर्क जानकारी नहीं",
+    "noHours": "कोई समय सारिणी कॉन्फ़िगर नहीं है",
     "address": "पता",
     "neighborhood": "पड़ोस",
     "country": "देश",

--- a/i18n/locales/pt/shell.json
+++ b/i18n/locales/pt/shell.json
@@ -154,6 +154,7 @@
     "onlineOrders": "Pedidos online",
     "contact": "Contato",
     "noContact": "Sem informações de contato",
+    "noHours": "Sem horário configurado",
     "address": "Endereço",
     "neighborhood": "Bairro",
     "country": "País",

--- a/i18n/locales/zh/shell.json
+++ b/i18n/locales/zh/shell.json
@@ -154,6 +154,7 @@
     "onlineOrders": "在线订单",
     "contact": "联系方式",
     "noContact": "无联系信息",
+    "noHours": "尚未配置营业时间",
     "address": "地址",
     "neighborhood": "街区",
     "country": "国家",

--- a/pages/negocio.vue
+++ b/pages/negocio.vue
@@ -486,7 +486,10 @@
       </div>
 
       <!-- ══════ HORARIO ══════ -->
-      <div v-if="businessProfile?.business_hours || isEditMode" class="bg-surface border-2 border-border rounded-xl p-4 sm:p-6">
+      <div
+        v-if="businessProfile || isEditMode"
+        class="bg-surface border-2 border-border rounded-xl p-4 sm:p-6"
+      >
         <h3 class="text-base sm:text-lg font-semibold text-text-primary mb-4 flex items-center gap-2">
           <ClockIcon class="w-5 h-5 text-primary flex-shrink-0" />
           {{ t('negocio.hours') }}
@@ -500,7 +503,13 @@
               {{ businessTimezoneLabel }}
             </span>
           </div>
-          <div class="space-y-0">
+          <p
+            v-if="!hasConfiguredBusinessHours"
+            class="text-sm text-text-secondary italic"
+          >
+            {{ t('negocio.noHours') }}
+          </p>
+          <div v-else class="space-y-0">
             <div
               v-for="(dayKey, index) in DAY_ORDER"
               :key="dayKey"
@@ -1036,6 +1045,12 @@ const timezoneLabel = (value?: string | null) => {
 }
 
 const businessTimezoneLabel = computed(() => timezoneLabel(businessProfile.value?.timezone))
+
+/** True when profile has a non-empty business_hours object (all-closed still counts as configured). */
+const hasConfiguredBusinessHours = computed(() => {
+  const hours = businessProfile.value?.business_hours
+  return !!hours && typeof hours === 'object' && Object.keys(hours).length > 0
+})
 
 const isToday = (i: number) => {
   const weekdayMap: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Show the Horario card whenever a profile exists (or in Edit), even if `business_hours` is missing
- Empty state uses `negocio.noHours` with secondary italic text (no amber)
- Configured hours keep the day list + today highlight; edit editor unchanged

Closes #2245  
Parent epic: #2244

## Test plan
- [ ] Tenant without `business_hours`: `/negocio` view shows Horario + “Sin horario configurado”
- [ ] Tenant with hours: day rows and today highlight unchanged
- [ ] Edit still shows timezone + day editor

## Validation evidence
```text
$ python3 # gate + noHours keys
validation_ok
```

## wr-context
See `.wr/2245.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)