### PR TITLE
Starter banner uses Paddle USD  /  / EUR €30

### DIFF
--- a/utils/publicCta.test.ts
+++ b/utils/publicCta.test.ts
@@ -99,23 +99,40 @@ test('trial banner price anchor stays COP for Colombia tenants', () => {
   )
 })
 
-test('trial banner price anchor avoids COP for Mexico tenants', () => {
+test('trial banner price anchor uses USD $9 for usd_9 catalog tenants', () => {
   assert.equal(
     resolveTrialPriceAnchor({ locale: 'es', countryCode: 'MX', currencyCode: 'MXN' }),
-    'el Plan Pro',
+    'menos de USD $9/mes',
   )
   assert.equal(
     resolveTrialPriceAnchor({ locale: 'en', countryCode: 'MX', currencyCode: 'MXN' }),
-    'Plan Pro',
+    'under USD $9/month',
   )
   assert.equal(
     resolveTrialPriceAnchor({ locale: 'es', countryCode: null, currencyCode: 'MXN' }),
-    'el Plan Pro',
+    'menos de USD $9/mes',
   )
-  assert.doesNotMatch(
-    resolveTrialPriceAnchor({ locale: 'es', countryCode: 'MX', currencyCode: 'MXN' }),
-    /COP/i,
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'es', countryCode: 'AR', currencyCode: 'ARS' }),
+    'menos de USD $9/mes',
   )
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'es', countryCode: 'PE', currencyCode: 'PEN' }),
+    'menos de USD $9/mes',
+  )
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'es', countryCode: 'CL', currencyCode: 'CLP' }),
+    'menos de USD $9/mes',
+  )
+  for (const opts of [
+    { locale: 'es', countryCode: 'MX', currencyCode: 'MXN' },
+    { locale: 'es', countryCode: 'AR', currencyCode: 'ARS' },
+    { locale: 'es', countryCode: null, currencyCode: 'ARS' },
+  ]) {
+    const line = resolveTrialPriceAnchor(opts)
+    assert.doesNotMatch(line, /COP/i)
+    assert.doesNotMatch(line, /\$30/)
+  }
 })
 
 test('public CTAs render EN + USD $30/month for US English market', () => {
@@ -140,7 +157,7 @@ test('omitted market keeps Colombia ES COP public CTAs', () => {
   assert.equal(omitted.button, 'Crear cuenta y elegir plan')
 })
 
-test('trial banner price anchor uses USD for US tenants', () => {
+test('trial banner price anchor uses USD $30 for usd_30 catalog tenants', () => {
   assert.equal(
     resolveTrialPriceAnchor({ locale: 'en', countryCode: 'US', currencyCode: 'USD' }),
     'under USD $30/month',
@@ -149,8 +166,38 @@ test('trial banner price anchor uses USD for US tenants', () => {
     resolveTrialPriceAnchor({ locale: 'es', countryCode: 'US', currencyCode: 'USD' }),
     'menos de USD $30/mes',
   )
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'es', countryCode: 'PA', currencyCode: 'USD' }),
+    'menos de USD $30/mes',
+  )
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'en', countryCode: 'GB', currencyCode: 'GBP' }),
+    'under USD $30/month',
+  )
   assert.doesNotMatch(
     resolveTrialPriceAnchor({ locale: 'en', countryCode: 'US', currencyCode: 'USD' }),
     /COP/i,
+  )
+})
+
+test('trial banner price anchor uses EUR €30 for eurozone catalog tenants', () => {
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'es', countryCode: 'ES', currencyCode: 'EUR' }),
+    'menos de EUR €30/mes',
+  )
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'en', countryCode: 'DE', currencyCode: 'EUR' }),
+    'under EUR €30/month',
+  )
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'es', countryCode: null, currencyCode: 'EUR' }),
+    'menos de EUR €30/mes',
+  )
+})
+
+test('trial banner price anchor keeps COP when country and currency are unknown', () => {
+  assert.equal(
+    resolveTrialPriceAnchor({ locale: 'es' }),
+    PUBLIC_OFFER.monthlyEquivalent,
   )
 })

--- a/utils/publicCta.ts
+++ b/utils/publicCta.ts
@@ -75,7 +75,19 @@ export function resolvePublicOffer(marketInput: ArticleMarketInput | ArticleMark
   return PUBLIC_OFFER
 }
 
-/** In-app Starter trial banner price slot (warocol.com#1917). */
+/** Paddle charge segments mirrored from api billing_pricing.resolve_price_segment. */
+const EUR_30_COUNTRIES = new Set(['ES', 'DE', 'FR', 'NL'])
+const USD_30_COUNTRIES = new Set(['US', 'PA', 'GB', 'CA', 'AU', 'NZ', 'SG', 'AE'])
+
+function trialPriceCopy(
+  isEn: boolean,
+  es: string,
+  en: string,
+): string {
+  return isEn ? en : es
+}
+
+/** In-app Starter trial banner price slot (warocol.com#1917, #2293). */
 export function resolveTrialPriceAnchor(options: {
   locale?: string | null
   countryCode?: string | null
@@ -84,19 +96,25 @@ export function resolveTrialPriceAnchor(options: {
   const isEn = String(options.locale || '').toLowerCase().startsWith('en')
   const country = String(options.countryCode || '').toUpperCase()
   const currency = String(options.currencyCode || '').toUpperCase()
-  const isMexico = country === 'MX' || currency === 'MXN'
-  const isUs = country === 'US' || currency === 'USD'
 
-  if (isMexico) {
-    // No approved MXN list price yet — avoid showing COP to MX tenants.
-    return isEn ? 'Plan Pro' : 'el Plan Pro'
+  const copLine = () => trialPriceCopy(isEn, PUBLIC_OFFER.monthlyEquivalent, 'under COP 8,000/month')
+  const usd9 = () => trialPriceCopy(isEn, 'menos de USD $9/mes', 'under USD $9/month')
+  const usd30 = () => trialPriceCopy(isEn, 'menos de USD $30/mes', 'under USD $30/month')
+  const eur30 = () => trialPriceCopy(isEn, 'menos de EUR €30/mes', 'under EUR €30/month')
+
+  // Marketing exception: CO stays COP even though Paddle charges usd_9.
+  if (!country && !currency) return copLine()
+  if (country === 'CO' || (!country && currency === 'COP')) return copLine()
+
+  if (country) {
+    if (EUR_30_COUNTRIES.has(country)) return eur30()
+    if (USD_30_COUNTRIES.has(country)) return usd30()
+    return usd9()
   }
 
-  if (isUs) {
-    return isEn ? 'under USD $30/month' : 'menos de USD $30/mes'
-  }
-
-  return isEn ? 'under COP 8,000/month' : PUBLIC_OFFER.monthlyEquivalent
+  if (currency === 'EUR') return eur30()
+  if (currency === 'USD') return usd30()
+  return usd9()
 }
 
 // Activate only after recording a verifiable source, date, scope and disclosure here.


### PR DESCRIPTION
## Summary
- Starter shell banner copy now follows Paddle charge segments: USD $9 (MX/AR/PE/CL and other usd_9), USD $30 (US/PA/intl allowlist), EUR €30 (ES/DE/FR/NL).
- Colombia still uses COP 8.000 marketing copy; empty country/currency still defaults to that COP line.
- Supersedes the “Plan Pro” fallback in #2288 / PR #2292 for this helper — merge this after or instead of #2292 to avoid a conflict on `resolveTrialPriceAnchor`.

Closes #2293

## Test plan
- [ ] AR/MX Starter banner shows USD $9, never COP or $30
- [ ] US/PA Starter banner shows USD $30
- [ ] ES/DE Starter banner shows EUR €30
- [ ] CO Starter banner still shows COP 8.000-style copy
- [ ] Unknown country/currency still shows the COP line

## Validation evidence
```text
$ node --test utils/publicCta.test.ts
ok 6 - trial banner price anchor stays COP for Colombia tenants
ok 7 - trial banner price anchor uses USD $9 for usd_9 catalog tenants
ok 10 - trial banner price anchor uses USD $30 for usd_30 catalog tenants
ok 11 - trial banner price anchor uses EUR €30 for eurozone catalog tenants
ok 12 - trial banner price anchor keeps COP when country and currency are unknown
# tests 12
# pass 12
# fail 0
```

## wr-context
See `.wr/2293.yaml` on this branch (LLM contract; gitignored locally).

Made with [Cursor](https://cursor.com)