### PR TITLE
feat(trail): send blog page_view beacons with visitor cookie

### DIFF
--- a/plugins/trail.client.ts
+++ b/plugins/trail.client.ts
@@ -1,0 +1,60 @@
+export default defineNuxtPlugin(() => {
+  const router = useRouter()
+  const visitorKey = ensureVisitorKey()
+
+  router.afterEach((to) => {
+    if (!shouldTrack(to.path)) return
+    const query = to.query
+    const payload = {
+      visitor_key: visitorKey,
+      site_key: 'warocol.com',
+      path: to.path,
+      referrer: document.referrer || undefined,
+      utm_source: firstQuery(query.utm_source),
+      utm_medium: firstQuery(query.utm_medium),
+      utm_campaign: firstQuery(query.utm_campaign),
+      utm_term: firstQuery(query.utm_term),
+      utm_content: firstQuery(query.utm_content),
+    }
+    const body = JSON.stringify(payload)
+    try {
+      if (navigator.sendBeacon) {
+        navigator.sendBeacon(
+          '/api/public/trail/events',
+          new Blob([body], { type: 'application/json' }),
+        )
+        return
+      }
+    } catch {
+      // fall through to fetch
+    }
+    fetch('/api/public/trail/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+      keepalive: true,
+    }).catch(() => {})
+  })
+})
+
+function shouldTrack(path: string): boolean {
+  if (path === '/' || path.startsWith('/blog')) return true
+  return false
+}
+
+function firstQuery(value: unknown): string | undefined {
+  if (Array.isArray(value)) return typeof value[0] === 'string' ? value[0] : undefined
+  return typeof value === 'string' && value.trim() ? value : undefined
+}
+
+function ensureVisitorKey(): string {
+  const cookie = useCookie('waro_visitor_key', {
+    maxAge: 60 * 60 * 24 * 365,
+    sameSite: 'lax',
+    path: '/',
+  })
+  if (!cookie.value) {
+    cookie.value = crypto.randomUUID()
+  }
+  return cookie.value
+}


### PR DESCRIPTION
## Summary
- Client plugin sends `page_view` for `/` and `/blog*` with a long-lived `waro_visitor_key` cookie.
- Payload is path-generic (UTMs/referrer when present). Dashboard/POS/menu are not tracked.

Closes uno0uno/waro-trail#3

Companion: API PR on `uno0uno/api-warolabs` (same branch `wr-3-colombia-ingest`).

## Test plan
- [ ] Open `/blog` then another `/blog/:slug` — two events, same visitor_key
- [ ] Reload days later — same cookie; new session (library 30 min / next day)
- [ ] `/dashboard` does not beacon

## Validation evidence
```
# UI-only client plugin — no targeted Vue test. Did not run bun build/lint.
# API companion: pytest tests/test_trail_ingest.py -q → 4 passed in 0.12s
```

## wr-context
See `waro-trail/.wr/3.yaml` (LLM contract).

Made with [Cursor](https://cursor.com)