### PR TITLE
Starter plan upsell uses tenant currency

### DIFF
--- a/utils/publicCta.test.ts
+++ b/utils/publicCta.test.ts
@@ -140,6 +140,36 @@ test('omitted market keeps Colombia ES COP public CTAs', () => {
   assert.equal(omitted.button, 'Crear cuenta y elegir plan')
 })
 
+test('trial banner price anchor avoids COP for Argentina and other catalog tenants', () => {
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'es', countryCode: 'AR', currencyCode: 'ARS' }),
+    'el Plan Pro',
+  )
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'en', countryCode: 'AR', currencyCode: 'ARS' }),
+    'Plan Pro',
+  )
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'es', countryCode: 'PE', currencyCode: 'PEN' }),
+    'el Plan Pro',
+  )
+  assert.doesNotMatch(
+    resolveTrialPriceAnchor({ locale: 'es', countryCode: 'AR', currencyCode: 'ARS' }),
+    /COP/i,
+  )
+  assert.doesNotMatch(
+    resolveTrialPriceAnchor({ locale: 'es', countryCode: null, currencyCode: 'ARS' }),
+    /COP/i,
+  )
+})
+
+test('trial banner price anchor keeps COP when country and currency are unknown', () => {
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'es' }),
+    PUBLIC_OFFER.monthlyEquivalent,
+  )
+})
+
 test('trial banner price anchor uses USD for US tenants', () => {
   assert.equal(
     resolveTrialPriceAnchor({ locale: 'en', countryCode: 'US', currencyCode: 'USD' }),

--- a/utils/publicCta.ts
+++ b/utils/publicCta.ts
@@ -87,13 +87,23 @@ export function resolveTrialPriceAnchor(options: {
   const isMexico = country === 'MX' || currency === 'MXN'
   const isUs = country === 'US' || currency === 'USD'
 
+  const planProFallback = () => (isEn ? 'Plan Pro' : 'el Plan Pro')
+
   if (isMexico) {
     // No approved MXN list price yet — avoid showing COP to MX tenants.
-    return isEn ? 'Plan Pro' : 'el Plan Pro'
+    return planProFallback()
   }
 
   if (isUs) {
     return isEn ? 'under USD $30/month' : 'menos de USD $30/mes'
+  }
+
+  // COP marketing copy is Colombia-only. Any other catalog country/currency
+  // (AR/ARS, PE/PEN, …) follows the MX fallback — no invented FX amounts.
+  const hasCountry = Boolean(country)
+  const hasCurrency = Boolean(currency)
+  if ((hasCountry && country !== 'CO') || (hasCurrency && currency !== 'COP')) {
+    return planProFallback()
   }
 
   return isEn ? 'under COP 8,000/month' : PUBLIC_OFFER.monthlyEquivalent


### PR DESCRIPTION
## Summary
- Starter shell banner `priceAnchor` no longer falls through to COP for AR/ARS (or other non-CO catalog countries).
- CO still sees COP 8.000-style copy; US stays USD $30; MX and AR use the Plan Pro fallback (no invented FX).

Closes #2288

## Test plan
- [ ] AR Starter tenant: banner does not say COP 8.000
- [ ] CO Starter tenant: still sees COP price copy
- [ ] MX still Plan Pro; US still USD $30

## Validation evidence
```text
$ node --test utils/publicCta.test.ts
ok 6 - trial banner price anchor stays COP for Colombia tenants
ok 7 - trial banner price anchor avoids COP for Mexico tenants
ok 10 - trial banner price anchor avoids COP for Argentina and other catalog tenants
ok 11 - trial banner price anchor keeps COP when country and currency are unknown
ok 12 - trial banner price anchor uses USD for US tenants
# tests 12
# pass 12
# fail 0
```

Made with [Cursor](https://cursor.com)