### PR TITLE
fix(shell): title the tenant picker as Select business

### DIFF
--- a/components/DashboardBottomNav.vue
+++ b/components/DashboardBottomNav.vue
@@ -180,11 +180,10 @@
     </UiBottomSheetModal>
 
     <!-- Tenant Selector Modal -->
-    <UiBottomSheetModal v-model="showTenantModal" :title="t('shell.settings')" max-height="lg">
+    <UiBottomSheetModal v-model="showTenantModal" :title="t('shell.selectTenant')" max-height="lg">
       <div class="p-4 space-y-6">
         <!-- Tenant Selector -->
         <div>
-          <label class="text-sm text-text-secondary font-medium mb-2 block">{{ t('shell.selectTenant') }}</label>
           <div class="space-y-2">
             <div v-if="isLoadingTenants" class="text-sm text-text-secondary py-2">
               {{ t('shell.loadingTenants') }}

--- a/components/DashboardTenantSelector.vue
+++ b/components/DashboardTenantSelector.vue
@@ -11,7 +11,7 @@
         <div class="absolute inset-0 bg-overlay-backdrop-strong/60 backdrop-blur-sm" @click="closeTenantModal" />
         <div class="relative w-full sm:w-[420px] sm:max-w-[90vw] bg-sheet-surface-bg sm:rounded-xl rounded-t-2xl shadow-2xl flex flex-col max-h-[80vh] sm:max-h-[60vh]">
           <div class="flex items-center justify-between px-5 pt-5 pb-3 border-b border-sheet-border flex-shrink-0">
-            <p class="text-sm font-semibold text-modal-surface-text">{{ t('shell.settings') }}</p>
+            <p class="text-sm font-semibold text-modal-surface-text">{{ t('shell.selectTenant') }}</p>
             <button @click="closeTenantModal" class="p-1.5 rounded-lg text-shell-notification-muted-text hover:bg-shell-notification-hover-bg hover:text-shell-notification-text focus:outline-none focus:ring-2 focus:ring-shell-action-focus-ring transition-colors">
               <XMarkIcon class="w-4 h-4" />
             </button>

--- a/i18n/locales/ar/shell.json
+++ b/i18n/locales/ar/shell.json
@@ -37,7 +37,7 @@
     "enableAlerts": "تفعيل صوت التنبيهات",
     "noNotifications": "لا توجد إشعارات جديدة",
     "noTenant": "لا يوجد مستأجر",
-    "selectTenant": "اختيار مستأجر",
+    "selectTenant": "اختيار عمل",
     "loadingTenants": "جارٍ تحميل المستأجرين...",
     "noTenants": "لا يوجد مستأجرون متاحون",
     "createTenant": "إنشاء",

--- a/i18n/locales/de/shell.json
+++ b/i18n/locales/de/shell.json
@@ -37,7 +37,7 @@
     "enableAlerts": "Warntöne aktivieren",
     "noNotifications": "Keine neuen Benachrichtigungen",
     "noTenant": "Kein Mandant",
-    "selectTenant": "Mandant auswählen",
+    "selectTenant": "Betrieb auswählen",
     "loadingTenants": "Mandanten werden geladen...",
     "noTenants": "Keine Mandanten verfügbar",
     "createTenant": "Erstellen",

--- a/i18n/locales/en/shell.json
+++ b/i18n/locales/en/shell.json
@@ -40,7 +40,7 @@
     "enableAlerts": "Enable sound alerts",
     "noNotifications": "No new notifications",
     "noTenant": "No tenant",
-    "selectTenant": "Select tenant",
+    "selectTenant": "Select business",
     "loadingTenants": "Loading tenants...",
     "noTenants": "No tenants available",
     "createTenant": "Create",

--- a/i18n/locales/es/shell.json
+++ b/i18n/locales/es/shell.json
@@ -40,7 +40,7 @@
     "enableAlerts": "Activar alertas sonoras",
     "noNotifications": "Sin notificaciones nuevas",
     "noTenant": "Sin tenant",
-    "selectTenant": "Seleccionar Tenant",
+    "selectTenant": "Seleccionar negocio",
     "loadingTenants": "Cargando tenants...",
     "noTenants": "No hay tenants disponibles",
     "createTenant": "Crear",

--- a/i18n/locales/fr/shell.json
+++ b/i18n/locales/fr/shell.json
@@ -37,7 +37,7 @@
     "enableAlerts": "Activer les alertes sonores",
     "noNotifications": "Aucune nouvelle notification",
     "noTenant": "Aucun tenant",
-    "selectTenant": "Sélectionner un tenant",
+    "selectTenant": "Sélectionner un établissement",
     "loadingTenants": "Chargement des tenants...",
     "noTenants": "Aucun tenant disponible",
     "createTenant": "Créer",

--- a/i18n/locales/hi/shell.json
+++ b/i18n/locales/hi/shell.json
@@ -37,7 +37,7 @@
     "enableAlerts": "ध्वनि अलर्ट सक्षम करें",
     "noNotifications": "कोई नई सूचना नहीं",
     "noTenant": "कोई टेनेंट नहीं",
-    "selectTenant": "टेनेंट चुनें",
+    "selectTenant": "व्यवसाय चुनें",
     "loadingTenants": "टेनेंट लोड हो रहे हैं...",
     "noTenants": "कोई टेनेंट उपलब्ध नहीं है",
     "createTenant": "बनाएँ",

--- a/i18n/locales/pt/shell.json
+++ b/i18n/locales/pt/shell.json
@@ -37,7 +37,7 @@
     "enableAlerts": "Ativar alertas sonoras",
     "noNotifications": "Sem novas notificações",
     "noTenant": "Sem tenant",
-    "selectTenant": "Selecionar Tenant",
+    "selectTenant": "Selecionar negócio",
     "loadingTenants": "Carregando tenants...",
     "noTenants": "Nenhum tenant disponível",
     "createTenant": "Criar",

--- a/i18n/locales/zh/shell.json
+++ b/i18n/locales/zh/shell.json
@@ -37,7 +37,7 @@
     "enableAlerts": "启用警报音",
     "noNotifications": "无新通知",
     "noTenant": "无租户",
-    "selectTenant": "选择租户",
+    "selectTenant": "选择商家",
     "loadingTenants": "正在加载租户...",
     "noTenants": "无可用租户",
     "createTenant": "创建",


### PR DESCRIPTION
## Summary
- Tenant picker title uses `shell.selectTenant` instead of Settings.
- Copy is “Select business” / “Seleccionar negocio” (and locale equivalents).
- Mobile sheet drops the duplicate inner label.

## Test plan
- [ ] Open header tenant picker — title is Select business, not Settings
- [ ] Create still opens the slide-over
- [ ] Mobile cog sheet title matches


Made with [Cursor](https://cursor.com)