### PR TITLE
feat(trail): send blog scroll milestones and page leave

### DIFF
--- a/components/blog/BlogArticleContent.vue
+++ b/components/blog/BlogArticleContent.vue
@@ -1,8 +1,13 @@
 <script setup lang="ts">
-import { computed, ref, onMounted, onUnmounted, nextTick } from 'vue'
+import { computed, ref, onMounted, onUnmounted, nextTick, watch } from 'vue'
 import MarkdownIt from 'markdown-it'
 import { blogLeadSource } from '~/utils/blogLeadCta'
 import type { BlogLeadCtaContent } from '~/utils/blogLeadCta'
+import {
+  TRAIL_SCROLL_THRESHOLDS,
+  articleScrollPct,
+  sendTrailEvent,
+} from '~/utils/trailBeacon'
 
 interface Props {
   content: string
@@ -26,6 +31,91 @@ const readingProgress = ref(0)
 const articleRef = ref<HTMLElement | null>(null)
 const leadModal = useLeadModal()
 const insertedCtas: HTMLElement[] = []
+const visitorCookie = useCookie<string | null>('waro_visitor_key')
+const firedScroll = new Set<number>()
+let maxScrollPct = 0
+let dwellAccumMs = 0
+let dwellStartedAt = 0
+let leaveSent = false
+
+function trailVisitorKey(): string | null {
+  const value = visitorCookie.value
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function trailPath(): string {
+  return props.slug ? `/blog/${props.slug}` : ''
+}
+
+function pauseTrailDwell() {
+  if (!dwellStartedAt) return
+  dwellAccumMs += Math.max(0, Math.round(performance.now() - dwellStartedAt))
+  dwellStartedAt = 0
+}
+
+function resumeTrailDwell() {
+  if (document.hidden || dwellStartedAt) return
+  dwellStartedAt = performance.now()
+}
+
+function onTrailVisibility() {
+  if (document.hidden) pauseTrailDwell()
+  else resumeTrailDwell()
+}
+
+function onTrailScroll() {
+  if (!articleRef.value || !props.slug) return
+  const pct = articleScrollPct(articleRef.value)
+  if (pct > maxScrollPct) maxScrollPct = pct
+  const visitorKey = trailVisitorKey()
+  if (!visitorKey) return
+  for (const threshold of TRAIL_SCROLL_THRESHOLDS) {
+    if (pct < threshold || firedScroll.has(threshold)) continue
+    firedScroll.add(threshold)
+    sendTrailEvent({
+      visitor_key: visitorKey,
+      path: trailPath(),
+      event_type: 'scroll_depth',
+      scroll_pct: threshold,
+    })
+  }
+}
+
+function sendTrailLeave() {
+  if (leaveSent || !props.slug) return
+  leaveSent = true
+  pauseTrailDwell()
+  const visitorKey = trailVisitorKey()
+  if (!visitorKey) return
+  sendTrailEvent({
+    visitor_key: visitorKey,
+    path: trailPath(),
+    event_type: 'page_leave',
+    scroll_pct: maxScrollPct,
+    dwell_ms: dwellAccumMs,
+  })
+}
+
+function resetTrailEngagement() {
+  firedScroll.clear()
+  maxScrollPct = 0
+  dwellAccumMs = 0
+  dwellStartedAt = 0
+  leaveSent = false
+}
+
+function startTrailEngagement() {
+  if (!props.slug) return
+  resetTrailEngagement()
+  resumeTrailDwell()
+  nextTick(() => onTrailScroll())
+}
+
+function stopTrailListeners() {
+  window.removeEventListener('scroll', onTrailScroll)
+  document.removeEventListener('visibilitychange', onTrailVisibility)
+  window.removeEventListener('pagehide', sendTrailLeave)
+}
 
 function buildMidCta(cta: BlogLeadCtaContent, index: number, source: string): HTMLElement {
   const wrap = document.createElement('div')
@@ -80,6 +170,13 @@ onMounted(() => {
   window.addEventListener('scroll', update, { passive: true })
   onUnmounted(() => window.removeEventListener('scroll', update))
 
+  if (props.slug) {
+    window.addEventListener('scroll', onTrailScroll, { passive: true })
+    document.addEventListener('visibilitychange', onTrailVisibility)
+    window.addEventListener('pagehide', sendTrailLeave)
+    startTrailEngagement()
+  }
+
   nextTick(() => {
     if (!articleRef.value) return
 
@@ -106,7 +203,15 @@ onMounted(() => {
   })
 })
 
+watch(() => props.slug, (next, prev) => {
+  if (!prev || next === prev) return
+  sendTrailLeave()
+  startTrailEngagement()
+})
+
 onUnmounted(() => {
+  stopTrailListeners()
+  sendTrailLeave()
   insertedCtas.splice(0).forEach(node => node.remove())
 })
 </script>

--- a/plugins/trail.client.ts
+++ b/plugins/trail.client.ts
@@ -1,3 +1,5 @@
+import { sendTrailEvent } from '~/utils/trailBeacon'
+
 export default defineNuxtPlugin(() => {
   const router = useRouter()
   const visitorKey = ensureVisitorKey()
@@ -5,35 +7,17 @@ export default defineNuxtPlugin(() => {
   router.afterEach((to) => {
     if (!shouldTrack(to.path)) return
     const query = to.query
-    const payload = {
+    sendTrailEvent({
       visitor_key: visitorKey,
-      site_key: 'warocol.com',
       path: to.path,
+      event_type: 'page_view',
       referrer: document.referrer || undefined,
       utm_source: firstQuery(query.utm_source),
       utm_medium: firstQuery(query.utm_medium),
       utm_campaign: firstQuery(query.utm_campaign),
       utm_term: firstQuery(query.utm_term),
       utm_content: firstQuery(query.utm_content),
-    }
-    const body = JSON.stringify(payload)
-    try {
-      if (navigator.sendBeacon) {
-        navigator.sendBeacon(
-          '/api/public/trail/events',
-          new Blob([body], { type: 'application/json' }),
-        )
-        return
-      }
-    } catch {
-      // fall through to fetch
-    }
-    fetch('/api/public/trail/events', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body,
-      keepalive: true,
-    }).catch(() => {})
+    })
   })
 })
 

--- a/utils/trailBeacon.ts
+++ b/utils/trailBeacon.ts
@@ -1,0 +1,53 @@
+export const TRAIL_SITE_KEY = 'warocol.com'
+export const TRAIL_EVENTS_URL = '/api/public/trail/events'
+export const TRAIL_SCROLL_THRESHOLDS = [25, 50, 75, 100] as const
+
+export type TrailEventType = 'page_view' | 'scroll_depth' | 'page_leave'
+
+export type TrailEventPayload = {
+  visitor_key: string
+  path: string
+  site_key?: string
+  event_type?: TrailEventType
+  scroll_pct?: number
+  dwell_ms?: number
+  referrer?: string
+  utm_source?: string
+  utm_medium?: string
+  utm_campaign?: string
+  utm_term?: string
+  utm_content?: string
+}
+
+export function sendTrailEvent(payload: TrailEventPayload): void {
+  const body = JSON.stringify({
+    site_key: TRAIL_SITE_KEY,
+    ...payload,
+  })
+  try {
+    if (navigator.sendBeacon) {
+      navigator.sendBeacon(
+        TRAIL_EVENTS_URL,
+        new Blob([body], { type: 'application/json' }),
+      )
+      return
+    }
+  } catch {
+    // fall through to fetch
+  }
+  fetch(TRAIL_EVENTS_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+    keepalive: true,
+  }).catch(() => {})
+}
+
+/** Article-body progress vs viewport, not window/document chrome. */
+export function articleScrollPct(el: HTMLElement): number {
+  const height = el.offsetHeight
+  if (height <= 0) return 0
+  const top = el.getBoundingClientRect().top + window.scrollY
+  const viewportBottom = window.scrollY + window.innerHeight
+  return Math.min(100, Math.max(0, Math.round(((viewportBottom - top) / height) * 100)))
+}


### PR DESCRIPTION
## Summary
- On `/blog/:slug`, fire `scroll_depth` once each at 25/50/75/100 of the **article body** (`articleRef`), not the window reading bar.
- Accrue engaged time only while the tab is visible; send one `page_leave` with `dwell_ms` + max `scroll_pct` on leave/`pagehide`.
- Keep existing `page_view` beacon and `waro_visitor_key`; do not mint a second cookie; dashboard/POS/menu stay untracked.

Closes uno0uno/waro-trail#9

Companion: api-warolabs `wr-9-blog-scroll-beacon`.

## Test plan
- [ ] Visit an article, scroll to the bottom: at most one event per threshold plus `page_view` + `page_leave`
- [ ] Background tab does not keep accruing dwell
- [ ] `/blog` index has no scroll milestones; crawler GET still has no JS scroll
- [ ] Reading progress bar still uses window height (visual only)

## Validation evidence
No bun build/lint (issue AC). Client beacon only; API contract covered in the companion api-warolabs PR (`pytest tests/test_trail_ingest.py` — 6 passed).

Made with [Cursor](https://cursor.com)