### PR TITLE
feat(negocio): catalog city combobox for all 23 Negocio countries

### DIFF
--- a/composables/useCityCatalog.search.test.ts
+++ b/composables/useCityCatalog.search.test.ts
@@ -45,12 +45,15 @@ describe('city catalog search helpers', () => {
     assert.match(message, /read-only/)
   })
 
-  it('treats CO AR MX US as curated catalogs and others as free-text', () => {
+  it('treats all 23 Negocio countries as curated catalogs', () => {
     assert.equal(hasCuratedCityCatalog('CO'), true)
     assert.equal(hasCuratedCityCatalog('AR'), true)
     assert.equal(hasCuratedCityCatalog('MX'), true)
     assert.equal(hasCuratedCityCatalog('US'), true)
-    assert.equal(hasCuratedCityCatalog('PE'), false)
+    assert.equal(hasCuratedCityCatalog('PE'), true)
+    assert.equal(hasCuratedCityCatalog('ES'), true)
+    assert.equal(hasCuratedCityCatalog('CL'), true)
     assert.equal(hasCuratedCityCatalog(''), true)
+    assert.equal(hasCuratedCityCatalog('ZZ'), false)
   })
 })

--- a/composables/useCityCatalog.ts
+++ b/composables/useCityCatalog.ts
@@ -27,8 +27,11 @@ export interface PublicCity {
   department_name?: string | null
 }
 
-/** Countries with a curated Negocio picker (warocol.com#2295). SSR dispatch stays CO-only. */
-export const CURATED_CITY_COUNTRY_CODES = new Set(['CO', 'AR', 'MX', 'US'])
+/** Negocio countries with a catalog picker (warocol.com#2308). SSR dispatch stays CO-only. */
+export const CURATED_CITY_COUNTRY_CODES = new Set([
+  'CO', 'PA', 'CL', 'US', 'CA', 'DO', 'UY', 'AU', 'NZ', 'SG', 'AE',
+  'AR', 'MX', 'PE', 'CR', 'BR', 'ES', 'GB', 'DE', 'FR', 'NL', 'IN', 'CN',
+])
 
 export function hasCuratedCityCatalog(countryCode?: string | null): boolean {
   const code = String(countryCode || 'CO').trim().toUpperCase() || 'CO'


### PR DESCRIPTION
## Summary
- Expand the Negocio city combobox from CO/AR/MX/US to all 23 timezone catalog countries.
- Unknown ISO codes still use free text. Empty country still counts as CO.
- Companion API save-gate: uno0uno/api-warolabs (this batch).

Closes #2308

## Test plan
- [ ] PE/ES/CL tenant: Ciudad is the ingredient-style combobox, not a text field
- [ ] Type a miss, blur: field clears; save does not store free text
- [ ] CO/AR still pick from catalog (AR includes Buenos Aires after #2309)

## Validation evidence
```
npm run test:catalog-search
Test Files  4 passed (4)
     Tests  14 passed (14)

node --test composables/useCityCatalog.search.test.ts
tests 4
pass 4
```

Made with [Cursor](https://cursor.com)