### PR TITLE
fix(negocio): calm offline toggles — primary instead of amber (#2242)

### DIFF
--- a/.wr/2242.yaml
+++ b/.wr/2242.yaml
@@ -1,0 +1,40 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 2242
+title: "Negocio: calm offline toggles — primary/surface instead of amber flood"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2242-calm-negocio-toggles
+
+paths:
+  - pages/negocio.vue
+
+ac:
+  - Directory + Pedidos online OFF use calm primary/surface (no amber fill/text)
+  - Titles/help use text-text-primary / text-text-secondary ON and OFF
+  - Switch ON stays primary
+  - Public-link inactive hint in same block uses calm primary treatment
+  - Status meaning via copy + switch (not amber alone)
+  - Dark mode readable via semantic tokens
+
+out_of_scope:
+  - Global design-token redesign
+  - City-missing / Starter quota amber warnings (true alerts)
+  - Typography scale / API
+
+hints:
+  entry: "pages/negocio.vue directory + online toggles + publicPageInactive"
+  pattern: "OFF → border-primary/30 bg-primary/5; ON → border-border bg-surface"
+  tests: "none (visual; no targeted front test)"
+  base_branch: "wr-2240-online-orders-toggle (#2241 open)"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "manual smoke /negocio OFF toggles without amber flood"

--- a/pages/negocio.vue
+++ b/pages/negocio.vue
@@ -155,19 +155,13 @@
         class="flex items-center justify-between gap-4 rounded-xl border-2 px-4 py-3 transition-colors"
         :class="businessProfile.is_active
           ? 'border-border bg-surface'
-          : 'border-amber-200 bg-amber-50 dark:border-amber-800/40 dark:bg-amber-950/20'"
+          : 'border-primary/30 bg-primary/5'"
       >
         <div class="min-w-0">
-          <p
-            class="text-sm font-semibold leading-snug"
-            :class="businessProfile.is_active ? 'text-text-primary' : 'text-amber-800 dark:text-amber-300'"
-          >
+          <p class="text-sm font-semibold leading-snug text-text-primary">
             {{ businessProfile.is_active ? t('negocio.visibleInDirectory') : t('negocio.hiddenBusiness') }}
           </p>
-          <p
-            class="text-xs mt-0.5 leading-snug"
-            :class="businessProfile.is_active ? 'text-text-secondary' : 'text-amber-700 dark:text-amber-400'"
-          >
+          <p class="text-xs mt-0.5 leading-snug text-text-secondary">
             {{ businessProfile.is_active ? t('negocio.appearsInDirectory', { path: publicCityPath }) : t('negocio.activateForDirectory') }}
           </p>
         </div>
@@ -210,19 +204,13 @@
         class="flex items-center justify-between gap-4 rounded-xl border-2 px-4 py-3 transition-colors"
         :class="businessProfile.accepts_online_orders
           ? 'border-border bg-surface'
-          : 'border-amber-200 bg-amber-50 dark:border-amber-800/40 dark:bg-amber-950/20'"
+          : 'border-primary/30 bg-primary/5'"
       >
         <div class="min-w-0">
-          <p
-            class="text-sm font-semibold leading-snug"
-            :class="businessProfile.accepts_online_orders ? 'text-text-primary' : 'text-amber-800 dark:text-amber-300'"
-          >
+          <p class="text-sm font-semibold leading-snug text-text-primary">
             {{ businessProfile.accepts_online_orders ? t('negocio.onlineOrdersActive') : t('negocio.onlineOrdersInactive') }}
           </p>
-          <p
-            class="text-xs mt-0.5 leading-snug"
-            :class="businessProfile.accepts_online_orders ? 'text-text-secondary' : 'text-amber-700 dark:text-amber-400'"
-          >
+          <p class="text-xs mt-0.5 leading-snug text-text-secondary">
             {{ t('negocio.onlineOrdersHelp') }}
           </p>
         </div>
@@ -289,10 +277,10 @@
 
         <div
           v-if="businessProfile && !businessProfile.is_active"
-          class="flex items-start gap-2 px-3 py-2 bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800/40 rounded-lg"
+          class="flex items-start gap-2 px-3 py-2 bg-primary/5 border border-primary/30 rounded-lg"
         >
-          <ExclamationTriangleIcon class="w-4 h-4 text-amber-700 dark:text-amber-400 flex-shrink-0 mt-0.5" />
-          <p class="text-xs text-amber-800 dark:text-amber-300 leading-snug">
+          <ExclamationTriangleIcon class="w-4 h-4 text-primary flex-shrink-0 mt-0.5" />
+          <p class="text-xs text-text-secondary leading-snug">
             {{ t('negocio.publicPageInactive') }}
           </p>
         </div>


### PR DESCRIPTION
## Summary
- Directory + Pedidos online OFF states use calm `primary/5` + `primary/30` (no amber flood)
- Titles/help stay on semantic text tokens; switch ON remains primary
- Public-link inactive hint matched
- Rebased onto `main` after #2241 merge (supersedes closed stacked PR #2243)

Closes #2242

## Test plan
- [ ] `/negocio` OFF toggles look calm (no amber panels)
- [ ] Pedidos online quick toggle still works

## Validation evidence
```text
Rebase onto origin/main: skipped already-merged #2240 commit; calm-colors commit applied cleanly.
```

## wr-context
See `.wr/2242.yaml` on this branch.

Refs: replaces https://github.com/uno0uno/warocol.com/pull/2243

Made with [Cursor](https://cursor.com)