### PR TITLE
fix(menu): keep category ingredients after save and uncrowd option rows

### DIFF
--- a/components/ingredientes/WarehouseCategoryIngredientSelector.test.ts
+++ b/components/ingredientes/WarehouseCategoryIngredientSelector.test.ts
@@ -335,4 +335,43 @@ describe('WarehouseCategoryIngredientSelector', () => {
       warehouse_category_id: 'category-1',
     }])
   })
+
+  it('keeps category rows when existing ids shrink after layout split', async () => {
+    vi.stubGlobal('$fetch', vi.fn(async () => ({
+      data: {
+        ingredients: [{
+          ingredient_id: 'ingredient-1',
+          name: 'Arroz',
+          unit: 'gr',
+          warehouse_category_id: 'category-1',
+        }],
+        empty_category_ids: [],
+        unavailable_category_ids: [],
+      },
+    })))
+    vi.stubGlobal('useI18n', () => ({ t: (key: string) => key }))
+    const wrapper = mount(WarehouseCategoryIngredientSelector, {
+      props: { existingIngredientIds: [] },
+      global: {
+        components: { UiWarehouseCategorySearchInput: WarehouseCategorySearchInputStub },
+      },
+    })
+
+    await wrapper.get('[data-test="select-category"]').trigger('click')
+    await flushPromises()
+    await wrapper.setProps({ existingIngredientIds: ['ingredient-1'] })
+    await flushPromises()
+    await wrapper.setProps({ existingIngredientIds: [] })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Arroz')
+    const emittedRows = wrapper.emitted('update:preparedRows') ?? []
+    expect(emittedRows.at(-1)?.[0]).toEqual([{
+      ingredient_id: 'ingredient-1',
+      name: 'Arroz',
+      quantity: null,
+      unit: 'gr',
+      warehouse_category_id: 'category-1',
+    }])
+  })
 })

--- a/components/ingredientes/WarehouseCategoryIngredientSelector.vue
+++ b/components/ingredientes/WarehouseCategoryIngredientSelector.vue
@@ -275,6 +275,7 @@ watch(
 watch(
   () => props.existingIngredientIds,
   (ids, previousIds) => {
+    if (!props.hidePreparedIngredientRows) return
     if (!selectedCategories.value.length) return
 
     const previous = new Set(previousIds ?? [])

--- a/components/menu/MenuModifierOptionEditor.vue
+++ b/components/menu/MenuModifierOptionEditor.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="border border-border rounded-lg p-3 sm:p-4 bg-background space-y-3">
-    <div class="grid grid-cols-1 md:grid-cols-12 gap-3">
-      <div class="md:col-span-3">
+    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      <div class="min-w-0">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.optionTypeRequired') }}</label>
         <select
           :value="uiOptionType"
@@ -16,7 +16,7 @@
         </select>
       </div>
 
-      <div class="md:col-span-3">
+      <div class="min-w-0">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.optionNameRequired') }}</label>
         <input
           v-model="modifier.name"
@@ -25,8 +25,10 @@
           class="input-base w-full px-3 py-2 text-sm"
         />
       </div>
+    </div>
 
-      <div class="md:col-span-2">
+    <div class="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-5">
+      <div class="col-span-2 min-w-0 sm:col-span-2 lg:col-span-2">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.additionalUnitPrice') }}</label>
         <div class="relative">
           <span class="absolute start-3 top-1/2 -translate-y-1/2 text-xs font-medium text-text-secondary">{{ currencyCode }}</span>
@@ -38,7 +40,7 @@
         </div>
       </div>
 
-      <div class="md:col-span-1">
+      <div class="min-w-0">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.maxShort') }}</label>
         <input
           :value="modifier.max_limit"
@@ -50,7 +52,7 @@
         />
       </div>
 
-      <div class="md:col-span-1">
+      <div class="min-w-0">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.includedShort') }}</label>
         <input
           :value="modifier.included_quantity"
@@ -62,24 +64,24 @@
         />
       </div>
 
-      <div class="md:col-span-1">
-        <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.order') }}</label>
-        <input
-          v-model.number="modifier.sort_order"
-          type="number"
-          min="0"
-          class="input-base w-full px-3 py-2 text-sm"
-        />
-      </div>
-
-      <div class="md:col-span-1 flex items-end justify-end">
+      <div class="col-span-2 flex items-end gap-2 sm:col-span-4 lg:col-span-1">
+        <div class="min-w-0 flex-1">
+          <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.order') }}</label>
+          <input
+            v-model.number="modifier.sort_order"
+            type="number"
+            min="0"
+            class="input-base w-full px-3 py-2 text-sm"
+          />
+        </div>
         <button
           type="button"
-          class="flex items-center justify-center w-full h-[38px] text-destructive hover:bg-destructive/5 rounded-lg transition-colors"
+          class="flex h-[38px] w-11 flex-shrink-0 items-center justify-center rounded-lg text-destructive hover:bg-destructive/5 transition-colors"
           :title="t('menu.modificadores.removeOption')"
+          :aria-label="t('menu.modificadores.removeOption')"
           @click="$emit('remove')"
         >
-          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
           </svg>
         </button>
@@ -92,8 +94,8 @@
       {{ quantityAdjustmentHint }}
     </p>
 
-    <div v-if="uiOptionType === 'WAREHOUSE'" class="grid grid-cols-1 md:grid-cols-12 gap-3">
-      <div class="md:col-span-5">
+    <div v-if="uiOptionType === 'WAREHOUSE'" class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-12">
+      <div class="min-w-0 sm:col-span-2 lg:col-span-5">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.warehouseItemRequired') }}</label>
         <UiIngredientSearchInput
           :key="`modifier-ing-${modifier.ingredient_id ?? index}`"
@@ -104,7 +106,7 @@
           @create="(name) => $emit('create-ingredient', name)"
         />
       </div>
-      <div class="md:col-span-2">
+      <div class="min-w-0 lg:col-span-2">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.quantity') }}</label>
         <UiDecimalInput
           v-model="modifier.ingredient_quantity"
@@ -113,7 +115,7 @@
           class="input-base w-full px-3 py-2 text-sm"
         />
       </div>
-      <div class="md:col-span-3">
+      <div class="min-w-0 lg:col-span-3">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.unit') }}</label>
         <select
           v-model="modifier.ingredient_unit"
@@ -127,13 +129,14 @@
           >{{ opt.label }}</option>
         </select>
       </div>
-      <div class="md:col-span-2 flex items-end">
-        <p class="text-xs text-text-secondary pb-2">{{ t('menu.modificadores.unitCost') }} {{ ingredientCostLabel }}</p>
+      <div class="min-w-0 rounded-lg border border-border bg-surface-secondary/40 px-3 py-2 lg:col-span-2">
+        <p class="text-xs font-medium text-text-secondary">{{ t('menu.modificadores.unitCost') }}</p>
+        <p class="mt-1 text-sm font-medium text-text-primary tabular-nums">{{ ingredientCostLabel }}</p>
       </div>
     </div>
 
-    <div v-else-if="uiOptionType === 'RESALE'" class="grid grid-cols-1 md:grid-cols-12 gap-3">
-      <div class="md:col-span-5">
+    <div v-else-if="uiOptionType === 'RESALE'" class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-12">
+      <div class="min-w-0 sm:col-span-2 lg:col-span-5">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.resaleProductRequired') }}</label>
         <UiProductSearchInput
           :key="`modifier-resale-${modifier.ingredient_id ?? index}`"
@@ -144,7 +147,7 @@
         />
         <p class="mt-1 text-xs text-text-tertiary">{{ t('menu.modificadores.resaleProductHelp') }}</p>
       </div>
-      <div class="md:col-span-2">
+      <div class="min-w-0 lg:col-span-2">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.quantity') }}</label>
         <UiDecimalInput
           v-model="modifier.ingredient_quantity"
@@ -153,7 +156,7 @@
           class="input-base w-full px-3 py-2 text-sm"
         />
       </div>
-      <div class="md:col-span-3">
+      <div class="min-w-0 lg:col-span-3">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.unit') }}</label>
         <select
           v-model="modifier.ingredient_unit"
@@ -167,27 +170,28 @@
           >{{ opt.label }}</option>
         </select>
       </div>
-      <div class="md:col-span-2 flex items-end">
-        <p class="text-xs text-text-secondary pb-2">{{ t('menu.modificadores.unitCost') }} {{ ingredientCostLabel }}</p>
+      <div class="min-w-0 rounded-lg border border-border bg-surface-secondary/40 px-3 py-2 lg:col-span-2">
+        <p class="text-xs font-medium text-text-secondary">{{ t('menu.modificadores.unitCost') }}</p>
+        <p class="mt-1 text-sm font-medium text-text-primary tabular-nums">{{ ingredientCostLabel }}</p>
       </div>
     </div>
 
-    <div v-else-if="uiOptionType === 'RECIPE'" class="space-y-2">
-      <div class="grid grid-cols-1 md:grid-cols-12 gap-3">
-        <div class="md:col-span-6">
-          <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.baseRecipeRequired') }}</label>
-          <select
-            v-model="modifier.recipe_base_type_id"
-            class="input-base w-full px-3 py-2 text-sm"
-            @change="onRecipeBaseChange"
-          >
-            <option value="">{{ t('menu.modificadores.chooseRecipe') }}</option>
-            <option v-for="recipe in recipeBases" :key="String(recipe.id)" :value="String(recipe.id)">
-              {{ recipe.name }}
-            </option>
-          </select>
-        </div>
-        <div class="md:col-span-3">
+    <div v-else-if="uiOptionType === 'RECIPE'" class="space-y-3">
+      <div class="min-w-0">
+        <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.baseRecipeRequired') }}</label>
+        <select
+          v-model="modifier.recipe_base_type_id"
+          class="input-base w-full px-3 py-2 text-sm"
+          @change="onRecipeBaseChange"
+        >
+          <option value="">{{ t('menu.modificadores.chooseRecipe') }}</option>
+          <option v-for="recipe in recipeBases" :key="String(recipe.id)" :value="String(recipe.id)">
+            {{ recipe.name }}
+          </option>
+        </select>
+      </div>
+      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div class="min-w-0">
           <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.recipeQuantity') }}</label>
           <UiDecimalInput
             v-model="modifier.recipe_base_quantity"
@@ -196,8 +200,9 @@
             class="input-base w-full px-3 py-2 text-sm"
           />
         </div>
-        <div class="md:col-span-3 flex items-end">
-          <p class="text-xs text-text-secondary pb-2">{{ t('menu.modificadores.unitCost') }} {{ recipeCostLabel }}</p>
+        <div class="min-w-0 rounded-lg border border-border bg-surface-secondary/40 px-3 py-2">
+          <p class="text-xs font-medium text-text-secondary">{{ t('menu.modificadores.unitCost') }}</p>
+          <p class="mt-1 text-sm font-medium text-text-primary tabular-nums">{{ recipeCostLabel }}</p>
         </div>
       </div>
       <div
@@ -218,11 +223,6 @@
 
       <div class="space-y-2 pt-2 border-t border-border">
         <h4 class="text-sm font-medium text-text-primary">{{ WAREHOUSE_COPY.recipeCostLines }}</h4>
-
-        <div v-if="modifier.recipe_lines.length === 0" class="text-center py-8 text-text-secondary border border-dashed border-border/80 rounded-lg mb-4">
-          <p class="text-sm font-medium">{{ t('menu.productos.emptyAdditionalLines') }}</p>
-          <p class="text-xs mt-1">{{ WAREHOUSE_COPY.addRecipeCostLinesHelp }}</p>
-        </div>
 
         <div v-if="modifier.recipe_lines.length" class="space-y-2">
           <div
@@ -286,8 +286,8 @@
       </div>
     </div>
 
-    <div v-else-if="uiOptionType === 'PRODUCT'" class="grid grid-cols-1 md:grid-cols-12 gap-3">
-      <div class="md:col-span-6">
+    <div v-else-if="uiOptionType === 'PRODUCT'" class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      <div class="min-w-0 sm:col-span-2">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ WAREHOUSE_COPY.menuProduct }} *</label>
         <UiProductSearchInput
           :key="`modifier-prod-${modifier.linked_product_id ?? index}`"
@@ -297,7 +297,7 @@
           @select="onProductSelect"
         />
       </div>
-      <div class="md:col-span-3">
+      <div class="min-w-0">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.productQuantity') }}</label>
         <UiDecimalInput
           v-model="modifier.linked_product_quantity"
@@ -306,8 +306,9 @@
           class="input-base w-full px-3 py-2 text-sm"
         />
       </div>
-      <div class="md:col-span-3 flex items-end">
-        <p class="text-xs text-text-secondary pb-2">{{ t('menu.modificadores.unitCost') }} {{ productCostLabel }}</p>
+      <div class="min-w-0 rounded-lg border border-border bg-surface-secondary/40 px-3 py-2">
+        <p class="text-xs font-medium text-text-secondary">{{ t('menu.modificadores.unitCost') }}</p>
+        <p class="mt-1 text-sm font-medium text-text-primary tabular-nums">{{ productCostLabel }}</p>
       </div>
     </div>
 

--- a/pages/menu/modificadores/[id].vue
+++ b/pages/menu/modificadores/[id].vue
@@ -129,7 +129,7 @@
 
               <WarehouseCategoryIngredientSelector
                 ref="warehouseCategorySelectorRef"
-                :key="`modifier-edit-category-bulk-${groupId}`"
+                :key="`modifier-edit-category-bulk-${groupId}-${categorySelectorEpoch}`"
                 class="mb-4"
                 :input-id="`modifier-edit-warehouse-category-bulk-${groupId}`"
                 :existing-ingredient-ids="existingWarehouseIngredientIds"
@@ -260,7 +260,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { useQueryCache } from '@pinia/colada'
 import { useTenantReactive } from '@/composables/useTenantReactive'
 import { useMenuIngredientsQuery } from '@/composables/queries/useMenuIngredients'
@@ -340,6 +340,7 @@ const isRefreshingGroup = computed(() => isLoadingGroup.value && groupData.value
 
 /** After save, keep the edited form instead of re-hydrating from GET. */
 const skipNextGroupHydrate = ref(false)
+const categorySelectorEpoch = ref(0)
 
 const { availableIngredients } = useMenuIngredientsQuery()
 
@@ -690,10 +691,12 @@ async function handleSubmit() {
     // Optimistic: keep current form (products, options, etc.); sync cache only.
     skipNextGroupHydrate.value = true
     groupData.value = response
+    await nextTick()
     skipNextGroupHydrate.value = false
 
     cache.invalidateQueries({ key: ['menu', 'modifier-groups'] })
     cache.invalidateQueries({ key: ['menu', 'modifier-stats'] })
+    categorySelectorEpoch.value += 1
     toast.success(t('menu.modificadores.updatedSuccess'), { title: t('menu.modificadores.saved') })
   } catch (error: any) {
     console.error('Error updating modifier group:', error)

--- a/pages/menu/productos/[id].vue
+++ b/pages/menu/productos/[id].vue
@@ -631,7 +631,7 @@
 
             <WarehouseCategoryIngredientSelector
               v-if="!isResaleProduct"
-              :key="`product-edit-category-ingredients-${productId}`"
+              :key="`product-edit-category-ingredients-${productId}-${categorySelectorEpoch}`"
               class="mb-4"
               input-id="product-edit-category-ingredients"
               :existing-ingredient-ids="existingIngredientIds"
@@ -643,12 +643,7 @@
             />
 
             <!-- Lista de ingredientes -->
-            <div v-if="form.ingredients.length === 0 && categoryPreparedRows.length === 0" class="text-center py-8 text-text-secondary border border-dashed border-border/80 rounded-lg mb-4">
-              <p class="text-sm font-medium">{{ t('menu.productos.emptyAdditionalLines') }}</p>
-              <p class="text-xs mt-1">{{ WAREHOUSE_COPY.addRecipeCostLinesHelp }}</p>
-            </div>
-
-            <div v-else class="space-y-3 mb-4">
+            <div v-if="form.ingredients.length" class="space-y-3 mb-4">
               <div
                 v-if="categoryPreparedRows.length && form.ingredients.length"
                 class="flex items-center gap-3 pt-1"
@@ -1210,6 +1205,7 @@ const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 const loadingUnits = ref<Set<string>>(new Set())
 const categoryPreparedRows = ref<PreparedWarehouseCategoryIngredient[]>([])
 const categorySelectorCategories = ref<WarehouseCategoryRow[]>([])
+const categorySelectorEpoch = ref(0)
 
 const { getIngredientUnitOptions: buildUnitOptions, defaultUnitForIngredient, mergeIngredientUnitFields, rehydrateIngredientCaches } = useIngredientUnitOptions()
 
@@ -1422,9 +1418,10 @@ const form = ref({
   costo_percibido: null as number | null,
 })
 
-const existingIngredientIds = computed(() =>
-  form.value.ingredients.map(row => row.ingredient_id).filter(Boolean),
-)
+const existingIngredientIds = computed(() => [
+  ...form.value.ingredients.map(row => row.ingredient_id),
+  ...categoryPreparedRows.value.map(row => row.ingredient_id),
+].filter(Boolean))
 const combinedIngredients = computed(() => [
   ...form.value.ingredients,
   ...mapPreparedRowsToProduct(categoryPreparedRows.value),
@@ -1837,8 +1834,10 @@ const handleSubmit = async () => {
       }
     }
 
-    cache.invalidateQueries()
+    cache.invalidateQueries({ key: ['menu', 'products'] })
+    cache.invalidateQueries({ key: ['menu', 'products-resale'] })
     await refresh()
+    categorySelectorEpoch.value += 1
     toast.success(t('menu.productos.updatedToast'), { title: t('menu.productos.saved') })
   } catch (error: any) {
     console.error('❌ Error al actualizar producto:', error)

--- a/pages/menu/productos/crear.vue
+++ b/pages/menu/productos/crear.vue
@@ -523,12 +523,7 @@
                   @update:prepared-rows="onCategoryPreparedRows"
                 />
 
-                <div v-if="form.ingredients.length === 0 && categoryPreparedRows.length === 0" class="text-center py-8 text-text-secondary border border-dashed border-border/80 rounded-lg mb-4">
-                    <p class="text-sm font-medium">{{ t('menu.productos.emptyAdditionalLines') }}</p>
-                  <p class="text-xs mt-1">{{ WAREHOUSE_COPY.addRecipeCostLinesHelp }}</p>
-                </div>
-
-                <div v-else class="space-y-3 mb-4">
+                <div v-if="form.ingredients.length" class="space-y-3 mb-4">
                   <div
                     v-if="categoryPreparedRows.length && form.ingredients.length"
                     class="flex items-center gap-3 pt-1"
@@ -1040,9 +1035,10 @@ const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 const loadingUnits = ref<Set<string>>(new Set())
 const categoryPreparedRows = ref<PreparedWarehouseCategoryIngredient[]>([])
 
-const existingIngredientIds = computed(() =>
-  form.value.ingredients.map(row => row.ingredient_id).filter(Boolean),
-)
+const existingIngredientIds = computed(() => [
+  ...form.value.ingredients.map(row => row.ingredient_id),
+  ...categoryPreparedRows.value.map(row => row.ingredient_id),
+].filter(Boolean))
 const combinedIngredients = computed(() => [
   ...form.value.ingredients,
   ...mapPreparedRowsToProduct(categoryPreparedRows.value),

--- a/pages/menu/recetas/[id].vue
+++ b/pages/menu/recetas/[id].vue
@@ -77,7 +77,7 @@
               <MenuIngredientProductHint class="mb-4" />
 
               <WarehouseCategoryIngredientSelector
-                :key="`recipe-edit-category-ingredients-${recipeId}`"
+                :key="`recipe-edit-category-ingredients-${recipeId}-${categorySelectorEpoch}`"
                 class="mb-4"
                 input-id="recipe-edit-category-ingredients"
                 :existing-ingredient-ids="existingIngredientIds"
@@ -88,13 +88,7 @@
                 @update:prepared-rows="onCategoryPreparedRows"
               />
 
-              <div v-if="form.ingredients.length === 0 && categoryPreparedRows.length === 0" class="text-center py-10 text-text-secondary border border-dashed border-border rounded-lg">
-                <Icon name="heroicons:cube" class="h-12 w-12 mx-auto mb-3 text-text-tertiary/50" />
-                <p class="text-sm font-medium mb-0.5">{{ t('menu.recetas.form.emptyLines') }}</p>
-                <p class="text-xs text-text-tertiary">{{ WAREHOUSE_COPY.recipeCompositionEmptyHelp }}</p>
-              </div>
-
-              <div v-else class="space-y-3">
+              <div v-if="form.ingredients.length" class="space-y-3">
                 <div
                   v-if="categoryPreparedRows.length && form.ingredients.length"
                   class="flex items-center gap-3 pt-1"
@@ -315,6 +309,7 @@ const purchaseUnitsCache = ref<Map<string, any[]>>(new Map())
 const loadingUnits = ref<Set<string>>(new Set())
 const categoryPreparedRows = ref<PreparedWarehouseCategoryIngredient[]>([])
 const categorySelectorCategories = ref<WarehouseCategoryRow[]>([])
+const categorySelectorEpoch = ref(0)
 
 function syncCategorySelectorLayout() {
   if (!availableIngredients.value.length) return
@@ -431,9 +426,10 @@ const form = ref({
   }>
 })
 
-const existingIngredientIds = computed(() =>
-  form.value.ingredients.map(row => row.ingredient_id).filter(Boolean),
-)
+const existingIngredientIds = computed(() => [
+  ...form.value.ingredients.map(row => row.ingredient_id),
+  ...categoryPreparedRows.value.map(row => row.ingredient_id),
+].filter(Boolean))
 const combinedIngredients = computed(() => [
   ...form.value.ingredients,
   ...mapPreparedRowsToRecipe(categoryPreparedRows.value),
@@ -548,8 +544,9 @@ const handleSubmit = async () => {
       }
     })
 
-    cache.invalidateQueries()
+    cache.invalidateQueries({ key: ['menu', 'recipe-bases'] })
     await refresh()
+    categorySelectorEpoch.value += 1
     toast.success(t('menu.recetas.form.updated'), { title: t('menu.common.guardado') })
   } catch (error: any) {
     console.error('Error updating recipe base:', error)

--- a/pages/menu/recetas/crear.vue
+++ b/pages/menu/recetas/crear.vue
@@ -101,15 +101,7 @@
                   @update:prepared-rows="onCategoryPreparedRows"
                 />
 
-                <div v-if="form.ingredients.length === 0 && categoryPreparedRows.length === 0" class="text-center py-10 text-text-secondary border border-dashed border-border rounded-lg">
-                  <svg class="w-12 h-12 mx-auto mb-3 text-text-tertiary/50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-                  </svg>
-                  <p class="text-sm font-medium mb-0.5">{{ t('menu.recetas.form.emptyLines') }}</p>
-                  <p class="text-xs text-text-tertiary">{{ WAREHOUSE_COPY.recipeCompositionEmptyHelp }}</p>
-                </div>
-
-                <div v-else class="space-y-3">
+                <div v-if="form.ingredients.length" class="space-y-3">
                   <div
                     v-if="categoryPreparedRows.length && form.ingredients.length"
                     class="flex items-center gap-3 pt-1"
@@ -331,9 +323,10 @@ function getIngredientUnitOptions(ingredientId: string) {
   })
 }
 
-const existingIngredientIds = computed(() =>
-  form.value.ingredients.map(row => row.ingredient_id).filter(Boolean),
-)
+const existingIngredientIds = computed(() => [
+  ...form.value.ingredients.map(row => row.ingredient_id),
+  ...categoryPreparedRows.value.map(row => row.ingredient_id),
+].filter(Boolean))
 const combinedIngredients = computed(() => [
   ...form.value.ingredients,
   ...mapPreparedRowsToRecipe(categoryPreparedRows.value),


### PR DESCRIPTION
## Summary
- Category-added ingredients in recetas, productos, and modificadores stay visible after Guardar/Actualizar without a full refresh.
- Modifier option editor no longer stacks Receta base, cantidad, and costo unitario on top of each other; Tipo sits on its own row.
- Empty “Sin líneas adicionales” boxes are gone where + Agregar already covers that action.

## Test plan
- [ ] Edit a modifier option typed Receta base: tipo/nombre and costo unitario do not overlap
- [ ] Insumos de la receta shows + Agregar without the dashed empty state
- [ ] Add ingredients by category on recetas, productos, and modificadores, click Actualizar/Guardar: new lines remain without a browser refresh


Made with [Cursor](https://cursor.com)