### PR TITLE
Negocio city picker from a per-country curated catalog

### DIFF
--- a/composables/useCityCatalog.search.test.ts
+++ b/composables/useCityCatalog.search.test.ts
@@ -4,6 +4,7 @@ import {
   filterCityCatalog,
   resolveCityFromSearchTerm,
   formatApiValidationError,
+  hasCuratedCityCatalog,
   type PublicCity,
 } from './useCityCatalog.ts'
 
@@ -42,5 +43,14 @@ describe('city catalog search helpers', () => {
       'fallback',
     )
     assert.match(message, /read-only/)
+  })
+
+  it('treats CO AR MX US as curated catalogs and others as free-text', () => {
+    assert.equal(hasCuratedCityCatalog('CO'), true)
+    assert.equal(hasCuratedCityCatalog('AR'), true)
+    assert.equal(hasCuratedCityCatalog('MX'), true)
+    assert.equal(hasCuratedCityCatalog('US'), true)
+    assert.equal(hasCuratedCityCatalog('PE'), false)
+    assert.equal(hasCuratedCityCatalog(''), true)
   })
 })

--- a/composables/useCityCatalog.ts
+++ b/composables/useCityCatalog.ts
@@ -19,11 +19,20 @@ import { computed } from 'vue'
 
 export interface PublicCity {
   country: string
+  country_code?: string | null
   city: string
   city_slug: string
   tenant_count: number
   department?: string | null
   department_name?: string | null
+}
+
+/** Countries with a curated Negocio picker (warocol.com#2295). SSR dispatch stays CO-only. */
+export const CURATED_CITY_COUNTRY_CODES = new Set(['CO', 'AR', 'MX', 'US'])
+
+export function hasCuratedCityCatalog(countryCode?: string | null): boolean {
+  const code = String(countryCode || 'CO').trim().toUpperCase() || 'CO'
+  return CURATED_CITY_COUNTRY_CODES.has(code)
 }
 
 /** Common misspellings / spoken variants → catalog slug (warocol.com#1740). */
@@ -229,6 +238,52 @@ export function useCityCatalog() {
     return findCity(seg)
   }
 
+  const extraCities = useState<PublicCity[]>('city-catalog-extra', () => [])
+  const extraCountry = useState<string>('city-catalog-extra-cc', () => '')
+  const extraLoading = useState<boolean>('city-catalog-extra-loading', () => false)
+  const extraError = useState<string | null>('city-catalog-extra-error', () => null)
+  const extraLoaded = useState<boolean>('city-catalog-extra-loaded', () => false)
+
+  const fetchCatalogForCountry = async (
+    countryCode: string,
+    opts?: { includeEmpty?: boolean },
+  ): Promise<void> => {
+    const cc = String(countryCode || 'CO').trim().toUpperCase() || 'CO'
+    if (cc === 'CO') {
+      await fetchCatalog(opts)
+      return
+    }
+    if (extraCountry.value === cc && extraCities.value.length > 0) {
+      extraError.value = null
+      extraLoaded.value = true
+      return
+    }
+    extraCountry.value = cc
+    extraLoading.value = true
+    extraError.value = null
+    extraLoaded.value = false
+    extraCities.value = []
+    try {
+      const res = await $fetch<{ success: boolean; data: PublicCity[] }>(
+        '/api/public/restaurant/cities',
+        {
+          params: {
+            include_empty: opts?.includeEmpty ? 'true' : 'false',
+            country_code: cc,
+          },
+        },
+      )
+      extraCities.value = res?.data ?? []
+      extraLoaded.value = true
+    } catch (err) {
+      extraCities.value = []
+      extraLoaded.value = true
+      extraError.value = err instanceof Error ? err.message : 'No se pudo cargar el catálogo de ciudades.'
+    } finally {
+      extraLoading.value = false
+    }
+  }
+
   return {
     cities,
     citySlugSet,
@@ -237,6 +292,11 @@ export function useCityCatalog() {
     isCityRoute,
     cityFromRoute,
     fetchCatalog,
+    fetchCatalogForCountry,
+    extraCities,
+    extraLoading,
+    extraError,
+    extraLoaded,
     isLoading,
     error,
     hasLoaded,

--- a/pages/negocio.vue
+++ b/pages/negocio.vue
@@ -471,7 +471,7 @@
                 {{ t('negocio.city') }}
                 <span v-if="isColombiaTenant" class="text-amber-600" aria-hidden="true">*</span>
               </label>
-              <template v-if="isColombiaTenant">
+              <template v-if="hasCityCatalog">
               <div ref="citySearchAnchorRef" class="relative">
                 <input
                   id="negocio-city"
@@ -482,7 +482,7 @@
                   :aria-expanded="cityDropdownOpen"
                   :aria-controls="cityListboxId"
                   :aria-activedescendant="activeCityOptionId"
-                  :aria-describedby="cityHelpId"
+                  :aria-describedby="isColombiaTenant ? cityHelpId : undefined"
                   autocomplete="off"
                   class="input-base w-full px-3 py-2 ps-9 pe-10 text-sm"
                   :placeholder="t('negocio.cityPlaceholder')"
@@ -549,7 +549,7 @@
                   </li>
                 </ul>
               </Teleport>
-              <p :id="cityHelpId" class="text-[10px] text-text-tertiary mt-1">
+              <p v-if="isColombiaTenant" :id="cityHelpId" class="text-[10px] text-text-tertiary mt-1">
                 {{ t('negocio.cityDirectoryHelp') }}
               </p>
               <p
@@ -857,6 +857,7 @@ import {
   filterCityCatalog,
   resolveCityFromSearchTerm,
   formatApiValidationError,
+  hasCuratedCityCatalog,
 } from '~/composables/useCityCatalog'
 import {
   normalizeStorefrontSlug,
@@ -894,10 +895,11 @@ const isStarterPlan = computed(() => accessStore.planSlug === 'starter')
 const tenantsStore = useTenantsStore()
 const { profile: financialProfile } = useTenantFinancialProfile()
 const { formatCurrency: formatTenantCurrency, currencyCode } = useFormatters()
-const isColombiaTenant = computed(() => {
-  const code = String(financialProfile.value?.country_code || '').trim().toUpperCase()
-  return !code || code === 'CO'
-})
+const tenantCountryCode = computed(() =>
+  String(financialProfile.value?.country_code || '').trim().toUpperCase(),
+)
+const isColombiaTenant = computed(() => !tenantCountryCode.value || tenantCountryCode.value === 'CO')
+const hasCityCatalog = computed(() => hasCuratedCityCatalog(tenantCountryCode.value))
 const { data: profileData, status: profileStatus, asyncStatus: profileAsyncStatus, error: profileError, refetch: refreshProfile } = useQuery({
   key: () => ['tenant', 'negocio-profile', currentTenant.value?.id],
   query: () => $fetch<{ success: boolean; data: any }>('/api/api/tenant/public-profile'),
@@ -947,14 +949,33 @@ const editForm = reactive({
 const {
   cities: cityCatalog,
   fetchCatalog: ensureCityCatalog,
-  isLoading: cityCatalogLoading,
-  error: cityCatalogError,
-  hasLoaded: cityCatalogLoaded,
+  fetchCatalogForCountry,
+  extraCities,
+  extraLoading,
+  extraError,
+  extraLoaded,
+  isLoading: cityCatalogLoadingCo,
+  error: cityCatalogErrorCo,
+  hasLoaded: cityCatalogLoadedCo,
 } = useCityCatalog()
-// Make sure the selector has the full catalog (include_empty=true). The SSR
-// plugin already warmed this — this is a no-op on subsequent visits and only
-// hits the API on a fresh client load.
-onMounted(() => { ensureCityCatalog({ includeEmpty: true }) })
+
+const pickerCities = computed(() => (isColombiaTenant.value ? cityCatalog.value : extraCities.value))
+const cityCatalogLoading = computed(() => (isColombiaTenant.value ? cityCatalogLoadingCo.value : extraLoading.value))
+const cityCatalogError = computed(() => (isColombiaTenant.value ? cityCatalogErrorCo.value : extraError.value))
+const cityCatalogLoaded = computed(() => (isColombiaTenant.value ? cityCatalogLoadedCo.value : extraLoaded.value))
+
+watch(
+  () => [hasCityCatalog.value, isColombiaTenant.value, tenantCountryCode.value] as const,
+  () => {
+    if (!hasCityCatalog.value) return
+    if (isColombiaTenant.value) {
+      void ensureCityCatalog({ includeEmpty: true })
+      return
+    }
+    void fetchCatalogForCountry(tenantCountryCode.value, { includeEmpty: true })
+  },
+  { immediate: true },
+)
 
 const CITY_RESULT_LIMIT = 40
 const cityListboxId = 'negocio-city-results'
@@ -967,11 +988,11 @@ const citySearchActiveIndex = ref(0)
 const cityDepartment = (city: PublicCity) => cityDepartmentLabel(city)
 
 const selectedCity = computed(() =>
-  cityCatalog.value.find((c) => c.city_slug === editForm.city_slug) ?? null,
+  pickerCities.value.find((c) => c.city_slug === editForm.city_slug) ?? null,
 )
 
 const visibleCityResults = computed(() =>
-  filterCityCatalog(cityCatalog.value, citySearchTerm.value, CITY_RESULT_LIMIT),
+  filterCityCatalog(pickerCities.value, citySearchTerm.value, CITY_RESULT_LIMIT),
 )
 
 const cityDropdownOpen = computed(() =>
@@ -993,7 +1014,7 @@ const { panelStyle: cityPanelStyle, updatePlacement: updateCitySearchPlacement }
 const cityEmptyMessage = computed(() => {
   if (cityCatalogLoading.value) return t('negocio.loadingCities')
   if (cityCatalogError.value) return t('negocio.cityCatalogUnavailable')
-  if (!cityCatalog.value.length && cityCatalogLoaded.value) return t('negocio.noCities')
+  if (!pickerCities.value.length && cityCatalogLoaded.value) return t('negocio.noCities')
   return t('negocio.noResults')
 })
 
@@ -1010,7 +1031,7 @@ const syncCitySearchTerm = () => {
 
 const onCityChange = (slug: string) => {
   editForm.city_slug = slug
-  const entry = cityCatalog.value.find((c) => c.city_slug === slug)
+  const entry = pickerCities.value.find((c) => c.city_slug === slug)
   editForm.city = entry?.city || ''
   syncCitySearchTerm()
 }
@@ -1030,7 +1051,7 @@ const clearCitySelection = () => {
 }
 
 const onCitySearchInput = () => {
-  const resolved = resolveCityFromSearchTerm(cityCatalog.value, citySearchTerm.value)
+  const resolved = resolveCityFromSearchTerm(pickerCities.value, citySearchTerm.value)
   if (resolved) {
     editForm.city_slug = resolved.city_slug
     editForm.city = resolved.city
@@ -1052,7 +1073,7 @@ const openCitySearch = () => {
 
 const closeCitySearch = () => {
   if (!editForm.city_slug && citySearchTerm.value.trim()) {
-    const match = resolveCityFromSearchTerm(cityCatalog.value, citySearchTerm.value)
+    const match = resolveCityFromSearchTerm(pickerCities.value, citySearchTerm.value)
     if (match) onCityChange(match.city_slug)
   }
   citySearchOpen.value = false
@@ -1179,10 +1200,6 @@ const hasSocialMedia = computed(() => {
   return sm && Object.values(sm).some(v => !!v)
 })
 
-const tenantCountryCode = computed(() =>
-  String(financialProfile.value?.country_code || '').trim().toUpperCase(),
-)
-const isColombiaTenant = computed(() => tenantCountryCode.value === 'CO')
 const phonePlaceholder = computed(() => phonePlaceholderForCountry(tenantCountryCode.value))
 
 const regionDisplayName = (code: string) => {
@@ -1371,7 +1388,7 @@ const saveOpsChanges = async () => {
         email: editForm.email || null,
         address: editForm.address || null,
         city: editForm.city || null,
-        city_slug: isColombiaTenant.value ? (editForm.city_slug || null) : null,
+        city_slug: hasCityCatalog.value ? (editForm.city_slug || null) : null,
         neighborhood: editForm.neighborhood || null,
         timezone: normalizeTimezone(editForm.timezone),
         accepts_online_orders: businessProfile.value?.accepts_online_orders ?? editForm.accepts_online_orders,


### PR DESCRIPTION
## Summary
- Mi Negocio uses a curated city combobox for AR/MX/US (short lists), not Bogotá/Medellín and not unbounded free text.
- Extra-country catalog is fetched into a separate state so SSR `isCitySlug` / `/bogota` stay Colombia-only.
- CO combobox, required city, and directory help are unchanged. Other countries keep free-text + `city_slug` null.

Companion: api-warolabs on `wr-2295-negocio-city-picker` (apply `sql/20260814_public_cities_country_code.sql` before relying on AR/MX/US rows).

Closes #2295

## Test plan
- [ ] AR tenant: city combobox shows Buenos Aires / Córdoba / Rosario / Mendoza — not Bogotá
- [ ] AR tenant: save a city; profile stores that slug, not `bogota`
- [ ] PE (or other) tenant: free-text city still works; `city_slug` stays null
- [ ] CO tenant: existing municipality combobox + required * + directory help
- [ ] `/bogota` and `/ciudades` still work (no AR slugs in SSR catalog)

## Validation evidence
```text
$ node --test composables/useCityCatalog.search.test.ts
# tests 4
# pass 4
# fail 0
```

Companion API:
```text
$ ./venv/bin/pytest tests/test_public_city_catalog.py -q
13 passed in 0.17s
```

## wr-context
See `.wr/2295.yaml` locally (gitignored).

Made with [Cursor](https://cursor.com)