### PR TITLE
fix(shell): use glass SubmitBusyOverlay on logout

### DIFF
--- a/.wr/2269.yaml
+++ b/.wr/2269.yaml
@@ -1,0 +1,40 @@
+# Compact plan for wr-fast. Keep <=80 lines.
+issue: 2269
+title: "fix(shell): use glass SubmitBusyOverlay on logout"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2269-logout-glass-overlay
+
+paths:
+  - components/DashboardSidebar.vue
+  - components/ui/SubmitBusyOverlay.vue
+  - .wr/2269.yaml
+
+ac:
+  - Logout shows fullscreen glass busy overlay (same as submit flows)
+  - Matrix indicator via UiSubmitBusyOverlay glass + matrix
+  - Copy uses shell.loggingOut / shell.pleaseWait (badge shell.logout)
+  - Remove opaque logout-overlay / logout-card CSS
+  - Logout flow unchanged; overlay blocks while busy (z-[9999])
+
+out_of_scope:
+  - customer-portal logout
+  - API/auth changes
+  - UiLoadingMatrix redesign
+
+hints:
+  entry: "components/DashboardSidebar.vue handleLogout"
+  pattern: "pages/menu/productos/crear.vue UiSubmitBusyOverlay glass+matrix"
+  tests: "rg logout-overlay DashboardSidebar → empty; rg UiSubmitBusyOverlay DashboardSidebar"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: ""

--- a/components/DashboardSidebar.vue
+++ b/components/DashboardSidebar.vue
@@ -1,15 +1,14 @@
 <template>
   <div>
-  <!-- Loading Global Overlay -->
-  <Teleport to="body">
-    <div v-if="isLoggingOut" class="logout-overlay fixed inset-0 flex items-center justify-center z-[9999]">
-      <div class="logout-card rounded-2xl shadow-xl p-8 flex flex-col items-center">
-        <UiLoadingMatrix class="mb-4" size="9px" color="currentColor" />
-        <p class="logout-title text-lg font-medium">{{ t('shell.loggingOut') }}</p>
-        <p class="logout-message text-sm mt-2">{{ t('shell.pleaseWait') }}</p>
-      </div>
-    </div>
-  </Teleport>
+  <UiSubmitBusyOverlay
+    :busy="isLoggingOut"
+    :label="t('shell.loggingOut')"
+    :hint="t('shell.pleaseWait')"
+    :badge="t('shell.logout')"
+    variant="glass"
+    indicator="matrix"
+    fullscreen-z-class="z-[9999]"
+  />
 
   <UiBaseSidebar
     :overlay="props.overlay"
@@ -273,22 +272,6 @@ const handleLogout = async () => {
 </script>
 
 <style scoped>
-.logout-overlay {
-  background-color: hsl(var(--nav-overlay-bg) / 0.5);
-}
-
-.logout-card {
-  background-color: hsl(var(--nav-overlay-card-bg));
-}
-
-.logout-title {
-  color: hsl(var(--nav-overlay-title));
-}
-
-.logout-message {
-  color: hsl(var(--nav-overlay-message));
-}
-
 /*
   Sidebar navigation states read semantic nav tokens. Alpha remains local here
   because the sidebar hierarchy depends on subtle idle/hover/active emphasis.

--- a/components/ui/SubmitBusyOverlay.vue
+++ b/components/ui/SubmitBusyOverlay.vue
@@ -8,14 +8,20 @@ const props = withDefaults(defineProps<{
   busy?: boolean
   label?: string
   hint?: string
+  /** Pill above the loader; defaults to common.submitBusy */
+  badge?: string
   fullscreen?: boolean
+  /** Tailwind z-* class for fullscreen overlay (logout needs above shell chrome) */
+  fullscreenZClass?: string
   variant?: OverlayVariant
   indicator?: OverlayIndicator
 }>(), {
   busy: false,
   label: '',
   hint: '',
+  badge: '',
   fullscreen: true,
+  fullscreenZClass: 'z-50',
   variant: 'glass',
   indicator: 'matrix',
 })
@@ -24,7 +30,7 @@ const { t } = useI18n({ useScope: 'global' })
 
 const overlayPositionClass = computed(() =>
   props.fullscreen
-    ? 'fixed inset-0 z-50'
+    ? `fixed inset-0 ${props.fullscreenZClass}`
     : 'absolute inset-0 z-20 rounded-[inherit]'
 )
 
@@ -36,6 +42,7 @@ const panelClass = computed(() =>
 
 const displayLabel = computed(() => props.label || t('common.processing'))
 const displayHint = computed(() => props.hint || '')
+const displayBadge = computed(() => props.badge || t('common.submitBusy'))
 const labelId = computed(() => `submit-busy-${displayLabel.value.toLowerCase().replace(/[^a-z0-9]+/g, '-') || 'state'}`)
 const hintId = computed(() => displayHint.value ? `${labelId.value}-hint` : undefined)
 </script>
@@ -67,7 +74,7 @@ const hintId = computed(() => displayHint.value ? `${labelId.value}-hint` : unde
             <div
               class="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-primary"
             >
-              {{ t('common.submitBusy') }}
+              {{ displayBadge }}
             </div>
 
             <CommonsTheCustomLoader


### PR DESCRIPTION
## Summary
- Replace opaque logout card with shared glass `UiSubmitBusyOverlay` (matrix)
- Optional `badge` + `fullscreenZClass` so logout copy/z-index fit the shell
- Remove custom `logout-overlay` / `logout-card` styles

Closes #2269

## Test plan
- [ ] Click Cerrar sesión in dashboard sidebar → glass overlay with matrix
- [ ] Overlay shows Cerrar sesión / Cerrando sesión... / Por favor espera (not “Enviando cambios”)
- [ ] Overlay sits above shell chrome; session still clears and redirects home
- [ ] Existing create/submit busy overlays still look the same

## Validation evidence
```
rg logout-overlay|logout-card|UiLoadingMatrix components/DashboardSidebar.vue
→ (empty — ok)

rg UiSubmitBusyOverlay|fullscreen-z-class|shell.loggingOut components/DashboardSidebar.vue
→ UiSubmitBusyOverlay + shell.loggingOut + fullscreen-z-class="z-[9999]"

rg displayBadge|fullscreenZClass|badge components/ui/SubmitBusyOverlay.vue
→ badge + fullscreenZClass props wired to displayBadge
```

## wr-context
See `.wr/2269.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)