### PR TITLE
feat(seo): 404 unknown blog slugs, alias 301s, branded error page

### DIFF
--- a/.wr/2313.yaml
+++ b/.wr/2313.yaml
@@ -1,0 +1,39 @@
+issue: 2313
+title: "SEO: 404 unknown blog slugs, alias 301s, noindex thin pages, branded 404"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2313-blog-seo-404
+risk: low
+
+paths:
+  - utils/blogSeoRedirects.js
+  - utils/blogSeoRedirects.test.js
+  - utils/thinPublicTenant.ts
+  - utils/thinPublicTenant.test.ts
+  - pages/blog/[slug].vue
+  - pages/[tenant]/index.vue
+  - error.vue
+  - nuxt.config.ts
+
+ac:
+  - Unknown /blog/:slug is HTTP 404 via createError fatal, not 200 with fallback title Artículo | Waro Colombia
+  - Branded error.vue renders (Quantico + HomeFoodBackground, Spanish)
+  - 301 single hop best-pos-for-restaurant and software-para-restaurantes
+  - Thin comandas/facturacion slugs stay 404 (no 301)
+  - Thin public tenants noindex via onboarding-/test- prefix or missing/empty menu; no customer names in git
+  - Published articles unchanged
+
+out_of_scope:
+  - facturacion US banner
+  - Hardcoded customer tenant slugs
+  - Redirect chains from software-para-restaurante
+
+hints:
+  entry: "pages/blog/[slug].vue useAsyncData + createError"
+  pattern: "utils/blogSeoRedirects.js + server/middleware/blog-seo-redirects.ts; pages/ciudades/[cc]/index.vue 404"
+  tests: "vitest run utils/blogSeoRedirects.test.js utils/thinPublicTenant.test.ts"
+
+skip:
+  audits: [ux, color, typography]

--- a/error.vue
+++ b/error.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+const error = useError()
+const is404 = computed(() => Number(error.value?.statusCode) === 404)
+
+useHead({
+  title: () => (is404.value ? 'Página no encontrada | Waro Colombia' : 'Error | Waro Colombia'),
+  meta: [{ name: 'robots', content: 'noindex, follow' }],
+})
+
+const goHome = async () => {
+  await clearError({ redirect: '/' })
+}
+
+const goBlog = async () => {
+  await clearError({ redirect: '/blog' })
+}
+</script>
+
+<template>
+  <div class="error-page">
+    <PublicHomeFoodBackground />
+    <div class="error-copy">
+      <p class="error-code font-quantico">{{ is404 ? '404' : (error?.statusCode || 500) }}</p>
+      <h1 class="font-quantico">
+        {{ is404 ? 'No encontramos esta página' : 'Algo salió mal' }}
+      </h1>
+      <p class="error-body">
+        {{ is404
+          ? 'El enlace no existe o ya no está publicado. Prueba el inicio o el blog.'
+          : 'No pudimos cargar esta página. Vuelve al inicio e inténtalo de nuevo.' }}
+      </p>
+      <div class="error-actions">
+        <button class="btn btn-primary" type="button" @click="goHome">
+          Ir al inicio
+        </button>
+        <button v-if="is404" class="btn btn-secondary" type="button" @click="goBlog">
+          Ir al blog
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.error-page {
+  position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 100dvh;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: transparent;
+  color: hsl(250, 30%, 16%);
+  padding: 1.5rem 1.25rem;
+}
+
+.error-copy {
+  position: relative;
+  z-index: 5;
+  max-width: 40rem;
+  text-align: center;
+}
+
+.error-code {
+  font-size: clamp(3rem, 8vw, 6rem);
+  font-weight: 900;
+  letter-spacing: -0.08em;
+  line-height: 0.9;
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  color: hsl(262, 83%, 58%);
+}
+
+h1 {
+  font-size: clamp(1.75rem, 4vw + 0.5vh, 3.25rem);
+  font-weight: 900;
+  letter-spacing: -0.04em;
+  line-height: 0.95;
+  text-transform: uppercase;
+  margin: 0 0 1rem;
+}
+
+.error-body {
+  font-size: clamp(1rem, 1.4vw + 0.4vh, 1.2rem);
+  line-height: 1.5;
+  color: hsl(220, 13%, 28%);
+  margin: 0 0 1.75rem;
+}
+
+.error-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1rem, 2.2vh, 1.35rem) clamp(2rem, 5vw, 3.25rem);
+  font-size: clamp(0.95rem, 1.2vw + 0.4vh, 1.15rem);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  border-radius: 10px;
+  cursor: pointer;
+  text-decoration: none;
+  min-width: min(100%, 220px);
+  min-height: 3.25rem;
+}
+
+.btn-primary {
+  background: hsl(262, 83%, 58%);
+  color: white;
+  border: 2px solid hsl(262, 83%, 58%);
+}
+
+.btn-secondary {
+  background: transparent;
+  color: hsl(250, 30%, 16%);
+  border: 2px solid hsl(250, 30%, 16%);
+}
+
+@media (max-width: 768px) {
+  .btn {
+    width: 100%;
+    max-width: 22rem;
+  }
+}
+</style>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -19,6 +19,14 @@ export default defineNuxtConfig({
       redirect: { to: '/blog/mejores-software-restaurantes-colombia', statusCode: 301 },
       prerender: false
     },
+    '/blog/software-para-restaurantes': {
+      redirect: { to: '/blog/mejores-software-restaurantes-colombia', statusCode: 301 },
+      prerender: false
+    },
+    '/blog/best-pos-for-restaurant': {
+      redirect: { to: '/blog/best-pos-system-for-restaurant', statusCode: 301 },
+      prerender: false
+    },
     '/blog/software-restaurantes-gratis-colombia': {
       redirect: { to: '/blog/software-para-restaurante-gratis', statusCode: 301 },
       prerender: false

--- a/pages/[tenant]/index.vue
+++ b/pages/[tenant]/index.vue
@@ -8,6 +8,7 @@ import DirectoryView from '~/components/directory/DirectoryView.vue'
 import { useOnlineCartStore } from '~/stores/online_cart'
 import { useToast } from '~/composables/useToast'
 import { useCityCatalog } from '~/composables/useCityCatalog'
+import { shouldNoindexPublicTenant } from '~/utils/thinPublicTenant'
 
 const route = useRoute()
 const router = useRouter()
@@ -130,6 +131,16 @@ const isRefreshing = computed(() =>
   (menuAsyncStatus.value === 'loading' && menuData.value != null)
 )
 
+const shouldNoindex = computed(() => {
+  if (isCity.value) return false
+  if (isInitialLoading.value) return false
+  return shouldNoindexPublicTenant({
+    slug: tenantSlug.value,
+    hasRestaurant: Boolean(restaurant.value),
+    productCount: products.value.length,
+  })
+})
+
 // Format business hours for schema.org
 function formatOpeningHours(businessHours) {
   if (!businessHours) return []
@@ -233,6 +244,7 @@ useSeoMeta({
   twitterTitle: () => restaurant.value?.seo_title || restaurant.value?.display_name || '',
   twitterDescription: () => restaurant.value?.seo_description || restaurant.value?.description || '',
   twitterImage: () => restaurant.value?.banner_url || restaurant.value?.logo_url || '',
+  robots: () => (shouldNoindex.value ? 'noindex, follow' : undefined),
 })
 
 useHead({

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -55,13 +55,26 @@ interface ArticleResponse {
 // Fetch article from API
 const slug = route.params.slug as string
 
-const { data: articleData, pending, error: fetchError } = useAsyncData<ArticleResponse>(
+const { data: articleData, pending, error: fetchError } = await useAsyncData<ArticleResponse>(
   `blog-article-${slug}`,
   () => $fetch(`/api/blog/${slug}`),
   { server: true }
 )
 
 const article = computed(() => articleData.value?.data || null)
+
+if (!pending.value && !article.value) {
+  const status = Number(
+    (fetchError.value as { statusCode?: number; status?: number } | null)?.statusCode
+    ?? (fetchError.value as { statusCode?: number; status?: number } | null)?.status
+    ?? 404,
+  )
+  throw createError({
+    statusCode: status >= 500 ? 502 : 404,
+    statusMessage: status >= 500 ? 'Bad Gateway' : 'Not Found',
+    fatal: true,
+  })
+}
 
 const articleMarket = computed(() =>
   resolveArticleMarket({
@@ -184,7 +197,7 @@ const articleSchema = computed(() => {
 })
 
 useSeoMeta({
-  title: () => article.value?.meta_title || article.value?.title || 'Artículo | Waro Colombia',
+  title: () => article.value?.meta_title || article.value?.title || '',
   description: () => article.value?.meta_descripcion || article.value?.description || '',
   ogType: 'article',
   ogSiteName: 'Waro Colombia',
@@ -218,20 +231,6 @@ useHead({
     <!-- Loading State -->
     <div v-if="pending" class="flex items-center justify-center min-h-screen">
       <CommonsTheCustomLoader size="large" />
-    </div>
-
-    <!-- Error State -->
-    <div v-else-if="fetchError" class="flex items-center justify-center min-h-screen">
-      <div class="text-center px-4">
-        <p class="text-2xl font-bold text-text-primary mb-2">Error al cargar el artículo</p>
-        <p class="text-lg text-text-secondary mb-4">{{ fetchError.message }}</p>
-        <NuxtLink
-          to="/blog"
-          class="text-lg text-badge-primary-text hover:text-badge-primary-text underline"
-        >
-          Volver al blog
-        </NuxtLink>
-      </div>
     </div>
 
     <!-- Article Content -->
@@ -301,18 +300,5 @@ useHead({
         </template>
       </BlogArticleContent>
     </article>
-
-    <!-- Not Found State -->
-    <div v-else class="flex items-center justify-center min-h-screen">
-      <div class="text-center px-4">
-        <p class="text-2xl font-bold text-text-primary mb-2">Artículo no encontrado</p>
-        <NuxtLink
-          to="/blog"
-          class="text-lg text-badge-primary-text hover:text-badge-primary-text underline"
-        >
-          Volver al blog
-        </NuxtLink>
-      </div>
-    </div>
   </div>
 </template>

--- a/utils/blogSeoRedirects.js
+++ b/utils/blogSeoRedirects.js
@@ -1,11 +1,13 @@
-/** Permanent blog slug consolidations (warocol.com#953). */
+/** Permanent blog slug consolidations (warocol.com#953, #2313). */
 export const BLOG_SEO_REDIRECTS = {
   '/blog/software-pos-restaurantes-colombia': '/blog/mejores-software-restaurantes-colombia',
   '/blog/sistema-pos-colombia': '/blog/mejores-software-restaurantes-colombia',
   '/blog/software-para-restaurante': '/blog/mejores-software-restaurantes-colombia',
+  '/blog/software-para-restaurantes': '/blog/mejores-software-restaurantes-colombia',
+  '/blog/best-pos-for-restaurant': '/blog/best-pos-system-for-restaurant',
   '/blog/software-restaurantes-gratis-colombia': '/blog/software-para-restaurante-gratis',
   '/blog/software-open-source-restaurantes': '/blog/software-para-restaurante-gratis',
-  '/blog/software-contable-restaurantes-gratis': '/blog/software-para-restaurante-gratis'
+  '/blog/software-contable-restaurantes-gratis': '/blog/software-para-restaurante-gratis',
 }
 
 export function blogSeoRedirectTarget(path) {

--- a/utils/blogSeoRedirects.test.js
+++ b/utils/blogSeoRedirects.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { blogSeoRedirectTarget } from './blogSeoRedirects.js'
+
+describe('blogSeoRedirectTarget', () => {
+  it('301s alias slugs in a single hop', () => {
+    expect(blogSeoRedirectTarget('/blog/best-pos-for-restaurant'))
+      .toBe('/blog/best-pos-system-for-restaurant')
+    expect(blogSeoRedirectTarget('/blog/software-para-restaurantes'))
+      .toBe('/blog/mejores-software-restaurantes-colombia')
+    expect(blogSeoRedirectTarget('/blog/software-para-restaurante'))
+      .toBe('/blog/mejores-software-restaurantes-colombia')
+  })
+
+  it('does not redirect unknown or canonical 404 slugs', () => {
+    expect(blogSeoRedirectTarget('/blog/software-comandas-restaurantes-gratis')).toBeUndefined()
+    expect(blogSeoRedirectTarget('/blog/facturacion-electronica-restaurante')).toBeUndefined()
+    expect(blogSeoRedirectTarget('/blog/best-pos-system-for-restaurant')).toBeUndefined()
+  })
+})

--- a/utils/thinPublicTenant.test.ts
+++ b/utils/thinPublicTenant.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { isThinPublicTenantSlug, shouldNoindexPublicTenant } from './thinPublicTenant'
+
+describe('thinPublicTenant', () => {
+  it('flags onboarding and test slugs', () => {
+    expect(isThinPublicTenantSlug('onboarding-a59cd6a740294f8a')).toBe(true)
+    expect(isThinPublicTenantSlug('TEST-EEUU-12-06-2026')).toBe(true)
+    expect(isThinPublicTenantSlug('mi-restaurante')).toBe(false)
+  })
+
+  it('noindexes missing or empty public profiles', () => {
+    expect(shouldNoindexPublicTenant({ slug: 'cafe', hasRestaurant: false, productCount: 0 })).toBe(true)
+    expect(shouldNoindexPublicTenant({ slug: 'cafe', hasRestaurant: true, productCount: 0 })).toBe(true)
+    expect(shouldNoindexPublicTenant({ slug: 'cafe', hasRestaurant: true, productCount: 3 })).toBe(false)
+    expect(shouldNoindexPublicTenant({
+      slug: 'onboarding-abc',
+      hasRestaurant: true,
+      productCount: 10,
+    })).toBe(true)
+  })
+})

--- a/utils/thinPublicTenant.ts
+++ b/utils/thinPublicTenant.ts
@@ -1,0 +1,15 @@
+/** Thin public tenant URLs that should not be indexed (#2313). */
+export function isThinPublicTenantSlug(slug: string): boolean {
+  const value = String(slug || '').trim().toLowerCase()
+  return value.startsWith('onboarding-') || value.startsWith('test-')
+}
+
+export function shouldNoindexPublicTenant(options: {
+  slug: string
+  hasRestaurant: boolean
+  productCount: number
+}): boolean {
+  if (isThinPublicTenantSlug(options.slug)) return true
+  if (!options.hasRestaurant) return true
+  return options.productCount <= 0
+}


### PR DESCRIPTION
## Summary
- Unknown `/blog/:slug` URLs now throw a fatal 404 instead of HTTP 200 with the fallback title “Artículo | Waro Colombia”.
- Alias slugs 301 in a single hop (`best-pos-for-restaurant`, `software-para-restaurantes`); thin unpublished slugs stay 404.
- Thin public tenants (`onboarding-` / `test-`, missing restaurant, empty menu) send `noindex`, and `error.vue` uses the public-home Quantico + food-background treatment.

Closes #2313

## Test plan
- [ ] Open `/blog/this-slug-does-not-exist` → HTTP 404 and branded error page (not “Artículo | Waro Colombia”)
- [ ] `/blog/best-pos-for-restaurant` → 301 to `/blog/best-pos-system-for-restaurant` (one hop)
- [ ] `/blog/software-para-restaurantes` → 301 to `/blog/mejores-software-restaurantes-colombia` (one hop; `/blog/software-para-restaurante` still 301s there)
- [ ] `/blog/software-comandas-restaurantes-gratis` and `/blog/facturacion-electronica-restaurante` → 404, no redirect
- [ ] A published article still 200s with its real title
- [ ] An `onboarding-*` or `test-*` public URL (or a tenant with no products) has `noindex, follow`
- [ ] Branded 404 is usable on mobile (Spanish copy, large tap targets)

## wr-context
See `.wr/2313.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)