### PR TITLE
feat(leads): send visitor_key cookie with blog CTA

### DIFF
--- a/components/modals/LeadModalForm.vue
+++ b/components/modals/LeadModalForm.vue
@@ -155,15 +155,18 @@ function validate(): boolean {
 async function handleSubmit() {
   if (!validate()) return
 
-  isSubmitting.value = true
+    isSubmitting.value = true
   try {
+    const visitorKey = useCookie('waro_visitor_key').value?.trim()
+    const body: Record<string, string> = {
+      email: form.value.email.trim().toLowerCase(),
+      phone: form.value.phone.replace(/\D/g, ''),
+      button_source: props.buttonSource,
+    }
+    if (visitorKey) body.visitor_key = visitorKey
     const res = await $fetch<{ success: boolean; already_registered: boolean }>('/api/leads/capture', {
       method: 'POST',
-      body: {
-        email: form.value.email.trim().toLowerCase(),
-        phone: form.value.phone.replace(/\D/g, ''),
-        button_source: props.buttonSource,
-      },
+      body,
     })
 
     isAlreadyRegistered.value = res.already_registered


### PR DESCRIPTION
## Summary
- Lead modal sends `waro_visitor_key` on `/api/leads/capture` when the cookie exists.
- Does not mint a key (batch #3 beacon owns that). Empty cookie is omitted.

Depends on warocol.com#2319 for the cookie to be set; this change is safe on main before that merges.

Refs uno0uno/waro-trail#4

## Test plan
- [ ] Submit blog CTA with cookie present → capture body includes visitor_key
- [ ] Submit without cookie → body has no visitor_key

## Validation evidence
No front unit test in this batch (plan: pytest for journey + lead attach). Modal change is the cookie forward only.

Made with [Cursor](https://cursor.com)