### PR TITLE
Polish billing confirmation verifying cards

### DIFF
--- a/.wr/2311.yaml
+++ b/.wr/2311.yaml
@@ -1,0 +1,43 @@
+# Compact Codex plan for wr-plan / wr-exec. Keep <=80 lines.
+issue: 2311
+title: "Polish billing confirmation verifying cards (motion + hierarchy)"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2311-confirmacion-status-cards
+
+paths:
+  - pages/billing/confirmacion.vue
+  - utils/billingConfirmStatus.ts
+  - utils/billingConfirmStatus.test.ts
+
+ac:
+  - Pending and activating cards are not empty bordered boxes; title, body, and status are distinct
+  - Waiting uses semantic tokens plus icon/well pulse; not color alone
+  - Pulse loops while verifying and is off under prefers-reduced-motion
+  - Ready / timeout / failed stay readable with the same card model
+  - Spanish titles wrap at narrow width; existing refresh and back actions remain
+  - No Paddle iframe, webhook, or API changes
+
+out_of_scope:
+  - Paddle iframe internals
+  - PayPal / Google Pay
+  - Telegram / billing webhooks
+  - Other billing pages
+  - pages/facturacion/index.vue (unrelated local dirty file)
+
+hints:
+  entry: "pages/billing/confirmacion.vue thank-you + pending cards"
+  pattern: "LeadModalForm success well: rounded-full bg + ring-8"
+  tests: "vitest run utils/billingConfirmStatus.test.ts"
+
+risk:
+  sensitive: false
+  areas: []
+
+skip:
+  audits: []
+
+next:
+  after_pr: "gh issue edit 2311 --add-label ready-for-review"

--- a/pages/billing/confirmacion.vue
+++ b/pages/billing/confirmacion.vue
@@ -8,11 +8,26 @@
     v-else-if="showThankYou"
     class="mx-auto flex min-h-[420px] max-w-lg items-center justify-center px-4"
   >
-    <div class="w-full rounded-xl border border-border bg-surface p-6 text-center shadow-sm sm:p-8">
-      <component :is="thankYouIcon" class="mx-auto h-14 w-14" :class="thankYouIconClass" aria-hidden="true" />
-      <h1 class="mt-4 text-2xl font-bold text-text-primary">{{ thankYouTitle }}</h1>
-      <p class="mt-2 text-sm leading-6 text-text-secondary">{{ thankYouDescription }}</p>
-      <p v-if="errorMessage" class="mt-3 text-sm text-status-danger-text" role="alert">{{ errorMessage }}</p>
+    <div
+      class="w-full rounded-2xl border bg-surface p-6 text-center sm:p-8"
+      :class="statusCardBorderClass(thankYouTone)"
+      :role="thankYouWaiting ? 'status' : undefined"
+      :aria-live="thankYouWaiting ? 'polite' : undefined"
+    >
+      <div
+        class="mx-auto flex h-16 w-16 items-center justify-center rounded-full"
+        :class="statusWellClass(thankYouTone)"
+      >
+        <component
+          :is="thankYouIcon"
+          class="h-8 w-8"
+          :class="[thankYouIconClass, thankYouWaiting ? 'animate-pulse motion-reduce:animate-none' : '']"
+          aria-hidden="true"
+        />
+      </div>
+      <h1 class="mt-5 text-xl font-bold leading-snug text-text-primary text-balance sm:text-2xl">{{ thankYouTitle }}</h1>
+      <p class="mt-2 text-sm leading-6 text-text-secondary text-pretty">{{ thankYouDescription }}</p>
+      <p v-if="errorMessage" class="mt-3 text-sm text-state-danger-text" role="alert">{{ errorMessage }}</p>
       <div class="mt-6 flex flex-col gap-3">
         <NuxtLink
           v-if="thankYouPhase === 'ready'"
@@ -74,12 +89,27 @@
     </div>
   </div>
 
-  <div v-else class="mx-auto flex min-h-[420px] max-w-lg items-center justify-center">
-    <div class="w-full rounded-xl border border-border bg-surface p-6 text-center shadow-sm sm:p-8">
-      <component :is="icon" class="mx-auto h-14 w-14" :class="iconClass" aria-hidden="true" />
-      <h1 class="mt-4 text-2xl font-bold text-text-primary">{{ title }}</h1>
-      <p class="mt-2 text-sm leading-6 text-text-secondary">{{ description }}</p>
-      <p v-if="errorMessage" class="mt-3 text-sm text-status-danger-text" role="alert">{{ errorMessage }}</p>
+  <div v-else class="mx-auto flex min-h-[420px] max-w-lg items-center justify-center px-4">
+    <div
+      class="w-full rounded-2xl border bg-surface p-6 text-center sm:p-8"
+      :class="statusCardBorderClass(returnTone)"
+      :role="returnWaiting ? 'status' : undefined"
+      :aria-live="returnWaiting ? 'polite' : undefined"
+    >
+      <div
+        class="mx-auto flex h-16 w-16 items-center justify-center rounded-full"
+        :class="statusWellClass(returnTone)"
+      >
+        <component
+          :is="icon"
+          class="h-8 w-8"
+          :class="[iconClass, returnWaiting ? 'animate-pulse motion-reduce:animate-none' : '']"
+          aria-hidden="true"
+        />
+      </div>
+      <h1 class="mt-5 text-xl font-bold leading-snug text-text-primary text-balance sm:text-2xl">{{ title }}</h1>
+      <p class="mt-2 text-sm leading-6 text-text-secondary text-pretty">{{ description }}</p>
+      <p v-if="errorMessage" class="mt-3 text-sm text-state-danger-text" role="alert">{{ errorMessage }}</p>
 
       <div class="mt-6 flex flex-col gap-3">
         <button
@@ -131,6 +161,12 @@ import {
   type PaddleThankYouPhase,
   type PaddleTxnStatusResponse,
 } from '~/utils/paddleThankYou'
+import {
+  returnToneFromView,
+  statusCardBorderClass,
+  statusWellClass,
+  thankYouToneFromPhase,
+} from '~/utils/billingConfirmStatus'
 
 // The API remains the auth boundary. This meta only lets pending sessions reach
 // the payment return page (Paddle / legacy Wompi) without weakening operational guards.
@@ -176,8 +212,8 @@ const icon = computed(() => view.value === 'approved'
   ? CheckCircleIcon
   : view.value === 'pending' ? ClockIcon : ExclamationTriangleIcon)
 const iconClass = computed(() => view.value === 'approved'
-  ? 'text-status-success-text'
-  : view.value === 'pending' ? 'text-status-warning-text' : 'text-status-danger-text')
+  ? 'text-state-success-icon'
+  : view.value === 'pending' ? 'text-state-warning-icon' : 'text-state-danger-icon')
 const title = computed(() => view.value === 'approved'
   ? t('onboarding.paymentApprovedTitle')
   : view.value === 'pending'
@@ -201,9 +237,9 @@ const thankYouIcon = computed(() =>
       : ClockIcon,
 )
 const thankYouIconClass = computed(() =>
-  thankYouPhase.value === 'ready' ? 'text-status-success-text'
-    : thankYouPhase.value === 'timeout' ? 'text-status-warning-text'
-      : 'text-status-warning-text',
+  thankYouPhase.value === 'ready' ? 'text-state-success-icon'
+    : thankYouPhase.value === 'timeout' ? 'text-state-warning-icon'
+      : 'text-state-warning-icon',
 )
 const thankYouTitle = computed(() =>
   thankYouPhase.value === 'ready' ? t('billing.paddleThankYouTitle')
@@ -215,6 +251,11 @@ const thankYouDescription = computed(() =>
     : thankYouPhase.value === 'timeout' ? t('billing.paddleThankYouTimeoutDescription')
       : t('billing.paddleThankYouActivatingDescription'),
 )
+
+const thankYouWaiting = computed(() => thankYouPhase.value === 'activating')
+const returnWaiting = computed(() => view.value === 'pending')
+const thankYouTone = computed(() => thankYouToneFromPhase(thankYouPhase.value))
+const returnTone = computed(() => returnToneFromView(view.value))
 
 const readPaddleTxnFromRoute = () => {
   const paddleTxn = typeof route.query.paddle_txn === 'string'

--- a/utils/billingConfirmStatus.test.ts
+++ b/utils/billingConfirmStatus.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import {
+  returnToneFromView,
+  statusCardBorderClass,
+  statusWellClass,
+  thankYouToneFromPhase,
+} from './billingConfirmStatus'
+
+describe('billingConfirmStatus', () => {
+  it('pulses waiting wells and disables motion when reduced', () => {
+    const waiting = statusWellClass('waiting')
+    expect(waiting).toContain('animate-pulse')
+    expect(waiting).toContain('motion-reduce:animate-none')
+    expect(statusWellClass('ready')).not.toContain('animate-pulse')
+    expect(statusWellClass('danger')).not.toContain('animate-pulse')
+    expect(statusWellClass('warning')).not.toContain('animate-pulse')
+  })
+
+  it('maps tones to semantic borders', () => {
+    expect(statusCardBorderClass('ready')).toBe('border-state-success-border')
+    expect(statusCardBorderClass('danger')).toBe('border-state-danger-border')
+    expect(statusCardBorderClass('waiting')).toBe('border-state-warning-border')
+    expect(statusCardBorderClass('warning')).toBe('border-state-warning-border')
+  })
+
+  it('maps thank-you and return views to tones', () => {
+    expect(thankYouToneFromPhase('activating')).toBe('waiting')
+    expect(thankYouToneFromPhase('ready')).toBe('ready')
+    expect(thankYouToneFromPhase('timeout')).toBe('warning')
+    expect(returnToneFromView('pending')).toBe('waiting')
+    expect(returnToneFromView('approved')).toBe('ready')
+    expect(returnToneFromView('failed')).toBe('danger')
+  })
+})

--- a/utils/billingConfirmStatus.ts
+++ b/utils/billingConfirmStatus.ts
@@ -1,0 +1,27 @@
+/** Visual tone for billing confirmation status cards (#2311). */
+export type ConfirmStatusTone = 'waiting' | 'ready' | 'warning' | 'danger'
+
+export function statusWellClass(tone: ConfirmStatusTone): string {
+  const pulse = tone === 'waiting' ? ' animate-pulse motion-reduce:animate-none' : ''
+  if (tone === 'ready') return `bg-state-success-bg ring-8 ring-state-success-bg/40${pulse}`
+  if (tone === 'danger') return `bg-state-danger-bg ring-8 ring-state-danger-bg/40${pulse}`
+  return `bg-state-warning-bg ring-8 ring-state-warning-bg/40${pulse}`
+}
+
+export function statusCardBorderClass(tone: ConfirmStatusTone): string {
+  if (tone === 'ready') return 'border-state-success-border'
+  if (tone === 'danger') return 'border-state-danger-border'
+  return 'border-state-warning-border'
+}
+
+export function thankYouToneFromPhase(phase: 'activating' | 'ready' | 'timeout'): ConfirmStatusTone {
+  if (phase === 'ready') return 'ready'
+  if (phase === 'timeout') return 'warning'
+  return 'waiting'
+}
+
+export function returnToneFromView(view: 'approved' | 'pending' | 'failed' | 'unknown' | 'loading' | 'thank_you'): ConfirmStatusTone {
+  if (view === 'approved') return 'ready'
+  if (view === 'pending') return 'waiting'
+  return 'danger'
+}


### PR DESCRIPTION
## Summary
- Pending and activating cards on billing confirmation use a status well with pulse, semantic borders, and clearer title/body hierarchy.
- Waiting motion stops under `prefers-reduced-motion`; ready/timeout/failed keep the same card without looping.
- Refresh and back-to-plan actions are unchanged; Paddle iframe is untouched.

Closes #2311

## Test plan
- [ ] Open billing confirmation while payment is pending — card is not a flat empty box; icon well pulses.
- [ ] After sandbox pay, activating thank-you card pulses until ready.
- [ ] Ready / timeout / failed stay readable (success vs warning vs danger).
- [ ] With OS reduced motion on, pulse does not run.
- [ ] Refresh status and back to My Plan still work.

## Validation evidence
```
npx vitest run utils/billingConfirmStatus.test.ts
 ✓ utils/billingConfirmStatus.test.ts (3 tests) 2ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
 Duration  3.13s
```

## wr-context
See `.wr/2311.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)