### PR TITLE
Starter banner: skeleton instead of COP 8.000 while country is unknown

### DIFF
--- a/components/SubscriptionBanner.vue
+++ b/components/SubscriptionBanner.vue
@@ -25,8 +25,17 @@
         />
       </svg>
 
-      <p class="text-xs sm:text-sm font-medium flex-1 leading-snug">
-        {{ message }}
+      <p
+        class="text-xs sm:text-sm font-medium flex-1 leading-snug"
+        :aria-busy="pricePending"
+      >
+        <template v-if="pricePendingParts">
+          {{ pricePendingParts.before }}<span
+            class="trial-price-skeleton"
+            aria-hidden="true"
+          /><template v-if="pricePendingParts.after">{{ pricePendingParts.after }}</template>
+        </template>
+        <template v-else>{{ message }}</template>
         <span
           v-if="graceDaysRemaining != null && level === 'read_only'"
           class="opacity-80"
@@ -54,6 +63,8 @@
 </template>
 
 <script setup lang="ts">
+import { TRIAL_PRICE_PENDING_SLOT } from '~/utils/publicCta'
+
 const props = defineProps<{
   level: 'starter' | 'full_with_warning' | 'read_only'
   message: string
@@ -61,6 +72,13 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n({ useScope: 'global' })
+
+const pricePendingParts = computed(() => {
+  if (!props.message.includes(TRIAL_PRICE_PENDING_SLOT)) return null
+  const [before, after] = props.message.split(TRIAL_PRICE_PENDING_SLOT)
+  return { before, after: after ?? '' }
+})
+const pricePending = computed(() => pricePendingParts.value != null)
 
 const isVisible = computed(
   () =>
@@ -86,3 +104,28 @@ const ctaLabel = computed(() => {
   return t('shell.subscriptionRenewCta')
 })
 </script>
+
+<style scoped>
+.trial-price-skeleton {
+  display: inline-block;
+  vertical-align: -0.15em;
+  width: 9.5rem;
+  height: 0.85em;
+  margin: 0 0.2em;
+  border-radius: 4px;
+  background: linear-gradient(
+    90deg,
+    currentColor 25%,
+    color-mix(in srgb, currentColor 45%, transparent) 50%,
+    currentColor 75%
+  );
+  background-size: 200% 100%;
+  opacity: 0.28;
+  animation: trial-price-shimmer 1.5s infinite;
+}
+@keyframes trial-price-shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+</style>
+

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -87,7 +87,7 @@ import { useNotifications } from '~/composables/useNotifications'
 import { useBilling } from '~/composables/useBilling'
 import { usePosMobileCart } from '~/composables/usePosMobileCart'
 import { getDashboardHome } from '~/utils/internalAccess'
-import { resolveTrialPriceAnchor } from '~/utils/publicCta'
+import { resolveTrialPriceAnchor, TRIAL_PRICE_PENDING_SLOT } from '~/utils/publicCta'
 import { useTenantFinancialProfile } from '~/composables/useTenantFinancialProfile'
 
 const { t, locale } = useI18n()
@@ -129,7 +129,9 @@ const subscriptionBannerMessage = computed(() => {
       countryCode: financialProfile.value?.country_code,
       currencyCode: financialProfile.value?.base_currency_code,
     })
-    return t('shell.subscriptionTrial', { priceAnchor })
+    return t('shell.subscriptionTrial', {
+      priceAnchor: priceAnchor ?? TRIAL_PRICE_PENDING_SLOT,
+    })
   }
   if (status.message) return status.message
   if (level === 'read_only') return t('shell.subscriptionReadOnly')

--- a/utils/publicCta.test.ts
+++ b/utils/publicCta.test.ts
@@ -195,9 +195,8 @@ test('trial banner price anchor uses EUR €30 for eurozone catalog tenants', ()
   )
 })
 
-test('trial banner price anchor keeps COP when country and currency are unknown', () => {
-  assert.equal(
-    resolveTrialPriceAnchor({ locale: 'es' }),
-    PUBLIC_OFFER.monthlyEquivalent,
-  )
+test('trial banner price anchor is pending when country and currency are unknown', () => {
+  assert.equal(resolveTrialPriceAnchor({ locale: 'es' }), null)
+  assert.equal(resolveTrialPriceAnchor({ locale: 'en' }), null)
+  assert.equal(resolveTrialPriceAnchor({}), null)
 })

--- a/utils/publicCta.ts
+++ b/utils/publicCta.ts
@@ -87,12 +87,14 @@ function trialPriceCopy(
   return isEn ? en : es
 }
 
-/** In-app Starter trial banner price slot (warocol.com#1917, #2293). */
+/** In-app Starter trial banner price slot (warocol.com#1917, #2293, #2302). */
+export const TRIAL_PRICE_PENDING_SLOT = '__PRICE_PENDING__'
+
 export function resolveTrialPriceAnchor(options: {
   locale?: string | null
   countryCode?: string | null
   currencyCode?: string | null
-} = {}): string {
+} = {}): string | null {
   const isEn = String(options.locale || '').toLowerCase().startsWith('en')
   const country = String(options.countryCode || '').toUpperCase()
   const currency = String(options.currencyCode || '').toUpperCase()
@@ -102,8 +104,9 @@ export function resolveTrialPriceAnchor(options: {
   const usd30 = () => trialPriceCopy(isEn, 'menos de USD $30/mes', 'under USD $30/month')
   const eur30 = () => trialPriceCopy(isEn, 'menos de EUR €30/mes', 'under EUR €30/month')
 
+  // No COP fallback while country/currency are still loading (warocol.com#2302).
+  if (!country && !currency) return null
   // Marketing exception: CO stays COP even though Paddle charges usd_9.
-  if (!country && !currency) return copLine()
   if (country === 'CO' || (!country && currency === 'COP')) return copLine()
 
   if (country) {


### PR DESCRIPTION
## Summary
- Starter banner no longer fills the price slot with COP 8.000 while country/currency are still loading.
- The rest of the trial copy and CTA stay visible; the price uses a skeleton until the financial profile arrives, then the existing CO / $9 / $30 / €30 mapping.

Closes #2302

## Test plan
- [ ] Starter tenant with slow/no financial profile: banner shows pulse in the price slot, not COP 8.000
- [ ] After profile load, CO still shows COP 8.000/month
- [ ] MX/AR → USD $9; US → USD $30; ES → EUR €30
- [ ] CTA “Quitar límites” remains visible during the wait

## Validation evidence
```
cd front_nuxt && node --test utils/publicCta.test.ts

# tests 12
# pass 12
# fail 0
# duration_ms 200.432167
```

## wr-context
See `.wr/2302.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)