### PR TITLE
fix(ciudades): remove illegal script-setup return

### DIFF
--- a/pages/ciudades/[cc]/[city].vue
+++ b/pages/ciudades/[cc]/[city].vue
@@ -18,31 +18,33 @@ const ccParam = Array.isArray(route.params.cc) ? route.params.cc[0] : route.para
 const cityParam = Array.isArray(route.params.city) ? route.params.city[0] : route.params.city
 const cc = String(ccParam || '').toLowerCase()
 const citySlug = String(cityParam || '').toLowerCase()
+const isExtraDirectory = EXTRA_DIRECTORY_COUNTRIES.has(cc) && Boolean(citySlug)
 
 if (cc === 'co') {
   await navigateTo(citySlug ? `/${citySlug}` : '/ciudades', { redirectCode: 301 })
-  return
-}
-if (!EXTRA_DIRECTORY_COUNTRIES.has(cc) || !citySlug) {
+} else if (!isExtraDirectory) {
   throw createError({ statusCode: 404, statusMessage: 'Not Found' })
 }
 
 const { data: responseData } = await useAsyncData(
   () => `extra-city-entry-${cc}-${citySlug}`,
-  () => $fetch<{ data?: PublicCity[] }>('/api/public/restaurant/cities', {
-    params: { country_code: cc.toUpperCase(), include_empty: true },
-  }),
+  () => isExtraDirectory
+    ? $fetch<{ data?: PublicCity[] }>('/api/public/restaurant/cities', {
+        params: { country_code: cc.toUpperCase(), include_empty: true },
+      })
+    : Promise.resolve({ data: [] as PublicCity[] }),
   { server: true },
 )
 
 const catalogEntry = (responseData.value?.data ?? []).find((city) => city.city_slug === citySlug)
-if (!catalogEntry) {
+if (isExtraDirectory && !catalogEntry) {
   throw createError({ statusCode: 404, statusMessage: 'Not Found' })
 }
 </script>
 
 <template>
   <DirectoryView
+    v-if="catalogEntry"
     :city-slug="citySlug"
     :country-code="cc"
     :city-name="catalogEntry.city"

--- a/pages/ciudades/[cc]/index.vue
+++ b/pages/ciudades/[cc]/index.vue
@@ -25,12 +25,11 @@ const siteUrl = (config.public as Record<string, unknown>).siteUrl as string || 
 
 const ccParam = Array.isArray(route.params.cc) ? route.params.cc[0] : route.params.cc
 const cc = String(ccParam || '').toLowerCase()
+const isExtraDirectory = EXTRA_DIRECTORY_COUNTRIES.has(cc)
 
 if (cc === 'co') {
   await navigateTo('/ciudades', { redirectCode: 301 })
-  return
-}
-if (!EXTRA_DIRECTORY_COUNTRIES.has(cc)) {
+} else if (!isExtraDirectory) {
   throw createError({ statusCode: 404, statusMessage: 'Not Found' })
 }
 
@@ -39,9 +38,11 @@ const countryCode = cc.toUpperCase()
 
 const { data: responseData } = await useAsyncData(
   () => `extra-city-hub-${cc}`,
-  () => $fetch<{ data?: PublicCity[] }>('/api/public/restaurant/cities', {
-    params: { country_code: countryCode, include_empty: false },
-  }),
+  () => isExtraDirectory
+    ? $fetch<{ data?: PublicCity[] }>('/api/public/restaurant/cities', {
+        params: { country_code: countryCode, include_empty: false },
+      })
+    : Promise.resolve({ data: [] as PublicCity[] }),
   { server: true },
 )
 
@@ -66,7 +67,7 @@ useHead({
 </script>
 
 <template>
-  <div class="ciudades-page">
+  <div v-if="isExtraDirectory" class="ciudades-page">
     <section class="ciudades-hero">
       <h1 class="ciudades-title font-quantico">RESTAURANTES EN {{ countryLabel.toUpperCase() }}</h1>
       <p class="ciudades-subtitle">


### PR DESCRIPTION
## Summary
- Vue SFC treats `<script setup>` as a module, so `return` after `navigateTo('/ciudades/co')` crashed the compiler overlay.
- Keep the CO redirect; skip extra-country fetch/render without a top-level `return`.

Fixes overlay: `'return' outside of function` in `pages/ciudades/[cc]/[city].vue`.

## Test plan
- [ ] `/ciudades/ar` compiles and renders (empty state OK)
- [ ] `/ciudades/ar/buenos-aires` compiles
- [ ] `/ciudades/co` still redirects to `/ciudades`
- [ ] Overlay no longer appears on extra-country city pages

## Validation evidence
Compiler-only fix; no pytest/vitest for these pages.

Made with [Cursor](https://cursor.com)