### PR TITLE
fix(ui): accordion for carga masiva help/history + units (#2267)

### DIFF
--- a/.wr/2267.yaml
+++ b/.wr/2267.yaml
@@ -1,0 +1,45 @@
+# Compact plan for wr-fast. Keep <=80 lines.
+issue: 2267
+title: "fix(ui): reusable accordion for carga masiva help + history"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2267-ui-accordion-menu-import
+base: wr-2265-menu-import-ux-copy
+
+paths:
+  - components/ui/UiAccordionSection.vue
+  - components/menu/MenuImportUpload.vue
+  - pages/finanzas/arqueo/index.vue
+  - i18n/locales/es/menu.json
+  - i18n/locales/en/menu.json
+  - i18n/locales/es/abastecimiento.json
+  - i18n/locales/en/abastecimiento.json
+  - .wr/2267.yaml
+
+ac:
+  - UiAccordionSection (chevron, tokens, closed by default, ~40px hit)
+  - MenuImportUpload help + history use it; no raw details
+  - Help includes WARO units list for warehouse/recipes/modifiers
+  - Optional arqueo hub migrated to same component
+
+out_of_scope:
+  - Recipe CSV auto-create bodega
+  - Nuxt UI UAccordion
+  - App-wide accordion migration
+
+hints:
+  entry: "components/ui/UiAccordionSection.vue"
+  pattern: "pages/finanzas/arqueo/index.vue details+chevron"
+  tests: "rg no <details in MenuImportUpload; python3 json load"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "merge after #2266"

--- a/.wr/2267.yaml
+++ b/.wr/2267.yaml
@@ -21,7 +21,7 @@ paths:
 ac:
   - UiAccordionSection (chevron, tokens, closed by default, ~40px hit)
   - MenuImportUpload help + history use it; no raw details
-  - Help includes WARO units list for warehouse/recipes/modifiers
+  - Help units: warehouse = FOOD_UNITS only (gr/kg/ml/lt/und); recipes/modifiers = base + configured purchase units
   - Optional arqueo hub migrated to same component
 
 out_of_scope:

--- a/components/menu/MenuImportUpload.vue
+++ b/components/menu/MenuImportUpload.vue
@@ -85,20 +85,20 @@
                 {{ t(i18nDownloadTemplate) }}
               </a>
             </div>
-            <details class="text-xs">
-              <summary class="cursor-pointer text-text-secondary hover:text-text-primary select-none">
-                {{ t(i18nHelpTitle) }}
-              </summary>
-              <div class="mt-2 space-y-1.5 text-text-secondary leading-relaxed">
+            <UiAccordionSection :title="t(i18nHelpTitle)">
+              <div class="space-y-1.5 text-xs text-text-secondary leading-relaxed">
                 <p>{{ t(i18nHelpBody) }}</p>
                 <p class="whitespace-pre-line text-text-tertiary">
                   {{ t(i18nHelpExample) }}
+                </p>
+                <p v-if="showUnitsHelp" class="text-text-tertiary">
+                  {{ t(i18nHelpUnits) }}
                 </p>
                 <p class="text-text-tertiary">
                   {{ t(i18nHelpColumnsNote) }}
                 </p>
               </div>
-            </details>
+            </UiAccordionSection>
           </section>
 
           <!-- Dropzone (hero) -->
@@ -211,25 +211,19 @@
           <p v-if="commitMsg" class="text-sm text-state-success-text">{{ commitMsg }}</p>
           <p v-if="errorMsg" class="text-sm text-destructive" role="alert">{{ errorMsg }}</p>
 
-          <details class="border-t border-border pt-4">
-            <summary
-              class="cursor-pointer text-xs font-semibold uppercase tracking-wide text-text-tertiary select-none hover:text-text-secondary"
-            >
-              {{ t(i18nStepHistory) }}
-              <span v-if="jobs.length" class="normal-case font-normal tracking-normal">
-                ({{ jobs.length }})
-              </span>
-            </summary>
-            <div class="mt-2">
-              <MenuImportJobHistory
-                :jobs="jobs"
-                hide-title
-                :empty="isMenuEntity ? t(`${i18nPrefix}NoJobs`) : t('abastecimiento.glossary.bulkImportNoJobs')"
-                :status-label-fn="statusLabel"
-                @select="loadJob"
-              />
-            </div>
-          </details>
+          <UiAccordionSection
+            class="mt-1"
+            :title="t(i18nStepHistory)"
+            :badge="jobs.length ? `(${jobs.length})` : undefined"
+          >
+            <MenuImportJobHistory
+              :jobs="jobs"
+              hide-title
+              :empty="isMenuEntity ? t(`${i18nPrefix}NoJobs`) : t('abastecimiento.glossary.bulkImportNoJobs')"
+              :status-label-fn="statusLabel"
+              @select="loadJob"
+            />
+          </UiAccordionSection>
         </div>
 
         <div class="flex-shrink-0 border-t border-border px-6 py-4 bg-surface space-y-2">
@@ -299,6 +293,7 @@ const i18nHelpTitle = computed(() => `${i18nPrefix.value}HelpTitle`)
 const i18nHelpBody = computed(() => `${i18nPrefix.value}HelpBody`)
 const i18nHelpExample = computed(() => `${i18nPrefix.value}HelpExample`)
 const i18nHelpColumnsNote = computed(() => `${i18nPrefix.value}HelpColumnsNote`)
+const i18nHelpUnits = computed(() => `${i18nPrefix.value}HelpUnits`)
 const i18nDropPrompt = computed(() => `${i18nPrefix.value}DropPrompt`)
 const i18nDropSelect = computed(() => `${i18nPrefix.value}DropSelect`)
 const i18nDropHint = computed(() => `${i18nPrefix.value}DropHint`)
@@ -310,6 +305,12 @@ const isMenuEntity = computed(
   () =>
     props.entity === 'recipe_bases'
     || props.entity === 'products'
+    || props.entity === 'modifiers',
+)
+const showUnitsHelp = computed(
+  () =>
+    props.entity === 'warehouse'
+    || props.entity === 'recipe_bases'
     || props.entity === 'modifiers',
 )
 

--- a/components/menu/MenuImportUpload.vue
+++ b/components/menu/MenuImportUpload.vue
@@ -86,17 +86,39 @@
               </a>
             </div>
             <UiAccordionSection :title="t(i18nHelpTitle)">
-              <div class="space-y-1.5 text-xs text-text-secondary leading-relaxed">
-                <p>{{ t(i18nHelpBody) }}</p>
-                <p class="whitespace-pre-line text-text-tertiary">
-                  {{ t(i18nHelpExample) }}
-                </p>
-                <p v-if="showUnitsHelp" class="text-text-tertiary">
-                  {{ t(i18nHelpUnits) }}
-                </p>
-                <p class="text-text-tertiary">
-                  {{ t(i18nHelpColumnsNote) }}
-                </p>
+              <div class="space-y-3">
+                <div>
+                  <h4 class="text-sm font-semibold text-text-primary">
+                    {{ t('menu.bulkImportHelpSections.overview') }}
+                  </h4>
+                  <p class="mt-1 pl-3 border-l-2 border-border text-xs text-text-secondary leading-relaxed">
+                    {{ t(i18nHelpBody) }}
+                  </p>
+                </div>
+                <div>
+                  <h4 class="text-sm font-semibold text-text-primary">
+                    {{ t('menu.bulkImportHelpSections.example') }}
+                  </h4>
+                  <p class="mt-1 pl-3 border-l-2 border-border text-xs text-text-secondary leading-relaxed whitespace-pre-line">
+                    {{ t(i18nHelpExample) }}
+                  </p>
+                </div>
+                <div v-if="showUnitsHelp">
+                  <h4 class="text-sm font-semibold text-text-primary">
+                    {{ t('menu.bulkImportHelpSections.units') }}
+                  </h4>
+                  <p class="mt-1 pl-3 border-l-2 border-border text-xs text-text-secondary leading-relaxed whitespace-pre-line">
+                    {{ t(i18nHelpUnits) }}
+                  </p>
+                </div>
+                <div>
+                  <h4 class="text-sm font-semibold text-text-primary">
+                    {{ t('menu.bulkImportHelpSections.columns') }}
+                  </h4>
+                  <p class="mt-1 pl-3 border-l-2 border-border text-xs text-text-secondary leading-relaxed">
+                    {{ t(i18nHelpColumnsNote) }}
+                  </p>
+                </div>
               </div>
             </UiAccordionSection>
           </section>

--- a/components/ui/UiAccordionSection.vue
+++ b/components/ui/UiAccordionSection.vue
@@ -1,0 +1,51 @@
+<template>
+  <details
+    class="group rounded-lg border border-border bg-surface"
+    :open="openByDefault || undefined"
+  >
+    <summary
+      class="cursor-pointer list-none min-h-[40px] px-3 py-2.5 flex items-center justify-between gap-3
+             text-sm font-medium text-text-primary select-none
+             focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 rounded-lg"
+    >
+      <span class="min-w-0 flex items-center gap-2">
+        <span class="truncate">{{ title }}</span>
+        <span
+          v-if="badge"
+          class="flex-shrink-0 text-xs font-normal text-text-tertiary normal-case tracking-normal"
+        >
+          {{ badge }}
+        </span>
+      </span>
+      <svg
+        class="w-4 h-4 flex-shrink-0 text-text-tertiary transition-transform group-open:rotate-180"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+      </svg>
+    </summary>
+    <div class="px-3 pb-3 pt-0.5">
+      <slot />
+    </div>
+  </details>
+</template>
+
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    title: string
+    badge?: string
+    openByDefault?: boolean
+  }>(),
+  { openByDefault: false },
+)
+</script>
+
+<style scoped>
+summary::-webkit-details-marker {
+  display: none;
+}
+</style>

--- a/components/ui/UiAccordionSection.vue
+++ b/components/ui/UiAccordionSection.vue
@@ -5,7 +5,7 @@
   >
     <summary
       class="cursor-pointer list-none min-h-[40px] px-3 py-2.5 flex items-center justify-between gap-3
-             text-sm font-medium text-text-primary select-none
+             text-sm font-semibold text-text-primary select-none
              focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 rounded-lg"
     >
       <span class="min-w-0 flex items-center gap-2">

--- a/i18n/locales/en/abastecimiento.json
+++ b/i18n/locales/en/abastecimiento.json
@@ -801,7 +801,8 @@
       "bulkImportHelpColumnsNote": "Do not rename the template columns (they stay in English on purpose). Names, quantities, and text values can be in your business language.",
       "bulkImportHelpTitle": "How to fill the file",
       "bulkImportHelpBody": "Each row is a warehouse item. For resale you can leave price/category empty and finish later in Products.",
-      "bulkImportHelpExample": "Example: Tomato · unit kg · cost 4000\nIncomplete resale: Coke 350ml · no price yet"
+      "bulkImportHelpExample": "Example: Tomato · unit kg · cost 4000\nIncomplete resale: Coke 350ml · no price yet",
+      "bulkImportHelpUnits": "Units WARO understands: weight gr, kg, libra, arroba, bulto_25kg; volume ml, lt, botella, galon; count und; time hr. Use a unit compatible with the warehouse item (or its purchase units)."
     },
     "calidad": {
       "qualityScore": "Data quality score",

--- a/i18n/locales/en/abastecimiento.json
+++ b/i18n/locales/en/abastecimiento.json
@@ -802,7 +802,7 @@
       "bulkImportHelpTitle": "How to fill the file",
       "bulkImportHelpBody": "Each row is a warehouse item. For resale you can leave price/category empty and finish later in Products.",
       "bulkImportHelpExample": "Example: Tomato · unit kg · cost 4000\nIncomplete resale: Coke 350ml · no price yet",
-      "bulkImportHelpUnits": "Units WARO understands: weight gr, kg, libra, arroba, bulto_25kg; volume ml, lt, botella, galon; count und; time hr. Use a unit compatible with the warehouse item (or its purchase units)."
+      "bulkImportHelpUnits": "Column unit (stock unit): only gr, kg, ml, lt, or und. Incomplete resale must use und. unit_weight_unit only allows gr or ml."
     },
     "calidad": {
       "qualityScore": "Data quality score",

--- a/i18n/locales/en/abastecimiento.json
+++ b/i18n/locales/en/abastecimiento.json
@@ -801,8 +801,8 @@
       "bulkImportHelpColumnsNote": "Do not rename the template columns (they stay in English on purpose). Names, quantities, and text values can be in your business language.",
       "bulkImportHelpTitle": "How to fill the file",
       "bulkImportHelpBody": "Each row is a warehouse item. For resale you can leave price/category empty and finish later in Products.",
-      "bulkImportHelpExample": "Example: Tomato · unit kg · cost 4000\nIncomplete resale: Coke 350ml · no price yet",
-      "bulkImportHelpUnits": "Column unit (stock unit): only gr, kg, ml, lt, or und. Incomplete resale must use und. unit_weight_unit only allows gr or ml."
+      "bulkImportHelpExample": "Tomato · unit kg · cost 4000\nIncomplete resale: Coke 350ml · no price yet",
+      "bulkImportHelpUnits": "Column unit (stock): only gr, kg, ml, lt, or und\nIncomplete resale: must use und\nunit_weight_unit: only gr or ml"
     },
     "calidad": {
       "qualityScore": "Data quality score",

--- a/i18n/locales/en/menu.json
+++ b/i18n/locales/en/menu.json
@@ -365,7 +365,7 @@
       "bulkImportHelpTitle": "How to fill the file",
       "bulkImportHelpBody": "Repeat the same recipe name on each ingredient line. Ingredients must already exist in the warehouse with a unit WARO understands.",
       "bulkImportHelpExample": "Example (same recipe on 2 lines):\nTomato sauce · Tomato · 1 · kg\nTomato sauce · Onion · 0.2 · kg",
-      "bulkImportHelpUnits": "Units WARO understands: weight gr, kg, libra, arroba, bulto_25kg; volume ml, lt, botella, galon; count und; time hr. Use a unit compatible with the warehouse item (or its purchase units)."
+      "bulkImportHelpUnits": "In unit use the warehouse item’s base unit (gr, kg, ml, lt, und) or a purchase unit already configured on that item (e.g. libra, arroba, bulto_25kg, botella, galon, hr). If that purchase unit is missing, the row fails."
     },
     "modificadores": {
       "searchPlaceholder": "Search group or product...",
@@ -516,7 +516,7 @@
       "bulkImportHelpTitle": "How to fill the file",
       "bulkImportHelpBody": "Repeat the group name on each option row. This import does not attach products; do that later on the group.",
       "bulkImportHelpExample": "Example (same group on 2 lines):\nCooking point · Medium · 0\nCooking point · Well done · 0",
-      "bulkImportHelpUnits": "Units WARO understands: weight gr, kg, libra, arroba, bulto_25kg; volume ml, lt, botella, galon; count und; time hr. Use a unit compatible with the warehouse item (or its purchase units)."
+      "bulkImportHelpUnits": "If the option deducts warehouse stock, in ingredient_unit use the item’s base unit (gr, kg, ml, lt, und) or a purchase unit already configured on that item (e.g. libra, arroba, bulto_25kg, botella, galon, hr)."
     },
     "categorias": {
       "searchPlaceholder": "Search category...",

--- a/i18n/locales/en/menu.json
+++ b/i18n/locales/en/menu.json
@@ -364,7 +364,8 @@
       "bulkImportHelpColumnsNote": "Do not rename the template columns (they stay in English on purpose). Names, quantities, and text values can be in your business language.",
       "bulkImportHelpTitle": "How to fill the file",
       "bulkImportHelpBody": "Repeat the same recipe name on each ingredient line. Ingredients must already exist in the warehouse with a unit WARO understands.",
-      "bulkImportHelpExample": "Example (same recipe on 2 lines):\nTomato sauce · Tomato · 1 · kg\nTomato sauce · Onion · 0.2 · kg"
+      "bulkImportHelpExample": "Example (same recipe on 2 lines):\nTomato sauce · Tomato · 1 · kg\nTomato sauce · Onion · 0.2 · kg",
+      "bulkImportHelpUnits": "Units WARO understands: weight gr, kg, libra, arroba, bulto_25kg; volume ml, lt, botella, galon; count und; time hr. Use a unit compatible with the warehouse item (or its purchase units)."
     },
     "modificadores": {
       "searchPlaceholder": "Search group or product...",
@@ -514,7 +515,8 @@
       "bulkImportHelpColumnsNote": "Do not rename the template columns (they stay in English on purpose). Names, quantities, and text values can be in your business language.",
       "bulkImportHelpTitle": "How to fill the file",
       "bulkImportHelpBody": "Repeat the group name on each option row. This import does not attach products; do that later on the group.",
-      "bulkImportHelpExample": "Example (same group on 2 lines):\nCooking point · Medium · 0\nCooking point · Well done · 0"
+      "bulkImportHelpExample": "Example (same group on 2 lines):\nCooking point · Medium · 0\nCooking point · Well done · 0",
+      "bulkImportHelpUnits": "Units WARO understands: weight gr, kg, libra, arroba, bulto_25kg; volume ml, lt, botella, galon; count und; time hr. Use a unit compatible with the warehouse item (or its purchase units)."
     },
     "categorias": {
       "searchPlaceholder": "Search category...",

--- a/i18n/locales/en/menu.json
+++ b/i18n/locales/en/menu.json
@@ -37,6 +37,12 @@
       "incompatibleUnitError": "Select a compatible unit for each warehouse item.",
       "rowsPerPage": "Rows per page"
     },
+    "bulkImportHelpSections": {
+      "overview": "Overview",
+      "example": "Example",
+      "units": "Units",
+      "columns": "Columns"
+    },
     "productos": {
       "editMode": "Edit mode",
       "viewCatalog": "View catalog",
@@ -279,7 +285,7 @@
       "bulkImportHelpColumnsNote": "Do not rename the template columns (they stay in English on purpose). Names, quantities, and text values can be in your business language.",
       "bulkImportHelpTitle": "How to fill the file",
       "bulkImportHelpBody": "Each row is a product: name, price, and category. To finish an incomplete warehouse resale, mark that row in the template to complete the pending resale.",
-      "bulkImportHelpExample": "Example: Americano coffee · 5000 · Hot drinks\nFinish resale: Coke 350ml · 3500 · Drinks"
+      "bulkImportHelpExample": "Americano coffee · 5000 · Hot drinks\nFinish resale: Coke 350ml · 3500 · Drinks"
     },
     "recetas": {
       "searchPlaceholder": "Search recipes...",
@@ -364,8 +370,8 @@
       "bulkImportHelpColumnsNote": "Do not rename the template columns (they stay in English on purpose). Names, quantities, and text values can be in your business language.",
       "bulkImportHelpTitle": "How to fill the file",
       "bulkImportHelpBody": "Repeat the same recipe name on each ingredient line. Ingredients must already exist in the warehouse with a unit WARO understands.",
-      "bulkImportHelpExample": "Example (same recipe on 2 lines):\nTomato sauce · Tomato · 1 · kg\nTomato sauce · Onion · 0.2 · kg",
-      "bulkImportHelpUnits": "In unit use the warehouse item’s base unit (gr, kg, ml, lt, und) or a purchase unit already configured on that item (e.g. libra, arroba, bulto_25kg, botella, galon, hr). If that purchase unit is missing, the row fails."
+      "bulkImportHelpExample": "Same recipe on 2 lines:\nTomato sauce · Tomato · 1 · kg\nTomato sauce · Onion · 0.2 · kg",
+      "bulkImportHelpUnits": "Item base unit: gr, kg, ml, lt, und\nOr a purchase unit already configured: libra, arroba, bulto_25kg, botella, galon, hr\nIf that purchase unit is missing on the item, the row fails."
     },
     "modificadores": {
       "searchPlaceholder": "Search group or product...",
@@ -515,8 +521,8 @@
       "bulkImportHelpColumnsNote": "Do not rename the template columns (they stay in English on purpose). Names, quantities, and text values can be in your business language.",
       "bulkImportHelpTitle": "How to fill the file",
       "bulkImportHelpBody": "Repeat the group name on each option row. This import does not attach products; do that later on the group.",
-      "bulkImportHelpExample": "Example (same group on 2 lines):\nCooking point · Medium · 0\nCooking point · Well done · 0",
-      "bulkImportHelpUnits": "If the option deducts warehouse stock, in ingredient_unit use the item’s base unit (gr, kg, ml, lt, und) or a purchase unit already configured on that item (e.g. libra, arroba, bulto_25kg, botella, galon, hr)."
+      "bulkImportHelpExample": "Same group on 2 lines:\nCooking point · Medium · 0\nCooking point · Well done · 0",
+      "bulkImportHelpUnits": "If the option deducts warehouse stock, in ingredient_unit use:\nBase unit: gr, kg, ml, lt, und\nOr a purchase unit already configured: libra, arroba, bulto_25kg, botella, galon, hr"
     },
     "categorias": {
       "searchPlaceholder": "Search category...",

--- a/i18n/locales/es/abastecimiento.json
+++ b/i18n/locales/es/abastecimiento.json
@@ -801,7 +801,8 @@
       "bulkImportHelpColumnsNote": "No renombres las columnas de la plantilla (están en inglés a propósito). Los nombres, cantidades y textos sí puedes escribirlos en el idioma de tu negocio.",
       "bulkImportHelpTitle": "Cómo llenar el archivo",
       "bulkImportHelpBody": "Cada fila es un artículo de bodega. Si es reventa, puedes dejar precio/categoría vacíos y completarlos después en Productos.",
-      "bulkImportHelpExample": "Ejemplo: Tomate · unidad kg · costo 4000\nReventa incompleta: Coca 350ml · sin precio aún"
+      "bulkImportHelpExample": "Ejemplo: Tomate · unidad kg · costo 4000\nReventa incompleta: Coca 350ml · sin precio aún",
+      "bulkImportHelpUnits": "Unidades que WARO entiende: peso gr, kg, libra, arroba, bulto_25kg; volumen ml, lt, botella, galon; conteo und; tiempo hr. Usa una unidad compatible con el artículo en bodega (o con sus unidades de compra)."
     },
     "calidad": {
       "qualityScore": "Score de calidad",

--- a/i18n/locales/es/abastecimiento.json
+++ b/i18n/locales/es/abastecimiento.json
@@ -801,8 +801,8 @@
       "bulkImportHelpColumnsNote": "No renombres las columnas de la plantilla (están en inglés a propósito). Los nombres, cantidades y textos sí puedes escribirlos en el idioma de tu negocio.",
       "bulkImportHelpTitle": "Cómo llenar el archivo",
       "bulkImportHelpBody": "Cada fila es un artículo de bodega. Si es reventa, puedes dejar precio/categoría vacíos y completarlos después en Productos.",
-      "bulkImportHelpExample": "Ejemplo: Tomate · unidad kg · costo 4000\nReventa incompleta: Coca 350ml · sin precio aún",
-      "bulkImportHelpUnits": "Columna unit (unidad de stock): solo gr, kg, ml, lt o und. Reventa incompleta debe ir en und. unit_weight_unit solo admite gr o ml."
+      "bulkImportHelpExample": "Tomate · unidad kg · costo 4000\nReventa incompleta: Coca 350ml · sin precio aún",
+      "bulkImportHelpUnits": "Columna unit (stock): solo gr, kg, ml, lt o und\nReventa incompleta: debe ir en und\nunit_weight_unit: solo gr o ml"
     },
     "calidad": {
       "qualityScore": "Score de calidad",

--- a/i18n/locales/es/abastecimiento.json
+++ b/i18n/locales/es/abastecimiento.json
@@ -802,7 +802,7 @@
       "bulkImportHelpTitle": "Cómo llenar el archivo",
       "bulkImportHelpBody": "Cada fila es un artículo de bodega. Si es reventa, puedes dejar precio/categoría vacíos y completarlos después en Productos.",
       "bulkImportHelpExample": "Ejemplo: Tomate · unidad kg · costo 4000\nReventa incompleta: Coca 350ml · sin precio aún",
-      "bulkImportHelpUnits": "Unidades que WARO entiende: peso gr, kg, libra, arroba, bulto_25kg; volumen ml, lt, botella, galon; conteo und; tiempo hr. Usa una unidad compatible con el artículo en bodega (o con sus unidades de compra)."
+      "bulkImportHelpUnits": "Columna unit (unidad de stock): solo gr, kg, ml, lt o und. Reventa incompleta debe ir en und. unit_weight_unit solo admite gr o ml."
     },
     "calidad": {
       "qualityScore": "Score de calidad",

--- a/i18n/locales/es/menu.json
+++ b/i18n/locales/es/menu.json
@@ -365,7 +365,7 @@
       "bulkImportHelpTitle": "Cómo llenar el archivo",
       "bulkImportHelpBody": "Repite el mismo nombre de receta en cada línea de ingredientes. Los ingredientes deben existir ya en bodega, con una unidad que WARO entienda.",
       "bulkImportHelpExample": "Ejemplo (misma receta en 2 líneas):\nSalsa tomate · Tomate · 1 · kg\nSalsa tomate · Cebolla · 0.2 · kg",
-      "bulkImportHelpUnits": "Unidades que WARO entiende: peso gr, kg, libra, arroba, bulto_25kg; volumen ml, lt, botella, galon; conteo und; tiempo hr. Usa una unidad compatible con el artículo en bodega (o con sus unidades de compra)."
+      "bulkImportHelpUnits": "En unit usa la unidad base del artículo en bodega (gr, kg, ml, lt, und) o una unidad de compra ya configurada en ese artículo (p. ej. libra, arroba, bulto_25kg, botella, galon, hr). Si no existe esa unidad de compra, la fila falla."
     },
     "modificadores": {
       "searchPlaceholder": "Buscar grupo o producto...",
@@ -516,7 +516,7 @@
       "bulkImportHelpTitle": "Cómo llenar el archivo",
       "bulkImportHelpBody": "Repite el nombre del grupo en cada opción. Esta carga no asigna productos; eso se hace después en el grupo.",
       "bulkImportHelpExample": "Ejemplo (mismo grupo en 2 líneas):\nPunto de cocción · Término medio · 0\nPunto de cocción · Bien asado · 0",
-      "bulkImportHelpUnits": "Unidades que WARO entiende: peso gr, kg, libra, arroba, bulto_25kg; volumen ml, lt, botella, galon; conteo und; tiempo hr. Usa una unidad compatible con el artículo en bodega (o con sus unidades de compra)."
+      "bulkImportHelpUnits": "Si la opción descuenta bodega, en ingredient_unit usa la unidad base del artículo (gr, kg, ml, lt, und) o una unidad de compra ya configurada en ese artículo (p. ej. libra, arroba, bulto_25kg, botella, galon, hr)."
     },
     "categorias": {
       "searchPlaceholder": "Buscar categoría...",

--- a/i18n/locales/es/menu.json
+++ b/i18n/locales/es/menu.json
@@ -364,7 +364,8 @@
       "bulkImportHelpColumnsNote": "No renombres las columnas de la plantilla (están en inglés a propósito). Los nombres, cantidades y textos sí puedes escribirlos en el idioma de tu negocio.",
       "bulkImportHelpTitle": "Cómo llenar el archivo",
       "bulkImportHelpBody": "Repite el mismo nombre de receta en cada línea de ingredientes. Los ingredientes deben existir ya en bodega, con una unidad que WARO entienda.",
-      "bulkImportHelpExample": "Ejemplo (misma receta en 2 líneas):\nSalsa tomate · Tomate · 1 · kg\nSalsa tomate · Cebolla · 0.2 · kg"
+      "bulkImportHelpExample": "Ejemplo (misma receta en 2 líneas):\nSalsa tomate · Tomate · 1 · kg\nSalsa tomate · Cebolla · 0.2 · kg",
+      "bulkImportHelpUnits": "Unidades que WARO entiende: peso gr, kg, libra, arroba, bulto_25kg; volumen ml, lt, botella, galon; conteo und; tiempo hr. Usa una unidad compatible con el artículo en bodega (o con sus unidades de compra)."
     },
     "modificadores": {
       "searchPlaceholder": "Buscar grupo o producto...",
@@ -514,7 +515,8 @@
       "bulkImportHelpColumnsNote": "No renombres las columnas de la plantilla (están en inglés a propósito). Los nombres, cantidades y textos sí puedes escribirlos en el idioma de tu negocio.",
       "bulkImportHelpTitle": "Cómo llenar el archivo",
       "bulkImportHelpBody": "Repite el nombre del grupo en cada opción. Esta carga no asigna productos; eso se hace después en el grupo.",
-      "bulkImportHelpExample": "Ejemplo (mismo grupo en 2 líneas):\nPunto de cocción · Término medio · 0\nPunto de cocción · Bien asado · 0"
+      "bulkImportHelpExample": "Ejemplo (mismo grupo en 2 líneas):\nPunto de cocción · Término medio · 0\nPunto de cocción · Bien asado · 0",
+      "bulkImportHelpUnits": "Unidades que WARO entiende: peso gr, kg, libra, arroba, bulto_25kg; volumen ml, lt, botella, galon; conteo und; tiempo hr. Usa una unidad compatible con el artículo en bodega (o con sus unidades de compra)."
     },
     "categorias": {
       "searchPlaceholder": "Buscar categoría...",

--- a/i18n/locales/es/menu.json
+++ b/i18n/locales/es/menu.json
@@ -37,6 +37,12 @@
       "incompatibleUnitError": "Selecciona una unidad compatible para cada artículo de bodega.",
       "rowsPerPage": "Filas por página"
     },
+    "bulkImportHelpSections": {
+      "overview": "Resumen",
+      "example": "Ejemplo",
+      "units": "Unidades",
+      "columns": "Columnas"
+    },
     "productos": {
       "editMode": "Modo edición",
       "viewCatalog": "Ver catálogo",
@@ -279,7 +285,7 @@
       "bulkImportHelpColumnsNote": "No renombres las columnas de la plantilla (están en inglés a propósito). Los nombres, cantidades y textos sí puedes escribirlos en el idioma de tu negocio.",
       "bulkImportHelpTitle": "Cómo llenar el archivo",
       "bulkImportHelpBody": "Cada fila es un producto: nombre, precio y categoría. Para terminar una reventa incompleta de bodega, marca esa fila como completar reventa en la plantilla.",
-      "bulkImportHelpExample": "Ejemplo: Café americano · 5000 · Bebidas calientes\nCompletar reventa: Coca 350ml · 3500 · Bebidas"
+      "bulkImportHelpExample": "Café americano · 5000 · Bebidas calientes\nCompletar reventa: Coca 350ml · 3500 · Bebidas"
     },
     "recetas": {
       "searchPlaceholder": "Buscar recetas...",
@@ -364,8 +370,8 @@
       "bulkImportHelpColumnsNote": "No renombres las columnas de la plantilla (están en inglés a propósito). Los nombres, cantidades y textos sí puedes escribirlos en el idioma de tu negocio.",
       "bulkImportHelpTitle": "Cómo llenar el archivo",
       "bulkImportHelpBody": "Repite el mismo nombre de receta en cada línea de ingredientes. Los ingredientes deben existir ya en bodega, con una unidad que WARO entienda.",
-      "bulkImportHelpExample": "Ejemplo (misma receta en 2 líneas):\nSalsa tomate · Tomate · 1 · kg\nSalsa tomate · Cebolla · 0.2 · kg",
-      "bulkImportHelpUnits": "En unit usa la unidad base del artículo en bodega (gr, kg, ml, lt, und) o una unidad de compra ya configurada en ese artículo (p. ej. libra, arroba, bulto_25kg, botella, galon, hr). Si no existe esa unidad de compra, la fila falla."
+      "bulkImportHelpExample": "Misma receta en 2 líneas:\nSalsa tomate · Tomate · 1 · kg\nSalsa tomate · Cebolla · 0.2 · kg",
+      "bulkImportHelpUnits": "Unidad base del artículo: gr, kg, ml, lt, und\nO unidad de compra ya configurada: libra, arroba, bulto_25kg, botella, galon, hr\nSi esa unidad de compra no existe en el artículo, la fila falla."
     },
     "modificadores": {
       "searchPlaceholder": "Buscar grupo o producto...",
@@ -515,8 +521,8 @@
       "bulkImportHelpColumnsNote": "No renombres las columnas de la plantilla (están en inglés a propósito). Los nombres, cantidades y textos sí puedes escribirlos en el idioma de tu negocio.",
       "bulkImportHelpTitle": "Cómo llenar el archivo",
       "bulkImportHelpBody": "Repite el nombre del grupo en cada opción. Esta carga no asigna productos; eso se hace después en el grupo.",
-      "bulkImportHelpExample": "Ejemplo (mismo grupo en 2 líneas):\nPunto de cocción · Término medio · 0\nPunto de cocción · Bien asado · 0",
-      "bulkImportHelpUnits": "Si la opción descuenta bodega, en ingredient_unit usa la unidad base del artículo (gr, kg, ml, lt, und) o una unidad de compra ya configurada en ese artículo (p. ej. libra, arroba, bulto_25kg, botella, galon, hr)."
+      "bulkImportHelpExample": "Mismo grupo en 2 líneas:\nPunto de cocción · Término medio · 0\nPunto de cocción · Bien asado · 0",
+      "bulkImportHelpUnits": "Si la opción descuenta bodega, en ingredient_unit usa:\nUnidad base: gr, kg, ml, lt, und\nO unidad de compra ya configurada: libra, arroba, bulto_25kg, botella, galon, hr"
     },
     "categorias": {
       "searchPlaceholder": "Buscar categoría...",

--- a/pages/finanzas/arqueo/index.vue
+++ b/pages/finanzas/arqueo/index.vue
@@ -106,49 +106,44 @@
       <!-- ── Nuevo arqueo (hub) ─────────────────────────────────────────────── -->
       <div>
         <h2 v-if="!hasOpenShift" class="text-sm font-semibold text-text-primary mb-2">{{ t('finanzas.arqueo.new') }}</h2>
-        <details v-else class="group rounded-lg border border-border bg-surface">
-          <summary class="cursor-pointer list-none px-4 py-3 text-sm font-semibold text-text-primary flex items-center justify-between">
-            {{ t('finanzas.arqueo.otherPeriod') }}
-            <svg class="w-4 h-4 text-text-secondary transition-transform group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-            </svg>
-          </summary>
-          <div class="px-4 pb-4 pt-1">
-            <p class="text-xs text-text-secondary mb-3">{{ t('finanzas.arqueo.otherPeriodHint') }}</p>
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <button
-                type="button"
-                class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/30 bg-primary/5 hover:bg-primary/10 transition-colors min-h-[44px] text-start"
-                @click="onOpenShiftClick(`/finanzas/arqueo/apertura?mode=day&start=${today}&end=${today}`)"
-              >
-                <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-primary/15 flex items-center justify-center text-primary" aria-hidden="true">
-                  <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                  </svg>
-                </div>
-                <div>
-                  <p class="text-sm font-semibold text-text-primary">{{ t('finanzas.common.fullDay') }}</p>
-                  <p class="text-xs text-text-secondary mt-0.5">{{ t('finanzas.arqueo.fullDayMode') }}</p>
-                </div>
-              </button>
-              <button
-                type="button"
-                class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/20 bg-surface hover:border-primary/40 hover:bg-primary/5 transition-colors min-h-[44px] text-start"
-                @click="onCashCloseClick(`/finanzas/arqueo/z?mode=template&start=${today}`)"
-              >
-                <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
-                  <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
-                  </svg>
-                </div>
-                <div>
-                  <p class="text-sm font-semibold text-text-primary">{{ t('finanzas.arqueo.templateMode') }}</p>
-                  <p class="text-xs text-text-secondary mt-0.5">{{ t('finanzas.arqueo.fixedShiftConfigured') }}</p>
-                </div>
-              </button>
-            </div>
+        <UiAccordionSection
+          v-else
+          :title="t('finanzas.arqueo.otherPeriod')"
+        >
+          <p class="text-xs text-text-secondary mb-3">{{ t('finanzas.arqueo.otherPeriodHint') }}</p>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <button
+              type="button"
+              class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/30 bg-primary/5 hover:bg-primary/10 transition-colors min-h-[44px] text-start"
+              @click="onOpenShiftClick(`/finanzas/arqueo/apertura?mode=day&start=${today}&end=${today}`)"
+            >
+              <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-primary/15 flex items-center justify-center text-primary" aria-hidden="true">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+              </div>
+              <div>
+                <p class="text-sm font-semibold text-text-primary">{{ t('finanzas.common.fullDay') }}</p>
+                <p class="text-xs text-text-secondary mt-0.5">{{ t('finanzas.arqueo.fullDayMode') }}</p>
+              </div>
+            </button>
+            <button
+              type="button"
+              class="flex items-start gap-3 p-4 rounded-lg border-2 border-primary/20 bg-surface hover:border-primary/40 hover:bg-primary/5 transition-colors min-h-[44px] text-start"
+              @click="onCashCloseClick(`/finanzas/arqueo/z?mode=template&start=${today}`)"
+            >
+              <div class="flex-shrink-0 w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center text-primary" aria-hidden="true">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
+                </svg>
+              </div>
+              <div>
+                <p class="text-sm font-semibold text-text-primary">{{ t('finanzas.arqueo.templateMode') }}</p>
+                <p class="text-xs text-text-secondary mt-0.5">{{ t('finanzas.arqueo.fixedShiftConfigured') }}</p>
+              </div>
+            </button>
           </div>
-        </details>
+        </UiAccordionSection>
         <div v-if="!hasOpenShift" class="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <button
             type="button"


### PR DESCRIPTION
## Summary
- New `UiAccordionSection` (chevron, tokens, closed by default)
- Carga masiva help + history use it; help lists allowed WARO units
- Arqueo “other period” hub migrated to the same component

Closes #2267

Stacked on #2266 (`wr-2265-menu-import-ux-copy`).

## Test plan
- [ ] Carga masiva: help/history accordion open/close; units text visible for bodega/recetas/modificadores
- [ ] Dropzone still primary; no raw unstyled details
- [ ] Arqueo hub with open shift: other-period accordion still works

## Validation evidence
```
python3 json load i18n → json ok
rg <details MenuImportUpload + arqueo targets → none (UiAccordionSection only)
```

## wr-context
See `.wr/2267.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)