### PR TITLE
fix(shell): skeleton the full Starter banner until country is known

### DIFF
--- a/components/SubscriptionBanner.vue
+++ b/components/SubscriptionBanner.vue
@@ -5,7 +5,13 @@
     :role="level === 'starter' ? 'status' : 'alert'"
   >
     <div class="flex items-center gap-3 px-4 sm:px-6 md:px-8 py-2.5">
+      <span
+        v-if="messagePending"
+        class="trial-banner-skeleton trial-banner-skeleton--icon flex-shrink-0"
+        aria-hidden="true"
+      />
       <svg
+        v-else
         class="w-4 h-4 flex-shrink-0"
         fill="currentColor"
         viewBox="0 0 20 20"
@@ -25,17 +31,20 @@
         />
       </svg>
 
-      <p
-        class="text-xs sm:text-sm font-medium flex-1 leading-snug"
-        :aria-busy="pricePending"
+      <div
+        v-if="messagePending"
+        class="flex-1 min-w-0 space-y-1.5 py-0.5"
+        aria-busy="true"
+        aria-hidden="true"
       >
-        <template v-if="pricePendingParts">
-          {{ pricePendingParts.before }}<span
-            class="trial-price-skeleton"
-            aria-hidden="true"
-          /><template v-if="pricePendingParts.after">{{ pricePendingParts.after }}</template>
-        </template>
-        <template v-else>{{ message }}</template>
+        <span class="trial-banner-skeleton trial-banner-skeleton--full" />
+        <span class="trial-banner-skeleton trial-banner-skeleton--mid" />
+      </div>
+      <p
+        v-else
+        class="text-xs sm:text-sm font-medium flex-1 leading-snug"
+      >
+        {{ message }}
         <span
           v-if="graceDaysRemaining != null && level === 'read_only'"
           class="opacity-80"
@@ -51,7 +60,13 @@
         </span>
       </p>
 
+      <span
+        v-if="messagePending"
+        class="trial-banner-skeleton trial-banner-skeleton--cta flex-shrink-0"
+        aria-hidden="true"
+      />
       <NuxtLink
+        v-else
         to="/gestion/billing"
         :class="ctaClass"
         class="flex-shrink-0 text-xs font-semibold px-3 py-1.5 rounded-lg min-h-[44px] flex items-center whitespace-nowrap transition-opacity hover:opacity-80"
@@ -63,22 +78,16 @@
 </template>
 
 <script setup lang="ts">
-import { TRIAL_PRICE_PENDING_SLOT } from '~/utils/publicCta'
-
 const props = defineProps<{
   level: 'starter' | 'full_with_warning' | 'read_only'
   message: string
+  messagePending?: boolean
   graceDaysRemaining?: number | null
 }>()
 
 const { t } = useI18n({ useScope: 'global' })
 
-const pricePendingParts = computed(() => {
-  if (!props.message.includes(TRIAL_PRICE_PENDING_SLOT)) return null
-  const [before, after] = props.message.split(TRIAL_PRICE_PENDING_SLOT)
-  return { before, after: after ?? '' }
-})
-const pricePending = computed(() => pricePendingParts.value != null)
+const messagePending = computed(() => Boolean(props.messagePending))
 
 const isVisible = computed(
   () =>
@@ -106,12 +115,8 @@ const ctaLabel = computed(() => {
 </script>
 
 <style scoped>
-.trial-price-skeleton {
-  display: inline-block;
-  vertical-align: -0.15em;
-  width: 9.5rem;
-  height: 0.85em;
-  margin: 0 0.2em;
+.trial-banner-skeleton {
+  display: block;
   border-radius: 4px;
   background: linear-gradient(
     90deg,
@@ -121,9 +126,29 @@ const ctaLabel = computed(() => {
   );
   background-size: 200% 100%;
   opacity: 0.28;
-  animation: trial-price-shimmer 1.5s infinite;
+  animation: trial-banner-shimmer 1.5s infinite;
 }
-@keyframes trial-price-shimmer {
+.trial-banner-skeleton--icon {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 9999px;
+}
+.trial-banner-skeleton--full {
+  height: 0.7rem;
+  width: 100%;
+  max-width: 42rem;
+}
+.trial-banner-skeleton--mid {
+  height: 0.7rem;
+  width: 72%;
+  max-width: 28rem;
+}
+.trial-banner-skeleton--cta {
+  width: 7.25rem;
+  height: 2.75rem;
+  border-radius: 0.5rem;
+}
+@keyframes trial-banner-shimmer {
   0% { background-position: -200% 0; }
   100% { background-position: 200% 0; }
 }

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -26,6 +26,7 @@
         v-if="showSubscriptionBanner && subscriptionBannerLevel"
         :level="subscriptionBannerLevel"
         :message="subscriptionBannerMessage"
+        :message-pending="starterBannerPending"
         :grace-days-remaining="accessStatus?.grace_days_remaining"
       />
 
@@ -87,7 +88,7 @@ import { useNotifications } from '~/composables/useNotifications'
 import { useBilling } from '~/composables/useBilling'
 import { usePosMobileCart } from '~/composables/usePosMobileCart'
 import { getDashboardHome } from '~/utils/internalAccess'
-import { resolveTrialPriceAnchor, TRIAL_PRICE_PENDING_SLOT } from '~/utils/publicCta'
+import { resolveTrialPriceAnchor } from '~/utils/publicCta'
 import { useTenantFinancialProfile } from '~/composables/useTenantFinancialProfile'
 
 const { t, locale } = useI18n()
@@ -118,6 +119,15 @@ const subscriptionBannerLevel = computed<SubscriptionBannerLevel | null>(() => {
 
 const showSubscriptionBanner = computed(() => subscriptionBannerLevel.value != null)
 
+const starterBannerPending = computed(() => {
+  if (subscriptionBannerLevel.value !== 'starter') return false
+  return !resolveTrialPriceAnchor({
+    locale: locale.value,
+    countryCode: financialProfile.value?.country_code,
+    currencyCode: financialProfile.value?.base_currency_code,
+  })
+})
+
 const subscriptionBannerMessage = computed(() => {
   const status = accessStatus.value
   const level = subscriptionBannerLevel.value
@@ -129,9 +139,8 @@ const subscriptionBannerMessage = computed(() => {
       countryCode: financialProfile.value?.country_code,
       currencyCode: financialProfile.value?.base_currency_code,
     })
-    return t('shell.subscriptionTrial', {
-      priceAnchor: priceAnchor ?? TRIAL_PRICE_PENDING_SLOT,
-    })
+    if (!priceAnchor) return ''
+    return t('shell.subscriptionTrial', { priceAnchor })
   }
   if (status.message) return status.message
   if (level === 'read_only') return t('shell.subscriptionReadOnly')

--- a/utils/publicCta.ts
+++ b/utils/publicCta.ts
@@ -88,8 +88,6 @@ function trialPriceCopy(
 }
 
 /** In-app Starter trial banner price slot (warocol.com#1917, #2293, #2302). */
-export const TRIAL_PRICE_PENDING_SLOT = '__PRICE_PENDING__'
-
 export function resolveTrialPriceAnchor(options: {
   locale?: string | null
   countryCode?: string | null


### PR DESCRIPTION
## Summary
- Follow-up to #2302 / #2303: the trial banner no longer shows copy like “Tu menú ya está creciendo… desde menos de USD $9/mes” with only the price as a hole.
- Until country/currency resolve, icon, full message, and CTA are skeleton; then the real localized price lands in one swap.

## Test plan
- [ ] Log in as Starter with a slow/unknown financial profile: the whole banner is skeleton (no visible copy or “Quitar límites”).
- [ ] After profile loads (CO): full copy with COP 8.000 and the real CTA.
- [ ] After profile loads (MX/AR): copy with USD $9; US/PA USD $30; ES/DE €30.
- [ ] Warning / read-only banners are unchanged (no skeleton).


Made with [Cursor](https://cursor.com)