### PR TITLE
fix(menu): hide unit cost on modifier option rows

### DIFF
--- a/.wr/2317.yaml
+++ b/.wr/2317.yaml
@@ -1,0 +1,35 @@
+issue: 2317
+title: "fix(menu): remove unit cost box from modifier option rows"
+repo: front_nuxt
+repo_remote: uno0uno/warocol.com
+cwd: /Users/saifer/Documents/WEBS/WARO COLOMBIA/front_nuxt
+stack: nuxt
+branch: wr-2317-hide-option-unit-cost
+
+paths:
+  - components/menu/MenuModifierOptionEditor.vue
+
+ac:
+  - No Costo unit. box on warehouse, resale, recipe, or menu-product option rows
+  - Receta base options do not show empty Insumos de la receta or a second + Agregar
+  - Existing extra recipe_lines still render so data is not lost
+  - Cantidad x receta usable without overlapping a cost box
+  - Published option save/load unchanged
+
+out_of_scope:
+  - Product/recipe composition cost UI outside modifiers
+  - API cost calculation
+  - Save payload / unit_cost persistence
+
+hints:
+  entry: "components/menu/MenuModifierOptionEditor.vue used on /menu/modificadores/:id and crear"
+  pattern: "Hide recipe_lines unless length > 0; drop unitCost boxes and unused cost computeds"
+  tests: "none (Vue editor UI only; do not run bun build/lint)"
+
+risk: low
+
+skip:
+  audits: [ux, color, typography]
+
+next:
+  after_pr: "ready-for-review label; skip wr-review (risk low)"

--- a/components/menu/MenuModifierOptionEditor.vue
+++ b/components/menu/MenuModifierOptionEditor.vue
@@ -94,7 +94,7 @@
       {{ quantityAdjustmentHint }}
     </p>
 
-    <div v-if="uiOptionType === 'WAREHOUSE'" class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-12">
+    <div v-if="uiOptionType === 'WAREHOUSE'" class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-10">
       <div class="min-w-0 sm:col-span-2 lg:col-span-5">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.warehouseItemRequired') }}</label>
         <UiIngredientSearchInput
@@ -129,13 +129,9 @@
           >{{ opt.label }}</option>
         </select>
       </div>
-      <div class="min-w-0 rounded-lg border border-border bg-surface-secondary/40 px-3 py-2 lg:col-span-2">
-        <p class="text-xs font-medium text-text-secondary">{{ t('menu.modificadores.unitCost') }}</p>
-        <p class="mt-1 text-sm font-medium text-text-primary tabular-nums">{{ ingredientCostLabel }}</p>
-      </div>
     </div>
 
-    <div v-else-if="uiOptionType === 'RESALE'" class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-12">
+    <div v-else-if="uiOptionType === 'RESALE'" class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-10">
       <div class="min-w-0 sm:col-span-2 lg:col-span-5">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.resaleProductRequired') }}</label>
         <UiProductSearchInput
@@ -170,10 +166,6 @@
           >{{ opt.label }}</option>
         </select>
       </div>
-      <div class="min-w-0 rounded-lg border border-border bg-surface-secondary/40 px-3 py-2 lg:col-span-2">
-        <p class="text-xs font-medium text-text-secondary">{{ t('menu.modificadores.unitCost') }}</p>
-        <p class="mt-1 text-sm font-medium text-text-primary tabular-nums">{{ ingredientCostLabel }}</p>
-      </div>
     </div>
 
     <div v-else-if="uiOptionType === 'RECIPE'" class="space-y-3">
@@ -190,20 +182,14 @@
           </option>
         </select>
       </div>
-      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <div class="min-w-0">
-          <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.recipeQuantity') }}</label>
-          <UiDecimalInput
-            v-model="modifier.recipe_base_quantity"
-            :min="0.01"
-            :precision="6"
-            class="input-base w-full px-3 py-2 text-sm"
-          />
-        </div>
-        <div class="min-w-0 rounded-lg border border-border bg-surface-secondary/40 px-3 py-2">
-          <p class="text-xs font-medium text-text-secondary">{{ t('menu.modificadores.unitCost') }}</p>
-          <p class="mt-1 text-sm font-medium text-text-primary tabular-nums">{{ recipeCostLabel }}</p>
-        </div>
+      <div class="min-w-0 sm:max-w-xs">
+        <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.recipeQuantity') }}</label>
+        <UiDecimalInput
+          v-model="modifier.recipe_base_quantity"
+          :min="0.01"
+          :precision="6"
+          class="input-base w-full min-h-[38px] px-3 py-2 text-sm"
+        />
       </div>
       <div
         v-if="modifier.recipe_base_type_id && recipeBaseIngredients.length > 0"
@@ -221,24 +207,24 @@
         </div>
       </div>
 
-      <div class="space-y-2 pt-2 border-t border-border">
-        <h4 class="text-sm font-medium text-text-primary">{{ WAREHOUSE_COPY.recipeCostLines }}</h4>
-
-        <div v-if="modifier.recipe_lines.length" class="space-y-2">
-          <div
-            v-for="(line, lineIndex) in modifier.recipe_lines"
-            :key="`${line.ingredient_id || 'new'}-${lineIndex}`"
-            class="grid grid-cols-1 gap-2 rounded-lg border border-border p-3 md:grid-cols-12"
-          >
-            <div class="md:col-span-5">
-              <label class="block text-xs font-medium text-text-secondary mb-1">{{ WAREHOUSE_COPY.warehouseItemOrResaleRequired }}</label>
-              <UiIngredientSearchInput
-                :key="`modifier-recipe-line-${line.ingredient_id || lineIndex}`"
-                :initial-value="recipeLineSearchLabel(line)"
-                :allow-create="true"
-                @select="ingredient => $emit('select-recipe-line', lineIndex, ingredient)"
-                @create="name => $emit('create-recipe-line', lineIndex, name)"
-              />
+      <div
+        v-if="modifier.recipe_lines.length"
+        class="space-y-2"
+      >
+        <div
+          v-for="(line, lineIndex) in modifier.recipe_lines"
+          :key="`${line.ingredient_id || 'new'}-${lineIndex}`"
+          class="grid grid-cols-1 gap-2 rounded-lg border border-border p-3 md:grid-cols-12"
+        >
+          <div class="md:col-span-5">
+            <label class="block text-xs font-medium text-text-secondary mb-1">{{ WAREHOUSE_COPY.warehouseItemOrResaleRequired }}</label>
+            <UiIngredientSearchInput
+              :key="`modifier-recipe-line-${line.ingredient_id || lineIndex}`"
+              :initial-value="recipeLineSearchLabel(line)"
+              :allow-create="true"
+              @select="ingredient => $emit('select-recipe-line', lineIndex, ingredient)"
+              @create="name => $emit('create-recipe-line', lineIndex, name)"
+            />
           </div>
           <div class="md:col-span-3">
             <UiDecimalInput
@@ -272,22 +258,12 @@
           >
             ×
           </button>
-          </div>
         </div>
-
-        <button
-          type="button"
-          class="inline-flex min-h-9 w-full items-center justify-center gap-1.5 rounded-lg bg-shell-icon-bg px-3 text-sm font-medium text-shell-icon-text"
-          @click="addRecipeLine"
-        >
-          <Icon name="heroicons:plus" class="h-4 w-4 flex-shrink-0" />
-          {{ t('menu.recetas.form.addLine') }}
-        </button>
       </div>
     </div>
 
-    <div v-else-if="uiOptionType === 'PRODUCT'" class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-      <div class="min-w-0 sm:col-span-2">
+    <div v-else-if="uiOptionType === 'PRODUCT'" class="space-y-3">
+      <div class="min-w-0">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ WAREHOUSE_COPY.menuProduct }} *</label>
         <UiProductSearchInput
           :key="`modifier-prod-${modifier.linked_product_id ?? index}`"
@@ -297,7 +273,7 @@
           @select="onProductSelect"
         />
       </div>
-      <div class="min-w-0">
+      <div class="min-w-0 sm:max-w-xs">
         <label class="block text-xs font-medium text-text-secondary mb-1">{{ t('menu.modificadores.productQuantity') }}</label>
         <UiDecimalInput
           v-model="modifier.linked_product_quantity"
@@ -305,10 +281,6 @@
           :precision="6"
           class="input-base w-full px-3 py-2 text-sm"
         />
-      </div>
-      <div class="min-w-0 rounded-lg border border-border bg-surface-secondary/40 px-3 py-2">
-        <p class="text-xs font-medium text-text-secondary">{{ t('menu.modificadores.unitCost') }}</p>
-        <p class="mt-1 text-sm font-medium text-text-primary tabular-nums">{{ productCostLabel }}</p>
       </div>
     </div>
 
@@ -345,7 +317,7 @@ import { formatDomainQuantity } from '~/utils/domainNumberFormat'
 import { fetchResaleLinkedIngredient } from '~/composables/useResaleLinkedIngredient'
 
 const { t } = useI18n({ useScope: 'global' })
-const { formatCurrency, currencyCode, currencyMinorUnits } = useFormatters()
+const { currencyCode, currencyMinorUnits } = useFormatters()
 const WAREHOUSE_COPY = useWarehouseCopy()
 
 const props = defineProps<{
@@ -408,15 +380,6 @@ function recipeLineSearchLabel(line: ModifierRecipeLineForm) {
   if (line.ingredient_name?.trim()) return line.ingredient_name.trim()
   if (!line.ingredient_id) return ''
   return String(props.getIngredientById(line.ingredient_id)?.name || '')
-}
-
-function addRecipeLine() {
-  props.modifier.recipe_lines.push({
-    ingredient_id: '',
-    ingredient_name: '',
-    quantity: null,
-    unit: null,
-  })
 }
 
 function removeRecipeLine(lineIndex: number) {
@@ -485,40 +448,6 @@ function scaledRecipeQty(ing: Record<string, unknown>) {
   return formatDomainQuantity(Number(ing.base_quantity ?? ing.quantity ?? 0) * mult, 6)
 }
 
-function estimateRecipeCost(): number | null {
-  if (!props.modifier.recipe_base_type_id) return null
-  let total = 0
-  let hasLine = false
-  for (const ing of recipeBaseIngredients.value) {
-    const qty = Number(ing.base_quantity ?? ing.quantity ?? 0) * (Number(props.modifier.recipe_base_quantity) || 1)
-    const unitCost = Number(ing.costo_unitario ?? ing.unit_cost ?? 0)
-    if (qty > 0) hasLine = true
-    total += qty * unitCost
-  }
-  return hasLine ? total : null
-}
-
-const ingredientCostLabel = computed(() => {
-  if (props.modifier.unit_cost != null) return formatCurrency(props.modifier.unit_cost)
-  const ing = props.modifier.ingredient_id
-    ? props.getIngredientById(props.modifier.ingredient_id)
-    : undefined
-  const unit = Number(ing?.costo_unitario ?? 0)
-  const qty = Number(props.modifier.ingredient_quantity) || 0
-  if (!unit || !qty) return '—'
-  return formatCurrency(unit * qty)
-})
-
-const recipeCostLabel = computed(() => {
-  if (props.modifier.unit_cost != null) return formatCurrency(props.modifier.unit_cost)
-  const est = estimateRecipeCost()
-  return est != null ? formatCurrency(est) : '—'
-})
-
-const productCostLabel = computed(() => {
-  if (props.modifier.unit_cost != null) return formatCurrency(props.modifier.unit_cost)
-  return '—'
-})
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- Remove the **Costo unit.** box from warehouse, resale, recipe, and menu-product modifier option rows so quantity stays usable.
- Hide empty **Insumos de la receta** and the inner **+ Agregar** on Receta base options; existing extra `recipe_lines` still render.
- Save/load and API cost calculation are unchanged.

Closes #2317

## Test plan
- [ ] Edit a modifier: warehouse, resale, recipe, and menu-product rows have no Costo unit. box
- [ ] Receta base option shows recipe ingredients (blue list) without empty Insumos / second Agregar
- [ ] If an option already has extra recipe_lines, they still appear and can be removed
- [ ] Save and reload — composition and prices unchanged

## Validation evidence
No targeted Vue test for this editor. Did not run bun build/lint (project rule). UI-only change in `MenuModifierOptionEditor.vue`.

## wr-context
See `.wr/2317.yaml` on this branch (LLM contract).

Made with [Cursor](https://cursor.com)